### PR TITLE
lsp: publish diagnostics on open/change

### DIFF
--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use tracing::level_filters::LevelFilter;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -37,4 +37,29 @@ pub struct Config {
         long_help("This argument also disables the spago.lock integration")
     )]
     pub source_command: Option<String>,
+
+    #[arg(
+        long,
+        help("Publish diagnostics on textDocument/didOpen"),
+        value_name("bool"),
+        action = ArgAction::Set,
+        default_value_t = true
+    )]
+    pub diagnostics_on_open: bool,
+
+    #[arg(
+        long,
+        help("Publish diagnostics on textDocument/didSave"),
+        value_name("bool"),
+        action = ArgAction::Set,
+        default_value_t = true
+    )]
+    pub diagnostics_on_save: bool,
+
+    #[arg(
+        long,
+        help("Publish diagnostics on textDocument/didChange (opt-in)"),
+        default_value_t = false
+    )]
+    pub diagnostics_on_change: bool,
 }

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -313,6 +313,7 @@ fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), L
     }
 
     state.invalidate_workspace_symbols();
+    state.invalidate_suggestions_cache();
 
     if state.config.diagnostics_on_change {
         event::emit_collect_diagnostics(state, p.text_document.uri)?;

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -308,12 +308,35 @@ fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), L
 
     state.invalidate_workspace_symbols();
 
+    if state.config.diagnostics_on_change {
+        event::emit_collect_diagnostics(state, p.text_document.uri)?;
+    }
+
+    Ok(())
+}
+
+fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspError> {
+    let uri = p.text_document.uri.as_str();
+    let text = p.text_document.text.as_str();
+
+    on_change(state, uri, text)?;
+
+    state.invalidate_workspace_symbols();
+    state.invalidate_suggestions_cache();
+
+    if state.config.diagnostics_on_open {
+        event::emit_collect_diagnostics(state, p.text_document.uri)?;
+    }
+
     Ok(())
 }
 
 fn did_save(state: &mut State, p: DidSaveTextDocumentParams) -> Result<(), LspError> {
     state.invalidate_suggestions_cache();
-    event::emit_collect_diagnostics(state, p.text_document.uri)?;
+
+    if state.config.diagnostics_on_save {
+        event::emit_collect_diagnostics(state, p.text_document.uri)?;
+    }
     Ok(())
 }
 
@@ -399,11 +422,12 @@ pub async fn start(config: Arc<cli::Config>) {
             .request_snapshot::<request::References>(references)
             .request_snapshot::<request::WorkspaceSymbolRequest>(workspace_symbols)
             .notification_ext::<notification::Initialized>(initialized)
-            .notification_ext::<notification::DidOpenTextDocument>(|_, _| Ok(()))
+            .notification_ext::<notification::DidOpenTextDocument>(did_open)
             .notification_ext::<notification::DidSaveTextDocument>(did_save)
             .notification_ext::<notification::DidCloseTextDocument>(|_, _| Ok(()))
             .notification_ext::<notification::DidChangeConfiguration>(|_, _| Ok(()))
             .notification_ext::<notification::DidChangeTextDocument>(did_change)
+            .notification_ext::<notification::DidChangeWatchedFiles>(|_, _| Ok(()))
             .event_ext::<event::CollectDiagnostics>(event::collect_diagnostics);
 
         ServiceBuilder::new()
@@ -426,5 +450,8 @@ pub async fn start(config: Arc<cli::Config>) {
         tokio_util::compat::TokioAsyncWriteCompatExt::compat_write(tokio::io::stdout()),
     );
 
-    server.run_buffered(stdin, stdout).await.unwrap();
+    if let Err(error) = server.run_buffered(stdin, stdout).await {
+        tracing::error!(?error, "LSP main loop exited");
+        process::exit(1);
+    }
 }

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -132,8 +132,14 @@ fn initialize(
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
-                text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::FULL,
+                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        open_close: Some(true),
+                        change: Some(TextDocumentSyncKind::FULL),
+                        // Clients may not send didSave unless we advertise it.
+                        save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                        ..TextDocumentSyncOptions::default()
+                    },
                 )),
                 ..ServerCapabilities::default()
             },


### PR DESCRIPTION
## Summary

Fix `purescript-analyzer` LSP behavior so non-editor clients (like opencode) can reliably retrieve diagnostics.

## Changes

- Accept and ignore `workspace/didChangeWatchedFiles` (prevents crashes on common client notifications).
- Publish diagnostics on `textDocument/didOpen` by default.
- Add CLI flags to control diagnostic publication triggers:
  - `--diagnostics-on-open=<bool>` (default: `true`)
  - `--diagnostics-on-save=<bool>` (default: `true`)
  - `--diagnostics-on-change` (default: `false`, opt-in)
- Replace `run_buffered(...).unwrap()` with error logging and graceful shutdown.

## Testing

- `cargo check -p purescript-analyzer --tests`

## Notes

- Diagnostics publication is implemented by emitting the existing internal `CollectDiagnostics` event.
- `--diagnostics-on-change` is intentionally opt-in to avoid expensive work on every change by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flags to control when diagnostics are published: diagnostics-on-open (enabled by default), diagnostics-on-save (enabled by default), and diagnostics-on-change (opt-in).

* **Bug Fixes**
  * Improved LSP document lifecycle handling so diagnostics respect the new flags; caches are invalidated appropriately on open/change/save. Startup error handling now logs failures and exits with a non-zero code on fatal server run errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purefunctor/purescript-alexandrite/pull/107)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->