### PR TITLE
spago: add subdir roots for git packages

### DIFF
--- a/compiler-lsp/spago/src/lockfile.rs
+++ b/compiler-lsp/spago/src/lockfile.rs
@@ -107,6 +107,11 @@ fn is_safe_subdir(subdir: &Path) -> bool {
         return false;
     }
 
+    // Treat a lone current-directory path as invalid (same as "missing").
+    if subdir == Path::new(".") {
+        return false;
+    }
+
     // Treat lockfile paths as untrusted input: only allow "normal" relative paths.
     !subdir.components().any(|component| match component {
         Component::Prefix(_) | Component::RootDir | Component::ParentDir => true,

--- a/compiler-lsp/spago/src/lockfile.rs
+++ b/compiler-lsp/spago/src/lockfile.rs
@@ -28,6 +28,9 @@ pub struct WorkspacePackage {
 #[derive(Debug, Deserialize)]
 pub struct ExtraPackage {
     pub subdir: Option<PathBuf>,
+
+    /// Present in Spago lockfile schema for some extra-packages (e.g. local/path-based).
+    /// Not currently used by `Lockfile::sources()`.
     pub path: Option<PathBuf>,
 }
 

--- a/compiler-lsp/spago/src/lockfile.rs
+++ b/compiler-lsp/spago/src/lockfile.rs
@@ -44,8 +44,12 @@ pub enum PackageEntry {
         #[serde(default)]
         subdir: Option<PathBuf>,
     },
-    Local { path: SmolStr },
-    Registry { version: SmolStr },
+    Local {
+        path: SmolStr,
+    },
+    Registry {
+        version: SmolStr,
+    },
 }
 
 impl Lockfile {

--- a/compiler-lsp/spago/src/lockfile.rs
+++ b/compiler-lsp/spago/src/lockfile.rs
@@ -107,15 +107,12 @@ fn is_safe_subdir(subdir: &Path) -> bool {
         return false;
     }
 
-    // Treat a lone current-directory path as invalid (same as "missing").
-    if subdir == Path::new(".") {
-        return false;
-    }
-
     // Treat lockfile paths as untrusted input: only allow "normal" relative paths.
     !subdir.components().any(|component| match component {
-        Component::Prefix(_) | Component::RootDir | Component::ParentDir => true,
-        Component::CurDir | Component::Normal(_) => false,
+        Component::Prefix(_) | Component::RootDir | Component::ParentDir | Component::CurDir => {
+            true
+        }
+        Component::Normal(_) => false,
     })
 }
 

--- a/compiler-lsp/spago/src/lockfile.rs
+++ b/compiler-lsp/spago/src/lockfile.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use globset::Glob;
 use rustc_hash::FxHashMap;
@@ -15,6 +15,9 @@ pub struct Lockfile {
 #[derive(Debug, Deserialize)]
 pub struct Workspace {
     pub packages: FxHashMap<SmolStr, WorkspacePackage>,
+
+    #[serde(default)]
+    pub extra_packages: FxHashMap<SmolStr, ExtraPackage>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -22,12 +25,22 @@ pub struct WorkspacePackage {
     pub path: PathBuf,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ExtraPackage {
+    pub subdir: Option<PathBuf>,
+    pub path: Option<PathBuf>,
+}
+
 pub type Packages = FxHashMap<SmolStr, PackageEntry>;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum PackageEntry {
-    Git { rev: SmolStr },
+    Git {
+        rev: SmolStr,
+        #[serde(default)]
+        subdir: Option<PathBuf>,
+    },
     Local { path: SmolStr },
     Registry { version: SmolStr },
 }
@@ -41,24 +54,40 @@ impl Lockfile {
         });
 
         let base = Path::new(".spago").join("p");
-        let packages = self.packages.iter().flat_map(move |(name, package)| match package {
-            PackageEntry::Git { rev } => {
-                let src = base.join(name).join(rev).join("src");
-                let test = base.join(name).join(rev).join("test");
-                [src, test]
+        let extra_packages = &self.workspace.extra_packages;
+
+        let packages = self.packages.iter().flat_map(move |(name, package)| {
+            let mut sources = Vec::new();
+            match package {
+                PackageEntry::Git { rev, subdir } => {
+                    sources.push(base.join(name).join(rev).join("src"));
+                    sources.push(base.join(name).join(rev).join("test"));
+
+                    let subdir = subdir.as_ref().or_else(|| {
+                        extra_packages
+                            .get(name)
+                            .and_then(|extra_package| extra_package.subdir.as_ref())
+                    });
+
+                    let subdir = subdir.filter(|subdir| is_safe_subdir(subdir));
+
+                    if let Some(subdir) = subdir {
+                        sources.push(base.join(name).join(rev).join(subdir).join("src"));
+                        sources.push(base.join(name).join(rev).join(subdir).join("test"));
+                    }
+                }
+                PackageEntry::Local { path } => {
+                    let base = Path::new(path);
+                    sources.push(base.join("src"));
+                    sources.push(base.join("test"));
+                }
+                PackageEntry::Registry { version } => {
+                    let name_version = format!("{name}-{version}");
+                    sources.push(base.join(&name_version).join("src"));
+                    sources.push(base.join(&name_version).join("test"));
+                }
             }
-            PackageEntry::Local { path } => {
-                let base = Path::new(path);
-                let src = base.join("src");
-                let test = base.join("test");
-                [src, test]
-            }
-            PackageEntry::Registry { version } => {
-                let name_version = format!("{name}-{version}");
-                let src = base.join(&name_version).join("src");
-                let test = base.join(&name_version).join("test");
-                [src, test]
-            }
+            sources
         });
 
         workspace.chain(packages)
@@ -71,6 +100,18 @@ impl Lockfile {
 
 fn with_root(root: impl AsRef<Path>) -> impl Fn(PathBuf) -> Option<PathBuf> {
     move |source| root.as_ref().join(source).canonicalize().ok()
+}
+
+fn is_safe_subdir(subdir: &Path) -> bool {
+    if subdir.as_os_str().is_empty() {
+        return false;
+    }
+
+    // Treat lockfile paths as untrusted input: only allow "normal" relative paths.
+    !subdir.components().any(|component| match component {
+        Component::Prefix(_) | Component::RootDir | Component::ParentDir => true,
+        Component::CurDir | Component::Normal(_) => false,
+    })
 }
 
 fn find_purs_files(root: PathBuf) -> impl Iterator<Item = PathBuf> {

--- a/compiler-lsp/spago/tests/fixture/spago.lock
+++ b/compiler-lsp/spago/tests/fixture/spago.lock
@@ -671,6 +671,7 @@
       "graphql-client": {
         "git": "https://github.com/OxfordAbstracts/purescript-graphql-client.git",
         "ref": "fe24db5f0a79137edb1019b5757ce70d44efae10",
+        "subdir": "subpkg",
         "dependencies": [
           "aff",
           "affjax",

--- a/compiler-lsp/spago/tests/fixture/spago.lock
+++ b/compiler-lsp/spago/tests/fixture/spago.lock
@@ -6,119 +6,15 @@
         "core": {
           "dependencies": [
             "console",
+            "deku-core",
             "effect",
             "fixture-local",
             "graphql-client",
             "prelude"
-          ],
-          "build_plan": [
-            "aff",
-            "affjax",
-            "affjax-node",
-            "affjax-web",
-            "ansi",
-            "argonaut-codecs",
-            "argonaut-core",
-            "arraybuffer-types",
-            "arrays",
-            "avar",
-            "bifunctors",
-            "catenable-lists",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "debug",
-            "distributive",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "exitcodes",
-            "filterable",
-            "fixture-local",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "fork",
-            "form-urlencoded",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "graphql-client",
-            "halogen-subscriptions",
-            "heterogeneous",
-            "http-methods",
-            "identity",
-            "integers",
-            "invariant",
-            "js-date",
-            "js-uri",
-            "lazy",
-            "lcg",
-            "lists",
-            "maybe",
-            "media-types",
-            "mmorph",
-            "newtype",
-            "node-buffer",
-            "node-event-emitter",
-            "node-fs",
-            "node-path",
-            "node-process",
-            "node-streams",
-            "nonempty",
-            "now",
-            "nullable",
-            "numbers",
-            "open-memoize",
-            "optparse",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "pipes",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "psci-support",
-            "quickcheck",
-            "random",
-            "record",
-            "refs",
-            "safe-coerce",
-            "spec",
-            "spec-discovery",
-            "spec-node",
-            "st",
-            "string-parsers",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-lists",
-            "typelevel-peano",
-            "typelevel-prelude",
-            "unfoldable",
-            "unicode",
-            "unsafe-coerce",
-            "unsafe-reference",
-            "variant",
-            "web-dom",
-            "web-events",
-            "web-file",
-            "web-html",
-            "web-storage",
-            "web-xhr"
           ]
         },
         "test": {
-          "dependencies": [],
-          "build_plan": []
+          "dependencies": []
         }
       }
     },
@@ -665,13 +561,57 @@
       }
     },
     "extra_packages": {
+      "deku-core": {
+        "git": "https://github.com/mikesol/purescript-deku.git",
+        "ref": "65d6e9d",
+        "subdir": "deku-core",
+        "dependencies": [
+          "aff",
+          "arrays",
+          "catenable-lists",
+          "control",
+          "debug",
+          "effect",
+          "either",
+          "fast-vect",
+          "filterable",
+          "foldable-traversable",
+          "foreign-object",
+          "free",
+          "heterogeneous",
+          "hyrule",
+          "maybe",
+          "newtype",
+          "nullable",
+          "ordered-collections",
+          "prelude",
+          "profunctor",
+          "quickcheck",
+          "record",
+          "safe-coerce",
+          "st",
+          "strings",
+          "stringutils",
+          "tldr",
+          "transformers",
+          "tuples",
+          "typelevel-prelude",
+          "unsafe-coerce",
+          "untagged-union",
+          "web-dom",
+          "web-dom-parser",
+          "web-events",
+          "web-html",
+          "web-uievents",
+          "yoga-json"
+        ]
+      },
       "fixture-local": {
         "path": "../fixture-local"
       },
       "graphql-client": {
         "git": "https://github.com/OxfordAbstracts/purescript-graphql-client.git",
         "ref": "fe24db5f0a79137edb1019b5757ce70d44efae10",
-        "subdir": "subpkg",
         "dependencies": [
           "aff",
           "affjax",
@@ -729,21 +669,19 @@
     "aff": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-5MmdI4+0RHBtSBy+YlU3/Cq4R5W2ih3OaRedJIrVHdk=",
+      "integrity": "sha256-9BRIrSdRoYybfiUmBqgKJ66cPqxYHb277bVWQMn/9sg=",
       "dependencies": [
-        "bifunctors",
         "control",
         "datetime",
         "effect",
         "either",
         "exceptions",
-        "foldable-traversable",
         "functions",
-        "maybe",
         "newtype",
         "parallel",
+        "partial",
         "prelude",
-        "refs",
+        "st",
         "tailrec",
         "transformers",
         "unsafe-coerce"
@@ -752,26 +690,37 @@
     "affjax": {
       "type": "registry",
       "version": "13.0.0",
-      "integrity": "sha256-blYfaoW4FYIrIdvmT4sB7nN7BathFaEfZuiVLPmHJOo=",
+      "integrity": "sha256-dpOV8ELNqUVBwxE6eKFdnFky+sLwPFANrFUzIxQablk=",
       "dependencies": [
         "aff",
         "argonaut-core",
         "arraybuffer-types",
+        "arrays",
+        "control",
+        "datetime",
+        "either",
+        "exceptions",
+        "foldable-traversable",
         "foreign",
         "form-urlencoded",
+        "functions",
         "http-methods",
-        "integers",
+        "lists",
+        "maybe",
         "media-types",
+        "newtype",
         "nullable",
-        "refs",
-        "unsafe-coerce",
+        "prelude",
+        "transformers",
+        "web-dom",
+        "web-file",
         "web-xhr"
       ]
     },
     "affjax-node": {
       "type": "registry",
       "version": "1.0.0",
-      "integrity": "sha256-NcmRTXJxJzgHuKoLh+36yA8UejkfouYcX3uevT+Trjc=",
+      "integrity": "sha256-GWxbB7X+Fac/9q+vWi0rE1E/MIvZjYUMrcYrtaQFWn0=",
       "dependencies": [
         "aff",
         "affjax",
@@ -783,7 +732,7 @@
     "affjax-web": {
       "type": "registry",
       "version": "1.0.0",
-      "integrity": "sha256-n/yJUk1wMxMN7fJ2TJ+fELgieomy29N617yOshAnrc0=",
+      "integrity": "sha256-sHg+G50LDoZYG6UHvUiH1ZLT/UHIXaEF5DUBaPXxtxM=",
       "dependencies": [
         "aff",
         "affjax",
@@ -795,35 +744,40 @@
     "ansi": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-ZMB6HD+q9CXvn9fRCmJ8dvuDrOVHcjombL3oNOerVnE=",
+      "integrity": "sha256-tOUaXJFzPSfBVAqLI8hc+Tz2M1rg16cXqyHaK/3SmFg=",
       "dependencies": [
         "foldable-traversable",
         "lists",
-        "strings"
+        "prelude"
       ]
     },
     "argonaut-codecs": {
       "type": "registry",
       "version": "9.1.0",
-      "integrity": "sha256-N6efXByUeg848ompEqJfVvZuZPfdRYDGlTDFn0G0Oh8=",
+      "integrity": "sha256-K910SBrmYallESsm8pxJYThs7lig6hxX3M4PW33Cgew=",
       "dependencies": [
         "argonaut-core",
         "arrays",
-        "effect",
+        "bifunctors",
+        "either",
+        "foldable-traversable",
         "foreign-object",
         "identity",
         "integers",
+        "lists",
         "maybe",
         "nonempty",
         "ordered-collections",
         "prelude",
-        "record"
+        "record",
+        "strings",
+        "tuples"
       ]
     },
     "argonaut-core": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=",
+      "integrity": "sha256-gYZihtBIKthVuXXoiPphMookSf8M5aHyFYkcIWqlxTM=",
       "dependencies": [
         "arrays",
         "control",
@@ -841,13 +795,13 @@
     "arraybuffer-types": {
       "type": "registry",
       "version": "3.0.2",
-      "integrity": "sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=",
+      "integrity": "sha256-p05cJnSkyeoB7VHzMyc2Eb1RwUaB7Nl0sQSqEGNEUD8=",
       "dependencies": []
     },
     "arrays": {
       "type": "registry",
       "version": "7.3.0",
-      "integrity": "sha256-tmcklBlc/muUtUfr9RapdCPwnlQeB3aSrC4dK85gQlc=",
+      "integrity": "sha256-GD4z7LCi9wzi7FCQqbWhvs8paoUK9NO+HwgXZ+KP8Rk=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -868,20 +822,21 @@
     "avar": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-f+bRR3qQPa/GVe4UbLQiJBy7+PzJkUCwT6qNn0UlkMY=",
+      "integrity": "sha256-8V4SxF4TIWZ9Ik1P4lPzIRUAZeFBe8w5WA2VcCEKsIk=",
       "dependencies": [
         "aff",
         "effect",
         "either",
         "exceptions",
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "bifunctors": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-6enQzl1vqnFTQZ1WX9BnoOOVdPGO9WZvVXldHckVQvY=",
+      "integrity": "sha256-CvZRb8uI75eKIqiYntR+k05Wk6tKlMS5w8sCA2AFna0=",
       "dependencies": [
         "const",
         "either",
@@ -893,7 +848,7 @@
     "catenable-lists": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=",
+      "integrity": "sha256-7+i/MHBLIRh604iCNT4ENWRWE/wuHIotER4kpdX9Ve0=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -907,7 +862,7 @@
     "console": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=",
+      "integrity": "sha256-3T5PPz1mATZmV0C4GzkCkpLlCa5xG7u8ZNgnLrrrI1Q=",
       "dependencies": [
         "effect",
         "prelude"
@@ -916,7 +871,7 @@
     "const": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=",
+      "integrity": "sha256-S+m0lQsxnji0z1XRUmkn+3RFuWJ5CXWuIr1u3i8Bfoc=",
       "dependencies": [
         "invariant",
         "newtype",
@@ -926,7 +881,7 @@
     "contravariant": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=",
+      "integrity": "sha256-nuckEWqL80NaPmR/l9AUyrfycNh18XcvlZV9PAamwqc=",
       "dependencies": [
         "const",
         "either",
@@ -938,7 +893,7 @@
     "control": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=",
+      "integrity": "sha256-0vxyYh5FL+ilxgLo954w1LqCUC0RSIivNNlb9CaNUQg=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -947,7 +902,7 @@
     "datetime": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=",
+      "integrity": "sha256-tbv6eDXy6QOD7YSknxYSbsDF32OC2JrNbSBpzMs7Doc=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -970,16 +925,62 @@
     "debug": {
       "type": "registry",
       "version": "6.0.2",
-      "integrity": "sha256-vmkYFuXYuELBzeauvgHG6E6Kf/Hp1dAnxwE9ByHfwSg=",
+      "integrity": "sha256-d/EzRm/J2JyzvlIeo2Ex78Y7HRB0IXBitnVJywL4gHk=",
       "dependencies": [
         "functions",
         "prelude"
       ]
     },
+    "deku-core": {
+      "type": "git",
+      "url": "https://github.com/mikesol/purescript-deku.git",
+      "rev": "65d6e9d289534d13d7d235fbe7f19e6e0bd17c72",
+      "subdir": "deku-core",
+      "dependencies": [
+        "aff",
+        "arrays",
+        "catenable-lists",
+        "control",
+        "debug",
+        "effect",
+        "either",
+        "fast-vect",
+        "filterable",
+        "foldable-traversable",
+        "foreign-object",
+        "free",
+        "heterogeneous",
+        "hyrule",
+        "maybe",
+        "newtype",
+        "nullable",
+        "ordered-collections",
+        "prelude",
+        "profunctor",
+        "quickcheck",
+        "record",
+        "safe-coerce",
+        "st",
+        "strings",
+        "stringutils",
+        "tldr",
+        "transformers",
+        "tuples",
+        "typelevel-prelude",
+        "unsafe-coerce",
+        "untagged-union",
+        "web-dom",
+        "web-dom-parser",
+        "web-events",
+        "web-html",
+        "web-uievents",
+        "yoga-json"
+      ]
+    },
     "distributive": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=",
+      "integrity": "sha256-netyJK4B32PDYHD0tF2AenKgo3urzbI770ycM0pArAo=",
       "dependencies": [
         "identity",
         "newtype",
@@ -991,7 +992,7 @@
     "effect": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=",
+      "integrity": "sha256-DdqU3bncRTjgMVPPRlAuGHVeajSPEcRaRhNuio7if6s=",
       "dependencies": [
         "prelude"
       ]
@@ -999,7 +1000,7 @@
     "either": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=",
+      "integrity": "sha256-tBHx3PgtH4GZOApZCDkcM7szRTYJinrUrVGWazQCUUg=",
       "dependencies": [
         "control",
         "invariant",
@@ -1010,7 +1011,7 @@
     "enums": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=",
+      "integrity": "sha256-sdZOmLX5+5pASGpvVyT0vSD5BBYQjZiayjV5XiPutso=",
       "dependencies": [
         "control",
         "either",
@@ -1027,7 +1028,7 @@
     "exceptions": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-K0T89IHtF3vBY7eSAO7eDOqSb2J9kZGAcDN5+IKsF8E=",
+      "integrity": "sha256-nRrr+N0wk0TUFOWLR7e1n1oxcXo/X345bQUtoY9lW6A=",
       "dependencies": [
         "effect",
         "either",
@@ -1038,7 +1039,7 @@
     "exists": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=",
+      "integrity": "sha256-vtLbrWNaI+pzx/2fw2AQnCovoLtcosClIhjO26QKkh8=",
       "dependencies": [
         "unsafe-coerce"
       ]
@@ -1046,22 +1047,49 @@
     "exitcodes": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-4wxViTbyOoyKJ/WaRGI6+hZmgMKI5Miv16lSwefiLSM=",
+      "integrity": "sha256-xBl4aFSEQ05Owp1ZvO6OxxvLK3LVzU35RSbj79SsePQ=",
       "dependencies": [
-        "enums"
+        "enums",
+        "maybe",
+        "prelude"
+      ]
+    },
+    "fast-vect": {
+      "type": "registry",
+      "version": "1.2.0",
+      "integrity": "sha256-nGfcPN8IPIH6EmmCLTLNnAui0KcEt9RsH7O0vZ8HuvU=",
+      "dependencies": [
+        "arrays",
+        "distributive",
+        "filterable",
+        "foldable-traversable",
+        "lists",
+        "maybe",
+        "ordered-collections",
+        "prelude",
+        "profunctor",
+        "tuples",
+        "unfoldable",
+        "unsafe-coerce"
       ]
     },
     "filterable": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-cCojJHRnTmpY1j1kegI4CFwghdQ2Fm/8dzM8IlC+lng=",
+      "integrity": "sha256-be7ci1Bzwud2waqoCtNGsTBZbt7fi+gCLvGddQQRJ3A=",
       "dependencies": [
         "arrays",
+        "control",
         "either",
         "foldable-traversable",
         "identity",
         "lists",
-        "ordered-collections"
+        "maybe",
+        "newtype",
+        "ordered-collections",
+        "prelude",
+        "st",
+        "tuples"
       ]
     },
     "fixture-local": {
@@ -1076,7 +1104,7 @@
     "foldable-traversable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=",
+      "integrity": "sha256-NGGWyCio/xjce6fPP7y3wwg7CheqllID6aJudDxbWhA=",
       "dependencies": [
         "bifunctors",
         "const",
@@ -1094,23 +1122,23 @@
     "foreign": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=",
+      "integrity": "sha256-jiDRMVQfovGsbbA/FzbzYf6iWk9i2b5gNrIjz+gFfsI=",
       "dependencies": [
         "either",
         "functions",
-        "identity",
         "integers",
         "lists",
         "maybe",
         "prelude",
         "strings",
-        "transformers"
+        "transformers",
+        "unsafe-coerce"
       ]
     },
     "foreign-object": {
       "type": "registry",
       "version": "4.1.0",
-      "integrity": "sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=",
+      "integrity": "sha256-x/Q7r80z/vmHRKvPwhYmHP/DnJciPtsyGfRTMzayKIU=",
       "dependencies": [
         "arrays",
         "foldable-traversable",
@@ -1123,21 +1151,24 @@
         "tailrec",
         "tuples",
         "typelevel-prelude",
-        "unfoldable"
+        "unfoldable",
+        "unsafe-coerce"
       ]
     },
     "fork": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-X7u0SuCvFbLbzuNEKLBNuWjmcroqMqit4xEzpQwAP7E=",
+      "integrity": "sha256-0keBVeZZg1eCZEy/En1CohVW829gQUqKtqBNIRa93/A=",
       "dependencies": [
-        "aff"
+        "aff",
+        "prelude",
+        "transformers"
       ]
     },
     "form-urlencoded": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-WUzk8DTjrbPVHKZ5w7XpPBO6ci6xFhvYguHp6RvX+18=",
+      "integrity": "sha256-+8F0S6thSLsC1GfQiTdTt6jyTMuhsgKLciBUzde9aFU=",
       "dependencies": [
         "foldable-traversable",
         "js-uri",
@@ -1151,7 +1182,7 @@
     "free": {
       "type": "registry",
       "version": "7.1.0",
-      "integrity": "sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=",
+      "integrity": "sha256-tUBInfUpRQEw4u94GWcYW7EYdmSdDHSRn88a+C0eltU=",
       "dependencies": [
         "catenable-lists",
         "control",
@@ -1172,7 +1203,7 @@
     "functions": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=",
+      "integrity": "sha256-0jgtOr+SFO4UScKc40oA/9Vdcf2rLn3h3vZlY0KfqVo=",
       "dependencies": [
         "prelude"
       ]
@@ -1180,7 +1211,7 @@
     "functors": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=",
+      "integrity": "sha256-W1o/4wcp6S3chodYL8uixlXK2mfr1L+SzM1R+whqUco=",
       "dependencies": [
         "bifunctors",
         "const",
@@ -1200,7 +1231,7 @@
     "gen": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=",
+      "integrity": "sha256-kyOateeOtQa07vfTMYeSuCKdelgKE1R65fwKkZ10wsY=",
       "dependencies": [
         "either",
         "foldable-traversable",
@@ -1272,12 +1303,15 @@
     "halogen-subscriptions": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-8/BPME/sC/kWMDxp0+n4k09gA1IIedXn2yUJ4pCH5xw=",
+      "integrity": "sha256-1eBtVZENgGtKuOY9H0iuYD3dO1CSqmOIyhYe4OhypOU=",
       "dependencies": [
         "arrays",
+        "contravariant",
+        "control",
         "effect",
         "foldable-traversable",
-        "functors",
+        "maybe",
+        "prelude",
         "refs",
         "safe-coerce",
         "unsafe-reference"
@@ -1286,9 +1320,10 @@
     "heterogeneous": {
       "type": "registry",
       "version": "0.6.0",
-      "integrity": "sha256-cfNYSK6yYmjTrkzk95Otpv6TUUkeBreexwqG/tBvUyg=",
+      "integrity": "sha256-nQgk2iHYe5LIi6ZzREgWaCU3y8oCwdhDSukT6xVMWdk=",
       "dependencies": [
         "either",
+        "foldable-traversable",
         "functors",
         "prelude",
         "record",
@@ -1299,17 +1334,46 @@
     "http-methods": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-Orr7rbDGcp7qoqmUMXPRMjBx+C4jqOQcFe9+gE3nMgU=",
+      "integrity": "sha256-S0UjrJSgwJxEsFHM/pX77dM8V4HfvvDqdHPckQrtxMs=",
       "dependencies": [
         "either",
         "prelude",
         "strings"
       ]
     },
+    "hyrule": {
+      "type": "registry",
+      "version": "2.3.8",
+      "integrity": "sha256-W9M8uvHbfEuI8O2+nJ0pA9m0riQiZWTue9ddfwz1EJI=",
+      "dependencies": [
+        "arrays",
+        "control",
+        "datetime",
+        "effect",
+        "either",
+        "filterable",
+        "foldable-traversable",
+        "js-timers",
+        "maybe",
+        "newtype",
+        "now",
+        "ordered-collections",
+        "prelude",
+        "record",
+        "refs",
+        "st",
+        "tuples",
+        "unsafe-coerce",
+        "unsafe-reference",
+        "web-events",
+        "web-html",
+        "web-uievents"
+      ]
+    },
     "identity": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=",
+      "integrity": "sha256-RY/iXPpxpqvKHYfJeFVNI1J06kohB9rbtWYuha8t0LE=",
       "dependencies": [
         "control",
         "invariant",
@@ -1320,7 +1384,7 @@
     "integers": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=",
+      "integrity": "sha256-Y8yozC1uHRLcruobEyv5/bMKzE1BoKJ/olHv6o+bgm8=",
       "dependencies": [
         "maybe",
         "numbers",
@@ -1330,38 +1394,60 @@
     "invariant": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=",
+      "integrity": "sha256-HyoT1I5qIHRq8RSZji6zZDvqnpVjLw748utrKwZtqsw=",
       "dependencies": [
         "control",
+        "prelude"
+      ]
+    },
+    "js-bigints": {
+      "type": "registry",
+      "version": "2.2.1",
+      "integrity": "sha256-r1rE6Olv5b3JrP32lY2uKJ+eBRTsrVnC983K8VWwqe4=",
+      "dependencies": [
+        "integers",
+        "maybe",
         "prelude"
       ]
     },
     "js-date": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=",
+      "integrity": "sha256-DNQrp4xYc8o80jtxo0aOkUeXGi6h0Xidkk2ZQ8Y4l5Y=",
       "dependencies": [
         "datetime",
         "effect",
-        "exceptions",
+        "enums",
         "foreign",
+        "functions",
         "integers",
-        "now"
+        "maybe",
+        "prelude"
+      ]
+    },
+    "js-timers": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-mYEL4zjFOzrDeVCnR9Hg3pcZaBZilB6zPGaZ4fzRmzg=",
+      "dependencies": [
+        "effect",
+        "prelude"
       ]
     },
     "js-uri": {
       "type": "registry",
       "version": "3.1.0",
-      "integrity": "sha256-3p0ynHveCJmC2CXze+eMBdW/2l5e953Q8XMAKz+jxUo=",
+      "integrity": "sha256-7waHOctAfqhhw540FNJ7C/YsDMQW9TmA+SpHhduH6Uw=",
       "dependencies": [
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "lazy": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=",
+      "integrity": "sha256-MHRC+1Pc+AjortBp4b/e1e6KpEpsDwaJBNBB7TOL+1I=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -1372,11 +1458,12 @@
     "lcg": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-h7ME5cthLfbgJOJdsZcSfFpwXsx4rf8YmhebU+3iSYg=",
+      "integrity": "sha256-bUYyfXYmjTn7zSpj2hTiePywzsuD80fCjkonsrpdGOw=",
       "dependencies": [
         "effect",
         "integers",
         "maybe",
+        "numbers",
         "partial",
         "prelude",
         "random"
@@ -1385,7 +1472,7 @@
     "lists": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=",
+      "integrity": "sha256-/mGd7wLoU+wsTcqii7SSUByxsvwvjnu2PjwAD47yYb4=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -1401,10 +1488,24 @@
         "unfoldable"
       ]
     },
+    "literals": {
+      "type": "registry",
+      "version": "1.0.2",
+      "integrity": "sha256-ZkGRFD6gb8etYvyMYpX1Z7lx1Tql7R1VGnD1Dzinup8=",
+      "dependencies": [
+        "integers",
+        "maybe",
+        "numbers",
+        "partial",
+        "prelude",
+        "typelevel-prelude",
+        "unsafe-coerce"
+      ]
+    },
     "maybe": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=",
+      "integrity": "sha256-8X6XEgtZ5lqfkEuc1hWOofnL6mwhk8gSJTxwvbR/SbY=",
       "dependencies": [
         "control",
         "invariant",
@@ -1415,7 +1516,7 @@
     "media-types": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=",
+      "integrity": "sha256-3Wyq+vfqJFTmy1k6DGVnXStxtZxgK631wusDPzlFVxg=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -1424,17 +1525,24 @@
     "mmorph": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-urZlZNNqGeQFe5D/ClHlR8QgGBNHTMFPtJ5S5IpflTQ=",
+      "integrity": "sha256-Cfltaq+tfYjuSoSBN/b8cSQZbvZTqIRs6ebQewbIkGs=",
       "dependencies": [
+        "bifunctors",
+        "either",
         "free",
         "functors",
-        "transformers"
+        "identity",
+        "maybe",
+        "newtype",
+        "prelude",
+        "transformers",
+        "tuples"
       ]
     },
     "newtype": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=",
+      "integrity": "sha256-dt6w0cty4OS+Pjt9fsh3iU6ottqSU83mdAZkaEEvo6c=",
       "dependencies": [
         "prelude",
         "safe-coerce"
@@ -1443,12 +1551,15 @@
     "node-buffer": {
       "type": "registry",
       "version": "9.0.0",
-      "integrity": "sha256-PWE2DJ5ruBLCmeA/fUiuySEFmUJ/VuRfyrnCuVZBlu4=",
+      "integrity": "sha256-RdQjilmEHqsT4fwpCr8Mavw8KTafYrS3ZM6zeAAVAl8=",
       "dependencies": [
         "arraybuffer-types",
         "effect",
+        "functions",
         "maybe",
         "nullable",
+        "partial",
+        "prelude",
         "st",
         "unsafe-coerce"
       ]
@@ -1456,7 +1567,7 @@
     "node-event-emitter": {
       "type": "registry",
       "version": "3.0.0",
-      "integrity": "sha256-Qw0MjsT4xRH2j2i4K8JmRjcMKnH5z1Cw39t00q4LE4w=",
+      "integrity": "sha256-wodx71NxJBPXOaawFn01V1ByYB2vT+I3RuV2giOVKMg=",
       "dependencies": [
         "effect",
         "either",
@@ -1470,8 +1581,9 @@
     "node-fs": {
       "type": "registry",
       "version": "9.2.0",
-      "integrity": "sha256-Sg0vkXycEzkEerX6hLccz21Ygd9w1+QSk1thotRZPGI=",
+      "integrity": "sha256-fxioTSm9y47WuYs9F/7nxCh/RVDCl3Kr3Hg779J4SJA=",
       "dependencies": [
+        "aff",
         "datetime",
         "effect",
         "either",
@@ -1487,14 +1599,13 @@
         "nullable",
         "partial",
         "prelude",
-        "strings",
-        "unsafe-coerce"
+        "strings"
       ]
     },
     "node-path": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-ePOElFamHkffhwJcS0Ozq4A14rflnkasFU6X2B8/yXs=",
+      "integrity": "sha256-j7n/SmpVz0FOMJl4XZop3ofJ+MeIPkMNqUEUKHEL6Us=",
       "dependencies": [
         "effect"
       ]
@@ -1502,23 +1613,25 @@
     "node-process": {
       "type": "registry",
       "version": "11.2.0",
-      "integrity": "sha256-+2MQDYChjGbVbapCyJtuWYwD41jk+BntF/kcOTKBMVs=",
+      "integrity": "sha256-onzKeNmaeYfN3HSDPqSFTrrP2Yl9tnVsfKKhnf2plxM=",
       "dependencies": [
         "effect",
+        "exceptions",
         "foreign",
         "foreign-object",
         "maybe",
         "node-event-emitter",
         "node-streams",
+        "nullable",
         "posix-types",
         "prelude",
-        "unsafe-coerce"
+        "strings"
       ]
     },
     "node-streams": {
       "type": "registry",
       "version": "9.0.1",
-      "integrity": "sha256-7RJ6RqjOlhW+QlDFQNUHlkCG/CuYTTLT8yary5jhhsU=",
+      "integrity": "sha256-yuVGm/R/tBr4Nphi+a1a984Z0fkmN9Q5wWtSmbmJTpA=",
       "dependencies": [
         "aff",
         "arrays",
@@ -1539,7 +1652,7 @@
     "nonempty": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=",
+      "integrity": "sha256-Ctkq8/+KiGqCE53Y/LvibA/coy7ev9HtRZU+GYS7yfQ=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -1552,35 +1665,37 @@
     "now": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=",
+      "integrity": "sha256-mTyG4s8tps3XIf0jjV/lME2/QlwMzrQly2wqfSSUM3o=",
       "dependencies": [
         "datetime",
-        "effect"
+        "effect",
+        "prelude"
       ]
     },
     "nullable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=",
+      "integrity": "sha256-CDAZk+L9Sc0GCFTkE8n+qdp4Ys8avvnkU+m2hVALt7M=",
       "dependencies": [
-        "effect",
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "numbers": {
       "type": "registry",
       "version": "9.0.1",
-      "integrity": "sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=",
+      "integrity": "sha256-ZydYckgwRAnRaFC7pu6fADhzdwX+UqHZrfJyet64zls=",
       "dependencies": [
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "open-memoize": {
       "type": "registry",
       "version": "6.2.0",
-      "integrity": "sha256-p1m7wF3aHQ80yUvqMs20OTMl496WS6YpKlmI2Nkg9j0=",
+      "integrity": "sha256-yJLuVYX8FocHIJ+6q7efH/Pj4S+e1Y57DZ5Dn7qf4ww=",
       "dependencies": [
         "either",
         "integers",
@@ -1596,12 +1711,10 @@
     "optparse": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-cEzEkNW4q0gZlXl4z0zn+H2vs6l2UAp7NPHCsois73k=",
+      "integrity": "sha256-2btDjHPRR0uujUQJuZAN9AzvVoXe7yG6IwnY5evERhQ=",
       "dependencies": [
-        "aff",
         "arrays",
         "bifunctors",
-        "console",
         "control",
         "effect",
         "either",
@@ -1610,7 +1723,6 @@
         "exitcodes",
         "foldable-traversable",
         "free",
-        "gen",
         "integers",
         "lazy",
         "lists",
@@ -1633,16 +1745,19 @@
     "ordered-collections": {
       "type": "registry",
       "version": "3.2.0",
-      "integrity": "sha256-o9jqsj5rpJmMdoe/zyufWHFjYYFTTsJpgcuCnqCO6PM=",
+      "integrity": "sha256-NaEXc2cz/7lJfxPWEja4XlZbGxuRqJwFKQJjsJf51kQ=",
       "dependencies": [
         "arrays",
+        "control",
         "foldable-traversable",
+        "functions",
         "gen",
         "lists",
         "maybe",
+        "newtype",
         "partial",
         "prelude",
-        "st",
+        "safe-coerce",
         "tailrec",
         "tuples",
         "unfoldable"
@@ -1651,7 +1766,7 @@
     "orders": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=",
+      "integrity": "sha256-nSMxZK7wxyDULkjZqvMyB71mVo6b0AyLLHosDVbv1XM=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -1660,7 +1775,7 @@
     "parallel": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=",
+      "integrity": "sha256-bAGpVhrFz2IyHkA4MR7+tE/19FZ7dzYBdYPgK5svkqw=",
       "dependencies": [
         "control",
         "effect",
@@ -1678,17 +1793,24 @@
     "partial": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=",
+      "integrity": "sha256-mdrlJBAgFMh79hNRW39uv7c+BwnnaOrAMmdh7+VhEhs=",
       "dependencies": []
     },
     "pipes": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-kvfqGM4cPA/wCcBHbp5psouFw5dZGvku2462x7ZBwSY=",
+      "integrity": "sha256-dtUNpG8BGVr7pu6mQZyAnUAftUHgNS7f0QH3Kw5UTpQ=",
       "dependencies": [
         "aff",
+        "control",
+        "effect",
+        "either",
+        "foldable-traversable",
+        "identity",
         "lists",
+        "maybe",
         "mmorph",
+        "newtype",
         "prelude",
         "tailrec",
         "transformers",
@@ -1698,22 +1820,23 @@
     "posix-types": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-ZfFz8RR1lee/o/Prccyeut3Q+9tYd08mlR72sIh6GzA=",
+      "integrity": "sha256-Je5jG439F/SFO/IvVevZnWVxDIonrehlKuJkefP2lHE=",
       "dependencies": [
         "maybe",
+        "newtype",
         "prelude"
       ]
     },
     "prelude": {
       "type": "registry",
       "version": "6.0.2",
-      "integrity": "sha256-kiAPZxihtAel8uRiTNdccf4qylp/9J3jNkEHNAD0MsE=",
+      "integrity": "sha256-IqykrDRquGUD/LRSad7y75hZv3bUsGQ4knc8tdez8Qw=",
       "dependencies": []
     },
     "profunctor": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-E58hSYdJvF2Qjf9dnWLPlJKh2Z2fLfFLkQoYi16vsFk=",
+      "integrity": "sha256-Ow0mJC+PIIRq/a3mzCWY5vxuTgR/e+Ee68+mWeSRnWY=",
       "dependencies": [
         "control",
         "distributive",
@@ -1728,7 +1851,7 @@
     "psci-support": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-C6ql4P9TEP06hft/1Z5QumPA4yARR4VIxDdhmL1EO+Y=",
+      "integrity": "sha256-mC945xpp0qnYugdbnlzZExDRr8bW4mDbdsQl0H8KmIQ=",
       "dependencies": [
         "console",
         "effect",
@@ -1738,7 +1861,7 @@
     "quickcheck": {
       "type": "registry",
       "version": "8.0.1",
-      "integrity": "sha256-ZvpccKQCvgslTXZCNmpYW4bUsFzhZd/kQUr2WmxFTGY=",
+      "integrity": "sha256-SfW+maesCt0jnnFhfrgJZGPcWLj8oFcGbcDIVklmdzc=",
       "dependencies": [
         "arrays",
         "console",
@@ -1765,23 +1888,23 @@
         "strings",
         "tailrec",
         "transformers",
-        "tuples",
-        "unfoldable"
+        "tuples"
       ]
     },
     "random": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-CJ611a35MPCE7XQMp0rdC6MCn76znlhisiCRgboAG+Q=",
+      "integrity": "sha256-7sZRo6P9UIiXDZ9s2QL9T8h3wlIwLdQrR4+oZKOijQw=",
       "dependencies": [
         "effect",
-        "integers"
+        "integers",
+        "prelude"
       ]
     },
     "record": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=",
+      "integrity": "sha256-WQ8fqp4X1wTA70J4qUcPW4Z7DCwx6e5KJnT/EuTdWSc=",
       "dependencies": [
         "functions",
         "prelude",
@@ -1791,7 +1914,7 @@
     "refs": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=",
+      "integrity": "sha256-KKD5G9dR2SauuDGULUJsxjqDOEi1Jqm+2Sq5U2mY8YU=",
       "dependencies": [
         "effect",
         "prelude"
@@ -1800,7 +1923,7 @@
     "safe-coerce": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=",
+      "integrity": "sha256-EJrxtKt5xC7TYjBZrSBO/J7Aw3DmtilYjt4olpAXWVc=",
       "dependencies": [
         "unsafe-coerce"
       ]
@@ -1808,7 +1931,7 @@
     "spec": {
       "type": "registry",
       "version": "8.1.1",
-      "integrity": "sha256-EM7UfQIaSgiw13LJ4ZASkfYmmRDKIlec3nYbGKFqGhk=",
+      "integrity": "sha256-b6qjDb7lUJGLV+WEoywLu6BCXC4zGpfbN43mTL+vBeI=",
       "dependencies": [
         "aff",
         "ansi",
@@ -1842,7 +1965,7 @@
     "spec-discovery": {
       "type": "registry",
       "version": "8.4.0",
-      "integrity": "sha256-ajaGtBe+WBnURPPxIfqyiBbxI9DvbCGpxpYYYrvi5nk=",
+      "integrity": "sha256-aFp8bllT/wrxQu8hMlDchQQY08dQAz+Xdq2hZi5z3yY=",
       "dependencies": [
         "aff",
         "effect",
@@ -1855,7 +1978,7 @@
     "spec-node": {
       "type": "registry",
       "version": "0.0.3",
-      "integrity": "sha256-Bjzg6l4uOfMN/FV0SKuT1Mm8eMP9sloLGVcY/0MeMnI=",
+      "integrity": "sha256-8/9+g0obbamV0YtqzmttbWs8HaWF7CEeW+eDtqzuAAo=",
       "dependencies": [
         "aff",
         "argonaut-codecs",
@@ -1887,8 +2010,9 @@
     "st": {
       "type": "registry",
       "version": "6.2.0",
-      "integrity": "sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=",
+      "integrity": "sha256-WI4MEkkwUd4pnwZQ3G8VKWgX5t1RSNJludm5e9boaRo=",
       "dependencies": [
+        "effect",
         "partial",
         "prelude",
         "tailrec",
@@ -1898,15 +2022,16 @@
     "string-parsers": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-9ATYh0S54ERoR+uhkCM59wBRvW/6zv6geHJ0TmcI644=",
+      "integrity": "sha256-xYexodEcW37sOLAw9R37uKTZjQFEolg3oti8E/sEry4=",
       "dependencies": [
         "arrays",
-        "bifunctors",
         "control",
         "either",
+        "enums",
         "foldable-traversable",
         "lists",
         "maybe",
+        "nonempty",
         "prelude",
         "strings",
         "tailrec"
@@ -1915,7 +2040,7 @@
     "strings": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=",
+      "integrity": "sha256-FNto2hoNW5Da6W6crIk77YXMagBvOGHZE1kO7eZ1vLM=",
       "dependencies": [
         "arrays",
         "control",
@@ -1935,10 +2060,24 @@
         "unsafe-coerce"
       ]
     },
+    "stringutils": {
+      "type": "registry",
+      "version": "0.0.12",
+      "integrity": "sha256-byI+JsFtMjrxwfNJJTOGPIE6e+LuFG/ztjUr+YhUGlQ=",
+      "dependencies": [
+        "arrays",
+        "functions",
+        "integers",
+        "maybe",
+        "prelude",
+        "strings",
+        "unsafe-coerce"
+      ]
+    },
     "tailrec": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=",
+      "integrity": "sha256-xrorCfP0xV1wubs27idQCHQqdvSUuqmmL/am7Ji1wVU=",
       "dependencies": [
         "bifunctors",
         "effect",
@@ -1950,10 +2089,18 @@
         "refs"
       ]
     },
+    "tldr": {
+      "type": "registry",
+      "version": "0.0.0",
+      "integrity": "sha256-cgG3625BnwVtM+CbuDtBt++AX4vu8e1QFarmDiAKtE8=",
+      "dependencies": [
+        "prelude"
+      ]
+    },
     "transformers": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-3Bm+Z6tsC/paG888XkywDngJ2JMos+JfOhRlkVfb7gI=",
+      "integrity": "sha256-QJmgNT/y7ljPHSsXaW4zxF/982BFiQ90KNL1g/NtEOQ=",
       "dependencies": [
         "control",
         "distributive",
@@ -1975,7 +2122,7 @@
     "tuples": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=",
+      "integrity": "sha256-BKy7EfK8S1KeTCwyWqyW1wwcpSAQuh3IsczSVgS6fzY=",
       "dependencies": [
         "control",
         "invariant",
@@ -1985,13 +2132,13 @@
     "type-equality": {
       "type": "registry",
       "version": "4.0.1",
-      "integrity": "sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=",
+      "integrity": "sha256-BBqYOSnAKmayRvR5mtZoCf4SlYs2ipatD/+5nQx73aw=",
       "dependencies": []
     },
     "typelevel-lists": {
       "type": "registry",
       "version": "2.1.0",
-      "integrity": "sha256-h7fTc4i98F/mRizWGIjm91eRwUQlC6/33Lm1JbnD3BE=",
+      "integrity": "sha256-0MjcPZTI31JjaveIUUBkUHr8QhUHy7NWj5iXNg/wZDU=",
       "dependencies": [
         "prelude",
         "tuples",
@@ -2003,13 +2150,9 @@
     "typelevel-peano": {
       "type": "registry",
       "version": "1.0.1",
-      "integrity": "sha256-DO/EazDNu07i2ekvj8vIdgH2HdKWUjfohNYo5aNQZy0=",
+      "integrity": "sha256-6ojCXDUL2LY6II8x2l6Ljmtta7A8feqXg/F39CTzMzk=",
       "dependencies": [
-        "arrays",
-        "console",
-        "effect",
         "prelude",
-        "psci-support",
         "typelevel-prelude",
         "unsafe-coerce"
       ]
@@ -2017,7 +2160,7 @@
     "typelevel-prelude": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=",
+      "integrity": "sha256-+pHi14/40mTj/+lmCWqL0T7iXIXD1+NSg/KItyyoB0A=",
       "dependencies": [
         "prelude",
         "type-equality"
@@ -2026,7 +2169,7 @@
     "unfoldable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=",
+      "integrity": "sha256-BK/6By1sKp/ztk+9CF3q43SV0QDTLVdsGqFerKHSmbg=",
       "dependencies": [
         "foldable-traversable",
         "maybe",
@@ -2038,78 +2181,149 @@
     "unicode": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-QJnTVZpmihEAUiMeYrfkusVoziJWp2hJsgi9bMQLue8=",
+      "integrity": "sha256-5KugCNyYxscmZpnMbssOQA96XimuBN/bjHpdrtd5qaY=",
       "dependencies": [
-        "foldable-traversable",
+        "arrays",
+        "enums",
+        "integers",
         "maybe",
-        "strings"
+        "partial",
+        "prelude",
+        "strings",
+        "unsafe-coerce"
       ]
     },
     "unsafe-coerce": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=",
+      "integrity": "sha256-0L1QsaY20OILjfU5TV72d3U/tSjhmL9hJ32WMp857Lk=",
       "dependencies": []
     },
     "unsafe-reference": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-zU7BhfJU14nXQRZG9iADsp0mSiKhz07OcKyjRB2YT+Y=",
+      "integrity": "sha256-ttSJTQUnK8AK2eGOsfRxLUJEDPL6pnmExjbiOqfwC6I=",
       "dependencies": [
         "prelude"
+      ]
+    },
+    "untagged-union": {
+      "type": "registry",
+      "version": "1.0.0",
+      "integrity": "sha256-MQvpb13TZEBoi9n/AoQ7ugniSQqbN6XQmAjii9pqJRk=",
+      "dependencies": [
+        "either",
+        "foreign",
+        "foreign-object",
+        "literals",
+        "maybe",
+        "newtype",
+        "prelude",
+        "tuples",
+        "unsafe-coerce"
       ]
     },
     "variant": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-SR//zQDg2dnbB8ZHslcxieUkCeNlbMToapvmh9onTtw=",
+      "integrity": "sha256-Ydrgl8liWEwYQOWW76PdZtg3vxKpoKgsnmFyTLgZkoU=",
       "dependencies": [
+        "control",
         "enums",
+        "foldable-traversable",
         "lists",
         "maybe",
         "partial",
         "prelude",
-        "record",
-        "tuples",
+        "type-equality",
         "unsafe-coerce"
       ]
     },
     "web-dom": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=",
+      "integrity": "sha256-rVeqkxChkjqisDvOujy9BMEgGqJkwX3t6g21bXfiG5o=",
       "dependencies": [
+        "effect",
+        "enums",
+        "maybe",
+        "newtype",
+        "nullable",
+        "prelude",
+        "unsafe-coerce",
         "web-events"
+      ]
+    },
+    "web-dom-parser": {
+      "type": "registry",
+      "version": "8.0.0",
+      "integrity": "sha256-g8utHk8RtXOyM6B+O0ko247v4K5fdbaj0wjztHEc53U=",
+      "dependencies": [
+        "arrays",
+        "effect",
+        "either",
+        "maybe",
+        "prelude",
+        "web-dom"
       ]
     },
     "web-events": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=",
+      "integrity": "sha256-wZNeldG0OU+8qGycUJ9e6vxf1/GC4Ep4OlRMhvjs9LA=",
       "dependencies": [
         "datetime",
+        "effect",
         "enums",
         "foreign",
-        "nullable"
+        "functions",
+        "maybe",
+        "newtype",
+        "nullable",
+        "prelude",
+        "unsafe-coerce"
       ]
     },
     "web-file": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=",
+      "integrity": "sha256-txsdkeWBKU/+5v9m5c6kysgJQSDyV1r7MHaeT4STpjQ=",
       "dependencies": [
+        "datetime",
+        "effect",
+        "enums",
         "foreign",
+        "integers",
+        "maybe",
         "media-types",
-        "web-dom"
+        "nullable",
+        "numbers",
+        "partial",
+        "prelude",
+        "tuples",
+        "unfoldable",
+        "unsafe-coerce",
+        "web-events"
       ]
     },
     "web-html": {
       "type": "registry",
       "version": "4.1.0",
-      "integrity": "sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=",
+      "integrity": "sha256-sMwdo5u2DBOFoQzcJLKBp9b4ChU8YSRBjSi9g1Wk42g=",
       "dependencies": [
+        "effect",
+        "enums",
+        "foreign",
+        "functions",
         "js-date",
+        "maybe",
+        "media-types",
+        "newtype",
+        "nullable",
+        "prelude",
+        "unsafe-coerce",
         "web-dom",
+        "web-events",
         "web-file",
         "web-storage"
       ]
@@ -2117,23 +2331,105 @@
     "web-storage": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=",
+      "integrity": "sha256-YJfos55oeKtBStNfoWfeflSy8j+4IDym5eaZtIY7YM4=",
       "dependencies": [
+        "effect",
+        "maybe",
         "nullable",
+        "prelude",
+        "unsafe-coerce",
         "web-events"
+      ]
+    },
+    "web-uievents": {
+      "type": "registry",
+      "version": "5.0.0",
+      "integrity": "sha256-yh9uVLIGu8wE1+jwLehtfsRfR1eyiShhIMMhBPqKybE=",
+      "dependencies": [
+        "effect",
+        "enums",
+        "maybe",
+        "nullable",
+        "prelude",
+        "unsafe-coerce",
+        "web-events",
+        "web-html"
       ]
     },
     "web-xhr": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-3dbIPVG66S+hPrgEVnpD78hrGjE7qlBbsReWOz89Ios=",
+      "integrity": "sha256-gxQgeGwvF/NyGdw0FJ9IzXI3gqIMNb8oQO8X+p5jDyw=",
       "dependencies": [
         "arraybuffer-types",
         "datetime",
+        "effect",
+        "either",
+        "enums",
+        "foreign",
         "http-methods",
+        "maybe",
+        "media-types",
+        "newtype",
+        "nullable",
+        "prelude",
+        "unsafe-coerce",
         "web-dom",
+        "web-events",
         "web-file",
         "web-html"
+      ]
+    },
+    "yoga-json": {
+      "type": "registry",
+      "version": "5.1.0",
+      "integrity": "sha256-DK+KyaQ7YyWo8p3SuZPPEMoVKy6HF1iV4rGFPXgBygw=",
+      "dependencies": [
+        "arrays",
+        "bifunctors",
+        "control",
+        "datetime",
+        "effect",
+        "either",
+        "exceptions",
+        "foldable-traversable",
+        "foreign",
+        "foreign-object",
+        "free",
+        "identity",
+        "integers",
+        "js-bigints",
+        "js-date",
+        "lists",
+        "maybe",
+        "newtype",
+        "nullable",
+        "numbers",
+        "ordered-collections",
+        "partial",
+        "prelude",
+        "record",
+        "strings",
+        "transformers",
+        "tuples",
+        "typelevel-prelude",
+        "unsafe-coerce",
+        "variant",
+        "yoga-tree"
+      ]
+    },
+    "yoga-tree": {
+      "type": "registry",
+      "version": "1.0.0",
+      "integrity": "sha256-s8rIVEQkRi1VrMc92T9ceXcY0X6r5A4QqT6f7GgmDQI=",
+      "dependencies": [
+        "arrays",
+        "control",
+        "foldable-traversable",
+        "free",
+        "maybe",
+        "prelude",
+        "tailrec"
       ]
     }
   }

--- a/compiler-lsp/spago/tests/fixture/spago.yaml
+++ b/compiler-lsp/spago/tests/fixture/spago.yaml
@@ -67,3 +67,46 @@ workspace:
         - variant
       git: https://github.com/OxfordAbstracts/purescript-graphql-client.git
       ref: fe24db5f0a79137edb1019b5757ce70d44efae10
+    deku-core:
+      git: "https://github.com/mikesol/purescript-deku.git"
+      subdir: deku-core
+      ref: "65d6e9d"
+      dependencies:
+        - aff
+        - arrays
+        - catenable-lists
+        - control
+        - debug
+        - effect
+        - either
+        - fast-vect
+        - filterable
+        - foldable-traversable
+        - foreign-object
+        - free
+        - heterogeneous
+        - hyrule
+        - maybe
+        - newtype
+        - nullable
+        - ordered-collections
+        - prelude
+        - profunctor
+        - quickcheck
+        - record
+        - safe-coerce
+        - st
+        - strings
+        - stringutils
+        - tldr
+        - transformers
+        - typelevel-prelude
+        - tuples
+        - unsafe-coerce
+        - untagged-union
+        - web-dom
+        - web-dom-parser
+        - web-events
+        - web-html
+        - web-uievents
+        - yoga-json

--- a/compiler-lsp/spago/tests/fixture/spago.yaml
+++ b/compiler-lsp/spago/tests/fixture/spago.yaml
@@ -3,6 +3,7 @@ package:
   dependencies:
     - console
     - effect
+    - deku-core
     - fixture-local
     - graphql-client
     - prelude

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -52,7 +52,19 @@ fn test_lockfile_sources_subdir_precedence_packages_over_workspace_extra_package
     assert!(
         sources
             .iter()
+            .any(|s| s == ".spago/p/foo/abcd/from-packages/test"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources
+            .iter()
             .all(|s| s != ".spago/p/foo/abcd/from-workspace/src"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources
+            .iter()
+            .all(|s| s != ".spago/p/foo/abcd/from-workspace/test"),
         "sources: {sources:?}"
     );
 }
@@ -88,7 +100,19 @@ fn test_lockfile_sources_subdir_fallback_to_workspace_extra_packages() {
     assert!(
         sources
             .iter()
+            .any(|s| s == ".spago/p/foo/abcd/from-workspace/test"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources
+            .iter()
             .all(|s| s != ".spago/p/foo/abcd/from-packages/src"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources
+            .iter()
+            .all(|s| s != ".spago/p/foo/abcd/from-packages/test"),
         "sources: {sources:?}"
     );
 }

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -13,6 +13,53 @@ fn test_parse_lockfile() {
 }
 
 #[test]
+fn test_lockfile_sources_subdir_precedence_packages_over_workspace_extra_packages() {
+    let lockfile = serde_json::from_str::<Lockfile>(
+        r#"{
+  "workspace": {
+    "packages": {},
+    "extra_packages": {
+      "foo": { "subdir": "from-workspace" }
+    }
+  },
+  "packages": {
+    "foo": { "type": "git", "rev": "abcd", "subdir": "from-packages" }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let sources = lockfile
+        .sources()
+        .filter_map(|source| source.to_str().map(|s| s.replace('\\', "/")))
+        .collect::<Vec<_>>();
+
+    assert!(
+        sources
+            .iter()
+            .any(|s| s == ".spago/p/foo/abcd/from-packages/src"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources
+            .iter()
+            .all(|s| s != ".spago/p/foo/abcd/from-workspace/src"),
+        "sources: {sources:?}"
+    );
+}
+
+#[test]
+fn test_parse_lockfile_without_extra_packages() {
+    let lockfile = serde_json::from_str::<Lockfile>(
+        r#"{
+  "workspace": { "packages": {} },
+  "packages": { "foo": { "type": "git", "rev": "abcd" } }
+}"#,
+    );
+    assert!(lockfile.is_ok(), "{lockfile:?}");
+}
+
+#[test]
 fn test_lockfile_sources() {
     let lockfile = serde_json::from_str::<Lockfile>(SPAGO_LOCK);
     assert!(lockfile.is_ok(), "{lockfile:?}");

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -34,37 +34,23 @@ fn test_lockfile_sources_subdir_precedence_packages_over_workspace_extra_package
         .filter_map(|source| source.to_str().map(|s| s.replace('\\', "/")))
         .collect::<Vec<_>>();
 
-    assert!(
-        sources.iter().any(|s| s == ".spago/p/foo/abcd/src"),
-        "sources: {sources:?}"
-    );
-    assert!(
-        sources.iter().any(|s| s == ".spago/p/foo/abcd/test"),
-        "sources: {sources:?}"
-    );
+    assert!(sources.iter().any(|s| s == ".spago/p/foo/abcd/src"), "sources: {sources:?}");
+    assert!(sources.iter().any(|s| s == ".spago/p/foo/abcd/test"), "sources: {sources:?}");
 
     assert!(
-        sources
-            .iter()
-            .any(|s| s == ".spago/p/foo/abcd/from-packages/src"),
+        sources.iter().any(|s| s == ".spago/p/foo/abcd/from-packages/src"),
         "sources: {sources:?}"
     );
     assert!(
-        sources
-            .iter()
-            .any(|s| s == ".spago/p/foo/abcd/from-packages/test"),
+        sources.iter().any(|s| s == ".spago/p/foo/abcd/from-packages/test"),
         "sources: {sources:?}"
     );
     assert!(
-        sources
-            .iter()
-            .all(|s| s != ".spago/p/foo/abcd/from-workspace/src"),
+        sources.iter().all(|s| s != ".spago/p/foo/abcd/from-workspace/src"),
         "sources: {sources:?}"
     );
     assert!(
-        sources
-            .iter()
-            .all(|s| s != ".spago/p/foo/abcd/from-workspace/test"),
+        sources.iter().all(|s| s != ".spago/p/foo/abcd/from-workspace/test"),
         "sources: {sources:?}"
     );
 }
@@ -92,27 +78,19 @@ fn test_lockfile_sources_subdir_fallback_to_workspace_extra_packages() {
         .collect::<Vec<_>>();
 
     assert!(
-        sources
-            .iter()
-            .any(|s| s == ".spago/p/deku-core/65d6e9d/deku-core/src"),
+        sources.iter().any(|s| s == ".spago/p/deku-core/65d6e9d/deku-core/src"),
         "sources: {sources:?}"
     );
     assert!(
-        sources
-            .iter()
-            .any(|s| s == ".spago/p/deku-core/65d6e9d/deku-core/test"),
+        sources.iter().any(|s| s == ".spago/p/deku-core/65d6e9d/deku-core/test"),
         "sources: {sources:?}"
     );
     assert!(
-        sources
-            .iter()
-            .all(|s| s != ".spago/p/deku-core/65d6e9d/from-packages/src"),
+        sources.iter().all(|s| s != ".spago/p/deku-core/65d6e9d/from-packages/src"),
         "sources: {sources:?}"
     );
     assert!(
-        sources
-            .iter()
-            .all(|s| s != ".spago/p/deku-core/65d6e9d/from-packages/test"),
+        sources.iter().all(|s| s != ".spago/p/deku-core/65d6e9d/from-packages/test"),
         "sources: {sources:?}"
     );
 }

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -76,11 +76,11 @@ fn test_lockfile_sources_subdir_fallback_to_workspace_extra_packages() {
   "workspace": {
     "packages": {},
     "extra_packages": {
-      "foo": { "subdir": "from-workspace" }
+      "deku-core": { "subdir": "deku-core" }
     }
   },
   "packages": {
-    "foo": { "type": "git", "rev": "abcd" }
+    "deku-core": { "type": "git", "rev": "65d6e9d" }
   }
 }"#,
     )
@@ -94,25 +94,25 @@ fn test_lockfile_sources_subdir_fallback_to_workspace_extra_packages() {
     assert!(
         sources
             .iter()
-            .any(|s| s == ".spago/p/foo/abcd/from-workspace/src"),
+            .any(|s| s == ".spago/p/deku-core/65d6e9d/deku-core/src"),
         "sources: {sources:?}"
     );
     assert!(
         sources
             .iter()
-            .any(|s| s == ".spago/p/foo/abcd/from-workspace/test"),
+            .any(|s| s == ".spago/p/deku-core/65d6e9d/deku-core/test"),
         "sources: {sources:?}"
     );
     assert!(
         sources
             .iter()
-            .all(|s| s != ".spago/p/foo/abcd/from-packages/src"),
+            .all(|s| s != ".spago/p/deku-core/65d6e9d/from-packages/src"),
         "sources: {sources:?}"
     );
     assert!(
         sources
             .iter()
-            .all(|s| s != ".spago/p/foo/abcd/from-packages/test"),
+            .all(|s| s != ".spago/p/deku-core/65d6e9d/from-packages/test"),
         "sources: {sources:?}"
     );
 }

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -49,6 +49,42 @@ fn test_lockfile_sources_subdir_precedence_packages_over_workspace_extra_package
 }
 
 #[test]
+fn test_lockfile_sources_subdir_fallback_to_workspace_extra_packages() {
+    let lockfile = serde_json::from_str::<Lockfile>(
+        r#"{
+  "workspace": {
+    "packages": {},
+    "extra_packages": {
+      "foo": { "subdir": "from-workspace" }
+    }
+  },
+  "packages": {
+    "foo": { "type": "git", "rev": "abcd" }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let sources = lockfile
+        .sources()
+        .filter_map(|source| source.to_str().map(|s| s.replace('\\', "/")))
+        .collect::<Vec<_>>();
+
+    assert!(
+        sources
+            .iter()
+            .any(|s| s == ".spago/p/foo/abcd/from-workspace/src"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources
+            .iter()
+            .all(|s| s != ".spago/p/foo/abcd/from-packages/src"),
+        "sources: {sources:?}"
+    );
+}
+
+#[test]
 fn test_parse_lockfile_without_extra_packages() {
     let lockfile = serde_json::from_str::<Lockfile>(
         r#"{

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -35,6 +35,15 @@ fn test_lockfile_sources_subdir_precedence_packages_over_workspace_extra_package
         .collect::<Vec<_>>();
 
     assert!(
+        sources.iter().any(|s| s == ".spago/p/foo/abcd/src"),
+        "sources: {sources:?}"
+    );
+    assert!(
+        sources.iter().any(|s| s == ".spago/p/foo/abcd/test"),
+        "sources: {sources:?}"
+    );
+
+    assert!(
         sources
             .iter()
             .any(|s| s == ".spago/p/foo/abcd/from-packages/src"),

--- a/compiler-lsp/spago/tests/snapshots/lockfile__lockfile_sources.snap
+++ b/compiler-lsp/spago/tests/snapshots/lockfile__lockfile_sources.snap
@@ -77,6 +77,8 @@ expression: sources
 .spago/p/gen-4.0.0/src
 .spago/p/gen-4.0.0/test
 .spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/src
+.spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/subpkg/src
+.spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/subpkg/test
 .spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/test
 .spago/p/halogen-subscriptions-2.0.0/src
 .spago/p/halogen-subscriptions-2.0.0/test

--- a/compiler-lsp/spago/tests/snapshots/lockfile__lockfile_sources.snap
+++ b/compiler-lsp/spago/tests/snapshots/lockfile__lockfile_sources.snap
@@ -1,5 +1,6 @@
 ---
 source: compiler-lsp/spago/tests/lockfile.rs
+assertion_line: 147
 expression: sources
 ---
 ./src
@@ -42,6 +43,10 @@ expression: sources
 .spago/p/datetime-6.1.0/test
 .spago/p/debug-6.0.2/src
 .spago/p/debug-6.0.2/test
+.spago/p/deku-core/65d6e9d289534d13d7d235fbe7f19e6e0bd17c72/deku-core/src
+.spago/p/deku-core/65d6e9d289534d13d7d235fbe7f19e6e0bd17c72/deku-core/test
+.spago/p/deku-core/65d6e9d289534d13d7d235fbe7f19e6e0bd17c72/src
+.spago/p/deku-core/65d6e9d289534d13d7d235fbe7f19e6e0bd17c72/test
 .spago/p/distributive-6.0.0/src
 .spago/p/distributive-6.0.0/test
 .spago/p/effect-4.0.0/src
@@ -56,6 +61,8 @@ expression: sources
 .spago/p/exists-6.0.0/test
 .spago/p/exitcodes-4.0.0/src
 .spago/p/exitcodes-4.0.0/test
+.spago/p/fast-vect-1.2.0/src
+.spago/p/fast-vect-1.2.0/test
 .spago/p/filterable-5.0.0/src
 .spago/p/filterable-5.0.0/test
 .spago/p/foldable-traversable-6.0.0/src
@@ -77,8 +84,6 @@ expression: sources
 .spago/p/gen-4.0.0/src
 .spago/p/gen-4.0.0/test
 .spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/src
-.spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/subpkg/src
-.spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/subpkg/test
 .spago/p/graphql-client/fe24db5f0a79137edb1019b5757ce70d44efae10/test
 .spago/p/halogen-subscriptions-2.0.0/src
 .spago/p/halogen-subscriptions-2.0.0/test
@@ -86,14 +91,20 @@ expression: sources
 .spago/p/heterogeneous-0.6.0/test
 .spago/p/http-methods-6.0.0/src
 .spago/p/http-methods-6.0.0/test
+.spago/p/hyrule-2.3.8/src
+.spago/p/hyrule-2.3.8/test
 .spago/p/identity-6.0.0/src
 .spago/p/identity-6.0.0/test
 .spago/p/integers-6.0.0/src
 .spago/p/integers-6.0.0/test
 .spago/p/invariant-6.0.0/src
 .spago/p/invariant-6.0.0/test
+.spago/p/js-bigints-2.2.1/src
+.spago/p/js-bigints-2.2.1/test
 .spago/p/js-date-8.0.0/src
 .spago/p/js-date-8.0.0/test
+.spago/p/js-timers-6.1.0/src
+.spago/p/js-timers-6.1.0/test
 .spago/p/js-uri-3.1.0/src
 .spago/p/js-uri-3.1.0/test
 .spago/p/lazy-6.0.0/src
@@ -102,6 +113,8 @@ expression: sources
 .spago/p/lcg-4.0.0/test
 .spago/p/lists-7.0.0/src
 .spago/p/lists-7.0.0/test
+.spago/p/literals-1.0.2/src
+.spago/p/literals-1.0.2/test
 .spago/p/maybe-6.0.0/src
 .spago/p/maybe-6.0.0/test
 .spago/p/media-types-6.0.0/src
@@ -174,8 +187,12 @@ expression: sources
 .spago/p/string-parsers-8.0.0/test
 .spago/p/strings-6.0.1/src
 .spago/p/strings-6.0.1/test
+.spago/p/stringutils-0.0.12/src
+.spago/p/stringutils-0.0.12/test
 .spago/p/tailrec-6.1.0/src
 .spago/p/tailrec-6.1.0/test
+.spago/p/tldr-0.0.0/src
+.spago/p/tldr-0.0.0/test
 .spago/p/transformers-6.1.0/src
 .spago/p/transformers-6.1.0/test
 .spago/p/tuples-7.0.0/src
@@ -196,10 +213,14 @@ expression: sources
 .spago/p/unsafe-coerce-6.0.0/test
 .spago/p/unsafe-reference-5.0.0/src
 .spago/p/unsafe-reference-5.0.0/test
+.spago/p/untagged-union-1.0.0/src
+.spago/p/untagged-union-1.0.0/test
 .spago/p/variant-8.0.0/src
 .spago/p/variant-8.0.0/test
 .spago/p/web-dom-6.0.0/src
 .spago/p/web-dom-6.0.0/test
+.spago/p/web-dom-parser-8.0.0/src
+.spago/p/web-dom-parser-8.0.0/test
 .spago/p/web-events-4.0.0/src
 .spago/p/web-events-4.0.0/test
 .spago/p/web-file-4.0.0/src
@@ -208,5 +229,11 @@ expression: sources
 .spago/p/web-html-4.1.0/test
 .spago/p/web-storage-5.0.0/src
 .spago/p/web-storage-5.0.0/test
+.spago/p/web-uievents-5.0.0/src
+.spago/p/web-uievents-5.0.0/test
 .spago/p/web-xhr-5.0.1/src
 .spago/p/web-xhr-5.0.1/test
+.spago/p/yoga-json-5.1.0/src
+.spago/p/yoga-json-5.1.0/test
+.spago/p/yoga-tree-1.0.0/src
+.spago/p/yoga-tree-1.0.0/test


### PR DESCRIPTION
## Summary
Fix PureScript LSP Spago lockfile source discovery for `workspace.extraPackages` entries that use `subdir` (monorepos), so modules inside subpackages get indexed/resolved correctly.

## Motivation
Projects using `extraPackages.<pkg>.subdir` could build with Spago but still get LSP false errors like `InvalidImportStatement Cannot import module 'Deku.Core'`, because the LSP wasn’t constructing `.spago/p/<pkg>/<rev>/<subdir>/{src,test}` roots from `spago.lock`.

## What Changed
- Parse `workspace.extra_packages` from `spago.lock` into the lockfile workspace model (defaulted so lockfiles without it still work).
- In `Lockfile::sources()`, when a package has a `subdir`, add additional candidate roots that insert `<subdir>` before `{src,test}`.
- Determine `subdir` with precedence:
- Prefer `packages.<name>.subdir` when present
- Otherwise fall back to `workspace.extra_packages.<name>.subdir`
- Keep existing non-subdir roots unchanged (additive behavior).

## Tests
- Added/updated `compiler-lsp/spago` lockfile fixture + unit tests asserting:
- `.spago/p/<name>/<rev>/<subdir>/src` and `/test` are included when `subdir` is present
- Precedence behavior when both `packages.*.subdir` and `workspace.extra_packages.*.subdir` exist
- Snapshot updated accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfile handling now supports workspace extra packages and optional subdirectories for git-hosted packages.
  * Source resolution prefers package-specific subdirs, falls back to workspace extra-package subdirs, and excludes unsafe/escaping paths so only normal relative subpaths are used.

* **Tests**
  * Added tests for subdirectory precedence, fallback behavior, and parsing lockfiles without extra packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purefunctor/purescript-alexandrite/pull/106)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->