### PR TITLE
Instantiate type applications in record fields

### DIFF
--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -29,12 +29,22 @@ where
 }
 
 fn should_instantiate_record_field(kind: &lowering::ExpressionKind) -> bool {
-    matches!(
+    if matches!(
         kind,
         lowering::ExpressionKind::Constructor { .. }
             | lowering::ExpressionKind::Variable { .. }
             | lowering::ExpressionKind::OperatorName { .. }
-    )
+    ) {
+        return true;
+    }
+
+    if let lowering::ExpressionKind::Application { arguments, .. } = kind
+        && let Some(lowering::ExpressionArgument::Type(_)) = arguments.iter().next()
+    {
+        return true;
+    }
+
+    false
 }
 
 fn instantiate_variable<Q>(

--- a/tests-integration/fixtures/checking/284_type_application_instantiation/Main.purs
+++ b/tests-integration/fixtures/checking/284_type_application_instantiation/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+const :: forall @a b. a -> b -> a
+const a _ = a
+
+data Either a b = Left a | Right b
+
+forceSolve =
+  { const: const @Int
+  , left: Left @Int
+  , right: Right @Int
+  }

--- a/tests-integration/fixtures/checking/284_type_application_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/284_type_application_instantiation/Main.snap
@@ -8,10 +8,11 @@ const :: forall (@a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Ty
 Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
 Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
 forceSolve ::
-  { const :: forall (b :: Type). Int -> (b :: Type) -> Int
-  , left :: forall (@b :: Type). Int -> Either Int (b :: Type)
-  , right :: forall (@b :: Type). (b :: Type) -> Either Int (b :: Type)
-  }
+  forall (t8 :: Type) (t7 :: Type) (t6 :: Type).
+    { const :: Int -> (t8 :: Type) -> Int
+    , left :: Int -> Either Int (t7 :: Type)
+    , right :: (t6 :: Type) -> Either Int (t6 :: Type)
+    }
 
 Types
 Either :: Type -> Type -> Type

--- a/tests-integration/fixtures/checking/284_type_application_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/284_type_application_instantiation/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/tests/checking/generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+const :: forall (@a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
+Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
+Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
+forceSolve ::
+  { const :: forall (b :: Type). Int -> (b :: Type) -> Int
+  , left :: forall (@b :: Type). Int -> Either Int (b :: Type)
+  , right :: forall (@b :: Type). (b :: Type) -> Either Int (b :: Type)
+  }
+
+Types
+Either :: Type -> Type -> Type
+
+Roles
+Either = [Representational, Representational]

--- a/tests-integration/tests/checking/generated.rs
+++ b/tests-integration/tests/checking/generated.rs
@@ -591,3 +591,5 @@ fn run_test(folder: &str, file: &str) {
 #[rustfmt::skip] #[test] fn test_282_lacks_empty_closed_row_skolem_main() { run_test("282_lacks_empty_closed_row_skolem", "Main"); }
 
 #[rustfmt::skip] #[test] fn test_283_coercible_via_newtype_superclass_main() { run_test("283_coercible_via_newtype_superclass", "Main"); }
+
+#[rustfmt::skip] #[test] fn test_284_type_application_instantiation_main() { run_test("284_type_application_instantiation", "Main"); }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for record fields when used with type applications, enabling better support for polymorphic functions instantiated with explicit type arguments.

* **Tests**
  * Added test case for type application instantiation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->