### PR TITLE
Fix parenthesized record field instantiation

### DIFF
--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -16,11 +16,7 @@ where
 {
     let id = super::infer_expression(state, context, expression)?;
 
-    let Some(kind) = context.lowered.info.get_expression_kind(expression) else {
-        return Ok(id);
-    };
-
-    if should_instantiate_record_field(kind) {
+    if should_instantiate_record_field(context, expression) {
         let id = toolkit::instantiate_unifications(state, context, id)?;
         toolkit::collect_wanteds(state, context, id)
     } else {
@@ -28,7 +24,17 @@ where
     }
 }
 
-fn should_instantiate_record_field(kind: &lowering::ExpressionKind) -> bool {
+fn should_instantiate_record_field<Q>(
+    context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
+) -> bool
+where
+    Q: ExternalQueries,
+{
+    let Some(kind) = context.lowered.info.get_expression_kind(expression) else {
+        return false;
+    };
+
     if matches!(
         kind,
         lowering::ExpressionKind::Constructor { .. }
@@ -38,10 +44,16 @@ fn should_instantiate_record_field(kind: &lowering::ExpressionKind) -> bool {
         return true;
     }
 
-    if let lowering::ExpressionKind::Application { arguments, .. } = kind
+    if let lowering::ExpressionKind::Typed { expression: Some(expression), .. }
+    | lowering::ExpressionKind::Parenthesized { parenthesized: Some(expression) } = kind
+    {
+        return should_instantiate_record_field(context, *expression);
+    }
+
+    if let lowering::ExpressionKind::Application { function: Some(function), arguments } = kind
         && let Some(lowering::ExpressionArgument::Type(_)) = arguments.iter().next()
     {
-        return true;
+        return should_instantiate_record_field(context, *function);
     }
 
     false

--- a/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.purs
+++ b/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+const :: forall @a @b. a -> b -> a
+const a _ = a
+
+choose :: Int -> (forall @a @b. a -> b -> a)
+choose _ a _ = a
+
+normal =
+  { parenthesised: (const)
+  }
+
+prenex =
+  { variable: choose
+  , application: choose 0
+  }

--- a/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/tests/checking/generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+const :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
+choose :: Int -> (forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type))
+normal ::
+  { parenthesised :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type) }
+prenex ::
+  { application :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
+  , variable :: Int -> (forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type))
+  }
+
+Types

--- a/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.snap
@@ -7,7 +7,8 @@ Terms
 const :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
 choose :: Int -> (forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type))
 normal ::
-  { parenthesised :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type) }
+  forall (t9 :: Type) (t8 :: Type).
+    { parenthesised :: (t9 :: Type) -> (t8 :: Type) -> (t9 :: Type) }
 prenex ::
   { application :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
   , variable :: Int -> (forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type))


### PR DESCRIPTION
## Summary
- Add a regression fixture for parenthesized polymorphic record fields.
- Look through parenthesized and typed expressions when deciding whether record fields need instantiation.
- Update the regression snapshot for the instantiated parenthesized field.

## Verification
- `just t checking 1777201800 1778051460 1778051520 1778051580 1778051640 1778051700`