### PR TITLE
Add empty did_close implementation to support generic lsp vscode extension

### DIFF
--- a/lsp/src/backend.rs
+++ b/lsp/src/backend.rs
@@ -79,6 +79,8 @@ impl LanguageServer for Backend {
         self.on_change(uri, text).await
     }
 
+    async fn did_close(&self, _p: DidCloseTextDocumentParams) {}
+
     async fn goto_definition(
         &self,
         p: GotoDefinitionParams,

--- a/lsp/src/backend.rs
+++ b/lsp/src/backend.rs
@@ -73,6 +73,8 @@ impl LanguageServer for Backend {
 
     async fn did_open(&self, _: DidOpenTextDocumentParams) {}
 
+    async fn did_save(&self, _: DidSaveTextDocumentParams) {}
+
     async fn did_change(&self, p: DidChangeTextDocumentParams) {
         let uri = p.text_document.uri.as_str();
         let text = p.content_changes[0].text.as_str().into();


### PR DESCRIPTION
Temp solution until/if there's a useful version of did_close. 

Command+click go to def was sometimes triggering the did_close event which then crashed the server. 