### PR TITLE
Use try_to_node in analyzer capabilities

### DIFF
--- a/compiler-lsp/analyzer/src/completion/edit.rs
+++ b/compiler-lsp/analyzer/src/completion/edit.rs
@@ -46,7 +46,9 @@ where
 
         let ptr = &context.indexed.source[import.id];
         let root = context.parsed.syntax_node();
-        let node = ptr.to_node(&root);
+        let Some(node) = ptr.try_to_node(&root) else {
+            return (None, None);
+        };
 
         let import_list =
             node.import_list().expect("invariant violated: ImportKind::Explicit w/ no ImportList");

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -47,7 +47,7 @@ fn definition_module_name(
     let (parsed, _) = engine.parsed(f_id).ok()?;
 
     let root = parsed.syntax_node();
-    let module = cst.to_node(&root);
+    let module = cst.try_to_node(&root)?;
     let module = {
         let mut buffer = SmolStrBuilder::default();
 
@@ -96,7 +96,7 @@ fn definition_import(
 
     let root = parsed.syntax_node();
     let ptr = &indexed.source[i_id];
-    let node = ptr.to_node(&root);
+    let node = ptr.try_to_node(&root)?;
 
     let statement = node.syntax().ancestors().find_map(cst::ImportStatement::cast)?;
     let module = statement.module_name()?;

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -55,7 +55,7 @@ fn hover_module_name(
     let (parsed, _) = engine.parsed(f_id).ok()?;
 
     let root = parsed.syntax_node();
-    let module = cst.to_node(&root);
+    let module = cst.try_to_node(&root)?;
     let module = {
         let mut buffer = SmolStrBuilder::default();
 
@@ -122,7 +122,7 @@ fn hover_import(engine: &QueryEngine, f_id: FileId, i_id: ImportItemId) -> Optio
     let node = {
         let root = parsed.syntax_node();
         let ptr = &indexed.source[i_id];
-        ptr.to_node(&root)
+        ptr.try_to_node(&root)?
     };
 
     let statement = node.syntax().ancestors().find_map(cst::ImportStatement::cast)?;
@@ -247,7 +247,7 @@ fn hover_let(
         let id = let_binding.equations.first().copied()?;
 
         let ptr = &lowered.source[id];
-        let node = ptr.to_node(root);
+        let node = ptr.try_to_node(root)?;
 
         let token = node.name_token()?;
         let text = token.text();

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -159,7 +159,7 @@ pub fn range_without_annotation(
 }
 
 pub fn text_range_after_annotation(ptr: &SyntaxNodePtr, root: &SyntaxNode) -> Option<TextRange> {
-    let node = ptr.to_node(root);
+    let node = ptr.try_to_node(root)?;
 
     let mut children = node.children_with_tokens().peekable();
     children.next_if(|child| matches!(child.kind(), SyntaxKind::Annotation));
@@ -178,7 +178,9 @@ pub fn annotation_syntax_range(
     root: &SyntaxNode,
     ptr: SyntaxNodePtr,
 ) -> (Option<TextRange>, Option<TextRange>) {
-    let node = ptr.to_node(root);
+    let Some(node) = ptr.try_to_node(root) else {
+        return (None, None);
+    };
     let mut children = node.children_with_tokens().peekable();
 
     let annotation = children

--- a/tests-integration/fixtures/lsp/013_completion_bad_cst/Main.purs
+++ b/tests-integration/fixtures/lsp/013_completion_bad_cst/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+-- https://github.com/purefunctor/purescript-analyzer/issues/37
+data Maybe a = Just a |
+--                     ^

--- a/tests-integration/tests/lsp.rs
+++ b/tests-integration/tests/lsp.rs
@@ -131,3 +131,14 @@ fn test_012_completion_edit_import_main() {
     let report = tests_integration::lsp::report(&engine, &files, id);
     insta::assert_snapshot!(report);
 }
+
+#[rustfmt::skip]
+#[test]
+fn test_013_completion_bad_cst_main() {
+    let (engine, files) = tests_integration::load_compiler(std::path::Path::new("fixtures/lsp/013_completion_bad_cst"));
+    let Some(id) = engine.module_file("Main") else {
+        return;
+    };
+    let report = tests_integration::lsp::report(&engine, &files, id);
+    insta::assert_snapshot!(report);
+}

--- a/tests-integration/tests/snapshots/lsp__013_completion_bad_cst_main.snap
+++ b/tests-integration/tests/snapshots/lsp__013_completion_bad_cst_main.snap
@@ -1,0 +1,7 @@
+---
+source: tests-integration/tests/lsp.rs
+expression: report
+---
+Completion at Position { line: 3, character: 23 }
+
+[]


### PR DESCRIPTION
Fixes #37. We should still consider moving to a different CST representation that allows zero-width nodes and tokens. This fix should be sufficient in the meantime to make the compiler a little bit more stable.
