### PR TITLE
Fix open row tail instance matching

### DIFF
--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -566,7 +566,7 @@ where
             Closed | Additional => Ok(MatchType::Apart),
             // we could potentially make progress by having the
             // wanted tail absorb the additional given fields
-            Open(wanted_tail) => blocking_type(state, context, wanted_tail),
+            Open(wanted_tail) => result.and_then(|| blocking_type(state, context, wanted_tail)),
         },
         // If the given row has a tail, match it against the
         // additional fields and tail from the wanted row
@@ -580,7 +580,7 @@ where
             // we cannot match it against fields in the wanted row
             Additional => Ok(MatchType::Apart),
             // we could make progress with an open wanted row
-            Open(wanted_tail) => blocking_type(state, context, wanted_tail),
+            Open(wanted_tail) => result.and_then(|| blocking_type(state, context, wanted_tail)),
             // we can match it directly with a closed wanted row
             Closed => Ok(result),
         },

--- a/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.purs
+++ b/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.purs
@@ -1,0 +1,45 @@
+module Main where
+
+class IsEq a b o | a b -> o where
+  isEq :: a -> b -> o
+
+data Unit = Unit
+data Output = Output
+
+instance IsEq a a Output where
+  isEq _ _ = Output
+else instance IsEq a b Output where
+  isEq _ _ = Output
+
+testEqConcrete :: Output
+testEqConcrete = isEq Unit Unit
+
+testSkolemRight :: forall x. x -> Output
+testSkolemRight x = isEq x Unit
+
+testSkolemLeft :: forall x. x -> Output
+testSkolemLeft x = isEq Unit x
+
+testSkolemIsEq :: forall x y. x -> y -> Output
+testSkolemIsEq x y = isEq y x
+
+class TypeEquals :: forall k. k -> k -> Constraint
+class TypeEquals a b | a -> b, b -> a
+
+instance TypeEquals a a
+
+typeEquals :: forall @a @b. TypeEquals a b => Unit
+typeEquals = Unit
+
+testOpenRows :: Unit
+testOpenRows = typeEquals @{ params :: Unit | _ } @{ query :: Unit | _ }
+
+class RowSame :: forall k. k -> k -> Constraint
+class RowSame a b where
+  rowSame :: Unit
+
+instance RowSame a a where
+  rowSame = Unit
+
+testOpenRowsNoFd :: Unit
+testOpenRowsNoFd = rowSame @{ params :: Unit | _ } @{ query :: Unit | _ }

--- a/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
+++ b/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
@@ -1,0 +1,53 @@
+---
+source: tests-integration/tests/checking/generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+isEq ::
+  forall (@a :: Type) (@b :: Type) (@o :: Type).
+    IsEq (a :: Type) (b :: Type) (o :: Type) => (a :: Type) -> (b :: Type) -> (o :: Type)
+Unit :: Unit
+Output :: Output
+testEqConcrete :: Output
+testSkolemRight :: forall (x :: Type). (x :: Type) -> Output
+testSkolemLeft :: forall (x :: Type). (x :: Type) -> Output
+testSkolemIsEq :: forall (x :: Type) (y :: Type). (x :: Type) -> (y :: Type) -> Output
+typeEquals ::
+  forall (t35 :: Type) (@a :: (t35 :: Type)) (@b :: (t35 :: Type)).
+    TypeEquals @(t35 :: Type) (a :: (t35 :: Type)) (b :: (t35 :: Type)) => Unit
+testOpenRows :: Unit
+rowSame ::
+  forall (k :: Type) (@a :: (k :: Type)) (@b :: (k :: Type)).
+    RowSame @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) => Unit
+testOpenRowsNoFd :: Unit
+
+Types
+IsEq :: Type -> Type -> Type -> Constraint
+Unit :: Type
+Output :: Type
+TypeEquals :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+RowSame :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+
+Classes
+class forall (a :: Type) (b :: Type) (o :: Type). IsEq (a :: Type) (b :: Type) (o :: Type)
+  isEq ::
+  forall (@a :: Type) (@b :: Type) (@o :: Type).
+    IsEq (a :: Type) (b :: Type) (o :: Type) => (a :: Type) -> (b :: Type) -> (o :: Type)
+class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). TypeEquals @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). RowSame @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+  rowSame ::
+  forall (k :: Type) (@a :: (k :: Type)) (@b :: (k :: Type)).
+    RowSame @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) => Unit
+
+Instances
+instance forall (t9 :: Type). IsEq (t9 :: Type) (t9 :: Type) Output
+instance forall (t11 :: Type) (t12 :: Type). IsEq (t11 :: Type) (t12 :: Type) Output
+instance forall (t16 :: Type) (t15 :: (t16 :: Type)).
+  TypeEquals @(t16 :: Type) (t15 :: (t16 :: Type)) (t15 :: (t16 :: Type))
+instance forall (t20 :: Type) (t19 :: (t20 :: Type)).
+  RowSame @(t20 :: Type) (t19 :: (t20 :: Type)) (t19 :: (t20 :: Type))
+
+Roles
+Unit = []
+Output = []

