### PR TITLE
Fix inference for bare row tails in syntax

### DIFF
--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -412,6 +412,12 @@ fn infer_row_kind<Q>(
 where
     Q: ExternalQueries,
 {
+    if items.is_empty()
+        && let Some(tail) = tail
+    {
+        return infer_kind(state, context, *tail);
+    }
+
     let field_kind = state.fresh_unification(context.queries, context.prim.t);
     let row_kind = context.intern_application(context.prim.row, field_kind);
 

--- a/tests-integration/fixtures/checking/1777201800_row_tail/Main.snap
+++ b/tests-integration/fixtures/checking/1777201800_row_tail/Main.snap
@@ -5,18 +5,14 @@ expression: report
 ---
 Terms
 Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-tail ::
-  forall (t4 :: Type) (r :: Row (t4 :: Type)).
-    Proxy @(Row (t4 :: Type)) (r :: Row (t4 :: Type)) -> Int
+tail :: forall (t4 :: Type) (r :: (t4 :: Type)). Proxy @(t4 :: Type) (r :: (t4 :: Type)) -> Int
 nonTail :: forall (t7 :: Type) (r :: (t7 :: Type)). Proxy @(t7 :: Type) (r :: (t7 :: Type)) -> Int
 asTail ::
   forall (t11 :: Type).
-    Array
-      (forall (r :: Row (t11 :: Type)). Proxy @(Row (t11 :: Type)) (r :: Row (t11 :: Type)) -> Int)
+    Array (forall (r :: (t11 :: Type)). Proxy @(t11 :: Type) (r :: (t11 :: Type)) -> Int)
 asNonTail ::
   forall (t15 :: Type).
-    Array
-      (forall (r :: Row (t15 :: Type)). Proxy @(Row (t15 :: Type)) (r :: Row (t15 :: Type)) -> Int)
+    Array (forall (r :: (t15 :: Type)). Proxy @(t15 :: Type) (r :: (t15 :: Type)) -> Int)
 
 Types
 Proxy :: forall (k :: Type). (k :: Type) -> Type

--- a/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.purs
+++ b/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+bareTail :: forall opts. ( | opts ) -> Int
+bareTail _ = 1
+
+plainTail :: forall opts. opts -> Int
+plainTail _ = 2
+
+recordTail :: forall opts. { | opts } -> Int
+recordTail _ = 3
+
+withBareTail = bareTail { option: 1 }
+withPlainTail = plainTail { option: 1 }
+withRecordTail = recordTail { option: 1 }

--- a/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.snap
+++ b/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 28
 expression: report
 ---
 Terms
-bareTail :: forall (t2 :: Type) (opts :: Row (t2 :: Type)). (opts :: Row (t2 :: Type)) -> Int
+bareTail :: forall (opts :: Type). (opts :: Type) -> Int
 plainTail :: forall (opts :: Type). (opts :: Type) -> Int
 recordTail :: forall (opts :: Row Type). {| (opts :: Row Type) } -> Int
 withBareTail :: Int
@@ -12,15 +12,3 @@ withPlainTail :: Int
 withRecordTail :: Int
 
 Types
-
-Diagnostics
-error[CannotUnify]: Cannot unify 'Row ?1' with 'Type'
-  --> 3:26..3:36
-  |
-3 | bareTail :: forall opts. ( | opts ) -> Int
-  |                          ^~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Row ?7' with 'Type'
-  --> 12:25..12:38
-   |
-12 | withBareTail = bareTail { option: 1 }
-   |                         ^~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.snap
+++ b/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/tests/checking/generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+bareTail :: forall (t2 :: Type) (opts :: Row (t2 :: Type)). (opts :: Row (t2 :: Type)) -> Int
+plainTail :: forall (opts :: Type). (opts :: Type) -> Int
+recordTail :: forall (opts :: Row Type). {| (opts :: Row Type) } -> Int
+withBareTail :: Int
+withPlainTail :: Int
+withRecordTail :: Int
+
+Types
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Row ?1' with 'Type'
+  --> 3:26..3:36
+  |
+3 | bareTail :: forall opts. ( | opts ) -> Int
+  |                          ^~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Row ?7' with 'Type'
+  --> 12:25..12:38
+   |
+12 | withBareTail = bareTail { option: 1 }
+   |                         ^~~~~~~~~~~~~

--- a/tests-integration/tests/checking/generated.rs
+++ b/tests-integration/tests/checking/generated.rs
@@ -599,3 +599,5 @@ fn run_test(folder: &str, file: &str) {
 #[rustfmt::skip] #[test] fn test_1778010840_wildcard_arity_main() { run_test("1778010840_wildcard_arity", "Main"); }
 
 #[rustfmt::skip] #[test] fn test_1778051400_record_pun_constrained_field_main() { run_test("1778051400_record_pun_constrained_field", "Main"); }
+
+#[rustfmt::skip] #[test] fn test_1778051460_bare_row_tail_syntax_main() { run_test("1778051460_bare_row_tail_syntax", "Main"); }


### PR DESCRIPTION
## Summary
- Add a regression fixture for bare row tail syntax.
- Infer the kind from the tail directly for empty row syntax.
- Update the existing row-tail snapshot and the new regression snapshot.

## Verification
- `just t checking 1777201800 1778051460 1778051520 1778051580 1778051640 1778051700`