### PR TITLE
More lexer work

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build_and_test:
-    name: Rust project - latest
+    name: Compilation
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,3 +22,8 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
+
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    run: cargo fmt -- --check

--- a/crates/parsing/src/lexer.rs
+++ b/crates/parsing/src/lexer.rs
@@ -190,6 +190,7 @@ impl<'a> Lexer<'a> {
             "data" => SyntaxKind::DataKw,
             "derive" => SyntaxKind::DeriveKw,
             "false" => SyntaxKind::LiteralFalse,
+            "forall" => SyntaxKind::ForallKw,
             "foreign" => SyntaxKind::ForeignKw,
             "import" => SyntaxKind::ImportKw,
             "infix" => SyntaxKind::InfixKw,
@@ -219,6 +220,11 @@ impl<'a> Lexer<'a> {
         self.take_while(is_operator);
         let offset_end = self.consumed();
         let kind = match &self.source[offset..offset_end] {
+            "∷" => SyntaxKind::Colon2,
+            "←" => SyntaxKind::LeftArrow,
+            "→" => SyntaxKind::RightArrow,
+            "⇒" => SyntaxKind::RightThickArrow,
+            "∀" => SyntaxKind::ForallKw,
             "=" => SyntaxKind::Equal,
             ":" => SyntaxKind::Colon,
             "::" => SyntaxKind::Colon2,

--- a/crates/parsing/src/lexer.rs
+++ b/crates/parsing/src/lexer.rs
@@ -608,6 +608,33 @@ mod tests {
     }
 
     #[test]
+    fn lex_some_keywords() {
+        expect_tokens(
+            "data type forall foreign ∷ ← → ⇒ ∀",
+            &[
+                DataKw,
+                Whitespace,
+                TypeKw,
+                Whitespace,
+                ForallKw,
+                Whitespace,
+                ForeignKw,
+                Whitespace,
+                Colon2,
+                Whitespace,
+                LeftArrow,
+                Whitespace,
+                RightArrow,
+                Whitespace,
+                RightThickArrow,
+                Whitespace,
+                ForallKw,
+                EndOfFile,
+            ],
+        );
+    }
+
+    #[test]
     fn lex_emojis() {
         lex("👋🌟😊🚀🔥");
     }

--- a/crates/parsing/src/lexer.rs
+++ b/crates/parsing/src/lexer.rs
@@ -1,4 +1,5 @@
 //! Text-based lexer into a sequence of [`SyntaxKind`]s.
+//! Based of off https://github.com/purescript/purescript/blob/master/src/Language/PureScript/CST/Lexer.hs
 
 use std::{ops::Range, str::Chars};
 
@@ -144,6 +145,9 @@ impl<'a> Lexer<'a> {
             '[' => self.take_single(SyntaxKind::LeftBrace),
             ']' => self.take_single(SyntaxKind::RightBrace),
 
+            '`' => self.take_single(SyntaxKind::Tick),
+            ',' => self.take_single(SyntaxKind::Comma),
+
             '\'' => self.take_char(),
             '"' => self.take_string(),
 
@@ -224,6 +228,7 @@ impl<'a> Lexer<'a> {
             "->" => SyntaxKind::RightArrow,
             "<=" => SyntaxKind::LeftThickArrow,
             "=>" => SyntaxKind::RightThickArrow,
+            "|" => SyntaxKind::Pipe,
             _ => SyntaxKind::Operator,
         };
         (kind, offset, None)
@@ -581,5 +586,23 @@ mod tests {
                 EndOfFile,
             ],
         )
+    }
+
+    #[test]
+    fn lex_tick_comma_pipe() {
+        expect_tokens(
+            "`,| || |+|",
+            &[Tick, Comma, Pipe, Whitespace, Operator, Whitespace, Operator, EndOfFile],
+        )
+    }
+
+    #[test]
+    fn lex_noise() {
+        lex("@jKUpg7LjW9$cPyb#b3iek1S17BvUSOIP0HfBuvv^3UF#w3UpRy@a$");
+    }
+
+    #[test]
+    fn lex_emojis() {
+        lex("👋🌟😊🚀🔥");
     }
 }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -44,6 +44,7 @@ pub enum SyntaxKind {
 
     LiteralChar,
     LiteralString,
+    LiteralRawString,
     LiteralInteger,
     LiteralNumber,
     LiteralTrue,

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -64,6 +64,7 @@ pub enum SyntaxKind {
 
     NewtypeDeclaration,
     NewtypeKw,
+    ForallKw,
 
     TypeDeclaration,
     TypeKw,

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -41,6 +41,9 @@ pub enum SyntaxKind {
     RightBracket,
     LeftBrace,
     RightBrace,
+    Tick,
+    Comma,
+    Pipe,
 
     LiteralChar,
     LiteralString,

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -23,6 +23,7 @@ pub enum SyntaxKind {
     ModuleName,
     Upper,
     Lower,
+    Hole,
     Operator,
 
     Equal,


### PR DESCRIPTION
Made the lexer more like the purescript lexer for parsing escapecodes and operators. String parsing also supports escape codes and raw string have been added. Also added some tests just for the sake of it. We also support the special unicode tokens.

Also added a formatting CI task so I don't forget it.
