### PR TITLE
Improve verifying step traces in build system

### DIFF
--- a/crates/building/src/lib.rs
+++ b/crates/building/src/lib.rs
@@ -58,7 +58,8 @@ mod tests {
         let content = files.content(id);
 
         runtime.set_content(id, content);
-        let _ = runtime.lowered(id);
+        let indexed_a = runtime.indexed(id);
+        let lowered_a = runtime.lowered(id);
         let resolved_a = runtime.resolved(id);
 
         assert_trace!(FileContent(id) => { built: 1, changed: 1 });
@@ -107,5 +108,10 @@ mod tests {
         assert!(Arc::ptr_eq(&resolved_a, &resolved_b));
         assert!(Arc::ptr_eq(&resolved_b, &resolved_c));
         assert!(Arc::ptr_eq(&resolved_a, &resolved_c));
+
+        assert!(!Arc::ptr_eq(&indexed_a, &indexed_b));
+        assert!(!Arc::ptr_eq(&indexed_a, &indexed_c));
+        assert!(!Arc::ptr_eq(&lowered_a, &lowered_b));
+        assert!(!Arc::ptr_eq(&lowered_a, &lowered_c));
     }
 }

--- a/crates/building/src/lib.rs
+++ b/crates/building/src/lib.rs
@@ -86,4 +86,25 @@ mod tests {
         assert!(indexed_b == indexed_d);
         assert!(!Arc::ptr_eq(&indexed_b, &indexed_d));
     }
+
+    #[test]
+    fn test_ptr_eq_deeper_query() {
+        let mut runtime = Runtime::default();
+        let mut files = Files::default();
+
+        let id = files.insert("./src/Main.purs", "module Main where\n\nlife = 42");
+        let content = files.content(id);
+
+        runtime.set_content(id, content);
+        let lowered_a = runtime.lowered(id);
+
+        let id = files.insert("./src/Main.purs", "module Main where\n\nlife = 42\n\n");
+        let content = files.content(id);
+
+        runtime.set_content(id, content);
+        let lowered_b = runtime.lowered(id);
+
+        assert!(lowered_a == lowered_b);
+        assert!(Arc::ptr_eq(&lowered_a, &lowered_b));
+    }
 }

--- a/crates/building/src/runtime.rs
+++ b/crates/building/src/runtime.rs
@@ -1,9 +1,11 @@
 //! Implements the core runtime for the query-based compiler.
 //!
-//! Our implementation is inspired by the verifying step traces described by
-//! the [Build systems à la carte: Theory and practice] paper. One divergence
-//! in this implementation is the absence of the result hashes, which are used
-//! to verify changes from external sources.
+//! Our implementation is inspired by the verifying step traces described in
+//! the [Build systems à la carte: Theory and practice] paper. However, it
+//! diverges from the original implementation with two key differences. For 
+//! one, we only retain the latest step trace for any given query key; and 
+//! more significantly, we use equality rather than hashing to compare cached 
+//! and computed values.
 //!
 //! Our queries are designed to be pure and hermetic—the only cause for them
 //! to be recomputed is a change in their inputs. The runtime currently does

--- a/crates/building/src/runtime.rs
+++ b/crates/building/src/runtime.rs
@@ -2,9 +2,9 @@
 //!
 //! Our implementation is inspired by the verifying step traces described in
 //! the [Build systems à la carte: Theory and practice] paper. However, it
-//! diverges from the original implementation with two key differences. For 
-//! one, we only retain the latest step trace for any given query key; and 
-//! more significantly, we use equality rather than hashing to compare cached 
+//! diverges from the original implementation with two key differences. For
+//! one, we only retain the latest step trace for any given query key; and
+//! more significantly, we use equality rather than hashing to compare cached
 //! and computed values.
 //!
 //! Our queries are designed to be pure and hermetic—the only cause for them

--- a/crates/building/src/runtime.rs
+++ b/crates/building/src/runtime.rs
@@ -36,13 +36,14 @@ pub enum QueryKey {
 }
 
 /// A verifying step trace.
+#[derive(Debug)]
 pub struct Trace {
     /// Timestamp of when the query was last called.
-    built: usize,
+    pub(crate) built: usize,
     /// Timestamp of when the query was last recomputed.
-    changed: usize,
+    pub(crate) changed: usize,
     /// The dependencies used to build the query.
-    dependencies: Arc<[QueryKey]>,
+    pub(crate) dependencies: Arc<[QueryKey]>,
 }
 
 impl Trace {
@@ -69,6 +70,12 @@ pub struct Runtime {
 
     parent: Option<QueryKey>,
     dependencies: FxHashMap<QueryKey, FxHashSet<QueryKey>>,
+}
+
+impl Runtime {
+    pub fn trace(&self, key: QueryKey) -> Option<&Trace> {
+        self.traces.get(&key)
+    }
 }
 
 /// Core functions for queries.

--- a/crates/lexing/src/lib.rs
+++ b/crates/lexing/src/lib.rs
@@ -6,7 +6,7 @@ mod lexer;
 pub use lexed::Lexed;
 use syntax::SyntaxKind;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Position {
     pub line: u32,
     pub column: u32,

--- a/crates/parsing/src/lib.rs
+++ b/crates/parsing/src/lib.rs
@@ -7,14 +7,14 @@ use syntax::{cst, SyntaxKind, SyntaxNode};
 mod builder;
 mod parser;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseError {
     pub offset: usize,
     pub position: Position,
     pub message: Arc<str>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedModule {
     node: GreenNode,
 }


### PR DESCRIPTION
This greatly improves the implementation of verifying step traces in the build system by using equality to make sure that the `changed` timestamps aren't updated as often as they need to be. 