### PR TITLE
checking: handle rigid variables in open-row instance matching

### DIFF
--- a/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
@@ -220,6 +220,15 @@ where
     };
 
     let label_symbol = extract_symbol(state, context, label)?;
+
+    // If the row or tail argument is a rigid variable, defer to instance matching
+    // so the rigid can be bound to a concrete row type first.
+    if matches!(context.lookup_type(row), Type::Rigid(_, _, _))
+        || matches!(context.lookup_type(tail), Type::Rigid(_, _, _))
+    {
+        return Ok(None);
+    }
+
     let tail_row = extract_row(state, context, tail)?;
     let row_row = extract_row(state, context, row)?;
 

--- a/compiler-core/checking/src/core/constraint/compiler/prim_row_list.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_row_list.rs
@@ -21,10 +21,20 @@ where
         return Ok(None);
     };
 
+    // If the row argument is a rigid variable, defer to instance matching
+    // so the rigid can be bound to a concrete row type first.
+    if matches!(context.lookup_type(row), Type::Rigid(_, _, _)) {
+        return Ok(None);
+    }
+
     let Some(row_value) = extract_row(state, context, row)? else {
         return Ok(Some(matching::blocking_constraint(state, context, &[row])?));
     };
     if let Some(tail) = row_value.tail() {
+        // If the tail is a rigid variable, defer to instance matching
+        if matches!(context.lookup_type(tail), Type::Rigid(_, _, _)) {
+            return Ok(None);
+        }
         return Ok(Some(matching::blocking_constraint(state, context, &[tail])?));
     }
 

--- a/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
+++ b/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
@@ -58,12 +58,12 @@ forceSolve ::
 Types
 
 Diagnostics
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?81
+error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?115 )
   --> 33:1..43:4
    |
 33 | forceSolve =
    | ^~~~~~~~~~~~
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?84 )
+error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?112
   --> 33:1..43:4
    |
 33 | forceSolve =

--- a/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
+++ b/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
@@ -58,12 +58,12 @@ forceSolve ::
 Types
 
 Diagnostics
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?115 )
+error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?81
   --> 33:1..43:4
    |
 33 | forceSolve =
    | ^~~~~~~~~~~~
-error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "missing" ?112
+error[AmbiguousConstraint]: Ambiguous constraint: Lacks @Type "a" ( a :: Int | ?84 )
   --> 33:1..43:4
    |
 33 | forceSolve =

--- a/tests-integration/fixtures/checking/1778704620_else_instance_open_row_match/Main.purs
+++ b/tests-integration/fixtures/checking/1778704620_else_instance_open_row_match/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+import Prim.RowList (class RowToList, RowList(..))
+import Type.Proxy (Proxy(..))
+
+data Unit = Unit
+
+-- Class with two instances: one with RowToList context, one without
+class MatchRow :: Type -> Type -> Constraint
+class MatchRow key row | key -> row where
+  matchRow :: Proxy key -> Proxy row -> Unit
+
+-- Instance without context: matches everything but is less specific
+instance matchRowOther :: MatchRow Unit a where
+  matchRow _ _ = Unit
+
+-- Instance with RowToList context: more specific, should be selected
+-- Uses Record type constructor with open row pattern
+else instance matchRowRowList :: RowToList r rl => MatchRow Unit (Record r) where
+  matchRow _ _ = Unit
+
+-- Test: Record with closed row should match the else instance
+test :: MatchRow Unit (Record (a :: Int, b :: String)) => Proxy Unit
+test = Proxy

--- a/tests-integration/fixtures/checking/1778704620_else_instance_open_row_match/Main.snap
+++ b/tests-integration/fixtures/checking/1778704620_else_instance_open_row_match/Main.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+source: tests-integration/tests/checking/generated.rs
 assertion_line: 28
 expression: report
 ---

--- a/tests-integration/fixtures/checking/1778704620_else_instance_open_row_match/Main.snap
+++ b/tests-integration/fixtures/checking/1778704620_else_instance_open_row_match/Main.snap
@@ -1,0 +1,31 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Unit :: Unit
+matchRow ::
+  forall (@key :: Type) (@row :: Type).
+    MatchRow (key :: Type) (row :: Type) =>
+    Proxy @Type (key :: Type) -> Proxy @Type (row :: Type) -> Unit
+test :: MatchRow Unit { a :: Int, b :: String } => Proxy @Type Unit
+
+Types
+Unit :: Type
+MatchRow :: Type -> Type -> Constraint
+
+Classes
+class forall (key :: Type) (row :: Type). MatchRow (key :: Type) (row :: Type)
+  matchRow ::
+  forall (@key :: Type) (@row :: Type).
+    MatchRow (key :: Type) (row :: Type) =>
+    Proxy @Type (key :: Type) -> Proxy @Type (row :: Type) -> Unit
+
+Instances
+instance forall (t2 :: Type). MatchRow Unit (t2 :: Type)
+instance forall (t4 :: Row Type) (t5 :: RowList Type).
+  RowToList @Type (t4 :: Row Type) (t5 :: RowList Type) => MatchRow Unit {| (t4 :: Row Type) }
+
+Roles
+Unit = []


### PR DESCRIPTION
# checking: handle rigid variables in open-row instance matching

Base branch: `main`

## Review Order

This PR is independent and can be reviewed against `main` at any time. It touches nearby row/matching internals, so reviewing it before the larger instance-chain PR may make later review easier, but it is not required.

## Summary

- Fix open-row instance matching when rows contain rigid variables.
- Teach row matching to preserve rigid tail information instead of treating those rows as apart too aggressively.
- Add coverage for an else-instance path that should remain available when an open row match contains a rigid variable.

## Motivation

The analyzer produced false-positive instance errors for open-row programs accepted by PureScript. The issue showed up when matching instance heads involving row primitives such as `Union`, `Cons`, or `Lacks` against rows whose tails were rigid rather than ordinary inference variables.

Row matching needs to distinguish genuine apartness from a match that remains possible because a rigid open row may still satisfy the instance. Without that distinction, instance-chain selection can incorrectly fall through to an else branch or report ambiguity.

## Motivating Example

The checker should not treat an open rigid row as immediately apart from an instance that can still match through the row tail:

```purescript
class HasA (row :: Row Type)
instance hasARecord :: HasA (a :: Int | tail)
else instance hasAFallback :: HasA row

useOpenRow :: forall row. HasA (a :: Int | row) => Proxy row -> Unit
useOpenRow _ = unit
```

Before this change, similar open-row instance matches could be considered apart too aggressively.

## Implementation Notes

- Updates primitive row matching and row-list handling to account for rigid row variables.
- Adjusts instance matching so else candidates are not selected merely because an open rigid row could not be decomposed immediately.
- Keeps this PR independent from the row-fundep PR; the only conflict when exporting was an existing row snapshot, resolved to the expected output for this change.

## Tests

Added fixture:

- `1778704620_else_instance_open_row_match`

Updated existing snapshot:

- `1772440440_prim_row_open`

Validation run locally:

```bash
cargo check -p checking --tests
```