--- a/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.purs
+++ b/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+data K1 = K1
+data Unit = Unit
+
+class C :: Type -> Row Type -> Constraint
+class C key row | key -> row where
+  c :: Proxy key -> Proxy row -> Unit
+
+instance C K1 (a :: Int, b :: Boolean) where
+  c _ _ = Unit
+else instance C key (a :: String, b :: Boolean | r) where
+  c _ _ = Unit
+
+test :: forall key. Proxy key -> Unit
+test key = c key (Proxy :: Proxy (a :: String, b :: Boolean | _))

--- a/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
@@ -35,10 +35,3 @@ Roles
 Proxy = [Phantom]
 K1 = []
 Unit = []
-
-Diagnostics
-error[NoInstanceFound]: No instance found for: C (key :: Type) ( a :: String, b :: Boolean | ?14 )
-  --> 18:1..18:38
-   |
-18 | test :: forall key. Proxy key -> Unit
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
@@ -1,0 +1,44 @@
+---
+source: tests-integration/tests/checking/generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+K1 :: K1
+Unit :: Unit
+c ::
+  forall (@key :: Type) (@row :: Row Type).
+    C (key :: Type) (row :: Row Type) =>
+    Proxy @Type (key :: Type) -> Proxy @(Row Type) (row :: Row Type) -> Unit
+test :: forall (key :: Type). Proxy @Type (key :: Type) -> Unit
+
+Types
+Proxy :: forall (k :: Type). (k :: Type) -> Type
+K1 :: Type
+Unit :: Type
+C :: Type -> Row Type -> Constraint
+
+Classes
+class forall (key :: Type) (row :: Row Type). C (key :: Type) (row :: Row Type)
+  c ::
+  forall (@key :: Type) (@row :: Row Type).
+    C (key :: Type) (row :: Row Type) =>
+    Proxy @Type (key :: Type) -> Proxy @(Row Type) (row :: Row Type) -> Unit
+
+Instances
+instance C K1 ( a :: Int, b :: Boolean )
+instance forall (t4 :: Type) (t5 :: Row Type).
+  C (t4 :: Type) ( a :: String, b :: Boolean | (t5 :: Row Type) )
+
+Roles
+Proxy = [Phantom]
+K1 = []
+Unit = []
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: C (key :: Type) ( a :: String, b :: Boolean | ?14 )
+  --> 18:1..18:38
+   |
+18 | test :: forall key. Proxy key -> Unit
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- Add regression coverage for matching semantics and open row instance chains.
- Preserve prior matching results when checking open row tail blockers.
- Update the open row instance chain snapshot to remove the previous missing-instance diagnostic.

## Verification
- `just t checking 1777201800 1778051460 1778051520 1778051580 1778051640 1778051700`