### PR TITLE
Fix constrained pattern scrutinee checking

### DIFF
--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -276,6 +276,7 @@ where
     };
 
     let expression_type = super::infer_expression(state, context, expression)?;
+    let expression_type = toolkit::instantiate_constrained(state, context, expression_type)?;
 
     let Some(binder) = guard.binder else {
         return Ok(());

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -49,9 +49,9 @@ where
     };
 
     let expression_type = if binder::requires_instantiation(context, binder) {
-        toolkit::instantiate_unifications(state, context, expression_type)?
+        toolkit::instantiate_constrained(state, context, expression_type)?
     } else {
-        expression_type
+        toolkit::collect_wanteds(state, context, expression_type)?
     };
 
     let binder_type = binder::check_binder(state, context, binder, expression_type)?;

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -226,6 +226,7 @@ where
     let mut trunk_types = vec![];
     for trunk in trunk.iter() {
         let trunk_type = super::infer_expression(state, context, *trunk)?;
+        let trunk_type = toolkit::instantiate_constrained(state, context, trunk_type)?;
         trunk_types.push(trunk_type);
     }
 

--- a/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.purs
+++ b/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+data Box a = Box a
+
+class Route route where
+  method :: Box route
+
+routeCase :: forall @route. Route route => route
+routeCase = case method @route of Box value -> value
+
+routeLet :: forall @route. Route route => route
+routeLet = let Box value = method @route in value
+
+routeGuard :: forall @route. Route route => route
+routeGuard | Box value <- method @route = value
+routeGuard = routeCase @route

--- a/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.snap
+++ b/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/tests/checking/generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
+method :: forall (@route :: Type). Route (route :: Type) => Box (route :: Type)
+routeCase :: forall (@route :: Type). Route (route :: Type) => (route :: Type)
+routeLet :: forall (@route :: Type). Route (route :: Type) => (route :: Type)
+routeGuard :: forall (@route :: Type). Route (route :: Type) => (route :: Type)
+
+Types
+Box :: Type -> Type
+Route :: Type -> Constraint
+
+Classes
+class forall (route :: Type). Route (route :: Type)
+  method :: forall (@route :: Type). Route (route :: Type) => Box (route :: Type)
+
+Roles
+Box = [Representational]
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Box ?3' with 'Route (route :: Type) => Box (route :: Type)'
+  --> 9:35..9:44
+  |
+9 | routeCase = case method @route of Box value -> value
+  |                                   ^~~~~~~~~
+error[CannotUnify]: Cannot unify 'Box ?5' with 'Route (route :: Type) => Box (route :: Type)'
+  --> 12:16..12:25
+   |
+12 | routeLet = let Box value = method @route in value
+   |                ^~~~~~~~~
+error[CannotUnify]: Cannot unify 'Box ?7' with 'Route (route :: Type) => Box (route :: Type)'
+  --> 15:14..15:23
+   |
+15 | routeGuard | Box value <- method @route = value
+   |              ^~~~~~~~~

--- a/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.snap
+++ b/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.snap
@@ -20,20 +20,3 @@ class forall (route :: Type). Route (route :: Type)
 
 Roles
 Box = [Representational]
-
-Diagnostics
-error[CannotUnify]: Cannot unify 'Box ?3' with 'Route (route :: Type) => Box (route :: Type)'
-  --> 9:35..9:44
-  |
-9 | routeCase = case method @route of Box value -> value
-  |                                   ^~~~~~~~~
-error[CannotUnify]: Cannot unify 'Box ?5' with 'Route (route :: Type) => Box (route :: Type)'
-  --> 12:16..12:25
-   |
-12 | routeLet = let Box value = method @route in value
-   |                ^~~~~~~~~
-error[CannotUnify]: Cannot unify 'Box ?7' with 'Route (route :: Type) => Box (route :: Type)'
-  --> 15:14..15:23
-   |
-15 | routeGuard | Box value <- method @route = value
-   |              ^~~~~~~~~


### PR DESCRIPTION
## Summary
- Add a regression fixture for pattern matching against constrained scrutinees.
- Instantiate constrained expression types before checking case, let, and guard binders.
- Update the regression snapshot to remove the previous unification diagnostics.

## Verification
- `just t checking 1777201800 1778051460 1778051520 1778051580 1778051640 1778051700`