### PR TITLE
Prevent parser from producing empty nodes

### DIFF
--- a/compiler-core/parsing/src/parser/generic.rs
+++ b/compiler-core/parsing/src/parser/generic.rs
@@ -55,7 +55,7 @@ pub(super) fn function_binders(p: &mut Parser, s: TokenSet) {
             p.error_recover("Unexpected token in function binders");
         }
     }
-    m.end(p, SyntaxKind::FunctionBinders);
+    m.end_non_empty(p, SyntaxKind::FunctionBinders);
 }
 
 pub(super) fn unconditional_or_conditionals(p: &mut Parser, s: SyntaxKind) {
@@ -76,7 +76,7 @@ pub(super) fn where_expression(p: &mut Parser) {
     if p.eat(SyntaxKind::WHERE) {
         binding::let_binding_statements(p);
     }
-    m.end(p, SyntaxKind::WhereExpression);
+    m.end_non_empty(p, SyntaxKind::WhereExpression);
 }
 
 fn conditionals(p: &mut Parser, s: SyntaxKind) {

--- a/compiler-core/parsing/tests/snapshots/parser__binder_array.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_array.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..70
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@18..19 " "
         WHERE@19..24 "where"
       LAYOUT_START@24..24 ""
-      ModuleImports@24..24
       ModuleStatements@24..69
         ValueEquation@24..38
           Annotation@24..26

--- a/compiler-core/parsing/tests/snapshots/parser__binder_boolean.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_boolean.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..63
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@20..21 " "
         WHERE@21..26 "where"
       LAYOUT_START@26..26 ""
-      ModuleImports@26..26
       ModuleStatements@26..62
         ValueEquation@26..44
           Annotation@26..28

--- a/compiler-core/parsing/tests/snapshots/parser__binder_char.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_char.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..38
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@17..18 " "
         WHERE@18..23 "where"
       LAYOUT_START@23..23 ""
-      ModuleImports@23..23
       ModuleStatements@23..37
         ValueEquation@23..37
           Annotation@23..25

--- a/compiler-core/parsing/tests/snapshots/parser__binder_constructor.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_constructor.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..139
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..138
         ValueEquation@30..59
           Annotation@30..32

--- a/compiler-core/parsing/tests/snapshots/parser__binder_digit.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_digit.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..55
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@18..19 " "
         WHERE@19..24 "where"
       LAYOUT_START@24..24 ""
-      ModuleImports@24..24
       ModuleStatements@24..54
         ValueEquation@24..39
           Annotation@24..26

--- a/compiler-core/parsing/tests/snapshots/parser__binder_negate.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_negate.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..59
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..58
         ValueEquation@25..41
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__binder_parenthesized.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_parenthesized.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..108
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@26..27 " "
         WHERE@27..32 "where"
       LAYOUT_START@32..32 ""
-      ModuleImports@32..32
       ModuleStatements@32..107
         ValueEquation@32..55
           Annotation@32..34

--- a/compiler-core/parsing/tests/snapshots/parser__binder_record.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_record.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..128
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..127
         ValueEquation@25..40
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__binder_string.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_string.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..69
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..68
         ValueEquation@25..45
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__binder_variable.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_variable.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..61
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@21..22 " "
         WHERE@22..27 "where"
       LAYOUT_START@27..27 ""
-      ModuleImports@27..27
       ModuleStatements@27..60
         ValueEquation@27..43
           Annotation@27..29

--- a/compiler-core/parsing/tests/snapshots/parser__binder_wildcard.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__binder_wildcard.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..44
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@21..22 " "
         WHERE@22..27 "where"
       LAYOUT_START@27..27 ""
-      ModuleImports@27..27
       ModuleStatements@27..43
         ValueEquation@27..43
           Annotation@27..29

--- a/compiler-core/parsing/tests/snapshots/parser__boolean_field.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__boolean_field.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..64
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..63
         ValueEquation@25..63
           Annotation@25..27
             TEXT@25..27 "\n\n"
           LOWER@27..32 "field"
-          FunctionBinders@32..32
           Unconditional@32..63
             Annotation@32..33
               TEXT@32..33 " "

--- a/compiler-core/parsing/tests/snapshots/parser__class_declaration_basic.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__class_declaration_basic.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..196
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..195
         ClassDeclaration@29..96
           Annotation@29..31

--- a/compiler-core/parsing/tests/snapshots/parser__class_declaration_constraints.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__class_declaration_constraints.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..190
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@34..35 " "
         WHERE@35..40 "where"
       LAYOUT_START@40..40 ""
-      ModuleImports@40..40
       ModuleStatements@40..189
         ClassDeclaration@40..107
           Annotation@40..42

--- a/compiler-core/parsing/tests/snapshots/parser__class_declaration_full.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__class_declaration_full.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..208
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@27..28 " "
         WHERE@28..33 "where"
       LAYOUT_START@33..33 ""
-      ModuleImports@33..33
       ModuleStatements@33..207
         ClassDeclaration@33..114
           Annotation@33..35

--- a/compiler-core/parsing/tests/snapshots/parser__class_declaration_functional_dependencies.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__class_declaration_functional_dependencies.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..188
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@45..46 " "
         WHERE@46..51 "where"
       LAYOUT_START@51..51 ""
-      ModuleImports@51..51
       ModuleStatements@51..187
         ClassDeclaration@51..114
           Annotation@51..53

--- a/compiler-core/parsing/tests/snapshots/parser__class_declaration_head.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__class_declaration_head.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..92
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@27..28 " "
         WHERE@28..33 "where"
       LAYOUT_START@33..33 ""
-      ModuleImports@33..33
       ModuleStatements@33..91
         ClassDeclaration@33..50
           Annotation@33..35

--- a/compiler-core/parsing/tests/snapshots/parser__comment_pre_post.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__comment_pre_post.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..51
@@ -17,8 +16,6 @@ snapshot_kind: text
           TEXT@33..45 " {- Post -} "
         WHERE@45..50 "where"
       LAYOUT_START@50..50 ""
-      ModuleImports@50..50
-      ModuleStatements@50..50
       LAYOUT_END@50..50 ""
       Annotation@50..51
         TEXT@50..51 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__data_eqaution_empty_variables.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__data_eqaution_empty_variables.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..73
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@36..37 " "
         WHERE@37..42 "where"
       LAYOUT_START@42..42 ""
-      ModuleImports@42..42
       ModuleStatements@42..72
         DataEquation@42..57
           Annotation@42..44

--- a/compiler-core/parsing/tests/snapshots/parser__data_equation.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__data_equation.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..59
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..58
         DataEquation@25..58
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__data_equation_empty.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__data_equation_empty.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..42
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..41
         DataEquation@30..41
           Annotation@30..32

--- a/compiler-core/parsing/tests/snapshots/parser__data_signature.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__data_signature.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..55
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@20..21 " "
         WHERE@21..26 "where"
       LAYOUT_START@26..26 ""
-      ModuleImports@26..26
       ModuleStatements@26..54
         DataSignature@26..54
           Annotation@26..28

--- a/compiler-core/parsing/tests/snapshots/parser__derive_declaration.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__derive_declaration.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..102
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..101
         DeriveDeclaration@30..62
           Annotation@30..32

--- a/compiler-core/parsing/tests/snapshots/parser__derive_declaration_constraints.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__derive_declaration_constraints.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..274
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@35..36 " "
         WHERE@36..41 "where"
       LAYOUT_START@41..41 ""
-      ModuleImports@41..41
       ModuleStatements@41..273
         DeriveDeclaration@41..90
           Annotation@41..43

--- a/compiler-core/parsing/tests/snapshots/parser__derive_declaration_name.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__derive_declaration_name.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..141
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@28..29 " "
         WHERE@29..34 "where"
       LAYOUT_START@34..34 ""
-      ModuleImports@34..34
       ModuleStatements@34..140
         DeriveDeclaration@34..84
           Annotation@34..37

--- a/compiler-core/parsing/tests/snapshots/parser__derive_declaration_name_constraints.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__derive_declaration_name_constraints.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..343
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@39..40 " "
         WHERE@40..45 "where"
       LAYOUT_START@45..45 ""
-      ModuleImports@45..45
       ModuleStatements@45..342
         DeriveDeclaration@45..112
           Annotation@45..48

--- a/compiler-core/parsing/tests/snapshots/parser__do_statement_binder.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__do_statement_binder.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..128
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@29..30 " "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleImports@35..35
       ModuleStatements@35..127
         ValueEquation@35..127
           Annotation@35..37
             TEXT@35..37 "\n\n"
           LOWER@37..41 "main"
-          FunctionBinders@41..41
           Unconditional@41..127
             Annotation@41..42
               TEXT@41..42 " "

--- a/compiler-core/parsing/tests/snapshots/parser__double_period_operator_name.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__double_period_operator_name.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..120
@@ -54,14 +53,12 @@ snapshot_kind: text
                 TEXT@82..83 " "
               OPERATOR_NAME@83..87 "(..)"
             RIGHT_PARENTHESIS@87..88 ")"
-          ImportAlias@88..88
         LAYOUT_SEPARATOR@88..88 ""
       ModuleStatements@88..119
         ValueEquation@88..101
           Annotation@88..90
             TEXT@88..90 "\n\n"
           LOWER@90..94 "name"
-          FunctionBinders@94..94
           Unconditional@94..101
             Annotation@94..95
               TEXT@94..95 " "
@@ -77,7 +74,6 @@ snapshot_kind: text
           Annotation@101..102
             TEXT@101..102 "\n"
           LOWER@102..110 "operator"
-          FunctionBinders@110..110
           Unconditional@110..119
             Annotation@110..111
               TEXT@110..111 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_ado_bind.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_ado_bind.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..71
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..70
         ValueEquation@30..70
           Annotation@30..32
             TEXT@30..32 "\n\n"
           LOWER@32..36 "main"
-          FunctionBinders@36..36
           Unconditional@36..70
             Annotation@36..37
               TEXT@36..37 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_ado_discard.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_ado_discard.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..66
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@27..28 " "
         WHERE@28..33 "where"
       LAYOUT_START@33..33 ""
-      ModuleImports@33..33
       ModuleStatements@33..65
         ValueEquation@33..65
           Annotation@33..35
             TEXT@33..35 "\n\n"
           LOWER@35..39 "main"
-          FunctionBinders@39..39
           Unconditional@39..65
             Annotation@39..40
               TEXT@39..40 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_ado_let.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_ado_let.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..68
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..67
         ValueEquation@29..67
           Annotation@29..31
             TEXT@29..31 "\n\n"
           LOWER@31..35 "main"
-          FunctionBinders@35..35
           Unconditional@35..67
             Annotation@35..36
               TEXT@35..36 " "
@@ -43,7 +40,6 @@ snapshot_kind: text
                         Annotation@47..48
                           TEXT@47..48 " "
                         LOWER@48..52 "life"
-                        FunctionBinders@52..52
                         Unconditional@52..57
                           Annotation@52..53
                             TEXT@52..53 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_application.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_application.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..58
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@28..30 "  "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleImports@35..35
       ModuleStatements@35..57
         ValueEquation@35..57
           Annotation@35..37
             TEXT@35..37 "\n\n"
           LOWER@37..48 "application"
-          FunctionBinders@48..48
           Unconditional@48..57
             Annotation@48..49
               TEXT@48..49 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_array.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_array.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..71
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..70
         ValueEquation@28..40
           Annotation@28..30
             TEXT@28..30 "\n\n"
           LOWER@30..35 "array"
-          FunctionBinders@35..35
           Unconditional@35..40
             Annotation@35..36
               TEXT@35..36 " "
@@ -37,7 +34,6 @@ snapshot_kind: text
           Annotation@40..41
             TEXT@40..41 "\n"
           LOWER@41..46 "array"
-          FunctionBinders@46..46
           Unconditional@46..52
             Annotation@46..47
               TEXT@46..47 " "
@@ -55,7 +51,6 @@ snapshot_kind: text
           Annotation@52..53
             TEXT@52..53 "\n"
           LOWER@53..58 "array"
-          FunctionBinders@58..58
           Unconditional@58..70
             Annotation@58..59
               TEXT@58..59 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_boolean.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_boolean.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..63
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..62
         ValueEquation@30..46
           Annotation@30..32
             TEXT@30..32 "\n\n"
           LOWER@32..39 "boolean"
-          FunctionBinders@39..39
           Unconditional@39..46
             Annotation@39..40
               TEXT@39..40 " "
@@ -36,7 +33,6 @@ snapshot_kind: text
           Annotation@46..47
             TEXT@46..47 "\n"
           LOWER@47..54 "boolean"
-          FunctionBinders@54..54
           Unconditional@54..62
             Annotation@54..55
               TEXT@54..55 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_case_guard.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_case_guard.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..107
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@26..27 " "
         WHERE@27..32 "where"
       LAYOUT_START@32..32 ""
-      ModuleImports@32..32
       ModuleStatements@32..106
         ValueEquation@32..106
           Annotation@32..34
             TEXT@32..34 "\n\n"
           LOWER@34..38 "main"
-          FunctionBinders@38..38
           Unconditional@38..106
             Annotation@38..39
               TEXT@38..39 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_case_multiple.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_case_multiple.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..87
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@28..29 " "
         WHERE@29..34 "where"
       LAYOUT_START@34..34 ""
-      ModuleImports@34..34
       ModuleStatements@34..86
         ValueEquation@34..86
           Annotation@34..36
             TEXT@34..36 "\n\n"
           LOWER@36..40 "main"
-          FunctionBinders@40..40
           Unconditional@40..86
             Annotation@40..41
               TEXT@40..41 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_case_simple.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_case_simple.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..77
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@27..28 " "
         WHERE@28..33 "where"
       LAYOUT_START@33..33 ""
-      ModuleImports@33..33
       ModuleStatements@33..76
         ValueEquation@33..76
           Annotation@33..35
             TEXT@33..35 "\n\n"
           LOWER@35..39 "main"
-          FunctionBinders@39..39
           Unconditional@39..76
             Annotation@39..40
               TEXT@39..40 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_char.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_char.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..40
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@21..22 " "
         WHERE@22..27 "where"
       LAYOUT_START@27..27 ""
-      ModuleImports@27..27
       ModuleStatements@27..39
         ValueEquation@27..39
           Annotation@27..29
             TEXT@27..29 "\n\n"
           LOWER@29..33 "char"
-          FunctionBinders@33..33
           Unconditional@33..39
             Annotation@33..34
               TEXT@33..34 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_digit.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_digit.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..56
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..55
         ValueEquation@28..42
           Annotation@28..30
             TEXT@28..30 "\n\n"
           LOWER@30..37 "integer"
-          FunctionBinders@37..37
           Unconditional@37..42
             Annotation@37..38
               TEXT@37..38 " "
@@ -36,7 +33,6 @@ snapshot_kind: text
           Annotation@42..43
             TEXT@42..43 "\n"
           LOWER@43..49 "number"
-          FunctionBinders@49..49
           Unconditional@49..55
             Annotation@49..50
               TEXT@49..50 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_do_ado_prefix.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_do_ado_prefix.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..104
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@28..29 " "
         WHERE@29..34 "where"
       LAYOUT_START@34..34 ""
-      ModuleImports@34..34
       ModuleStatements@34..103
         ValueEquation@34..63
           Annotation@34..36
             TEXT@34..36 "\n\n"
           LOWER@36..40 "main"
-          FunctionBinders@40..40
           Unconditional@40..63
             Annotation@40..41
               TEXT@40..41 " "
@@ -54,7 +51,6 @@ snapshot_kind: text
           Annotation@63..65
             TEXT@63..65 "\n\n"
           LOWER@65..69 "main"
-          FunctionBinders@69..69
           Unconditional@69..103
             Annotation@69..70
               TEXT@69..70 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_do_bind.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_do_bind.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..55
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..54
         ValueEquation@25..54
           Annotation@25..27
             TEXT@25..27 "\n\n"
           LOWER@27..31 "main"
-          FunctionBinders@31..31
           Unconditional@31..54
             Annotation@31..32
               TEXT@31..32 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_do_discard.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_do_discard.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..56
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@26..27 " "
         WHERE@27..32 "where"
       LAYOUT_START@32..32 ""
-      ModuleImports@32..32
       ModuleStatements@32..55
         ValueEquation@32..55
           Annotation@32..34
             TEXT@32..34 "\n\n"
           LOWER@34..38 "main"
-          FunctionBinders@38..38
           Unconditional@38..55
             Annotation@38..39
               TEXT@38..39 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_do_let.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_do_let.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..56
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..55
         ValueEquation@28..55
           Annotation@28..30
             TEXT@28..30 "\n\n"
           LOWER@30..34 "main"
-          FunctionBinders@34..34
           Unconditional@34..55
             Annotation@34..35
               TEXT@34..35 " "
@@ -43,7 +40,6 @@ snapshot_kind: text
                         Annotation@45..46
                           TEXT@45..46 " "
                         LOWER@46..50 "life"
-                        FunctionBinders@50..50
                         Unconditional@50..55
                           Annotation@50..51
                             TEXT@50..51 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_do_statements.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_do_statements.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..112
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@29..30 " "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleImports@35..35
       ModuleStatements@35..111
         ValueEquation@35..111
           Annotation@35..37
             TEXT@35..37 "\n\n"
           LOWER@37..41 "main"
-          FunctionBinders@41..41
           Unconditional@41..111
             Annotation@41..42
               TEXT@41..42 " "
@@ -43,7 +40,6 @@ snapshot_kind: text
                         Annotation@52..53
                           TEXT@52..53 " "
                         LOWER@53..57 "life"
-                        FunctionBinders@57..57
                         Unconditional@57..62
                           Annotation@57..58
                             TEXT@57..58 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_hole.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_hole.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..42
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@21..22 " "
         WHERE@22..27 "where"
       LAYOUT_START@27..27 ""
-      ModuleImports@27..27
       ModuleStatements@27..41
         ValueEquation@27..41
           Annotation@27..29
             TEXT@27..29 "\n\n"
           LOWER@29..33 "hole"
-          FunctionBinders@33..33
           Unconditional@33..41
             Annotation@33..34
               TEXT@33..34 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_if_then_else.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_if_then_else.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..69
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@27..28 " "
         WHERE@28..33 "where"
       LAYOUT_START@33..33 ""
-      ModuleImports@33..33
       ModuleStatements@33..68
         ValueEquation@33..68
           Annotation@33..35
             TEXT@33..35 "\n\n"
           LOWER@35..47 "if_then_else"
-          FunctionBinders@47..47
           Unconditional@47..68
             Annotation@47..48
               TEXT@47..48 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_lambda.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_lambda.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..69
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..68
         ValueEquation@29..47
           Annotation@29..31
             TEXT@29..31 "\n\n"
           LOWER@31..37 "lambda"
-          FunctionBinders@37..37
           Unconditional@37..47
             Annotation@37..38
               TEXT@37..38 " "
@@ -47,7 +44,6 @@ snapshot_kind: text
           Annotation@47..48
             TEXT@47..48 "\n"
           LOWER@48..54 "lambda"
-          FunctionBinders@54..54
           Unconditional@54..68
             Annotation@54..55
               TEXT@54..55 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_let_in.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_let_in.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..180
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..179
         ValueEquation@28..53
           Annotation@28..30
             TEXT@28..30 "\n\n"
           LOWER@30..36 "let_in"
-          FunctionBinders@36..36
           Unconditional@36..53
             Annotation@36..37
               TEXT@36..37 " "
@@ -37,7 +34,6 @@ snapshot_kind: text
                     Annotation@42..43
                       TEXT@42..43 " "
                     LOWER@43..44 "x"
-                    FunctionBinders@44..44
                     Unconditional@44..48
                       Annotation@44..45
                         TEXT@44..45 " "
@@ -62,7 +58,6 @@ snapshot_kind: text
           Annotation@53..55
             TEXT@53..55 "\n\n"
           LOWER@55..61 "let_in"
-          FunctionBinders@61..61
           Unconditional@61..82
             Annotation@61..62
               TEXT@61..62 " "
@@ -78,7 +73,6 @@ snapshot_kind: text
                     Annotation@69..70
                       TEXT@69..70 " "
                     LOWER@70..71 "x"
-                    FunctionBinders@71..71
                     Unconditional@71..75
                       Annotation@71..72
                         TEXT@71..72 " "
@@ -103,7 +97,6 @@ snapshot_kind: text
           Annotation@82..84
             TEXT@82..84 "\n\n"
           LOWER@84..90 "let_in"
-          FunctionBinders@90..90
           Unconditional@90..119
             Annotation@90..91
               TEXT@90..91 " "
@@ -119,7 +112,6 @@ snapshot_kind: text
                     Annotation@98..103
                       TEXT@98..103 "\n    "
                     LOWER@103..104 "x"
-                    FunctionBinders@104..104
                     Unconditional@104..108
                       Annotation@104..105
                         TEXT@104..105 " "
@@ -144,7 +136,6 @@ snapshot_kind: text
           Annotation@119..121
             TEXT@119..121 "\n\n"
           LOWER@121..127 "let_in"
-          FunctionBinders@127..127
           Unconditional@127..179
             Annotation@127..128
               TEXT@127..128 " "
@@ -173,7 +164,6 @@ snapshot_kind: text
                     Annotation@151..156
                       TEXT@151..156 "\n    "
                     LOWER@156..160 "life"
-                    FunctionBinders@160..160
                     Unconditional@160..165
                       Annotation@160..161
                         TEXT@160..161 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_name.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_name.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..64
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@21..22 " "
         WHERE@22..27 "where"
       LAYOUT_START@27..27 ""
-      ModuleImports@27..27
       ModuleStatements@27..63
         ValueEquation@27..40
           Annotation@27..29
             TEXT@27..29 "\n\n"
           LOWER@29..33 "name"
-          FunctionBinders@33..33
           Unconditional@33..40
             Annotation@33..34
               TEXT@33..34 " "
@@ -37,7 +34,6 @@ snapshot_kind: text
           Annotation@40..41
             TEXT@40..41 "\n"
           LOWER@41..45 "name"
-          FunctionBinders@45..45
           Unconditional@45..52
             Annotation@45..46
               TEXT@45..46 " "
@@ -53,7 +49,6 @@ snapshot_kind: text
           Annotation@52..53
             TEXT@52..53 "\n"
           LOWER@53..57 "name"
-          FunctionBinders@57..57
           Unconditional@57..63
             Annotation@57..58
               TEXT@57..58 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_negate.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_negate.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..55
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..54
         ValueEquation@29..42
           Annotation@29..31
             TEXT@29..31 "\n\n"
           LOWER@31..37 "negate"
-          FunctionBinders@37..37
           Unconditional@37..42
             Annotation@37..38
               TEXT@37..38 " "
@@ -38,7 +35,6 @@ snapshot_kind: text
           Annotation@42..43
             TEXT@42..43 "\n"
           LOWER@43..49 "negate"
-          FunctionBinders@49..49
           Unconditional@49..54
             Annotation@49..50
               TEXT@49..50 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_parenthesized.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_parenthesized.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..82
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@30..31 " "
         WHERE@31..36 "where"
       LAYOUT_START@36..36 ""
-      ModuleImports@36..36
       ModuleStatements@36..81
         ValueEquation@36..57
           Annotation@36..38
             TEXT@36..38 "\n\n"
           LOWER@38..51 "parenthesized"
-          FunctionBinders@51..51
           Unconditional@51..57
             Annotation@51..52
               TEXT@51..52 " "
@@ -39,7 +36,6 @@ snapshot_kind: text
           Annotation@57..58
             TEXT@57..58 "\n"
           LOWER@58..71 "parenthesized"
-          FunctionBinders@71..71
           Unconditional@71..81
             Annotation@71..72
               TEXT@71..72 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_prefixed.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_prefixed.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..110
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@25..26 " "
         WHERE@26..31 "where"
       LAYOUT_START@31..31 ""
-      ModuleImports@31..31
       ModuleStatements@31..109
         ValueEquation@31..58
           Annotation@31..33
             TEXT@31..33 "\n\n"
           LOWER@33..41 "prefixed"
-          FunctionBinders@41..41
           Unconditional@41..58
             Annotation@41..42
               TEXT@41..42 " "
@@ -39,7 +36,6 @@ snapshot_kind: text
           Annotation@58..59
             TEXT@58..59 "\n"
           LOWER@59..67 "prefixed"
-          FunctionBinders@67..67
           Unconditional@67..84
             Annotation@67..68
               TEXT@67..68 " "
@@ -57,7 +53,6 @@ snapshot_kind: text
           Annotation@84..85
             TEXT@84..85 "\n"
           LOWER@85..93 "prefixed"
-          FunctionBinders@93..93
           Unconditional@93..109
             Annotation@93..94
               TEXT@93..94 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_record.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_record.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..122
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..121
         ValueEquation@29..42
           Annotation@29..31
             TEXT@29..31 "\n\n"
           LOWER@31..37 "record"
-          FunctionBinders@37..37
           Unconditional@37..42
             Annotation@37..38
               TEXT@37..38 " "
@@ -37,7 +34,6 @@ snapshot_kind: text
           Annotation@42..43
             TEXT@42..43 "\n"
           LOWER@43..49 "record"
-          FunctionBinders@49..49
           Unconditional@49..55
             Annotation@49..50
               TEXT@49..50 " "
@@ -56,7 +52,6 @@ snapshot_kind: text
           Annotation@55..56
             TEXT@55..56 "\n"
           LOWER@56..62 "record"
-          FunctionBinders@62..62
           Unconditional@62..71
             Annotation@62..63
               TEXT@62..63 " "
@@ -81,7 +76,6 @@ snapshot_kind: text
           Annotation@71..72
             TEXT@71..72 "\n"
           LOWER@72..78 "record"
-          FunctionBinders@78..78
           Unconditional@78..93
             Annotation@78..79
               TEXT@78..79 " "
@@ -118,7 +112,6 @@ snapshot_kind: text
           Annotation@93..94
             TEXT@93..94 "\n"
           LOWER@94..100 "record"
-          FunctionBinders@100..100
           Unconditional@100..121
             Annotation@100..101
               TEXT@100..101 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_record_access.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_record_access.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..273
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@29..30 " "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleImports@35..35
       ModuleStatements@35..272
         ValueEquation@35..56
           Annotation@35..37
             TEXT@35..37 "\n\n"
           LOWER@37..43 "access"
-          FunctionBinders@43..43
           Unconditional@43..56
             Annotation@43..44
               TEXT@43..44 " "
@@ -41,7 +38,6 @@ snapshot_kind: text
           Annotation@56..57
             TEXT@56..57 "\n"
           LOWER@57..63 "access"
-          FunctionBinders@63..63
           Unconditional@63..80
             Annotation@63..64
               TEXT@63..64 " "
@@ -64,7 +60,6 @@ snapshot_kind: text
           Annotation@80..82
             TEXT@80..82 "\n\n"
           LOWER@82..89 "keyword"
-          FunctionBinders@89..89
           Unconditional@89..105
             Annotation@89..90
               TEXT@89..90 " "
@@ -84,7 +79,6 @@ snapshot_kind: text
           Annotation@105..106
             TEXT@105..106 "\n"
           LOWER@106..113 "keyword"
-          FunctionBinders@113..113
           Unconditional@113..136
             Annotation@113..114
               TEXT@113..114 " "
@@ -107,7 +101,6 @@ snapshot_kind: text
           Annotation@136..138
             TEXT@136..138 "\n\n"
           LOWER@138..144 "string"
-          FunctionBinders@144..144
           Unconditional@144..161
             Annotation@144..145
               TEXT@144..145 " "
@@ -127,7 +120,6 @@ snapshot_kind: text
           Annotation@161..162
             TEXT@161..162 "\n"
           LOWER@162..168 "string"
-          FunctionBinders@168..168
           Unconditional@168..193
             Annotation@168..169
               TEXT@168..169 " "
@@ -150,7 +142,6 @@ snapshot_kind: text
           Annotation@193..195
             TEXT@193..195 "\n\n"
           LOWER@195..205 "raw_string"
-          FunctionBinders@205..205
           Unconditional@205..226
             Annotation@205..206
               TEXT@205..206 " "
@@ -170,7 +161,6 @@ snapshot_kind: text
           Annotation@226..227
             TEXT@226..227 "\n"
           LOWER@227..237 "raw_string"
-          FunctionBinders@237..237
           Unconditional@237..272
             Annotation@237..238
               TEXT@237..238 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_record_argument.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_record_argument.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..68
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@29..30 " "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleImports@35..35
       ModuleStatements@35..67
         ValueEquation@35..67
           Annotation@35..37
             TEXT@35..37 "\n\n"
           LOWER@37..44 "example"
-          FunctionBinders@44..44
           Unconditional@44..67
             Annotation@44..45
               TEXT@44..45 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_record_update_branch.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_record_update_branch.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..70
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@35..36 " "
         WHERE@36..41 "where"
       LAYOUT_START@41..41 ""
-      ModuleImports@41..41
       ModuleStatements@41..69
         ValueEquation@41..69
           Annotation@41..43
             TEXT@41..43 "\n\n"
           LOWER@43..49 "branch"
-          FunctionBinders@49..49
           Unconditional@49..69
             Annotation@49..50
               TEXT@49..50 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_record_update_leaf.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_record_update_leaf.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..60
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@33..34 " "
         WHERE@34..39 "where"
       LAYOUT_START@39..39 ""
-      ModuleImports@39..39
       ModuleStatements@39..59
         ValueEquation@39..59
           Annotation@39..41
             TEXT@39..41 "\n\n"
           LOWER@41..45 "leaf"
-          FunctionBinders@45..45
           Unconditional@45..59
             Annotation@45..46
               TEXT@45..46 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_section.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_section.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..44
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..43
         ValueEquation@30..43
           Annotation@30..32
             TEXT@30..32 "\n\n"
           LOWER@32..39 "section"
-          FunctionBinders@39..39
           Unconditional@39..43
             Annotation@39..40
               TEXT@39..40 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_string.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_string.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..69
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..68
         ValueEquation@29..47
           Annotation@29..31
             TEXT@29..31 "\n\n"
           LOWER@31..37 "string"
-          FunctionBinders@37..37
           Unconditional@37..47
             Annotation@37..38
               TEXT@37..38 " "
@@ -36,7 +33,6 @@ snapshot_kind: text
           Annotation@47..48
             TEXT@47..48 "\n"
           LOWER@48..54 "string"
-          FunctionBinders@54..54
           Unconditional@54..68
             Annotation@54..55
               TEXT@54..55 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_tick.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_tick.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..85
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@21..22 " "
         WHERE@22..27 "where"
       LAYOUT_START@27..27 ""
-      ModuleImports@27..27
       ModuleStatements@27..84
         ValueEquation@27..55
           Annotation@27..29
             TEXT@27..29 "\n\n"
           LOWER@29..33 "tick"
-          FunctionBinders@33..33
           Unconditional@33..55
             Annotation@33..34
               TEXT@33..34 " "
@@ -63,7 +60,6 @@ snapshot_kind: text
           Annotation@55..56
             TEXT@55..56 "\n"
           LOWER@56..60 "tick"
-          FunctionBinders@60..60
           Unconditional@60..84
             Annotation@60..61
               TEXT@60..61 " "

--- a/compiler-core/parsing/tests/snapshots/parser__expression_typed.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_typed.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..47
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..46
         ValueEquation@28..46
           Annotation@28..30
             TEXT@28..30 "\n\n"
           LOWER@30..35 "typed"
-          FunctionBinders@35..35
           Unconditional@35..46
             Annotation@35..36
               TEXT@35..36 " "

--- a/compiler-core/parsing/tests/snapshots/parser__foreign_import.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__foreign_import.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..96
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@20..21 " "
         WHERE@21..26 "where"
       LAYOUT_START@26..26 ""
-      ModuleImports@26..26
       ModuleStatements@26..95
         ForeignImportDataDeclaration@26..60
           Annotation@26..28

--- a/compiler-core/parsing/tests/snapshots/parser__infix_declaration.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__infix_declaration.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..135
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..134
         InfixDeclaration@29..47
           Annotation@29..31

--- a/compiler-core/parsing/tests/snapshots/parser__instance_chain.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_chain.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..86
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@20..21 " "
         WHERE@21..26 "where"
       LAYOUT_START@26..26 ""
-      ModuleImports@26..26
       ModuleStatements@26..85
         InstanceChain@26..85
           InstanceDeclaration@26..52

--- a/compiler-core/parsing/tests/snapshots/parser__instance_chain_else_newline.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_chain_else_newline.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..150
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@31..32 " "
         WHERE@32..37 "where"
       LAYOUT_START@37..37 ""
-      ModuleImports@37..37
       ModuleStatements@37..149
         InstanceChain@37..149
           InstanceDeclaration@37..127

--- a/compiler-core/parsing/tests/snapshots/parser__instance_constraints.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_constraints.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..149
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@26..27 " "
         WHERE@27..32 "where"
       LAYOUT_START@32..32 ""
-      ModuleImports@32..32
       ModuleStatements@32..148
         InstanceChain@32..148
           InstanceDeclaration@32..79

--- a/compiler-core/parsing/tests/snapshots/parser__instance_declaration.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_declaration.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..171
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@26..27 " "
         WHERE@27..32 "where"
       LAYOUT_START@32..32 ""
-      ModuleImports@32..32
       ModuleStatements@32..170
         InstanceChain@32..170
           InstanceDeclaration@32..170

--- a/compiler-core/parsing/tests/snapshots/parser__instance_distinct.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_distinct.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..84
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..83
         InstanceChain@29..55
           InstanceDeclaration@29..55

--- a/compiler-core/parsing/tests/snapshots/parser__instance_name.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_name.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..68
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..67
         InstanceChain@25..67
           InstanceDeclaration@25..67

--- a/compiler-core/parsing/tests/snapshots/parser__instance_prefixed.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__instance_prefixed.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..55
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..54
         InstanceChain@29..54
           InstanceDeclaration@29..54

--- a/compiler-core/parsing/tests/snapshots/parser__keyword_in_row_record.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__keyword_in_row_record.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..147
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@25..26 " "
         WHERE@26..31 "where"
       LAYOUT_START@31..31 ""
-      ModuleImports@31..31
       ModuleStatements@31..146
         TypeSynonymEquation@31..62
           Annotation@31..33

--- a/compiler-core/parsing/tests/snapshots/parser__let_binding_pattern.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__let_binding_pattern.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..77
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..76
         ValueEquation@30..76
           Annotation@30..32
             TEXT@30..32 "\n\n"
           LOWER@32..36 "main"
-          FunctionBinders@36..36
           Unconditional@36..76
             Annotation@36..37
               TEXT@36..37 " "

--- a/compiler-core/parsing/tests/snapshots/parser__lexer_error_inserted.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__lexer_error_inserted.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..54
@@ -34,8 +33,6 @@ snapshot_kind: text
           TEXT@47..48 " "
         WHERE@48..53 "where"
       LAYOUT_START@53..53 ""
-      ModuleImports@53..53
-      ModuleStatements@53..53
       LAYOUT_END@53..53 ""
       Annotation@53..54
         TEXT@53..54 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..26
@@ -22,8 +21,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
-      ModuleStatements@25..25
       LAYOUT_END@25..25 ""
       Annotation@25..26
         TEXT@25..26 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_class.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_class.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..59
@@ -44,8 +43,6 @@ snapshot_kind: text
           TEXT@52..53 " "
         WHERE@53..58 "where"
       LAYOUT_START@58..58 ""
-      ModuleImports@58..58
-      ModuleStatements@58..58
       LAYOUT_END@58..58 ""
       Annotation@58..59
         TEXT@58..59 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_class_error_end.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_class_error_end.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..47
@@ -23,8 +22,6 @@ snapshot_kind: text
           TEXT@40..41 " "
         WHERE@41..46 "where"
       LAYOUT_START@46..46 ""
-      ModuleImports@46..46
-      ModuleStatements@46..46
       LAYOUT_END@46..46 ""
       Annotation@46..47
         TEXT@46..47 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_comma_error.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_comma_error.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..52
@@ -31,8 +30,6 @@ snapshot_kind: text
           TEXT@45..46 " "
         WHERE@46..51 "where"
       LAYOUT_START@51..51 ""
-      ModuleImports@51..51
-      ModuleStatements@51..51
       LAYOUT_END@51..51 ""
       Annotation@51..52
         TEXT@51..52 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..68
@@ -42,8 +41,6 @@ snapshot_kind: text
           TEXT@61..62 " "
         WHERE@62..67 "where"
       LAYOUT_START@67..67 ""
-      ModuleImports@67..67
-      ModuleStatements@67..67
       LAYOUT_END@67..67 ""
       Annotation@67..68
         TEXT@67..68 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data_comma_error.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data_comma_error.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..63
@@ -34,8 +33,6 @@ snapshot_kind: text
           TEXT@56..57 " "
         WHERE@57..62 "where"
       LAYOUT_START@62..62 ""
-      ModuleImports@62..62
-      ModuleStatements@62..62
       LAYOUT_END@62..62 ""
       Annotation@62..63
         TEXT@62..63 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_after_double_period.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_after_double_period.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..70
@@ -32,8 +31,6 @@ snapshot_kind: text
           TEXT@63..64 " "
         WHERE@64..69 "where"
       LAYOUT_START@69..69 ""
-      ModuleImports@69..69
-      ModuleStatements@69..69
       LAYOUT_END@69..69 ""
       Annotation@69..70
         TEXT@69..70 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_before_double_period.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_before_double_period.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..70
@@ -32,8 +31,6 @@ snapshot_kind: text
           TEXT@63..64 " "
         WHERE@64..69 "where"
       LAYOUT_START@69..69 ""
-      ModuleImports@69..69
-      ModuleStatements@69..69
       LAYOUT_END@69..69 ""
       Annotation@69..70
         TEXT@69..70 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_empty.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_empty.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..48
@@ -25,8 +24,6 @@ snapshot_kind: text
           TEXT@41..42 " "
         WHERE@42..47 "where"
       LAYOUT_START@47..47 ""
-      ModuleImports@47..47
-      ModuleStatements@47..47
       LAYOUT_END@47..47 ""
       Annotation@47..48
         TEXT@47..48 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_invalid.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_invalid.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..54
@@ -32,8 +31,6 @@ snapshot_kind: text
           TEXT@47..48 " "
         WHERE@48..53 "where"
       LAYOUT_START@53..53 ""
-      ModuleImports@53..53
-      ModuleStatements@53..53
       LAYOUT_END@53..53 ""
       Annotation@53..54
         TEXT@53..54 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_recovery.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_data_item_recovery.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..58
@@ -33,8 +32,6 @@ snapshot_kind: text
           TEXT@51..52 " "
         WHERE@52..57 "where"
       LAYOUT_START@57..57 ""
-      ModuleImports@57..57
-      ModuleStatements@57..57
       LAYOUT_END@57..57 ""
       Annotation@57..58
         TEXT@57..58 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_empty.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_empty.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..21
@@ -21,8 +20,6 @@ snapshot_kind: text
           TEXT@14..15 " "
         WHERE@15..20 "where"
       LAYOUT_START@20..20 ""
-      ModuleImports@20..20
-      ModuleStatements@20..20
       LAYOUT_END@20..20 ""
       Annotation@20..21
         TEXT@20..21 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_invalid.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_invalid.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..53
@@ -33,8 +32,6 @@ snapshot_kind: text
           TEXT@46..47 " "
         WHERE@47..52 "where"
       LAYOUT_START@52..52 ""
-      ModuleImports@52..52
-      ModuleStatements@52..52
       LAYOUT_END@52..52 ""
       Annotation@52..53
         TEXT@52..53 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_module.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_module.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..49
@@ -26,8 +25,6 @@ snapshot_kind: text
           TEXT@42..43 " "
         WHERE@43..48 "where"
       LAYOUT_START@48..48 ""
-      ModuleImports@48..48
-      ModuleStatements@48..48
       LAYOUT_END@48..48 ""
       Annotation@48..49
         TEXT@48..49 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_operator.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_operator.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..40
@@ -22,8 +21,6 @@ snapshot_kind: text
           TEXT@33..34 " "
         WHERE@34..39 "where"
       LAYOUT_START@39..39 ""
-      ModuleImports@39..39
-      ModuleStatements@39..39
       LAYOUT_END@39..39 ""
       Annotation@39..40
         TEXT@39..40 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_type_operator.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_type_operator.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..49
@@ -25,8 +24,6 @@ snapshot_kind: text
           TEXT@42..43 " "
         WHERE@43..48 "where"
       LAYOUT_START@48..48 ""
-      ModuleImports@48..48
-      ModuleStatements@48..48
       LAYOUT_END@48..48 ""
       Annotation@48..49
         TEXT@48..49 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_type_operator_error.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_type_operator_error.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..74
@@ -45,8 +44,6 @@ snapshot_kind: text
           TEXT@67..68 " "
         WHERE@68..73 "where"
       LAYOUT_START@73..73 ""
-      ModuleImports@73..73
-      ModuleStatements@73..73
       LAYOUT_END@73..73 ""
       Annotation@73..74
         TEXT@73..74 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_export_type_operator_error_end.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_export_type_operator_error_end.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..53
@@ -23,8 +22,6 @@ snapshot_kind: text
           TEXT@46..47 " "
         WHERE@47..52 "where"
       LAYOUT_START@52..52 ""
-      ModuleImports@52..52
-      ModuleStatements@52..52
       LAYOUT_END@52..52 ""
       Annotation@52..53
         TEXT@52..53 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_header.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_header.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..18
@@ -15,8 +14,6 @@ snapshot_kind: text
           TEXT@11..12 " "
         WHERE@12..17 "where"
       LAYOUT_START@17..17 ""
-      ModuleImports@17..17
-      ModuleStatements@17..17
       LAYOUT_END@17..17 ""
       Annotation@17..18
         TEXT@17..18 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_header_prefixed.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_header_prefixed.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..29
@@ -17,8 +16,6 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
-      ModuleStatements@28..28
       LAYOUT_END@28..28 ""
       Annotation@28..29
         TEXT@28..29 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_import.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_import.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..285
@@ -24,7 +23,6 @@ snapshot_kind: text
             Annotation@33..34
               TEXT@33..34 " "
             UPPER@34..41 "Prelude"
-          ImportAlias@41..41
         LAYOUT_SEPARATOR@41..41 ""
         ImportStatement@41..58
           Annotation@41..42
@@ -36,7 +34,6 @@ snapshot_kind: text
             Qualifier@49..54
               TEXT@49..54 "Data."
             UPPER@54..58 "List"
-          ImportAlias@58..58
         LAYOUT_SEPARATOR@58..58 ""
         ImportStatement@58..79
           Annotation@58..59
@@ -53,7 +50,6 @@ snapshot_kind: text
             ImportValue@73..78
               LOWER@73..78 "value"
             RIGHT_PARENTHESIS@78..79 ")"
-          ImportAlias@79..79
         LAYOUT_SEPARATOR@79..79 ""
         ImportStatement@79..106
           Annotation@79..80
@@ -73,7 +69,6 @@ snapshot_kind: text
                 TEXT@99..100 " "
               UPPER@100..105 "Class"
             RIGHT_PARENTHESIS@105..106 ")"
-          ImportAlias@106..106
         LAYOUT_SEPARATOR@106..106 ""
         ImportStatement@106..125
           Annotation@106..107
@@ -90,7 +85,6 @@ snapshot_kind: text
             ImportType@120..124
               UPPER@120..124 "List"
             RIGHT_PARENTHESIS@124..125 ")"
-          ImportAlias@125..125
         LAYOUT_SEPARATOR@125..125 ""
         ImportStatement@125..154
           Annotation@125..126
@@ -115,7 +109,6 @@ snapshot_kind: text
                 UPPER@151..152 "B"
                 RIGHT_PARENTHESIS@152..153 ")"
             RIGHT_PARENTHESIS@153..154 ")"
-          ImportAlias@154..154
         LAYOUT_SEPARATOR@154..154 ""
         ImportStatement@154..180
           Annotation@154..155
@@ -134,7 +127,6 @@ snapshot_kind: text
               TypeItemsAll@175..179
                 DOUBLE_PERIOD_OPERATOR_NAME@175..179 "(..)"
             RIGHT_PARENTHESIS@179..180 ")"
-          ImportAlias@180..180
         LAYOUT_SEPARATOR@180..180 ""
         ImportStatement@180..200
           Annotation@180..181
@@ -173,7 +165,6 @@ snapshot_kind: text
             ImportValue@226..230
               LOWER@226..230 "cons"
             RIGHT_PARENTHESIS@230..231 ")"
-          ImportAlias@231..231
         LAYOUT_SEPARATOR@231..231 ""
         ImportStatement@231..253
           Annotation@231..232
@@ -190,7 +181,6 @@ snapshot_kind: text
             ImportOperator@249..252
               OPERATOR_NAME@249..252 "(+)"
             RIGHT_PARENTHESIS@252..253 ")"
-          ImportAlias@253..253
         LAYOUT_SEPARATOR@253..253 ""
         ImportStatement@253..284
           Annotation@253..254
@@ -210,8 +200,6 @@ snapshot_kind: text
                 TEXT@279..280 " "
               OPERATOR_NAME@280..283 "(+)"
             RIGHT_PARENTHESIS@283..284 ")"
-          ImportAlias@284..284
-      ModuleStatements@284..284
       LAYOUT_END@284..284 ""
       Annotation@284..285
         TEXT@284..285 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_import_error.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_import_error.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..243
@@ -24,7 +23,6 @@ snapshot_kind: text
             Annotation@38..39
               TEXT@38..39 " "
             ERROR@39..39 ""
-          ImportAlias@39..39
         ERROR@39..46
           ERROR@39..39 ""
           LOWER@39..46 "prelude"
@@ -39,7 +37,6 @@ snapshot_kind: text
             Qualifier@54..59
               TEXT@54..59 "Data."
             UPPER@59..63 "List"
-          ImportAlias@63..63
         LAYOUT_SEPARATOR@63..63 ""
         ImportStatement@63..98
           Annotation@63..64
@@ -68,7 +65,6 @@ snapshot_kind: text
                   LOWER@93..96 "nil"
                 RIGHT_PARENTHESIS@96..97 ")"
             RIGHT_PARENTHESIS@97..98 ")"
-          ImportAlias@98..98
         LAYOUT_SEPARATOR@98..98 ""
         ImportStatement@98..132
           Annotation@98..99
@@ -97,7 +93,6 @@ snapshot_kind: text
                   DOUBLE_PERIOD@128..130 ".."
                 RIGHT_PARENTHESIS@130..131 ")"
             RIGHT_PARENTHESIS@131..132 ")"
-          ImportAlias@132..132
         LAYOUT_SEPARATOR@132..132 ""
         ImportStatement@132..166
           Annotation@132..133
@@ -126,7 +121,6 @@ snapshot_kind: text
                   UPPER@160..164 "Cons"
                 RIGHT_PARENTHESIS@164..165 ")"
             RIGHT_PARENTHESIS@165..166 ")"
-          ImportAlias@166..166
         LAYOUT_SEPARATOR@166..166 ""
         ImportStatement@166..189
           Annotation@166..167
@@ -146,7 +140,6 @@ snapshot_kind: text
               ERROR@185..185 ""
               INTEGER@185..188 "123"
             RIGHT_PARENTHESIS@188..189 ")"
-          ImportAlias@189..189
         LAYOUT_SEPARATOR@189..189 ""
         ImportStatement@189..206
           Annotation@189..190
@@ -158,7 +151,6 @@ snapshot_kind: text
             Qualifier@197..202
               TEXT@197..202 "Data."
             UPPER@202..206 "List"
-          ImportAlias@206..206
         ERROR@206..218
           ERROR@206..206 ""
           Annotation@206..207
@@ -180,8 +172,6 @@ snapshot_kind: text
             Qualifier@226..236
               TEXT@226..236 "Recovered."
             UPPER@236..242 "Import"
-          ImportAlias@242..242
-      ModuleStatements@242..242
       LAYOUT_END@242..242 ""
       Annotation@242..243
         TEXT@242..243 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__module_incomplete_import.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__module_incomplete_import.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..32
@@ -26,11 +25,9 @@ snapshot_kind: text
             Qualifier@26..31
               TEXT@26..31 "Data."
             ERROR@31..31 ""
-          ImportAlias@31..31
         ERROR@31..31
           ERROR@31..31 ""
           ERROR@31..31 ""
-      ModuleStatements@31..31
       LAYOUT_END@31..31 ""
       Annotation@31..32
         TEXT@31..32 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__newtype_equation.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__newtype_equation.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..54
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..53
         NewtypeEquation@28..53
           Annotation@28..30

--- a/compiler-core/parsing/tests/snapshots/parser__newtype_signature.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__newtype_signature.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..52
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..51
         NewtypeSignature@29..51
           Annotation@29..31

--- a/compiler-core/parsing/tests/snapshots/parser__newtype_variables.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__newtype_variables.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..60
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..59
         NewtypeEquation@29..59
           Annotation@29..31

--- a/compiler-core/parsing/tests/snapshots/parser__non_reserved.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__non_reserved.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..66
@@ -27,7 +26,6 @@ snapshot_kind: text
           TEXT@31..32 " "
         WHERE@32..37 "where"
       LAYOUT_START@37..37 ""
-      ModuleImports@37..37
       ModuleStatements@37..65
         ValueSignature@37..55
           Annotation@37..39

--- a/compiler-core/parsing/tests/snapshots/parser__operator_chain_prefixed.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__operator_chain_prefixed.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..148
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@28..29 " "
         WHERE@29..34 "where"
       LAYOUT_START@34..34 ""
-      ModuleImports@34..34
       ModuleStatements@34..147
         ValueEquation@34..66
           Annotation@34..36
             TEXT@34..36 "\n\n"
           LOWER@36..46 "expression"
-          FunctionBinders@46..46
           Unconditional@46..66
             Annotation@46..47
               TEXT@46..47 " "

--- a/compiler-core/parsing/tests/snapshots/parser__record_item_labels_invalid.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__record_item_labels_invalid.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..139
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..138
         ValueEquation@29..64
           Annotation@29..31

--- a/compiler-core/parsing/tests/snapshots/parser__recover_until_end.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__recover_until_end.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..114
@@ -127,9 +126,7 @@ snapshot_kind: text
               ERROR@113..113 ""
               LAYOUT_END@113..113 ""
             ERROR@113..113 ""
-          ImportAlias@113..113
         ERROR@113..113 ""
-      ModuleStatements@113..113
       ERROR@113..113 ""
       Annotation@113..114
         TEXT@113..114 "\n"

--- a/compiler-core/parsing/tests/snapshots/parser__type_application.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_application.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..51
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..50
         ValueSignature@28..50
           Annotation@28..30

--- a/compiler-core/parsing/tests/snapshots/parser__type_arrow.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_arrow.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..61
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@16..17 " "
         WHERE@17..22 "where"
       LAYOUT_START@22..22 ""
-      ModuleImports@22..22
       ModuleStatements@22..60
         ValueSignature@22..39
           Annotation@22..24

--- a/compiler-core/parsing/tests/snapshots/parser__type_constrained.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_constrained.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..79
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..78
         ValueSignature@28..51
           Annotation@28..30

--- a/compiler-core/parsing/tests/snapshots/parser__type_hole.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_hole.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..37
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@15..16 " "
         WHERE@16..21 "where"
       LAYOUT_START@21..21 ""
-      ModuleImports@21..21
       ModuleStatements@21..36
         ValueSignature@21..36
           Annotation@21..23

--- a/compiler-core/parsing/tests/snapshots/parser__type_integer.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_integer.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..55
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@18..19 " "
         WHERE@19..24 "where"
       LAYOUT_START@24..24 ""
-      ModuleImports@24..24
       ModuleStatements@24..54
         ValueSignature@24..40
           Annotation@24..26

--- a/compiler-core/parsing/tests/snapshots/parser__type_kinded.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_kinded.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..42
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@17..18 " "
         WHERE@18..23 "where"
       LAYOUT_START@23..23 ""
-      ModuleImports@23..23
       ModuleStatements@23..41
         ValueSignature@23..41
           Annotation@23..25

--- a/compiler-core/parsing/tests/snapshots/parser__type_operator.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_operator.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..49
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..48
         ValueSignature@25..48
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__type_operator_name.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_operator_name.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..52
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@23..24 " "
         WHERE@24..29 "where"
       LAYOUT_START@29..29 ""
-      ModuleImports@29..29
       ModuleStatements@29..51
         ValueSignature@29..51
           Annotation@29..31

--- a/compiler-core/parsing/tests/snapshots/parser__type_parenthesized.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_parenthesized.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..242
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@24..25 " "
         WHERE@25..30 "where"
       LAYOUT_START@30..30 ""
-      ModuleImports@30..30
       ModuleStatements@30..241
         ValueSignature@30..55
           Annotation@30..32

--- a/compiler-core/parsing/tests/snapshots/parser__type_parenthesized_function.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_parenthesized_function.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..87
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@32..33 " "
         WHERE@33..38 "where"
       LAYOUT_START@38..38 ""
-      ModuleImports@38..38
       ModuleStatements@38..86
         ValueSignature@38..86
           Annotation@38..40

--- a/compiler-core/parsing/tests/snapshots/parser__type_prefixed.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_prefixed.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..90
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..89
         ValueSignature@25..55
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__type_record.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_record.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..187
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@17..18 " "
         WHERE@18..23 "where"
       LAYOUT_START@23..23 ""
-      ModuleImports@23..23
       ModuleStatements@23..185
         ValueSignature@23..36
           Annotation@23..25

--- a/compiler-core/parsing/tests/snapshots/parser__type_role.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_role.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..170
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@15..16 " "
         WHERE@16..21 "where"
       LAYOUT_START@21..21 ""
-      ModuleImports@21..21
       ModuleStatements@21..169
         TypeRoleDeclaration@21..48
           Annotation@21..23

--- a/compiler-core/parsing/tests/snapshots/parser__type_role_error.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_role_error.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..64
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@20..21 " "
         WHERE@21..26 "where"
       LAYOUT_START@26..26 ""
-      ModuleImports@26..26
       ModuleStatements@26..63
         TypeRoleDeclaration@26..63
           Annotation@26..28

--- a/compiler-core/parsing/tests/snapshots/parser__type_string.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_string.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..65
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@17..18 " "
         WHERE@18..23 "where"
       LAYOUT_START@23..23 ""
-      ModuleImports@23..23
       ModuleStatements@23..64
         ValueSignature@23..42
           Annotation@23..25

--- a/compiler-core/parsing/tests/snapshots/parser__type_synonym.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_synonym.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..111
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@18..19 " "
         WHERE@19..24 "where"
       LAYOUT_START@24..24 ""
-      ModuleImports@24..24
       ModuleStatements@24..110
         TypeSynonymSignature@24..43
           Annotation@24..26

--- a/compiler-core/parsing/tests/snapshots/parser__type_wildcard.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__type_wildcard.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..41
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@19..20 " "
         WHERE@20..25 "where"
       LAYOUT_START@25..25 ""
-      ModuleImports@25..25
       ModuleStatements@25..40
         ValueSignature@25..40
           Annotation@25..27

--- a/compiler-core/parsing/tests/snapshots/parser__value_annotation.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_annotation.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..349
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@22..23 " "
         WHERE@23..28 "where"
       LAYOUT_START@28..28 ""
-      ModuleImports@28..28
       ModuleStatements@28..348
         ValueSignature@28..60
           Annotation@28..32

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..78
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@20..21 " "
         WHERE@21..26 "where"
       LAYOUT_START@26..26 ""
-      ModuleImports@26..26
       ModuleStatements@26..77
         ValueEquation@26..77
           Annotation@26..28
@@ -60,7 +58,6 @@ snapshot_kind: text
                   Annotation@51..54
                     TEXT@51..54 "\n  "
                   LOWER@54..56 "a2"
-                  FunctionBinders@56..56
                   Unconditional@56..64
                     Annotation@56..57
                       TEXT@56..57 " "
@@ -87,7 +84,6 @@ snapshot_kind: text
                   Annotation@64..67
                     TEXT@64..67 "\n  "
                   LOWER@67..69 "b2"
-                  FunctionBinders@69..69
                   Unconditional@69..77
                     Annotation@69..70
                       TEXT@69..70 " "

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_guard.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_guard.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..67
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@25..26 " "
         WHERE@26..31 "where"
       LAYOUT_START@31..31 ""
-      ModuleImports@31..31
       ModuleStatements@31..66
         ValueEquation@31..66
           Annotation@31..33

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_binder.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_binder.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..75
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@31..32 " "
         WHERE@32..37 "where"
       LAYOUT_START@37..37 ""
-      ModuleImports@37..37
       ModuleStatements@37..74
         ValueEquation@37..74
           Annotation@37..39

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_full.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_full.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..158
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@29..30 " "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleImports@35..35
       ModuleStatements@35..157
         ValueEquation@35..157
           Annotation@35..37
@@ -102,7 +100,6 @@ snapshot_kind: text
                     Annotation@87..90
                       TEXT@87..90 "\n  "
                     LOWER@90..91 "e"
-                    FunctionBinders@91..91
                     Unconditional@91..99
                       Annotation@91..92
                         TEXT@91..92 " "
@@ -196,7 +193,6 @@ snapshot_kind: text
                     Annotation@145..148
                       TEXT@145..148 "\n  "
                     LOWER@148..149 "l"
-                    FunctionBinders@149..149
                     Unconditional@149..157
                       Annotation@149..150
                         TEXT@149..150 " "

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_multiple.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_multiple.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..85
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@33..34 " "
         WHERE@34..39 "where"
       LAYOUT_START@39..39 ""
-      ModuleImports@39..39
       ModuleStatements@39..84
         ValueEquation@39..84
           Annotation@39..41

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_pattern.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_pattern.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..73
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@31..32 " "
         WHERE@32..37 "where"
       LAYOUT_START@37..37 ""
-      ModuleImports@37..37
       ModuleStatements@37..72
         ValueEquation@37..72
           Annotation@37..39

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_where.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_guard_where.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..102
@@ -15,7 +14,6 @@ snapshot_kind: text
           TEXT@30..31 " "
         WHERE@31..36 "where"
       LAYOUT_START@36..36 ""
-      ModuleImports@36..36
       ModuleStatements@36..101
         ValueEquation@36..101
           Annotation@36..38
@@ -102,7 +100,6 @@ snapshot_kind: text
                     Annotation@89..92
                       TEXT@89..92 "\n  "
                     LOWER@92..93 "e"
-                    FunctionBinders@93..93
                     Unconditional@93..101
                       Annotation@93..94
                         TEXT@93..94 " "

--- a/compiler-core/parsing/tests/snapshots/parser__value_equation_recovery.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__value_equation_recovery.snap
@@ -1,7 +1,6 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
 expression: "(node, errors)"
-snapshot_kind: text
 ---
 (
     Module@0..133
@@ -15,13 +14,11 @@ snapshot_kind: text
           TEXT@28..29 " "
         WHERE@29..34 "where"
       LAYOUT_START@34..34 ""
-      ModuleImports@34..34
       ModuleStatements@34..132
         ValueEquation@34..45
           Annotation@34..36
             TEXT@34..36 "\n\n"
           LOWER@36..40 "pass"
-          FunctionBinders@40..40
           Unconditional@40..45
             Annotation@40..41
               TEXT@40..41 " "
@@ -36,12 +33,10 @@ snapshot_kind: text
           Annotation@45..46
             TEXT@45..46 "\n"
           LOWER@46..50 "fail"
-          FunctionBinders@50..50
           Unconditional@50..52
             Annotation@50..51
               TEXT@50..51 " "
             EQUAL@51..52 "="
-            WhereExpression@52..52
         ERROR@52..59
           ERROR@52..52 ""
           Annotation@52..53
@@ -52,7 +47,6 @@ snapshot_kind: text
           Annotation@59..60
             TEXT@59..60 "\n"
           LOWER@60..64 "pass"
-          FunctionBinders@64..64
           Unconditional@64..69
             Annotation@64..65
               TEXT@64..65 " "
@@ -67,7 +61,6 @@ snapshot_kind: text
           Annotation@69..71
             TEXT@69..71 "\n\n"
           LOWER@71..79 "bindings"
-          FunctionBinders@79..79
           Unconditional@79..132
             Annotation@79..80
               TEXT@79..80 " "
@@ -86,7 +79,6 @@ snapshot_kind: text
                   Annotation@92..95
                     TEXT@92..95 "\n  "
                   LOWER@95..99 "pass"
-                  FunctionBinders@99..99
                   Unconditional@99..104
                     Annotation@99..100
                       TEXT@99..100 " "
@@ -101,12 +93,10 @@ snapshot_kind: text
                   Annotation@104..107
                     TEXT@104..107 "\n  "
                   LOWER@107..111 "fail"
-                  FunctionBinders@111..111
                   Unconditional@111..113
                     Annotation@111..112
                       TEXT@111..112 " "
                     EQUAL@112..113 "="
-                    WhereExpression@113..113
                 ERROR@113..120
                   ERROR@113..113 ""
                   Annotation@113..114
@@ -117,7 +107,6 @@ snapshot_kind: text
                   Annotation@120..123
                     TEXT@120..123 "\n  "
                   LOWER@123..127 "pass"
-                  FunctionBinders@127..127
                   Unconditional@127..132
                     Annotation@127..128
                       TEXT@127..128 " "

--- a/compiler-lsp/analyzer/src/completion.rs
+++ b/compiler-lsp/analyzer/src/completion.rs
@@ -76,11 +76,16 @@ struct Context<'a> {
 
 impl Context<'_> {
     fn insert_import_range(&self) -> Option<Range> {
-        let cst = self.parsed.cst().imports()?;
-        let offset = cst.syntax().text_range().end();
-        let mut position = locate::offset_to_position(self.content, offset);
+        let range = self.parsed.cst().imports().map_or_else(
+            || Some(self.parsed.cst().header()?.syntax().text_range()),
+            |cst| Some(cst.syntax().text_range()),
+        )?;
+
+        let mut position = locate::offset_to_position(self.content, range.end());
+
         position.line += 1;
         position.character = 0;
+
         Some(Range::new(position, position))
     }
 


### PR DESCRIPTION
Removes empty nodes from the parser, as they're not supported by rowan. These nodes were detected using the following command:

```
rg --pcre2 "([A-Z](?=.*[a-z])[a-zA-Z]+)@\b(\d+)\.\.\2\b" -or '$1' --no-heading --no-filename --no-line-number | sort | uniq
```

See also: change in analyzer code to account for missing "marker" node. Thankfully we didn't have much application code that relied on these yet.

- **Remove empty nodes from parser**
- **Fix insert_import_range**
