### PR TITLE
Bracket -> Curly

### DIFF
--- a/crates/lexing/src/layout.rs
+++ b/crates/lexing/src/layout.rs
@@ -429,7 +429,7 @@ impl<'a, 'b> InsertWithLayout<'a, 'b> {
                 self.push_stack(self.now_position, Delimiter::Paren);
             }
 
-            SyntaxKind::LeftBracket => {
+            SyntaxKind::LeftCurly => {
                 self.pop_stack_if(|delimiter| delimiter == Delimiter::Qualified);
                 self.insert_default();
                 self.push_stack(self.now_position, Delimiter::Brace);
@@ -449,7 +449,7 @@ impl<'a, 'b> InsertWithLayout<'a, 'b> {
                 self.insert_token(self.now_token);
             }
 
-            SyntaxKind::RightBracket => {
+            SyntaxKind::RightCurly => {
                 self.pop_stack_if(|delimiter| delimiter == Delimiter::Qualified);
                 self.collapse_and_commit(InsertWithLayout::indented_p);
                 self.pop_stack_if(|delimiter| delimiter == Delimiter::Property);

--- a/crates/lexing/src/lexer.rs
+++ b/crates/lexing/src/lexer.rs
@@ -93,8 +93,8 @@ impl<'a> Lexer<'a> {
 
             '(' => self.take_single(SyntaxKind::LeftParenthesis),
             ')' => self.take_single(SyntaxKind::RightParenthesis),
-            '{' => self.take_single(SyntaxKind::LeftBracket),
-            '}' => self.take_single(SyntaxKind::RightBracket),
+            '{' => self.take_single(SyntaxKind::LeftCurly),
+            '}' => self.take_single(SyntaxKind::RightCurly),
             '[' => self.take_single(SyntaxKind::LeftSquare),
             ']' => self.take_single(SyntaxKind::RightSquare),
 

--- a/crates/parsing/src/grammar/rules.rs
+++ b/crates/parsing/src/grammar/rules.rs
@@ -138,7 +138,7 @@ fn at_expr_start(parser: &Parser) -> bool {
             | SyntaxKind::AsKw
             | SyntaxKind::LeftParenthesis
             | SyntaxKind::LeftSquare
-            | SyntaxKind::LeftBracket
+            | SyntaxKind::LeftCurly
             | SyntaxKind::LiteralChar
             | SyntaxKind::LiteralString
             | SyntaxKind::LiteralRawString
@@ -453,7 +453,7 @@ fn expr_lambda(parser: &mut Parser) {
 }
 
 fn at_record_update(parser: &Parser) -> bool {
-    if !parser.at(SyntaxKind::LeftBracket) {
+    if !parser.at(SyntaxKind::LeftCurly) {
         return false;
     }
 
@@ -461,7 +461,7 @@ fn at_record_update(parser: &Parser) -> bool {
         return false;
     }
 
-    if !matches!(parser.nth(2), SyntaxKind::Equal | SyntaxKind::LeftBracket) {
+    if !matches!(parser.nth(2), SyntaxKind::Equal | SyntaxKind::LeftCurly) {
         return false;
     }
 
@@ -473,9 +473,9 @@ fn expr_6(parser: &mut Parser) {
     expr_7(parser);
     if at_record_update(parser) {
         let mut wrapped = parser.start();
-        parser.expect(SyntaxKind::LeftBracket);
+        parser.expect(SyntaxKind::LeftCurly);
         separated(parser, SyntaxKind::Comma, record_update_leaf_or_branch);
-        parser.expect(SyntaxKind::RightBracket);
+        parser.expect(SyntaxKind::RightCurly);
         wrapped.end(parser, SyntaxKind::Wrapped);
         marker.end(parser, SyntaxKind::RecordUpdateExpression);
     } else {
@@ -492,11 +492,11 @@ fn record_update_leaf_or_branch(parser: &mut Parser) {
             expr_0(parser);
             leaf_or_branch.end(parser, SyntaxKind::RecordUpdateLeaf);
         }
-        SyntaxKind::LeftBracket => {
+        SyntaxKind::LeftCurly => {
             let mut wrapped = parser.start();
             parser.consume();
             separated(parser, SyntaxKind::Comma, record_update_leaf_or_branch);
-            parser.expect(SyntaxKind::RightBracket);
+            parser.expect(SyntaxKind::RightCurly);
             wrapped.end(parser, SyntaxKind::Wrapped);
             leaf_or_branch.end(parser, SyntaxKind::RecordUpdateBranch);
         }
@@ -533,7 +533,7 @@ fn expr_atom(parser: &mut Parser) {
             expr_array(parser);
             return expression.end(parser, SyntaxKind::LiteralExpression);
         }
-        SyntaxKind::LeftBracket => {
+        SyntaxKind::LeftCurly => {
             expr_record(parser);
             return expression.end(parser, SyntaxKind::LiteralExpression);
         }
@@ -798,7 +798,7 @@ fn type_atom(parser: &mut Parser) {
             ty.end(parser, SyntaxKind::WildcardType);
             return;
         }
-        SyntaxKind::LeftBracket => {
+        SyntaxKind::LeftCurly => {
             type_record(parser, ty);
             return;
         }
@@ -822,13 +822,13 @@ fn type_atom(parser: &mut Parser) {
 
 fn type_record(parser: &mut Parser, mut ty: NodeMarker) {
     let mut wrapped = parser.start();
-    parser.expect(SyntaxKind::LeftBracket);
+    parser.expect(SyntaxKind::LeftCurly);
 
     let mut inner = parser.start();
 
     match parser.current() {
         // '{' '}'
-        SyntaxKind::RightBracket => (),
+        SyntaxKind::RightCurly => (),
         // '{' '|' type_0 '}'
         SyntaxKind::Pipe => {
             row_tail(parser);
@@ -841,7 +841,7 @@ fn type_record(parser: &mut Parser, mut ty: NodeMarker) {
     }
 
     inner.end(parser, SyntaxKind::RowInner);
-    parser.expect(SyntaxKind::RightBracket);
+    parser.expect(SyntaxKind::RightCurly);
     wrapped.end(parser, SyntaxKind::Wrapped);
     ty.end(parser, SyntaxKind::RecordType);
 }
@@ -1037,7 +1037,7 @@ fn at_pat_start(parser: &Parser) -> bool {
             | SyntaxKind::AsKw
             | SyntaxKind::Upper
             | SyntaxKind::LeftParenthesis
-            | SyntaxKind::LeftBracket
+            | SyntaxKind::LeftCurly
             | SyntaxKind::LeftSquare
     )
 }
@@ -1106,7 +1106,7 @@ fn pat_atom(parser: &mut Parser) {
             pat_array(parser);
             marker.end(parser, SyntaxKind::LiteralBinder);
         }
-        SyntaxKind::LeftBracket => {
+        SyntaxKind::LeftCurly => {
             pat_record(parser);
             marker.end(parser, SyntaxKind::LiteralBinder);
         }
@@ -1169,14 +1169,14 @@ fn array_container(parser: &mut Parser, rule: impl Fn(&mut Parser)) {
 fn record_container(parser: &mut Parser, pun_kind: SyntaxKind, rule: impl Fn(&mut Parser)) {
     let mut marker = parser.start();
     let mut wrapped = parser.start();
-    parser.expect(SyntaxKind::LeftBracket);
-    if parser.at(SyntaxKind::RightBracket) {
-        parser.expect(SyntaxKind::RightBracket);
+    parser.expect(SyntaxKind::LeftCurly);
+    if parser.at(SyntaxKind::RightCurly) {
+        parser.expect(SyntaxKind::RightCurly);
     } else {
         separated(parser, SyntaxKind::Comma, |parser| {
             record_field_or_pun(parser, pun_kind, &rule);
         });
-        parser.expect(SyntaxKind::RightBracket);
+        parser.expect(SyntaxKind::RightCurly);
     }
     wrapped.end(parser, SyntaxKind::Wrapped);
     marker.end(parser, SyntaxKind::LiteralRecord);

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@empty-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@empty-record.input.snap
@@ -7,10 +7,10 @@ Input: {}
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@invalid-record-field.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@invalid-record-field.input.snap
@@ -7,7 +7,7 @@ Input: { 1: "hello" }
 
 Start { kind: LiteralExpression }
   Start { kind: LiteralRecord }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: Separated }
       Start { kind: RecordField }
         Start { kind: Error }
@@ -19,7 +19,7 @@ Start { kind: LiteralExpression }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@invalid-record-pun.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@invalid-record-pun.input.snap
@@ -7,7 +7,7 @@ Input: { "a" }
 
 Start { kind: LiteralExpression }
   Start { kind: LiteralRecord }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: Separated }
       Start { kind: RecordField }
         Start { kind: Name }
@@ -17,7 +17,7 @@ Start { kind: LiteralExpression }
         Error { message: "expected an expression" }
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@literals.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@literals.input.snap
@@ -42,14 +42,14 @@ Start { kind: LiteralExpression }
       Token { kind: Comma }
       Start { kind: LiteralExpression }
         Start { kind: LiteralRecord }
-          Token { kind: LeftBracket }
-          Token { kind: RightBracket }
+          Token { kind: LeftCurly }
+          Token { kind: RightCurly }
         Finish
       Finish
       Token { kind: Comma }
       Start { kind: LiteralExpression }
         Start { kind: LiteralRecord }
-          Token { kind: LeftBracket }
+          Token { kind: LeftCurly }
           Start { kind: Separated }
             Start { kind: RecordPun }
               Start { kind: NameRef }
@@ -77,7 +77,7 @@ Start { kind: LiteralExpression }
               Finish
             Finish
           Finish
-          Token { kind: RightBracket }
+          Token { kind: RightCurly }
         Finish
       Finish
     Finish

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@non-empty-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@non-empty-record.input.snap
@@ -7,7 +7,7 @@ Input: { a :: Hello, b :: Hello }
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
       Start { kind: Separated }
         Start { kind: RowField }
@@ -39,7 +39,7 @@ Start { kind: RecordType }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@non-empty-tail-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@non-empty-tail-record.input.snap
@@ -7,7 +7,7 @@ Input: { a :: Int, b :: Int | r }
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
       Start { kind: Separated }
         Start { kind: RowField }
@@ -47,7 +47,7 @@ Start { kind: RecordType }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@record-update-branch.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@record-update-branch.input.snap
@@ -14,14 +14,14 @@ Start { kind: RecordUpdateExpression }
     Finish
   Finish
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: Separated }
       Start { kind: RecordUpdateBranch }
         Start { kind: Name }
           Token { kind: Label }
         Finish
         Start { kind: Wrapped }
-          Token { kind: LeftBracket }
+          Token { kind: LeftCurly }
           Start { kind: Separated }
             Start { kind: RecordUpdateLeaf }
               Start { kind: Name }
@@ -33,11 +33,11 @@ Start { kind: RecordUpdateExpression }
               Finish
             Finish
           Finish
-          Token { kind: RightBracket }
+          Token { kind: RightCurly }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@record-update-leaf.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@record-update-leaf.input.snap
@@ -14,7 +14,7 @@ Start { kind: RecordUpdateExpression }
     Finish
   Finish
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: Separated }
       Start { kind: RecordUpdateLeaf }
         Start { kind: Name }
@@ -36,7 +36,7 @@ Start { kind: RecordUpdateExpression }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@tail-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/grammar_tests__expect_parse@tail-record.input.snap
@@ -7,7 +7,7 @@ Input: { | r }
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
       Start { kind: RowTail }
         Token { kind: Pipe }
@@ -18,7 +18,7 @@ Start { kind: RecordType }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@empty-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@empty-record.input.snap
@@ -7,10 +7,10 @@ Input: {}
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@invalid-record-field.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@invalid-record-field.input.snap
@@ -8,7 +8,7 @@ Input: { 1: "hello" }
 Start { kind: LiteralExpression }
   Start { kind: LiteralRecord }
     Start { kind: Wrapped }
-      Token { kind: LeftBracket }
+      Token { kind: LeftCurly }
       Start { kind: Separated }
         Start { kind: RecordField }
           Start { kind: Error }
@@ -21,7 +21,7 @@ Start { kind: LiteralExpression }
           Finish
         Finish
       Finish
-      Token { kind: RightBracket }
+      Token { kind: RightCurly }
     Finish
   Finish
 Finish

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@invalid-record-pun.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@invalid-record-pun.input.snap
@@ -8,7 +8,7 @@ Input: { "a" }
 Start { kind: LiteralExpression }
   Start { kind: LiteralRecord }
     Start { kind: Wrapped }
-      Token { kind: LeftBracket }
+      Token { kind: LeftCurly }
       Start { kind: Separated }
         Start { kind: RecordField }
           Start { kind: Name }
@@ -18,7 +18,7 @@ Start { kind: LiteralExpression }
           Error { message: "expected an expression" }
         Finish
       Finish
-      Token { kind: RightBracket }
+      Token { kind: RightCurly }
     Finish
   Finish
 Finish

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@literals.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@literals.input.snap
@@ -46,8 +46,8 @@ Start { kind: LiteralExpression }
         Start { kind: LiteralExpression }
           Start { kind: LiteralRecord }
             Start { kind: Wrapped }
-              Token { kind: LeftBracket }
-              Token { kind: RightBracket }
+              Token { kind: LeftCurly }
+              Token { kind: RightCurly }
             Finish
           Finish
         Finish
@@ -55,7 +55,7 @@ Start { kind: LiteralExpression }
         Start { kind: LiteralExpression }
           Start { kind: LiteralRecord }
             Start { kind: Wrapped }
-              Token { kind: LeftBracket }
+              Token { kind: LeftCurly }
               Start { kind: Separated }
                 Start { kind: RecordPun }
                   Start { kind: NameRef }
@@ -83,7 +83,7 @@ Start { kind: LiteralExpression }
                   Finish
                 Finish
               Finish
-              Token { kind: RightBracket }
+              Token { kind: RightCurly }
             Finish
           Finish
         Finish

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@non-empty-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@non-empty-record.input.snap
@@ -7,7 +7,7 @@ Input: { a :: Hello, b :: Hello }
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
       Start { kind: Separated }
         Start { kind: RowField }
@@ -39,7 +39,7 @@ Start { kind: RecordType }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@non-empty-tail-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@non-empty-tail-record.input.snap
@@ -7,7 +7,7 @@ Input: { a :: Int, b :: Int | r }
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
       Start { kind: Separated }
         Start { kind: RowField }
@@ -47,7 +47,7 @@ Start { kind: RecordType }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@record-update-branch.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@record-update-branch.input.snap
@@ -14,14 +14,14 @@ Start { kind: RecordUpdateExpression }
     Finish
   Finish
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: Separated }
       Start { kind: RecordUpdateBranch }
         Start { kind: Name }
           Token { kind: Label }
         Finish
         Start { kind: Wrapped }
-          Token { kind: LeftBracket }
+          Token { kind: LeftCurly }
           Start { kind: Separated }
             Start { kind: RecordUpdateLeaf }
               Start { kind: Name }
@@ -33,11 +33,11 @@ Start { kind: RecordUpdateExpression }
               Finish
             Finish
           Finish
-          Token { kind: RightBracket }
+          Token { kind: RightCurly }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@record-update-leaf.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@record-update-leaf.input.snap
@@ -14,7 +14,7 @@ Start { kind: RecordUpdateExpression }
     Finish
   Finish
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: Separated }
       Start { kind: RecordUpdateLeaf }
         Start { kind: Name }
@@ -36,7 +36,7 @@ Start { kind: RecordUpdateExpression }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@tail-record.input.snap
+++ b/crates/parsing/src/grammar/snapshots/parsing__grammar__tests__expect_parse@tail-record.input.snap
@@ -7,7 +7,7 @@ Input: { | r }
 
 Start { kind: RecordType }
   Start { kind: Wrapped }
-    Token { kind: LeftBracket }
+    Token { kind: LeftCurly }
     Start { kind: RowInner }
       Start { kind: RowTail }
         Token { kind: Pipe }
@@ -18,7 +18,7 @@ Start { kind: RecordType }
         Finish
       Finish
     Finish
-    Token { kind: RightBracket }
+    Token { kind: RightCurly }
   Finish
 Finish
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -69,8 +69,8 @@ pub enum SyntaxKind {
     RightThickArrow,
     LeftParenthesis,
     RightParenthesis,
-    LeftBracket,
-    RightBracket,
+    LeftCurly,
+    RightCurly,
     LeftSquare,
     RightSquare,
 


### PR DESCRIPTION
I immediately misread `Bracket` for `[]` when it actually meant `{}`. I don't think I'm alone in my mild confusion - but I also think it's rude to bulk rename code. I hope I will be forgiven.

I think Wikipedia agrees with me on the naming.
https://en.wikipedia.org/wiki/Bracket

I used this command to rename everything nice and quick:
```
sed -i 's/LeftBracket/LeftCurly/g' lib/**/*.*
sed -i 's/RightBracket/RightCurly/g' lib/**/*.*
```
