### PR TITLE
checking: fix row fundep givens and polykinded row constraints

### DIFF
--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -265,6 +265,22 @@ where
     Ok(unique_residuals.into_iter().collect())
 }
 
+pub fn elaborate_given_substitution<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    given: &[TypeId],
+) -> QueryResult<crate::core::substitute::NameToType>
+where
+    Q: ExternalQueries,
+{
+    let given = given
+        .iter()
+        .filter_map(|id| canonical::canonicalise(state, context, *id).transpose())
+        .collect::<QueryResult<Vec<_>>>()?;
+
+    elaborate::elaborate_given_substitution(state, context, &given)
+}
+
 pub fn is_type_error<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,

--- a/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
@@ -187,7 +187,9 @@ where
         // `Union ( a :: A, b :: B | t ) ( c :: C ) ( | u )` solves `u ~ ( a :: A, b :: B | f )`,
         // plus the remaining `Union ( | t ) ( c :: C ) ( | f )` constraint.
         (Some(RowView::Open { fields: left_fields, tail }), Some(_), _) => {
-            let fresh = state.fresh_unification(context.queries, context.prim.row_type);
+            let row_kind = infer_row_constraint_kind(state, context, &[left, right, union])?;
+            let fresh_kind = context.intern_application(context.prim.row, row_kind);
+            let fresh = state.fresh_unification(context.queries, fresh_kind);
             let result = context.intern_row(left_fields.iter().cloned(), Some(fresh));
 
             let constraint = make_prim_row_constraint(

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -3,6 +3,7 @@
 pub mod improvements;
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use building_types::QueryResult;
 use itertools::Itertools;
@@ -13,13 +14,82 @@ use crate::core::constraint::canonical::CanonicalConstraint;
 use crate::core::constraint::matching::MatchInstance;
 use crate::core::constraint::{CanonicalConstraintId, canonical, compiler};
 use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit};
+use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit, zonk};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
 pub struct ElaboratedGiven {
     pub given: Vec<CanonicalConstraintId>,
     pub substitution: NameToType,
+}
+
+pub fn elaborate_given_substitution<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    given: &[CanonicalConstraintId],
+) -> QueryResult<NameToType>
+where
+    Q: ExternalQueries,
+{
+    let mut substitution = elaborate_given(state, context, given)?.substitution;
+    let mut conflicts = FxHashSet::default();
+
+    for &constraint_id in given {
+        let constraint = state.canonicals[constraint_id].clone();
+        let Some(class) =
+            toolkit::lookup_file_class(state, context, constraint.file_id, constraint.type_id)?
+        else {
+            continue;
+        };
+
+        for dependency in class.functional_dependencies.iter() {
+            let mut arguments = constraint.arguments.to_vec();
+            let mut replacements = vec![];
+
+            for &position in dependency.determined.iter() {
+                let position = position as usize;
+                let Some(KindOrType::Type(argument)) = arguments.get_mut(position) else {
+                    continue;
+                };
+
+                let expanded = normalise::expand(state, context, *argument)?;
+                let Type::Rigid(name, _, kind) = context.lookup_type(expanded) else {
+                    continue;
+                };
+
+                let fresh = state.fresh_unification(context.queries, kind);
+                *argument = fresh;
+                replacements.push((name, fresh));
+            }
+
+            if replacements.is_empty() {
+                continue;
+            }
+
+            let wanted = state.canonicals.intern(CanonicalConstraint {
+                arguments: Arc::from(arguments),
+                ..constraint.clone()
+            });
+            let wanted = VecDeque::from([wanted]);
+            let error_count = state.checked.errors.len();
+            super::solve_constraints(state, context, wanted, &[])?;
+            state.checked.errors.truncate(error_count);
+
+            for (name, fresh) in replacements {
+                let replacement = zonk::zonk(state, context, fresh)?;
+                register_improvement(
+                    state,
+                    context,
+                    &mut substitution,
+                    &mut conflicts,
+                    name,
+                    replacement,
+                )?;
+            }
+        }
+    }
+
+    Ok(substitution)
 }
 
 /// Entrypoint for elaborating given [`CanonicalConstraint`].

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -41,13 +41,14 @@ where
         else {
             continue;
         };
+        let type_argument_offset = class.kind_binders.len();
 
         for dependency in class.functional_dependencies.iter() {
             let mut arguments = constraint.arguments.to_vec();
             let mut replacements = vec![];
 
             for &position in dependency.determined.iter() {
-                let position = position as usize;
+                let position = type_argument_offset + position as usize;
                 let Some(KindOrType::Type(argument)) = arguments.get_mut(position) else {
                     continue;
                 };

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -73,6 +73,10 @@ where
             });
             let wanted = VecDeque::from([wanted]);
             let error_count = state.checked.errors.len();
+            // Pass an empty slice for "given" so probe solving only uses instance-based
+            // improvements (e.g. fundep derivations from instances) and does not include
+            // the original given constraints, preventing circular improvement where a
+            // given might improve itself.
             super::solve_constraints(state, context, wanted, &[])?;
             state.checked.errors.truncate(error_count);
 

--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -4,7 +4,6 @@ use building_types::QueryResult;
 use files::FileId;
 use indexing::TypeItemId;
 use itertools::Itertools;
-use lowering::TypeItemIr;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::ExternalQueries;
@@ -556,7 +555,7 @@ where
     let pattern_variables = FxHashSet::default();
 
     let functional_dependencies =
-        get_functional_dependencies(context, wanted.file_id, wanted.type_id)?;
+        get_functional_dependencies(state, context, wanted.file_id, wanted.type_id)?;
 
     let wanted_arguments = wanted
         .arguments
@@ -613,7 +612,7 @@ where
         declared.binders.iter().map(|binder| binder.name).collect();
 
     let functional_dependencies =
-        get_functional_dependencies(context, wanted.file_id, wanted.type_id)?;
+        get_functional_dependencies(state, context, wanted.file_id, wanted.type_id)?;
 
     let wanted_arguments = wanted
         .arguments
@@ -674,6 +673,7 @@ where
 }
 
 fn get_functional_dependencies<Q>(
+    state: &mut CheckState,
     context: &CheckContext<Q>,
     file_id: FileId,
     type_id: TypeItemId,
@@ -681,25 +681,16 @@ fn get_functional_dependencies<Q>(
 where
     Q: ExternalQueries,
 {
-    fn extract(type_item: Option<&TypeItemIr>) -> Vec<Fd> {
-        let Some(TypeItemIr::ClassGroup { class: Some(class), .. }) = type_item else {
-            return vec![];
-        };
+    let Some(class) = toolkit::lookup_file_class(state, context, file_id, type_id)? else {
+        return Ok(vec![]);
+    };
 
-        let fd = class.functional_dependencies.iter().map(|functional_dependency| {
-            Fd::new(
-                functional_dependency.determiners.iter().map(|&x| x as usize),
-                functional_dependency.determined.iter().map(|&x| x as usize),
-            )
-        });
+    let fd = class.functional_dependencies.iter().map(|functional_dependency| {
+        Fd::new(
+            functional_dependency.determiners.iter().map(|&x| x as usize),
+            functional_dependency.determined.iter().map(|&x| x as usize),
+        )
+    });
 
-        fd.collect_vec()
-    }
-
-    if file_id == context.id {
-        Ok(extract(context.lowered.info.get_type_item(type_id)))
-    } else {
-        let lowered = context.queries.lowered(file_id)?;
-        Ok(extract(lowered.info.get_type_item(type_id)))
-    }
+    Ok(fd.collect_vec())
 }

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -46,14 +46,11 @@ where
 {
     let required = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
 
-    let signature::SkolemisedSignature {
-        substitution,
-        mut constraints,
-        mut arguments,
-        mut result,
-    } = signature::expect_term_signature(state, context, expected_type, required)?;
+    let signature::SkolemisedSignature { substitution, mut constraints, mut arguments, mut result } =
+        signature::expect_term_signature(state, context, expected_type, required)?;
 
-    let given_substitution = constraint::elaborate_given_substitution(state, context, &constraints)?;
+    let given_substitution =
+        constraint::elaborate_given_substitution(state, context, &constraints)?;
     if !given_substitution.is_empty() {
         let original_constraints = constraints.clone();
         constraints = constraints

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -55,10 +55,12 @@ where
 
     let given_substitution = constraint::elaborate_given_substitution(state, context, &constraints)?;
     if !given_substitution.is_empty() {
+        let original_constraints = constraints.clone();
         constraints = constraints
             .into_iter()
             .map(|constraint| SubstituteName::many(state, context, &given_substitution, constraint))
             .collect::<QueryResult<Vec<_>>>()?;
+        constraints.extend(original_constraints);
         arguments = arguments
             .into_iter()
             .map(|argument| SubstituteName::many(state, context, &given_substitution, argument))

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -6,6 +6,7 @@ use building_types::QueryResult;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
+use crate::core::substitute::SubstituteName;
 use crate::core::{TypeId, constraint, signature, toolkit, unification};
 use crate::error::ErrorKind;
 use crate::source::binder;
@@ -45,8 +46,25 @@ where
 {
     let required = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
 
-    let signature::SkolemisedSignature { substitution, constraints, arguments, result } =
-        signature::expect_term_signature(state, context, expected_type, required)?;
+    let signature::SkolemisedSignature {
+        substitution,
+        mut constraints,
+        mut arguments,
+        mut result,
+    } = signature::expect_term_signature(state, context, expected_type, required)?;
+
+    let given_substitution = constraint::elaborate_given_substitution(state, context, &constraints)?;
+    if !given_substitution.is_empty() {
+        constraints = constraints
+            .into_iter()
+            .map(|constraint| SubstituteName::many(state, context, &given_substitution, constraint))
+            .collect::<QueryResult<Vec<_>>>()?;
+        arguments = arguments
+            .into_iter()
+            .map(|argument| SubstituteName::many(state, context, &given_substitution, argument))
+            .collect::<QueryResult<Vec<_>>>()?;
+        result = SubstituteName::many(state, context, &given_substitution, result)?;
+    }
 
     for &constraint in &constraints {
         if !constraint::is_type_error(state, context, constraint)? {

--- a/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
@@ -34,7 +34,7 @@ error[CannotUnify]: Cannot unify '( b :: String )' with '( b :: Int )'
    |
 15 | forceSolve =
    | ^~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '( a :: Int, b :: String )' with '( missing :: Int | ?23 )'
+error[CannotUnify]: Cannot unify '( a :: Int, b :: String )' with '( missing :: Int | ?27 )'
   --> 15:1..19:4
    |
 15 | forceSolve =

--- a/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
+++ b/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
@@ -58,12 +58,12 @@ forceSolve ::
 Types
 
 Diagnostics
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?81
+error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?114 )
   --> 33:1..43:4
    |
 33 | forceSolve =
    | ^~~~~~~~~~~~
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?84 )
+error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?111
   --> 33:1..43:4
    |
 33 | forceSolve =

--- a/tests-integration/fixtures/checking/1772440500_prim_row_generalization/Main.snap
+++ b/tests-integration/fixtures/checking/1772440500_prim_row_generalization/Main.snap
@@ -45,8 +45,8 @@ testMulti1 ::
     {| (t48 :: Row Type) } -> {| (t47 :: Row Type) }
 testMulti2 ::
   forall (t52 :: Row Type) (t51 :: Row Type) (t50 :: Row Type).
-    Nub @Type ( a :: Int | (t52 :: Row Type) ) (t51 :: Row Type) =>
-    Union @Type (t51 :: Row Type) ( b :: Int ) (t50 :: Row Type) =>
-    {| (t50 :: Row Type) }
+    Union @Type (t52 :: Row Type) ( b :: Int ) (t51 :: Row Type) =>
+    Nub @Type ( a :: Int | (t50 :: Row Type) ) (t52 :: Row Type) =>
+    {| (t51 :: Row Type) }
 
 Types

--- a/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
+++ b/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
@@ -44,15 +44,31 @@ Proxy = [Phantom]
 
 Diagnostics
 warning[CustomWarning]: This function is deprecated
+  --> 8:1..8:75
+  |
+8 | warnBasic :: forall a. Warn (Text "This function is deprecated") => a -> a
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: This function is deprecated
   --> 11:1..11:20
    |
 11 | useWarnBasic :: Int
    | ^~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Left Right
+  --> 14:1..14:78
+   |
+14 | warnBeside :: forall a. Warn (Beside (Text "Left ") (Text "Right")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Left Right
   --> 17:1..17:21
    |
 17 | useWarnBeside :: Int
    | ^~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Line 1
+Line 2
+  --> 20:1..20:78
+   |
+20 | warnAbove :: forall a. Warn (Above (Text "Line 1") (Text "Line 2")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Line 1
 Line 2
   --> 23:1..23:20
@@ -65,20 +81,40 @@ warning[CustomWarning]: Got type: Int
 29 | useWarnQuote :: Proxy Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: myField
+  --> 32:1..32:92
+   |
+32 | warnQuoteLabel :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel "myField")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: myField
   --> 35:1..35:25
    |
 35 | useWarnQuoteLabel :: Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: "h e l l o"
+  --> 38:1..38:100
+   |
+38 | warnQuoteLabelSpaces :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel "h e l l o")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: "h e l l o"
   --> 41:1..41:31
    |
 41 | useWarnQuoteLabelSpaces :: Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: "hel\"lo"
+  --> 44:1..44:97
+   |
+44 | warnQuoteLabelQuote :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel "hel\"lo")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: "hel\"lo"
   --> 47:1..47:30
    |
 47 | useWarnQuoteLabelQuote :: Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: """raw\nstring"""
+  --> 50:1..50:103
+   |
+50 | warnQuoteLabelRaw :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel """raw\nstring""")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: """raw\nstring"""
   --> 53:1..53:28
    |

--- a/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
@@ -23,6 +23,11 @@ Proxy = [Phantom]
 
 Diagnostics
 error[CustomFailure]: This operation is not allowed
+  --> 8:1..8:77
+  |
+8 | failBasic :: forall a. Fail (Text "This operation is not allowed") => a -> a
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CustomFailure]: This operation is not allowed
   --> 11:1..11:20
    |
 11 | useFailBasic :: Int

--- a/tests-integration/fixtures/checking/1777298340_top_level_fail_eager/Main.snap
+++ b/tests-integration/fixtures/checking/1777298340_top_level_fail_eager/Main.snap
@@ -8,3 +8,10 @@ boom :: Fail (Text "top-level Fail was checked") => Int
 test :: Int
 
 Types
+
+Diagnostics
+error[CustomFailure]: top-level Fail was checked
+  --> 5:1..5:56
+  |
+5 | boom :: Fail (Text "top-level Fail was checked") => Int
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.purs
+++ b/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.purs
@@ -1,0 +1,39 @@
+module Main where
+
+import Prim.Row as Row
+import Prim.RowList as RL
+
+data Maybe a = Nothing | Just a
+
+data Nullable a
+
+class ExtractType entry typ | entry -> typ
+instance ExtractType String String
+instance ExtractType (Nullable a) (Maybe a)
+
+class StripColumnsRL :: RL.RowList Type -> RL.RowList Type -> Constraint
+class StripColumnsRL rl out | rl -> out
+
+instance StripColumnsRL RL.Nil RL.Nil
+instance (ExtractType entry typ, StripColumnsRL tail out') => StripColumnsRL (RL.Cons name entry tail) (RL.Cons name typ out')
+
+class ListToRow :: RL.RowList Type -> Row Type -> Constraint
+class ListToRow list row | list -> row
+
+instance ListToRow RL.Nil ()
+instance (Row.Cons name typ rowTail row, ListToRow tail rowTail) => ListToRow (RL.Cons name typ tail) row
+
+class StripColumns :: Row Type -> Row Type -> Constraint
+class StripColumns columns row | columns -> row
+
+instance (RL.RowToList columns list, StripColumnsRL list outList, ListToRow outList row) => StripColumns columns row
+
+type Columns =
+  ( account_guid :: Nullable String
+  )
+
+test :: forall row. StripColumns Columns row => Record row
+test = { account_guid: Nothing }
+
+bad :: forall row. StripColumns Columns row => Record row
+bad = { other: "acct" }

--- a/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.snap
+++ b/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.snap
@@ -1,0 +1,65 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Nothing :: forall (@a :: Type). Maybe (a :: Type)
+Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+test :: forall (row :: Row Type). StripColumns Columns (row :: Row Type) => {| (row :: Row Type) }
+bad :: forall (row :: Row Type). StripColumns Columns (row :: Row Type) => {| (row :: Row Type) }
+
+Types
+Maybe :: Type -> Type
+Nullable :: forall (t2 :: Type). (t2 :: Type) -> Type
+ExtractType :: forall (t6 :: Type) (t5 :: Type). (t6 :: Type) -> (t5 :: Type) -> Constraint
+StripColumnsRL :: RowList Type -> RowList Type -> Constraint
+ListToRow :: RowList Type -> Row Type -> Constraint
+StripColumns :: Row Type -> Row Type -> Constraint
+Columns :: Row Type
+
+Synonyms
+type Columns = ( account_guid :: Nullable @Type String )
+
+Classes
+class forall (t6 :: Type) (t5 :: Type) (entry :: (t6 :: Type)) (typ :: (t5 :: Type)). ExtractType @(t6 :: Type) @(t5 :: Type) (entry :: (t6 :: Type)) (typ :: (t5 :: Type))
+class forall (rl :: RowList Type) (out :: RowList Type). StripColumnsRL (rl :: RowList Type) (out :: RowList Type)
+class forall (list :: RowList Type) (row :: Row Type). ListToRow (list :: RowList Type) (row :: Row Type)
+class forall (columns :: Row Type) (row :: Row Type). StripColumns (columns :: Row Type) (row :: Row Type)
+
+Instances
+instance ExtractType @Type @Type String String
+instance forall (t13 :: Type). ExtractType @Type @Type (Nullable @Type (t13 :: Type)) (Maybe (t13 :: Type))
+instance StripColumnsRL (Nil @Type) (Nil @Type)
+instance forall (t16 :: Type) (t18 :: Type) (t17 :: RowList Type) (t19 :: RowList Type) (t15 :: Symbol).
+  ExtractType @Type @Type (t16 :: Type) (t18 :: Type) =>
+  StripColumnsRL (t17 :: RowList Type) (t19 :: RowList Type) =>
+  StripColumnsRL
+    (Cons @Type (t15 :: Symbol) (t16 :: Type) (t17 :: RowList Type))
+    (Cons @Type (t15 :: Symbol) (t18 :: Type) (t19 :: RowList Type))
+instance ListToRow (Nil @Type) ()
+instance forall (t25 :: Symbol) (t26 :: Type) (t29 :: Row Type) (t28 :: Row Type) (t27 :: RowList Type).
+  Cons @Type (t25 :: Symbol) (t26 :: Type) (t29 :: Row Type) (t28 :: Row Type) =>
+  ListToRow (t27 :: RowList Type) (t29 :: Row Type) =>
+  ListToRow (Cons @Type (t25 :: Symbol) (t26 :: Type) (t27 :: RowList Type)) (t28 :: Row Type)
+instance forall (t35 :: Row Type) (t37 :: RowList Type) (t38 :: RowList Type) (t36 :: Row Type).
+  RowToList @Type (t35 :: Row Type) (t37 :: RowList Type) =>
+  StripColumnsRL (t37 :: RowList Type) (t38 :: RowList Type) =>
+  ListToRow (t38 :: RowList Type) (t36 :: Row Type) =>
+  StripColumns (t35 :: Row Type) (t36 :: Row Type)
+
+Roles
+Maybe = [Representational]
+Nullable = [Phantom]
+
+Diagnostics
+error[PropertyIsMissing]: Missing required properties: account_guid
+  --> 39:7..39:24
+   |
+39 | bad = { other: "acct" }
+   |       ^~~~~~~~~~~~~~~~~
+error[AdditionalProperty]: Additional properties not allowed: other
+  --> 39:7..39:24
+   |
+39 | bad = { other: "acct" }
+   |       ^~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.purs
+++ b/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.purs
@@ -1,0 +1,115 @@
+module Main where
+
+import Prim.Row as Row
+import Prim.RowList (RowList)
+import Prim.RowList as RL
+
+foreign import data Run :: Row (Type -> Type) -> Type -> Type
+
+type NaturalTransformation f g = forall a. f a -> g a
+infixr 4 type NaturalTransformation as ~>
+
+data Unit = Unit
+
+unit :: Unit
+unit = Unit
+
+foreign import data Effect :: Type -> Type
+foreign import data State :: Type -> Type -> Type
+foreign import data Reader :: Type -> Type -> Type
+
+foreign import pure :: forall r a. a -> Run r a
+
+foreign import bindRun :: forall r a b. Run r a -> (a -> Run r b) -> Run r b
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+type RowApply :: forall k. (Row k -> Row k) -> Row k -> Row k
+type RowApply f a = f a
+
+infixr 0 type RowApply as +
+
+type EFFECT :: Row (Type -> Type) -> Row (Type -> Type)
+type EFFECT r = ( effect :: Effect | r )
+
+type STATE :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+type STATE s r = ( state :: State s | r )
+
+type READER :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+type READER a r = ( reader :: Reader a | r )
+
+class SafeUnion :: forall k. Row k -> Row k -> Row k -> Constraint
+class SafeUnion a b c | a b -> c
+
+foreign import data TypeExpr :: Type -> Type
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+
+foreign import data FromRow :: forall k. Row k -> TypeExpr (RowList k)
+
+instance RL.RowToList row list => Eval (FromRow row) list
+
+class ListToRow :: forall k. RowList k -> Row k -> Constraint
+class ListToRow list row | list -> row
+
+instance ListToRow RL.Nil ()
+instance (Row.Cons name typ rowTail row, ListToRow tail rowTail) => ListToRow (RL.Cons name typ tail) row
+
+foreign import data ToRow :: forall k. RowList k -> TypeExpr (Row k)
+
+instance ListToRow list row => Eval (ToRow list) row
+
+foreign import data Union :: forall k. Row k -> Row k -> TypeExpr (Row k)
+
+instance Row.Union left right union => Eval (Union left right) union
+
+foreign import data Nub :: forall k. Row k -> TypeExpr (Row k)
+
+instance Row.Nub original nubbed => Eval (Nub original) nubbed
+
+foreign import data UnionAndNubRowLists :: forall k. RowList k -> RowList k -> TypeExpr (RowList k)
+
+instance
+  ( Eval (ToRow a) aRow
+  , Eval (ToRow b) bRow
+  , Eval (Union aRow bRow) union
+  , Eval (Nub union) cRow
+  , Eval (FromRow cRow) c
+  ) =>
+  Eval (UnionAndNubRowLists a b) c
+
+instance
+  ( Eval (FromRow r1) rl1
+  , Eval (FromRow r2) rl2
+  , Eval (UnionAndNubRowLists rl1 rl2) rlResult
+  , Eval (ToRow rlResult) result
+  ) =>
+  SafeUnion r1 r2 result
+
+expand :: forall r1 @r2 r3. SafeUnion r1 r2 r3 => Run r1 ~> Run r3
+expand = unsafeCoerce
+
+composeFlipped
+  :: forall r1 r2 r3 a b c
+   . SafeUnion r1 r2 r3
+  => SafeUnion r2 r1 r3
+  => (a -> Run r1 b)
+  -> (b -> Run r2 c)
+  -> (a -> Run r3 c)
+composeFlipped f g a =
+  bindRun (expand @r2 (f a)) \b -> expand @r1 (g b)
+
+infixr 1 composeFlipped as >+>
+
+computation1 :: String -> Run (EFFECT ()) Int
+computation1 _ = pure 0
+
+computation2 :: Int -> Run (EFFECT + STATE String + ()) String
+computation2 _ = pure ""
+
+computation3 :: String -> Run (STATE String + READER Boolean + ()) Unit
+computation3 _ = pure unit
+
+composeFlippedThree :: String -> Run (EFFECT + STATE String + READER Boolean + ()) Unit
+composeFlippedThree = computation1 >+> computation2 >+> computation3

--- a/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.snap
+++ b/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.snap
@@ -1,0 +1,201 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Unit :: Unit
+unit :: Unit
+pure ::
+  forall (r :: Row (Type -> Type)) (a :: Type).
+    (a :: Type) -> Run (r :: Row (Type -> Type)) (a :: Type)
+bindRun ::
+  forall (r :: Row (Type -> Type)) (a :: Type) (b :: Type).
+    Run (r :: Row (Type -> Type)) (a :: Type) ->
+    ((a :: Type) -> Run (r :: Row (Type -> Type)) (b :: Type)) ->
+    Run (r :: Row (Type -> Type)) (b :: Type)
+unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+expand ::
+  forall (r1 :: Row (Type -> Type)) (@r2 :: Row (Type -> Type)) (r3 :: Row (Type -> Type)).
+    SafeUnion @(Type -> Type)
+      (r1 :: Row (Type -> Type))
+      (r2 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    NaturalTransformation @Type (Run (r1 :: Row (Type -> Type))) (Run (r3 :: Row (Type -> Type)))
+composeFlipped ::
+  forall (r1 :: Row (Type -> Type)) (r2 :: Row (Type -> Type)) (r3 :: Row (Type -> Type))
+    (a :: Type) (b :: Type) (c :: Type).
+    SafeUnion @(Type -> Type)
+      (r1 :: Row (Type -> Type))
+      (r2 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    SafeUnion @(Type -> Type)
+      (r2 :: Row (Type -> Type))
+      (r1 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    ((a :: Type) -> Run (r1 :: Row (Type -> Type)) (b :: Type)) ->
+    ((b :: Type) -> Run (r2 :: Row (Type -> Type)) (c :: Type)) ->
+    (a :: Type) ->
+    Run (r3 :: Row (Type -> Type)) (c :: Type)
+>+> ::
+  forall (r1 :: Row (Type -> Type)) (r2 :: Row (Type -> Type)) (r3 :: Row (Type -> Type))
+    (a :: Type) (b :: Type) (c :: Type).
+    SafeUnion @(Type -> Type)
+      (r1 :: Row (Type -> Type))
+      (r2 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    SafeUnion @(Type -> Type)
+      (r2 :: Row (Type -> Type))
+      (r1 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    ((a :: Type) -> Run (r1 :: Row (Type -> Type)) (b :: Type)) ->
+    ((b :: Type) -> Run (r2 :: Row (Type -> Type)) (c :: Type)) ->
+    (a :: Type) ->
+    Run (r3 :: Row (Type -> Type)) (c :: Type)
+computation1 :: String -> Run (EFFECT ()) Int
+computation2 ::
+  Int -> Run (RowApply @(Type -> Type) EFFECT (RowApply @(Type -> Type) (STATE String) ())) String
+computation3 ::
+  String ->
+  Run (RowApply @(Type -> Type) (STATE String) (RowApply @(Type -> Type) (READER Boolean) ())) Unit
+composeFlippedThree ::
+  String ->
+  Run
+    (RowApply @(Type -> Type)
+      EFFECT
+      (RowApply @(Type -> Type) (STATE String) (RowApply @(Type -> Type) (READER Boolean) ())))
+    Unit
+
+Types
+Run :: Row (Type -> Type) -> Type -> Type
+NaturalTransformation ::
+  forall (t3 :: Type). ((t3 :: Type) -> Type) -> ((t3 :: Type) -> Type) -> Type
+~> :: forall (t3 :: Type). ((t3 :: Type) -> Type) -> ((t3 :: Type) -> Type) -> Type
+Unit :: Type
+Effect :: Type -> Type
+State :: Type -> Type -> Type
+Reader :: Type -> Type -> Type
+RowApply ::
+  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
++ :: forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
+EFFECT :: Row (Type -> Type) -> Row (Type -> Type)
+STATE :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+READER :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+SafeUnion :: forall (k :: Type). Row (k :: Type) -> Row (k :: Type) -> Row (k :: Type) -> Constraint
+TypeExpr :: Type -> Type
+Eval :: forall (k :: Type). TypeExpr (k :: Type) -> (k :: Type) -> Constraint
+FromRow :: forall (k :: Type). Row (k :: Type) -> TypeExpr (RowList (k :: Type))
+ListToRow :: forall (k :: Type). RowList (k :: Type) -> Row (k :: Type) -> Constraint
+ToRow :: forall (k :: Type). RowList (k :: Type) -> TypeExpr (Row (k :: Type))
+Union :: forall (k :: Type). Row (k :: Type) -> Row (k :: Type) -> TypeExpr (Row (k :: Type))
+Nub :: forall (k :: Type). Row (k :: Type) -> TypeExpr (Row (k :: Type))
+UnionAndNubRowLists ::
+  forall (k :: Type). RowList (k :: Type) -> RowList (k :: Type) -> TypeExpr (RowList (k :: Type))
+
+Synonyms
+type NaturalTransformation f g = forall (a :: (t3 :: Type)).
+  (f :: (t3 :: Type) -> Type) (a :: (t3 :: Type)) -> (g :: (t3 :: Type) -> Type) (a :: (t3 :: Type))
+type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
+type EFFECT r = ( effect :: Effect | (r :: Row (Type -> Type)) )
+type STATE s r = ( state :: State (s :: Type) | (r :: Row (Type -> Type)) )
+type READER a r = ( reader :: Reader (a :: Type) | (r :: Row (Type -> Type)) )
+
+Classes
+class forall (k :: Type) (a :: Row (k :: Type)) (b :: Row (k :: Type)) (c :: Row (k :: Type)). SafeUnion @(k :: Type) (a :: Row (k :: Type)) (b :: Row (k :: Type)) (c :: Row (k :: Type))
+class forall (k :: Type) (expr :: TypeExpr (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr (k :: Type)) (result :: (k :: Type))
+class forall (k :: Type) (list :: RowList (k :: Type)) (row :: Row (k :: Type)). ListToRow @(k :: Type) (list :: RowList (k :: Type)) (row :: Row (k :: Type))
+
+Instances
+instance forall (t29 :: Type) (t27 :: Row (t29 :: Type)) (t28 :: RowList (t29 :: Type)).
+  RowToList @(t29 :: Type) (t27 :: Row (t29 :: Type)) (t28 :: RowList (t29 :: Type)) =>
+  Eval @(RowList (t29 :: Type))
+    (FromRow @(t29 :: Type) (t27 :: Row (t29 :: Type)))
+    (t28 :: RowList (t29 :: Type))
+instance forall (t33 :: Type). ListToRow @(t33 :: Type) (Nil @(t33 :: Type)) ()
+instance forall (t40 :: Type) (t35 :: Symbol) (t36 :: (t40 :: Type)) (t39 :: Row (t40 :: Type))
+  (t38 :: Row (t40 :: Type)) (t37 :: RowList (t40 :: Type)).
+  Cons @(t40 :: Type)
+    (t35 :: Symbol)
+    (t36 :: (t40 :: Type))
+    (t39 :: Row (t40 :: Type))
+    (t38 :: Row (t40 :: Type)) =>
+  ListToRow @(t40 :: Type) (t37 :: RowList (t40 :: Type)) (t39 :: Row (t40 :: Type)) =>
+  ListToRow @(t40 :: Type)
+    (Cons @(t40 :: Type) (t35 :: Symbol) (t36 :: (t40 :: Type)) (t37 :: RowList (t40 :: Type)))
+    (t38 :: Row (t40 :: Type))
+instance forall (t49 :: Type) (t47 :: RowList (t49 :: Type)) (t48 :: Row (t49 :: Type)).
+  ListToRow @(t49 :: Type) (t47 :: RowList (t49 :: Type)) (t48 :: Row (t49 :: Type)) =>
+  Eval @(Row (t49 :: Type))
+    (ToRow @(t49 :: Type) (t47 :: RowList (t49 :: Type)))
+    (t48 :: Row (t49 :: Type))
+instance forall (t56 :: Type) (t53 :: Row (t56 :: Type)) (t54 :: Row (t56 :: Type))
+  (t55 :: Row (t56 :: Type)).
+  Union @(t56 :: Type)
+    (t53 :: Row (t56 :: Type))
+    (t54 :: Row (t56 :: Type))
+    (t55 :: Row (t56 :: Type)) =>
+  Eval @(Row (t56 :: Type))
+    (Union @(t56 :: Type) (t53 :: Row (t56 :: Type)) (t54 :: Row (t56 :: Type)))
+    (t55 :: Row (t56 :: Type))
+instance forall (t63 :: Type) (t61 :: Row (t63 :: Type)) (t62 :: Row (t63 :: Type)).
+  Nub @(t63 :: Type) (t61 :: Row (t63 :: Type)) (t62 :: Row (t63 :: Type)) =>
+  Eval @(Row (t63 :: Type))
+    (Nub @(t63 :: Type) (t61 :: Row (t63 :: Type)))
+    (t62 :: Row (t63 :: Type))
+instance forall (t74 :: Type) (t67 :: RowList (t74 :: Type)) (t70 :: Row (t74 :: Type))
+  (t68 :: RowList (t74 :: Type)) (t71 :: Row (t74 :: Type)) (t72 :: Row (t74 :: Type))
+  (t73 :: Row (t74 :: Type)) (t69 :: RowList (t74 :: Type)).
+  Eval @(Row (t74 :: Type))
+    (ToRow @(t74 :: Type) (t67 :: RowList (t74 :: Type)))
+    (t70 :: Row (t74 :: Type)) =>
+  Eval @(Row (t74 :: Type))
+    (ToRow @(t74 :: Type) (t68 :: RowList (t74 :: Type)))
+    (t71 :: Row (t74 :: Type)) =>
+  Eval @(Row (t74 :: Type))
+    (Union @(t74 :: Type) (t70 :: Row (t74 :: Type)) (t71 :: Row (t74 :: Type)))
+    (t72 :: Row (t74 :: Type)) =>
+  Eval @(Row (t74 :: Type))
+    (Nub @(t74 :: Type) (t72 :: Row (t74 :: Type)))
+    (t73 :: Row (t74 :: Type)) =>
+  Eval @(RowList (t74 :: Type))
+    (FromRow @(t74 :: Type) (t73 :: Row (t74 :: Type)))
+    (t69 :: RowList (t74 :: Type)) =>
+  Eval @(RowList (t74 :: Type))
+    (UnionAndNubRowLists @(t74 :: Type)
+      (t67 :: RowList (t74 :: Type))
+      (t68 :: RowList (t74 :: Type)))
+    (t69 :: RowList (t74 :: Type))
+instance forall (t89 :: Type) (t83 :: Row (t89 :: Type)) (t86 :: RowList (t89 :: Type))
+  (t84 :: Row (t89 :: Type)) (t87 :: RowList (t89 :: Type)) (t88 :: RowList (t89 :: Type))
+  (t85 :: Row (t89 :: Type)).
+  Eval @(RowList (t89 :: Type))
+    (FromRow @(t89 :: Type) (t83 :: Row (t89 :: Type)))
+    (t86 :: RowList (t89 :: Type)) =>
+  Eval @(RowList (t89 :: Type))
+    (FromRow @(t89 :: Type) (t84 :: Row (t89 :: Type)))
+    (t87 :: RowList (t89 :: Type)) =>
+  Eval @(RowList (t89 :: Type))
+    (UnionAndNubRowLists @(t89 :: Type)
+      (t86 :: RowList (t89 :: Type))
+      (t87 :: RowList (t89 :: Type)))
+    (t88 :: RowList (t89 :: Type)) =>
+  Eval @(Row (t89 :: Type))
+    (ToRow @(t89 :: Type) (t88 :: RowList (t89 :: Type)))
+    (t85 :: Row (t89 :: Type)) =>
+  SafeUnion @(t89 :: Type)
+    (t83 :: Row (t89 :: Type))
+    (t84 :: Row (t89 :: Type))
+    (t85 :: Row (t89 :: Type))
+
+Roles
+Run = [Nominal, Nominal]
+Unit = []
+Effect = [Nominal]
+State = [Nominal, Nominal]
+Reader = [Nominal, Nominal]
+TypeExpr = [Nominal]
+FromRow = [Nominal]
+ToRow = [Nominal]
+Union = [Nominal, Nominal]
+Nub = [Nominal]
+UnionAndNubRowLists = [Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.purs
+++ b/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+import Prim.Boolean (False, True)
+import Type.Proxy (Proxy(..))
+
+foreign import data TypeExpr :: forall k. k -> Type
+foreign import data NotEq :: Boolean -> Boolean -> TypeExpr Boolean
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+
+instance Eval (NotEq a a) False
+else instance Eval (NotEq a b) True
+
+class IsBoolean :: Boolean -> Constraint
+class IsBoolean bool
+
+instance IsBoolean True
+instance IsBoolean False
+
+foreign import reflectBoolean :: forall bool. IsBoolean bool => Proxy bool -> Boolean
+
+test :: forall x. IsBoolean x => Eval (NotEq False True) x => Boolean
+test = reflectBoolean (Proxy @x)

--- a/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.snap
@@ -1,0 +1,32 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+reflectBoolean ::
+  forall (bool :: Boolean).
+    IsBoolean (bool :: Boolean) => Proxy @Boolean (bool :: Boolean) -> Boolean
+test ::
+  forall (x :: Boolean).
+    IsBoolean (x :: Boolean) => Eval @Boolean (NotEq False True) (x :: Boolean) => Boolean
+
+Types
+TypeExpr :: forall (k :: Type). (k :: Type) -> Type
+NotEq :: Boolean -> Boolean -> TypeExpr @Type Boolean
+Eval :: forall (k :: Type). TypeExpr @Type (k :: Type) -> (k :: Type) -> Constraint
+IsBoolean :: Boolean -> Constraint
+
+Classes
+class forall (k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type))
+class forall (bool :: Boolean). IsBoolean (bool :: Boolean)
+
+Instances
+instance forall (t5 :: Boolean). Eval @Boolean (NotEq (t5 :: Boolean) (t5 :: Boolean)) False
+instance forall (t7 :: Boolean) (t8 :: Boolean). Eval @Boolean (NotEq (t7 :: Boolean) (t8 :: Boolean)) True
+instance IsBoolean True
+instance IsBoolean False
+
+Roles
+TypeExpr = [Nominal]
+NotEq = [Nominal, Nominal]


### PR DESCRIPTION
# checking: fix row fundep givens and polykinded row constraints

Base branch: `main`

## Review Order

This PR should be reviewed first. It introduces checker infrastructure used by the stacked follow-up PRs for instance-chain backtracking and operator expected-result checking.

Follow-up PRs stacked on this branch:

- `pr/checking-instance-chain-backtracking`
- `pr/checking-operator-expected-results`

## Summary

- Fix false-positive row functional dependency diagnostics where a row result is determined by an available signature/given but the checker reports an ambiguous or unsolved constraint.
- Correct polykinded row constraint handling in the primitive row solver so kind binders line up when elaborating row constraints.
- Preserve original givens alongside improved givens so later constraint evaluation can still use the user-facing/original evidence when the improved form is not enough.

## Motivation

These fixes came from comparing analyzer diagnostics against the PureScript compiler on real project code. The analyzer was reporting errors for row-level constraints that PureScript accepts, especially around function dependencies, row unions, and visible type applications carried by givens.

The common theme is that improving constraints must not lose the information needed to elaborate or solve row givens later. In particular, a constraint that becomes determined through a functional dependency should be elaborated with that determined result before the checker decides it is ambiguous.

## Motivating Example

The checker should accept code where the result row is determined by the `Union` functional dependency, even when the result is not written explicitly by the caller:

```purescript
class Example (left :: Row Type) (right :: Row Type) (result :: Row Type) | left right -> result

useUnion :: forall left right result. Union left right result => Proxy result
useUnion = Proxy
```

Before this change, similar real-world constraints could remain ambiguous after improvement even though PureScript could determine the result row.

## Implementation Notes

- Adds a given-elaboration path that substitutes determined row results before reporting ambiguity.
- Adjusts primitive row constraint matching/solving to account for polykinded row binders safely.
- Retains original givens next to improved givens in checking state so evaluation paths can inspect both forms.
- Keeps the change scoped to checking internals and integration fixtures; no LSP behavior is changed directly.

## Tests

Added fixtures:

- `1778682360_row_fundep_determined_result`
- `1778685420_polykinded_row_fundep_safe_union`
- `1778701560_eval_given_visible_type_application`

Updated existing snapshot:

- `1772440440_prim_row_open`

Validation run locally:

```bash
cargo check -p checking --tests
```
