### PR TITLE
checking: backtrack instance-chain subgoals and bound recursive probes

### DIFF
--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -25,109 +25,10 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::{KindOrType, Type, TypeId, unification};
+use crate::core::{TypeId, unification};
 use crate::error::ErrorKind;
 use crate::implication::{ImplicationId, Patterns};
 use crate::state::{CheckState, UnificationState};
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum ProbeTypeKey {
-    Application(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
-    KindApplication(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
-    Forall(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
-    Constrained(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
-    Function(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
-    Kinded(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
-    Constructor(files::FileId, indexing::TypeItemId),
-    Integer(i32),
-    String(lowering::StringKind, crate::core::SmolStrId),
-    Row(Vec<(smol_str::SmolStr, ProbeTypeKey)>, Option<Box<ProbeTypeKey>>),
-    Variable,
-    Free(crate::core::SmolStrId),
-    Unknown(crate::core::SmolStrId),
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum ProbeArgKey {
-    Kind(ProbeTypeKey),
-    Type(ProbeTypeKey),
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct ProbeKey {
-    file_id: files::FileId,
-    type_id: indexing::TypeItemId,
-    arguments: Vec<ProbeArgKey>,
-}
-
-fn probe_type_key<Q>(state: &CheckState, context: &CheckContext<Q>, id: TypeId) -> ProbeTypeKey
-where
-    Q: ExternalQueries,
-{
-    match context.lookup_type(id) {
-        Type::Application(left, right) => ProbeTypeKey::Application(
-            Box::new(probe_type_key(state, context, left)),
-            Box::new(probe_type_key(state, context, right)),
-        ),
-        Type::KindApplication(left, right) => ProbeTypeKey::KindApplication(
-            Box::new(probe_type_key(state, context, left)),
-            Box::new(probe_type_key(state, context, right)),
-        ),
-        Type::Forall(binder, inner) => ProbeTypeKey::Forall(
-            Box::new(probe_type_key(state, context, context.lookup_forall_binder(binder).kind)),
-            Box::new(probe_type_key(state, context, inner)),
-        ),
-        Type::Constrained(left, right) => ProbeTypeKey::Constrained(
-            Box::new(probe_type_key(state, context, left)),
-            Box::new(probe_type_key(state, context, right)),
-        ),
-        Type::Function(left, right) => ProbeTypeKey::Function(
-            Box::new(probe_type_key(state, context, left)),
-            Box::new(probe_type_key(state, context, right)),
-        ),
-        Type::Kinded(left, right) => ProbeTypeKey::Kinded(
-            Box::new(probe_type_key(state, context, left)),
-            Box::new(probe_type_key(state, context, right)),
-        ),
-        Type::Constructor(file_id, type_id) => ProbeTypeKey::Constructor(file_id, type_id),
-        Type::Integer(value) => ProbeTypeKey::Integer(value),
-        Type::String(kind, value) => ProbeTypeKey::String(kind, value),
-        Type::Row(row_id) => {
-            let row = context.lookup_row_type(row_id);
-            let fields = row
-                .fields
-                .iter()
-                .map(|field| (field.label.clone(), probe_type_key(state, context, field.id)))
-                .collect();
-            let tail = row.tail.map(|tail| Box::new(probe_type_key(state, context, tail)));
-            ProbeTypeKey::Row(fields, tail)
-        }
-        Type::Rigid(..) | Type::Unification(_) => ProbeTypeKey::Variable,
-        Type::Free(value) => ProbeTypeKey::Free(value),
-        Type::Unknown(value) => ProbeTypeKey::Unknown(value),
-    }
-}
-
-fn probe_key<Q>(
-    state: &CheckState,
-    context: &CheckContext<Q>,
-    id: CanonicalConstraintId,
-) -> ProbeKey
-where
-    Q: ExternalQueries,
-{
-    let canonical = &state.canonicals[id];
-    let arguments = canonical
-        .arguments
-        .iter()
-        .map(|argument| match *argument {
-            KindOrType::Kind(id) => ProbeArgKey::Kind(probe_type_key(state, context, id)),
-            KindOrType::Type(id) => ProbeArgKey::Type(probe_type_key(state, context, id)),
-        })
-        .collect();
-
-    ProbeKey { file_id: canonical.file_id, type_id: canonical.type_id, arguments }
-}
 
 pub fn solve_implication<Q>(
     state: &mut CheckState,
@@ -281,16 +182,6 @@ where
         let Some(wanted) = work.constraints.pop_front() else {
             break 'work;
         };
-
-        if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last()
-            && {
-                let wanted_probe = probe_key(state, context, wanted);
-                ancestors.iter().any(|probe| probe.iter().any(|active| active == &wanted_probe))
-            }
-        {
-            residuals.push(wanted);
-            continue 'work;
-        }
 
         let mut blocked = FxHashSet::default();
         let mut blocked_on_skolem = false;

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -282,14 +282,12 @@ where
             break 'work;
         };
 
-        if !state.candidate_constraint_probes.is_empty() {
-            let wanted_probe = probe_key(state, context, wanted);
-            if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last()
-                && ancestors.iter().any(|probe| probe.iter().any(|active| active == &wanted_probe))
-            {
-                residuals.push(wanted);
-                continue 'work;
-            }
+        let wanted_probe = probe_key(state, context, wanted);
+        if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last()
+            && ancestors.iter().any(|probe| probe.iter().any(|active| active == &wanted_probe))
+        {
+            residuals.push(wanted);
+            continue 'work;
         }
 
         let mut blocked = FxHashSet::default();

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -282,9 +282,11 @@ where
             break 'work;
         };
 
-        let wanted_probe = probe_key(state, context, wanted);
         if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last()
-            && ancestors.iter().any(|probe| probe.iter().any(|active| active == &wanted_probe))
+            && {
+                let wanted_probe = probe_key(state, context, wanted);
+                ancestors.iter().any(|probe| probe.iter().any(|active| active == &wanted_probe))
+            }
         {
             residuals.push(wanted);
             continue 'work;

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -265,6 +265,22 @@ where
     Ok(unique_residuals.into_iter().collect())
 }
 
+pub fn elaborate_given_substitution<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    given: &[TypeId],
+) -> QueryResult<crate::core::substitute::NameToType>
+where
+    Q: ExternalQueries,
+{
+    let given = given
+        .iter()
+        .filter_map(|id| canonical::canonicalise(state, context, *id).transpose())
+        .collect::<QueryResult<Vec<_>>>()?;
+
+    elaborate::elaborate_given_substitution(state, context, &given)
+}
+
 pub fn is_type_error<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -284,14 +284,11 @@ where
 
         if !state.candidate_constraint_probes.is_empty() {
             let wanted_probe = probe_key(state, context, wanted);
-            if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last() {
-                if ancestors
-                    .iter()
-                    .any(|probe| probe.iter().any(|active| active == &wanted_probe))
-                {
-                    residuals.push(wanted);
-                    continue 'work;
-                }
+            if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last()
+                && ancestors.iter().any(|probe| probe.iter().any(|active| active == &wanted_probe))
+            {
+                residuals.push(wanted);
+                continue 'work;
             }
         }
 

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -284,13 +284,14 @@ where
 
         if !state.candidate_constraint_probes.is_empty() {
             let wanted_probe = probe_key(state, context, wanted);
-            if state
-                .candidate_constraint_probes
-                .iter()
-                .any(|probe| probe.iter().any(|active| active == &wanted_probe))
-            {
-                residuals.push(wanted);
-                continue 'work;
+            if let Some((_, ancestors)) = state.candidate_constraint_probes.split_last() {
+                if ancestors
+                    .iter()
+                    .any(|probe| probe.iter().any(|active| active == &wanted_probe))
+                {
+                    residuals.push(wanted);
+                    continue 'work;
+                }
             }
         }
 

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -25,10 +25,109 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::{TypeId, unification};
+use crate::core::{KindOrType, Type, TypeId, unification};
 use crate::error::ErrorKind;
 use crate::implication::{ImplicationId, Patterns};
 use crate::state::{CheckState, UnificationState};
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum ProbeTypeKey {
+    Application(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
+    KindApplication(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
+    Forall(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
+    Constrained(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
+    Function(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
+    Kinded(Box<ProbeTypeKey>, Box<ProbeTypeKey>),
+    Constructor(files::FileId, indexing::TypeItemId),
+    Integer(i32),
+    String(lowering::StringKind, crate::core::SmolStrId),
+    Row(Vec<(smol_str::SmolStr, ProbeTypeKey)>, Option<Box<ProbeTypeKey>>),
+    Variable,
+    Free(crate::core::SmolStrId),
+    Unknown(crate::core::SmolStrId),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum ProbeArgKey {
+    Kind(ProbeTypeKey),
+    Type(ProbeTypeKey),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ProbeKey {
+    file_id: files::FileId,
+    type_id: indexing::TypeItemId,
+    arguments: Vec<ProbeArgKey>,
+}
+
+fn probe_type_key<Q>(state: &CheckState, context: &CheckContext<Q>, id: TypeId) -> ProbeTypeKey
+where
+    Q: ExternalQueries,
+{
+    match context.lookup_type(id) {
+        Type::Application(left, right) => ProbeTypeKey::Application(
+            Box::new(probe_type_key(state, context, left)),
+            Box::new(probe_type_key(state, context, right)),
+        ),
+        Type::KindApplication(left, right) => ProbeTypeKey::KindApplication(
+            Box::new(probe_type_key(state, context, left)),
+            Box::new(probe_type_key(state, context, right)),
+        ),
+        Type::Forall(binder, inner) => ProbeTypeKey::Forall(
+            Box::new(probe_type_key(state, context, context.lookup_forall_binder(binder).kind)),
+            Box::new(probe_type_key(state, context, inner)),
+        ),
+        Type::Constrained(left, right) => ProbeTypeKey::Constrained(
+            Box::new(probe_type_key(state, context, left)),
+            Box::new(probe_type_key(state, context, right)),
+        ),
+        Type::Function(left, right) => ProbeTypeKey::Function(
+            Box::new(probe_type_key(state, context, left)),
+            Box::new(probe_type_key(state, context, right)),
+        ),
+        Type::Kinded(left, right) => ProbeTypeKey::Kinded(
+            Box::new(probe_type_key(state, context, left)),
+            Box::new(probe_type_key(state, context, right)),
+        ),
+        Type::Constructor(file_id, type_id) => ProbeTypeKey::Constructor(file_id, type_id),
+        Type::Integer(value) => ProbeTypeKey::Integer(value),
+        Type::String(kind, value) => ProbeTypeKey::String(kind, value),
+        Type::Row(row_id) => {
+            let row = context.lookup_row_type(row_id);
+            let fields = row
+                .fields
+                .iter()
+                .map(|field| (field.label.clone(), probe_type_key(state, context, field.id)))
+                .collect();
+            let tail = row.tail.map(|tail| Box::new(probe_type_key(state, context, tail)));
+            ProbeTypeKey::Row(fields, tail)
+        }
+        Type::Rigid(..) | Type::Unification(_) => ProbeTypeKey::Variable,
+        Type::Free(value) => ProbeTypeKey::Free(value),
+        Type::Unknown(value) => ProbeTypeKey::Unknown(value),
+    }
+}
+
+fn probe_key<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    id: CanonicalConstraintId,
+) -> ProbeKey
+where
+    Q: ExternalQueries,
+{
+    let canonical = &state.canonicals[id];
+    let arguments = canonical
+        .arguments
+        .iter()
+        .map(|argument| match *argument {
+            KindOrType::Kind(id) => ProbeArgKey::Kind(probe_type_key(state, context, id)),
+            KindOrType::Type(id) => ProbeArgKey::Type(probe_type_key(state, context, id)),
+        })
+        .collect();
+
+    ProbeKey { file_id: canonical.file_id, type_id: canonical.type_id, arguments }
+}
 
 pub fn solve_implication<Q>(
     state: &mut CheckState,
@@ -182,6 +281,18 @@ where
         let Some(wanted) = work.constraints.pop_front() else {
             break 'work;
         };
+
+        if !state.candidate_constraint_probes.is_empty() {
+            let wanted_probe = probe_key(state, context, wanted);
+            if state
+                .candidate_constraint_probes
+                .iter()
+                .any(|probe| probe.iter().any(|active| active == &wanted_probe))
+            {
+                residuals.push(wanted);
+                continue 'work;
+            }
+        }
 
         let mut blocked = FxHashSet::default();
         let mut blocked_on_skolem = false;

--- a/compiler-core/checking/src/core/constraint/canonical.rs
+++ b/compiler-core/checking/src/core/constraint/canonical.rs
@@ -46,6 +46,10 @@ pub struct Canonicals {
     cache: FxHashMap<TypeId, CanonicalConstraintId>,
 }
 
+pub(crate) struct CanonicalsCheckpoint {
+    cache: FxHashMap<TypeId, CanonicalConstraintId>,
+}
+
 impl Canonicals {
     pub fn intern(&mut self, canonical: CanonicalConstraint) -> Id<CanonicalConstraint> {
         self.interner.intern(canonical)
@@ -80,6 +84,14 @@ impl Canonicals {
         // taken into account before checking that the cache is not overwritten.
         // debug_assert!(previous.is_none(), "critical violation: canonical cache overwrite");
         id
+    }
+
+    pub(crate) fn checkpoint(&self) -> CanonicalsCheckpoint {
+        CanonicalsCheckpoint { cache: self.cache.clone() }
+    }
+
+    pub(crate) fn restore(&mut self, checkpoint: CanonicalsCheckpoint) {
+        self.cache = checkpoint.cache;
     }
 }
 

--- a/compiler-core/checking/src/core/constraint/canonical.rs
+++ b/compiler-core/checking/src/core/constraint/canonical.rs
@@ -46,10 +46,6 @@ pub struct Canonicals {
     cache: FxHashMap<TypeId, CanonicalConstraintId>,
 }
 
-pub(crate) struct CanonicalsCheckpoint {
-    cache: FxHashMap<TypeId, CanonicalConstraintId>,
-}
-
 impl Canonicals {
     pub fn intern(&mut self, canonical: CanonicalConstraint) -> Id<CanonicalConstraint> {
         self.interner.intern(canonical)
@@ -84,14 +80,6 @@ impl Canonicals {
         // taken into account before checking that the cache is not overwritten.
         // debug_assert!(previous.is_none(), "critical violation: canonical cache overwrite");
         id
-    }
-
-    pub(crate) fn checkpoint(&self) -> CanonicalsCheckpoint {
-        CanonicalsCheckpoint { cache: self.cache.clone() }
-    }
-
-    pub(crate) fn restore(&mut self, checkpoint: CanonicalsCheckpoint) {
-        self.cache = checkpoint.cache;
     }
 }
 

--- a/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
@@ -187,7 +187,9 @@ where
         // `Union ( a :: A, b :: B | t ) ( c :: C ) ( | u )` solves `u ~ ( a :: A, b :: B | f )`,
         // plus the remaining `Union ( | t ) ( c :: C ) ( | f )` constraint.
         (Some(RowView::Open { fields: left_fields, tail }), Some(_), _) => {
-            let fresh = state.fresh_unification(context.queries, context.prim.row_type);
+            let row_kind = infer_row_constraint_kind(state, context, &[left, right, union])?;
+            let fresh_kind = context.intern_application(context.prim.row, row_kind);
+            let fresh = state.fresh_unification(context.queries, fresh_kind);
             let result = context.intern_row(left_fields.iter().cloned(), Some(fresh));
 
             let constraint = make_prim_row_constraint(

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -3,6 +3,7 @@
 pub mod improvements;
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use building_types::QueryResult;
 use itertools::Itertools;
@@ -13,13 +14,82 @@ use crate::core::constraint::canonical::CanonicalConstraint;
 use crate::core::constraint::matching::MatchInstance;
 use crate::core::constraint::{CanonicalConstraintId, canonical, compiler};
 use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit};
+use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit, zonk};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
 pub struct ElaboratedGiven {
     pub given: Vec<CanonicalConstraintId>,
     pub substitution: NameToType,
+}
+
+pub fn elaborate_given_substitution<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    given: &[CanonicalConstraintId],
+) -> QueryResult<NameToType>
+where
+    Q: ExternalQueries,
+{
+    let mut substitution = elaborate_given(state, context, given)?.substitution;
+    let mut conflicts = FxHashSet::default();
+
+    for &constraint_id in given {
+        let constraint = state.canonicals[constraint_id].clone();
+        let Some(class) =
+            toolkit::lookup_file_class(state, context, constraint.file_id, constraint.type_id)?
+        else {
+            continue;
+        };
+
+        for dependency in class.functional_dependencies.iter() {
+            let mut arguments = constraint.arguments.to_vec();
+            let mut replacements = vec![];
+
+            for &position in dependency.determined.iter() {
+                let position = position as usize;
+                let Some(KindOrType::Type(argument)) = arguments.get_mut(position) else {
+                    continue;
+                };
+
+                let expanded = normalise::expand(state, context, *argument)?;
+                let Type::Rigid(name, _, kind) = context.lookup_type(expanded) else {
+                    continue;
+                };
+
+                let fresh = state.fresh_unification(context.queries, kind);
+                *argument = fresh;
+                replacements.push((name, fresh));
+            }
+
+            if replacements.is_empty() {
+                continue;
+            }
+
+            let wanted = state.canonicals.intern(CanonicalConstraint {
+                arguments: Arc::from(arguments),
+                ..constraint.clone()
+            });
+            let wanted = VecDeque::from([wanted]);
+            let error_count = state.checked.errors.len();
+            super::solve_constraints(state, context, wanted, &[])?;
+            state.checked.errors.truncate(error_count);
+
+            for (name, fresh) in replacements {
+                let replacement = zonk::zonk(state, context, fresh)?;
+                register_improvement(
+                    state,
+                    context,
+                    &mut substitution,
+                    &mut conflicts,
+                    name,
+                    replacement,
+                )?;
+            }
+        }
+    }
+
+    Ok(substitution)
 }
 
 /// Entrypoint for elaborating given [`CanonicalConstraint`].

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -41,13 +41,14 @@ where
         else {
             continue;
         };
+        let type_argument_offset = class.kind_binders.len();
 
         for dependency in class.functional_dependencies.iter() {
             let mut arguments = constraint.arguments.to_vec();
             let mut replacements = vec![];
 
             for &position in dependency.determined.iter() {
-                let position = position as usize;
+                let position = type_argument_offset + position as usize;
                 let Some(KindOrType::Type(argument)) = arguments.get_mut(position) else {
                     continue;
                 };

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -73,6 +73,10 @@ where
             });
             let wanted = VecDeque::from([wanted]);
             let error_count = state.checked.errors.len();
+            // Pass an empty slice for "given" so probe solving only uses instance-based
+            // improvements (e.g. fundep derivations from instances) and does not include
+            // the original given constraints, preventing circular improvement where a
+            // given might improve itself.
             super::solve_constraints(state, context, wanted, &[])?;
             state.checked.errors.truncate(error_count);
 

--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -229,26 +229,43 @@ where
     Q: ExternalQueries,
     Compare: FnMut(&mut CheckState, &CheckContext<Q>, TypeId, TypeId) -> QueryResult<MatchType>,
 {
-    let left_tail = context.intern_row(left_fields, left_tail);
-    let right_tail = context.intern_row(right_fields, right_tail);
+    enum RowRest {
+        Additional,
+        Open(TypeId),
+        Closed,
+    }
 
-    if let (Type::Row(left_row), Type::Row(right_row)) =
-        (context.lookup_type(left_tail), context.lookup_type(right_tail))
-    {
-        let left_row = context.lookup_row_type(left_row);
-        let right_row = context.lookup_row_type(right_row);
-
-        if left_row.fields.is_empty()
-            && left_row.tail.is_none()
-            && right_row.fields.is_empty()
-            && right_row.tail.is_none()
-        {
-            Ok(MatchType::Match { bindings: vec![] })
-        } else {
-            Ok(MatchType::Apart)
+    impl RowRest {
+        fn new(fields: &[RowField], tail: Option<TypeId>) -> RowRest {
+            if !fields.is_empty() {
+                RowRest::Additional
+            } else if let Some(tail) = tail {
+                RowRest::Open(tail)
+            } else {
+                RowRest::Closed
+            }
         }
-    } else {
-        compare(state, context, left_tail, right_tail)
+    }
+
+    use RowRest::*;
+
+    let left_rest = RowRest::new(&left_fields, left_tail);
+    let right_rest = RowRest::new(&right_fields, right_tail);
+
+    match right_rest {
+        Additional => match left_rest {
+            Closed | Additional => Ok(MatchType::Apart),
+            Open(left_tail) => blocking_type(state, context, left_tail),
+        },
+        Open(right_tail) => {
+            let left = context.intern_row(left_fields, left_tail);
+            compare(state, context, left, right_tail)
+        }
+        Closed => match left_rest {
+            Additional => Ok(MatchType::Apart),
+            Open(left_tail) => blocking_type(state, context, left_tail),
+            Closed => Ok(MatchType::Match { bindings: vec![] }),
+        },
     }
 }
 
@@ -518,6 +535,18 @@ where
     }
 
     Ok(walker.blocking)
+}
+
+pub fn blocking_type<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    id: TypeId,
+) -> QueryResult<MatchType>
+where
+    Q: ExternalQueries,
+{
+    let stuck = collect_blocking(state, context, &[id])?;
+    if !stuck.is_empty() { Ok(MatchType::Stuck { stuck }) } else { Ok(MatchType::Apart) }
 }
 
 pub fn blocking_constraint<Q>(

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -46,14 +46,11 @@ where
 {
     let required = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
 
-    let signature::SkolemisedSignature {
-        substitution,
-        mut constraints,
-        mut arguments,
-        mut result,
-    } = signature::expect_term_signature(state, context, expected_type, required)?;
+    let signature::SkolemisedSignature { substitution, mut constraints, mut arguments, mut result } =
+        signature::expect_term_signature(state, context, expected_type, required)?;
 
-    let given_substitution = constraint::elaborate_given_substitution(state, context, &constraints)?;
+    let given_substitution =
+        constraint::elaborate_given_substitution(state, context, &constraints)?;
     if !given_substitution.is_empty() {
         let original_constraints = constraints.clone();
         constraints = constraints

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -55,10 +55,12 @@ where
 
     let given_substitution = constraint::elaborate_given_substitution(state, context, &constraints)?;
     if !given_substitution.is_empty() {
+        let original_constraints = constraints.clone();
         constraints = constraints
             .into_iter()
             .map(|constraint| SubstituteName::many(state, context, &given_substitution, constraint))
             .collect::<QueryResult<Vec<_>>>()?;
+        constraints.extend(original_constraints);
         arguments = arguments
             .into_iter()
             .map(|argument| SubstituteName::many(state, context, &given_substitution, argument))

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -6,6 +6,7 @@ use building_types::QueryResult;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
+use crate::core::substitute::SubstituteName;
 use crate::core::{TypeId, constraint, signature, toolkit, unification};
 use crate::error::ErrorKind;
 use crate::source::binder;
@@ -45,8 +46,25 @@ where
 {
     let required = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
 
-    let signature::SkolemisedSignature { substitution, constraints, arguments, result } =
-        signature::expect_term_signature(state, context, expected_type, required)?;
+    let signature::SkolemisedSignature {
+        substitution,
+        mut constraints,
+        mut arguments,
+        mut result,
+    } = signature::expect_term_signature(state, context, expected_type, required)?;
+
+    let given_substitution = constraint::elaborate_given_substitution(state, context, &constraints)?;
+    if !given_substitution.is_empty() {
+        constraints = constraints
+            .into_iter()
+            .map(|constraint| SubstituteName::many(state, context, &given_substitution, constraint))
+            .collect::<QueryResult<Vec<_>>>()?;
+        arguments = arguments
+            .into_iter()
+            .map(|argument| SubstituteName::many(state, context, &given_substitution, argument))
+            .collect::<QueryResult<Vec<_>>>()?;
+        result = SubstituteName::many(state, context, &given_substitution, result)?;
+    }
 
     for &constraint in &constraints {
         if !constraint::is_type_error(state, context, constraint)? {

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -105,6 +105,7 @@ pub(crate) struct CheckStateCheckpoint {
     canonicals: CanonicalsCheckpoint,
     canonical_errors: FxHashMap<CanonicalConstraintId, Vec<ErrorKind>>,
     error_count: usize,
+    candidate_constraint_probe_cache: FxHashMap<Vec<ProbeKey>, bool>,
 }
 
 /// Tracks type variable bindings during kind inference.
@@ -288,6 +289,7 @@ impl CheckState {
             canonicals: self.canonicals.checkpoint(),
             canonical_errors: self.canonical_errors.clone(),
             error_count: self.checked.errors.len(),
+            candidate_constraint_probe_cache: self.candidate_constraint_probe_cache.clone(),
         }
     }
 
@@ -296,6 +298,7 @@ impl CheckState {
         self.canonicals.restore(checkpoint.canonicals);
         self.canonical_errors = checkpoint.canonical_errors;
         self.checked.errors.truncate(checkpoint.error_count);
+        self.candidate_constraint_probe_cache = checkpoint.candidate_constraint_probe_cache;
     }
 
     pub fn fresh_unification(&mut self, queries: &impl ExternalQueries, kind: TypeId) -> TypeId {

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -8,7 +8,9 @@ use files::FileId;
 use rustc_hash::FxHashMap;
 
 use crate::context::CheckContext;
-use crate::core::constraint::{CanonicalConstraintId, Canonicals, canonical::CanonicalsCheckpoint};
+use crate::core::constraint::{
+    CanonicalConstraintId, Canonicals, ProbeKey, canonical::CanonicalsCheckpoint,
+};
 use crate::core::exhaustive::{
     ExhaustivenessReport, Pattern, PatternConstructor, PatternId, PatternInterner, PatternKind,
 };
@@ -227,6 +229,8 @@ pub struct CheckState {
     pub canonical_errors: FxHashMap<CanonicalConstraintId, Vec<ErrorKind>>,
 
     pub defer_expansion: bool,
+    pub candidate_constraint_probes: Vec<Vec<ProbeKey>>,
+    pub candidate_constraint_probe_cache: FxHashMap<Vec<ProbeKey>, bool>,
     pub depth: Depth,
 
     pub crumbs: Vec<ErrorCrumb>,
@@ -244,6 +248,8 @@ impl CheckState {
             canonicals: Default::default(),
             canonical_errors: Default::default(),
             defer_expansion: Default::default(),
+            candidate_constraint_probes: Default::default(),
+            candidate_constraint_probe_cache: Default::default(),
             depth: Depth(0),
             crumbs: Default::default(),
         }

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -8,7 +8,7 @@ use files::FileId;
 use rustc_hash::FxHashMap;
 
 use crate::context::CheckContext;
-use crate::core::constraint::{CanonicalConstraintId, Canonicals};
+use crate::core::constraint::{CanonicalConstraintId, Canonicals, canonical::CanonicalsCheckpoint};
 use crate::core::exhaustive::{
     ExhaustivenessReport, Pattern, PatternConstructor, PatternId, PatternInterner, PatternKind,
 };
@@ -56,6 +56,12 @@ pub struct Unifications {
     unique: u32,
 }
 
+#[derive(Debug)]
+struct UnificationsCheckpoint {
+    entries: Vec<UnificationEntry>,
+    unique: u32,
+}
+
 impl Unifications {
     pub fn fresh(&mut self, depth: Depth, kind: TypeId) -> u32 {
         let unique = self.unique;
@@ -81,6 +87,22 @@ impl Unifications {
     pub fn iter(&self) -> impl Iterator<Item = &UnificationEntry> {
         self.entries.iter()
     }
+
+    fn checkpoint(&self) -> UnificationsCheckpoint {
+        UnificationsCheckpoint { entries: self.entries.clone(), unique: self.unique }
+    }
+
+    fn restore(&mut self, checkpoint: UnificationsCheckpoint) {
+        self.entries = checkpoint.entries;
+        self.unique = checkpoint.unique;
+    }
+}
+
+pub(crate) struct CheckStateCheckpoint {
+    unifications: UnificationsCheckpoint,
+    canonicals: CanonicalsCheckpoint,
+    canonical_errors: FxHashMap<CanonicalConstraintId, Vec<ErrorKind>>,
+    error_count: usize,
 }
 
 /// Tracks type variable bindings during kind inference.
@@ -252,6 +274,22 @@ impl CheckState {
         let result = f(self);
         self.crumbs.pop();
         result
+    }
+
+    pub(crate) fn checkpoint(&self) -> CheckStateCheckpoint {
+        CheckStateCheckpoint {
+            unifications: self.unifications.checkpoint(),
+            canonicals: self.canonicals.checkpoint(),
+            canonical_errors: self.canonical_errors.clone(),
+            error_count: self.checked.errors.len(),
+        }
+    }
+
+    pub(crate) fn restore(&mut self, checkpoint: CheckStateCheckpoint) {
+        self.unifications.restore(checkpoint.unifications);
+        self.canonicals.restore(checkpoint.canonicals);
+        self.canonical_errors = checkpoint.canonical_errors;
+        self.checked.errors.truncate(checkpoint.error_count);
     }
 
     pub fn fresh_unification(&mut self, queries: &impl ExternalQueries, kind: TypeId) -> TypeId {

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -8,9 +8,7 @@ use files::FileId;
 use rustc_hash::FxHashMap;
 
 use crate::context::CheckContext;
-use crate::core::constraint::{
-    CanonicalConstraintId, Canonicals, ProbeKey, canonical::CanonicalsCheckpoint,
-};
+use crate::core::constraint::{CanonicalConstraintId, Canonicals};
 use crate::core::exhaustive::{
     ExhaustivenessReport, Pattern, PatternConstructor, PatternId, PatternInterner, PatternKind,
 };
@@ -58,12 +56,6 @@ pub struct Unifications {
     unique: u32,
 }
 
-#[derive(Debug)]
-struct UnificationsCheckpoint {
-    entries: Vec<UnificationEntry>,
-    unique: u32,
-}
-
 impl Unifications {
     pub fn fresh(&mut self, depth: Depth, kind: TypeId) -> u32 {
         let unique = self.unique;
@@ -89,23 +81,6 @@ impl Unifications {
     pub fn iter(&self) -> impl Iterator<Item = &UnificationEntry> {
         self.entries.iter()
     }
-
-    fn checkpoint(&self) -> UnificationsCheckpoint {
-        UnificationsCheckpoint { entries: self.entries.clone(), unique: self.unique }
-    }
-
-    fn restore(&mut self, checkpoint: UnificationsCheckpoint) {
-        self.entries = checkpoint.entries;
-        self.unique = checkpoint.unique;
-    }
-}
-
-pub(crate) struct CheckStateCheckpoint {
-    unifications: UnificationsCheckpoint,
-    canonicals: CanonicalsCheckpoint,
-    canonical_errors: FxHashMap<CanonicalConstraintId, Vec<ErrorKind>>,
-    error_count: usize,
-    candidate_constraint_probe_cache: FxHashMap<Vec<ProbeKey>, bool>,
 }
 
 /// Tracks type variable bindings during kind inference.
@@ -230,8 +205,6 @@ pub struct CheckState {
     pub canonical_errors: FxHashMap<CanonicalConstraintId, Vec<ErrorKind>>,
 
     pub defer_expansion: bool,
-    pub candidate_constraint_probes: Vec<Vec<ProbeKey>>,
-    pub candidate_constraint_probe_cache: FxHashMap<Vec<ProbeKey>, bool>,
     pub depth: Depth,
 
     pub crumbs: Vec<ErrorCrumb>,
@@ -249,8 +222,6 @@ impl CheckState {
             canonicals: Default::default(),
             canonical_errors: Default::default(),
             defer_expansion: Default::default(),
-            candidate_constraint_probes: Default::default(),
-            candidate_constraint_probe_cache: Default::default(),
             depth: Depth(0),
             crumbs: Default::default(),
         }
@@ -281,24 +252,6 @@ impl CheckState {
         let result = f(self);
         self.crumbs.pop();
         result
-    }
-
-    pub(crate) fn checkpoint(&self) -> CheckStateCheckpoint {
-        CheckStateCheckpoint {
-            unifications: self.unifications.checkpoint(),
-            canonicals: self.canonicals.checkpoint(),
-            canonical_errors: self.canonical_errors.clone(),
-            error_count: self.checked.errors.len(),
-            candidate_constraint_probe_cache: self.candidate_constraint_probe_cache.clone(),
-        }
-    }
-
-    pub(crate) fn restore(&mut self, checkpoint: CheckStateCheckpoint) {
-        self.unifications.restore(checkpoint.unifications);
-        self.canonicals.restore(checkpoint.canonicals);
-        self.canonical_errors = checkpoint.canonical_errors;
-        self.checked.errors.truncate(checkpoint.error_count);
-        self.candidate_constraint_probe_cache = checkpoint.candidate_constraint_probe_cache;
     }
 
     pub fn fresh_unification(&mut self, queries: &impl ExternalQueries, kind: TypeId) -> TypeId {

--- a/tests-compatibility/src/lib.rs
+++ b/tests-compatibility/src/lib.rs
@@ -153,10 +153,10 @@ pub fn build_warmed_engine(sources: &[(String, String)]) -> WarmedEngine {
     }
 
     for &file_id in &candidates {
-        if let Ok((parsed, _)) = engine.parsed(file_id) {
-            if let Some(module_name) = parsed.module_name() {
-                engine.set_module_file(&module_name.to_string(), file_id);
-            }
+        if let Ok((parsed, _)) = engine.parsed(file_id)
+            && let Some(module_name) = parsed.module_name()
+        {
+            engine.set_module_file(module_name.as_ref(), file_id);
         }
     }
 

--- a/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
@@ -34,7 +34,7 @@ error[CannotUnify]: Cannot unify '( b :: String )' with '( b :: Int )'
    |
 15 | forceSolve =
    | ^~~~~~~~~~~~
-error[CannotUnify]: Cannot unify '( a :: Int, b :: String )' with '( missing :: Int | ?23 )'
+error[CannotUnify]: Cannot unify '( a :: Int, b :: String )' with '( missing :: Int | ?27 )'
   --> 15:1..19:4
    |
 15 | forceSolve =

--- a/tests-integration/fixtures/checking/1772440500_prim_row_generalization/Main.snap
+++ b/tests-integration/fixtures/checking/1772440500_prim_row_generalization/Main.snap
@@ -45,8 +45,8 @@ testMulti1 ::
     {| (t48 :: Row Type) } -> {| (t47 :: Row Type) }
 testMulti2 ::
   forall (t52 :: Row Type) (t51 :: Row Type) (t50 :: Row Type).
-    Nub @Type ( a :: Int | (t52 :: Row Type) ) (t51 :: Row Type) =>
-    Union @Type (t51 :: Row Type) ( b :: Int ) (t50 :: Row Type) =>
-    {| (t50 :: Row Type) }
+    Union @Type (t52 :: Row Type) ( b :: Int ) (t51 :: Row Type) =>
+    Nub @Type ( a :: Int | (t50 :: Row Type) ) (t52 :: Row Type) =>
+    {| (t51 :: Row Type) }
 
 Types

--- a/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
+++ b/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
@@ -44,15 +44,31 @@ Proxy = [Phantom]
 
 Diagnostics
 warning[CustomWarning]: This function is deprecated
+  --> 8:1..8:75
+  |
+8 | warnBasic :: forall a. Warn (Text "This function is deprecated") => a -> a
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: This function is deprecated
   --> 11:1..11:20
    |
 11 | useWarnBasic :: Int
    | ^~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Left Right
+  --> 14:1..14:78
+   |
+14 | warnBeside :: forall a. Warn (Beside (Text "Left ") (Text "Right")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Left Right
   --> 17:1..17:21
    |
 17 | useWarnBeside :: Int
    | ^~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Line 1
+Line 2
+  --> 20:1..20:78
+   |
+20 | warnAbove :: forall a. Warn (Above (Text "Line 1") (Text "Line 2")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Line 1
 Line 2
   --> 23:1..23:20
@@ -65,20 +81,40 @@ warning[CustomWarning]: Got type: Int
 29 | useWarnQuote :: Proxy Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: myField
+  --> 32:1..32:92
+   |
+32 | warnQuoteLabel :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel "myField")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: myField
   --> 35:1..35:25
    |
 35 | useWarnQuoteLabel :: Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: "h e l l o"
+  --> 38:1..38:100
+   |
+38 | warnQuoteLabelSpaces :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel "h e l l o")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: "h e l l o"
   --> 41:1..41:31
    |
 41 | useWarnQuoteLabelSpaces :: Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: "hel\"lo"
+  --> 44:1..44:97
+   |
+44 | warnQuoteLabelQuote :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel "hel\"lo")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: "hel\"lo"
   --> 47:1..47:30
    |
 47 | useWarnQuoteLabelQuote :: Int
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+warning[CustomWarning]: Label: """raw\nstring"""
+  --> 50:1..50:103
+   |
+50 | warnQuoteLabelRaw :: forall a. Warn (Beside (Text "Label: ") (QuoteLabel """raw\nstring""")) => a -> a
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 warning[CustomWarning]: Label: """raw\nstring"""
   --> 53:1..53:28
    |

--- a/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
@@ -23,6 +23,11 @@ Proxy = [Phantom]
 
 Diagnostics
 error[CustomFailure]: This operation is not allowed
+  --> 8:1..8:77
+  |
+8 | failBasic :: forall a. Fail (Text "This operation is not allowed") => a -> a
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CustomFailure]: This operation is not allowed
   --> 11:1..11:20
    |
 11 | useFailBasic :: Int

--- a/tests-integration/fixtures/checking/1777298340_top_level_fail_eager/Main.snap
+++ b/tests-integration/fixtures/checking/1777298340_top_level_fail_eager/Main.snap
@@ -8,3 +8,10 @@ boom :: Fail (Text "top-level Fail was checked") => Int
 test :: Int
 
 Types
+
+Diagnostics
+error[CustomFailure]: top-level Fail was checked
+  --> 5:1..5:56
+  |
+5 | boom :: Fail (Text "top-level Fail was checked") => Int
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.purs
+++ b/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.purs
@@ -1,0 +1,39 @@
+module Main where
+
+import Prim.Row as Row
+import Prim.RowList as RL
+
+data Maybe a = Nothing | Just a
+
+data Nullable a
+
+class ExtractType entry typ | entry -> typ
+instance ExtractType String String
+instance ExtractType (Nullable a) (Maybe a)
+
+class StripColumnsRL :: RL.RowList Type -> RL.RowList Type -> Constraint
+class StripColumnsRL rl out | rl -> out
+
+instance StripColumnsRL RL.Nil RL.Nil
+instance (ExtractType entry typ, StripColumnsRL tail out') => StripColumnsRL (RL.Cons name entry tail) (RL.Cons name typ out')
+
+class ListToRow :: RL.RowList Type -> Row Type -> Constraint
+class ListToRow list row | list -> row
+
+instance ListToRow RL.Nil ()
+instance (Row.Cons name typ rowTail row, ListToRow tail rowTail) => ListToRow (RL.Cons name typ tail) row
+
+class StripColumns :: Row Type -> Row Type -> Constraint
+class StripColumns columns row | columns -> row
+
+instance (RL.RowToList columns list, StripColumnsRL list outList, ListToRow outList row) => StripColumns columns row
+
+type Columns =
+  ( account_guid :: Nullable String
+  )
+
+test :: forall row. StripColumns Columns row => Record row
+test = { account_guid: Nothing }
+
+bad :: forall row. StripColumns Columns row => Record row
+bad = { other: "acct" }

--- a/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.snap
+++ b/tests-integration/fixtures/checking/1778682360_row_fundep_determined_result/Main.snap
@@ -1,0 +1,65 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Nothing :: forall (@a :: Type). Maybe (a :: Type)
+Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+test :: forall (row :: Row Type). StripColumns Columns (row :: Row Type) => {| (row :: Row Type) }
+bad :: forall (row :: Row Type). StripColumns Columns (row :: Row Type) => {| (row :: Row Type) }
+
+Types
+Maybe :: Type -> Type
+Nullable :: forall (t2 :: Type). (t2 :: Type) -> Type
+ExtractType :: forall (t6 :: Type) (t5 :: Type). (t6 :: Type) -> (t5 :: Type) -> Constraint
+StripColumnsRL :: RowList Type -> RowList Type -> Constraint
+ListToRow :: RowList Type -> Row Type -> Constraint
+StripColumns :: Row Type -> Row Type -> Constraint
+Columns :: Row Type
+
+Synonyms
+type Columns = ( account_guid :: Nullable @Type String )
+
+Classes
+class forall (t6 :: Type) (t5 :: Type) (entry :: (t6 :: Type)) (typ :: (t5 :: Type)). ExtractType @(t6 :: Type) @(t5 :: Type) (entry :: (t6 :: Type)) (typ :: (t5 :: Type))
+class forall (rl :: RowList Type) (out :: RowList Type). StripColumnsRL (rl :: RowList Type) (out :: RowList Type)
+class forall (list :: RowList Type) (row :: Row Type). ListToRow (list :: RowList Type) (row :: Row Type)
+class forall (columns :: Row Type) (row :: Row Type). StripColumns (columns :: Row Type) (row :: Row Type)
+
+Instances
+instance ExtractType @Type @Type String String
+instance forall (t13 :: Type). ExtractType @Type @Type (Nullable @Type (t13 :: Type)) (Maybe (t13 :: Type))
+instance StripColumnsRL (Nil @Type) (Nil @Type)
+instance forall (t16 :: Type) (t18 :: Type) (t17 :: RowList Type) (t19 :: RowList Type) (t15 :: Symbol).
+  ExtractType @Type @Type (t16 :: Type) (t18 :: Type) =>
+  StripColumnsRL (t17 :: RowList Type) (t19 :: RowList Type) =>
+  StripColumnsRL
+    (Cons @Type (t15 :: Symbol) (t16 :: Type) (t17 :: RowList Type))
+    (Cons @Type (t15 :: Symbol) (t18 :: Type) (t19 :: RowList Type))
+instance ListToRow (Nil @Type) ()
+instance forall (t25 :: Symbol) (t26 :: Type) (t29 :: Row Type) (t28 :: Row Type) (t27 :: RowList Type).
+  Cons @Type (t25 :: Symbol) (t26 :: Type) (t29 :: Row Type) (t28 :: Row Type) =>
+  ListToRow (t27 :: RowList Type) (t29 :: Row Type) =>
+  ListToRow (Cons @Type (t25 :: Symbol) (t26 :: Type) (t27 :: RowList Type)) (t28 :: Row Type)
+instance forall (t35 :: Row Type) (t37 :: RowList Type) (t38 :: RowList Type) (t36 :: Row Type).
+  RowToList @Type (t35 :: Row Type) (t37 :: RowList Type) =>
+  StripColumnsRL (t37 :: RowList Type) (t38 :: RowList Type) =>
+  ListToRow (t38 :: RowList Type) (t36 :: Row Type) =>
+  StripColumns (t35 :: Row Type) (t36 :: Row Type)
+
+Roles
+Maybe = [Representational]
+Nullable = [Phantom]
+
+Diagnostics
+error[PropertyIsMissing]: Missing required properties: account_guid
+  --> 39:7..39:24
+   |
+39 | bad = { other: "acct" }
+   |       ^~~~~~~~~~~~~~~~~
+error[AdditionalProperty]: Additional properties not allowed: other
+  --> 39:7..39:24
+   |
+39 | bad = { other: "acct" }
+   |       ^~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.purs
+++ b/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.purs
@@ -1,0 +1,115 @@
+module Main where
+
+import Prim.Row as Row
+import Prim.RowList (RowList)
+import Prim.RowList as RL
+
+foreign import data Run :: Row (Type -> Type) -> Type -> Type
+
+type NaturalTransformation f g = forall a. f a -> g a
+infixr 4 type NaturalTransformation as ~>
+
+data Unit = Unit
+
+unit :: Unit
+unit = Unit
+
+foreign import data Effect :: Type -> Type
+foreign import data State :: Type -> Type -> Type
+foreign import data Reader :: Type -> Type -> Type
+
+foreign import pure :: forall r a. a -> Run r a
+
+foreign import bindRun :: forall r a b. Run r a -> (a -> Run r b) -> Run r b
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+type RowApply :: forall k. (Row k -> Row k) -> Row k -> Row k
+type RowApply f a = f a
+
+infixr 0 type RowApply as +
+
+type EFFECT :: Row (Type -> Type) -> Row (Type -> Type)
+type EFFECT r = ( effect :: Effect | r )
+
+type STATE :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+type STATE s r = ( state :: State s | r )
+
+type READER :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+type READER a r = ( reader :: Reader a | r )
+
+class SafeUnion :: forall k. Row k -> Row k -> Row k -> Constraint
+class SafeUnion a b c | a b -> c
+
+foreign import data TypeExpr :: Type -> Type
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+
+foreign import data FromRow :: forall k. Row k -> TypeExpr (RowList k)
+
+instance RL.RowToList row list => Eval (FromRow row) list
+
+class ListToRow :: forall k. RowList k -> Row k -> Constraint
+class ListToRow list row | list -> row
+
+instance ListToRow RL.Nil ()
+instance (Row.Cons name typ rowTail row, ListToRow tail rowTail) => ListToRow (RL.Cons name typ tail) row
+
+foreign import data ToRow :: forall k. RowList k -> TypeExpr (Row k)
+
+instance ListToRow list row => Eval (ToRow list) row
+
+foreign import data Union :: forall k. Row k -> Row k -> TypeExpr (Row k)
+
+instance Row.Union left right union => Eval (Union left right) union
+
+foreign import data Nub :: forall k. Row k -> TypeExpr (Row k)
+
+instance Row.Nub original nubbed => Eval (Nub original) nubbed
+
+foreign import data UnionAndNubRowLists :: forall k. RowList k -> RowList k -> TypeExpr (RowList k)
+
+instance
+  ( Eval (ToRow a) aRow
+  , Eval (ToRow b) bRow
+  , Eval (Union aRow bRow) union
+  , Eval (Nub union) cRow
+  , Eval (FromRow cRow) c
+  ) =>
+  Eval (UnionAndNubRowLists a b) c
+
+instance
+  ( Eval (FromRow r1) rl1
+  , Eval (FromRow r2) rl2
+  , Eval (UnionAndNubRowLists rl1 rl2) rlResult
+  , Eval (ToRow rlResult) result
+  ) =>
+  SafeUnion r1 r2 result
+
+expand :: forall r1 @r2 r3. SafeUnion r1 r2 r3 => Run r1 ~> Run r3
+expand = unsafeCoerce
+
+composeFlipped
+  :: forall r1 r2 r3 a b c
+   . SafeUnion r1 r2 r3
+  => SafeUnion r2 r1 r3
+  => (a -> Run r1 b)
+  -> (b -> Run r2 c)
+  -> (a -> Run r3 c)
+composeFlipped f g a =
+  bindRun (expand @r2 (f a)) \b -> expand @r1 (g b)
+
+infixr 1 composeFlipped as >+>
+
+computation1 :: String -> Run (EFFECT ()) Int
+computation1 _ = pure 0
+
+computation2 :: Int -> Run (EFFECT + STATE String + ()) String
+computation2 _ = pure ""
+
+computation3 :: String -> Run (STATE String + READER Boolean + ()) Unit
+computation3 _ = pure unit
+
+composeFlippedThree :: String -> Run (EFFECT + STATE String + READER Boolean + ()) Unit
+composeFlippedThree = computation1 >+> computation2 >+> computation3

--- a/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.snap
+++ b/tests-integration/fixtures/checking/1778685420_polykinded_row_fundep_safe_union/Main.snap
@@ -1,0 +1,201 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+Unit :: Unit
+unit :: Unit
+pure ::
+  forall (r :: Row (Type -> Type)) (a :: Type).
+    (a :: Type) -> Run (r :: Row (Type -> Type)) (a :: Type)
+bindRun ::
+  forall (r :: Row (Type -> Type)) (a :: Type) (b :: Type).
+    Run (r :: Row (Type -> Type)) (a :: Type) ->
+    ((a :: Type) -> Run (r :: Row (Type -> Type)) (b :: Type)) ->
+    Run (r :: Row (Type -> Type)) (b :: Type)
+unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+expand ::
+  forall (r1 :: Row (Type -> Type)) (@r2 :: Row (Type -> Type)) (r3 :: Row (Type -> Type)).
+    SafeUnion @(Type -> Type)
+      (r1 :: Row (Type -> Type))
+      (r2 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    NaturalTransformation @Type (Run (r1 :: Row (Type -> Type))) (Run (r3 :: Row (Type -> Type)))
+composeFlipped ::
+  forall (r1 :: Row (Type -> Type)) (r2 :: Row (Type -> Type)) (r3 :: Row (Type -> Type))
+    (a :: Type) (b :: Type) (c :: Type).
+    SafeUnion @(Type -> Type)
+      (r1 :: Row (Type -> Type))
+      (r2 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    SafeUnion @(Type -> Type)
+      (r2 :: Row (Type -> Type))
+      (r1 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    ((a :: Type) -> Run (r1 :: Row (Type -> Type)) (b :: Type)) ->
+    ((b :: Type) -> Run (r2 :: Row (Type -> Type)) (c :: Type)) ->
+    (a :: Type) ->
+    Run (r3 :: Row (Type -> Type)) (c :: Type)
+>+> ::
+  forall (r1 :: Row (Type -> Type)) (r2 :: Row (Type -> Type)) (r3 :: Row (Type -> Type))
+    (a :: Type) (b :: Type) (c :: Type).
+    SafeUnion @(Type -> Type)
+      (r1 :: Row (Type -> Type))
+      (r2 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    SafeUnion @(Type -> Type)
+      (r2 :: Row (Type -> Type))
+      (r1 :: Row (Type -> Type))
+      (r3 :: Row (Type -> Type)) =>
+    ((a :: Type) -> Run (r1 :: Row (Type -> Type)) (b :: Type)) ->
+    ((b :: Type) -> Run (r2 :: Row (Type -> Type)) (c :: Type)) ->
+    (a :: Type) ->
+    Run (r3 :: Row (Type -> Type)) (c :: Type)
+computation1 :: String -> Run (EFFECT ()) Int
+computation2 ::
+  Int -> Run (RowApply @(Type -> Type) EFFECT (RowApply @(Type -> Type) (STATE String) ())) String
+computation3 ::
+  String ->
+  Run (RowApply @(Type -> Type) (STATE String) (RowApply @(Type -> Type) (READER Boolean) ())) Unit
+composeFlippedThree ::
+  String ->
+  Run
+    (RowApply @(Type -> Type)
+      EFFECT
+      (RowApply @(Type -> Type) (STATE String) (RowApply @(Type -> Type) (READER Boolean) ())))
+    Unit
+
+Types
+Run :: Row (Type -> Type) -> Type -> Type
+NaturalTransformation ::
+  forall (t3 :: Type). ((t3 :: Type) -> Type) -> ((t3 :: Type) -> Type) -> Type
+~> :: forall (t3 :: Type). ((t3 :: Type) -> Type) -> ((t3 :: Type) -> Type) -> Type
+Unit :: Type
+Effect :: Type -> Type
+State :: Type -> Type -> Type
+Reader :: Type -> Type -> Type
+RowApply ::
+  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
++ :: forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
+EFFECT :: Row (Type -> Type) -> Row (Type -> Type)
+STATE :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+READER :: Type -> Row (Type -> Type) -> Row (Type -> Type)
+SafeUnion :: forall (k :: Type). Row (k :: Type) -> Row (k :: Type) -> Row (k :: Type) -> Constraint
+TypeExpr :: Type -> Type
+Eval :: forall (k :: Type). TypeExpr (k :: Type) -> (k :: Type) -> Constraint
+FromRow :: forall (k :: Type). Row (k :: Type) -> TypeExpr (RowList (k :: Type))
+ListToRow :: forall (k :: Type). RowList (k :: Type) -> Row (k :: Type) -> Constraint
+ToRow :: forall (k :: Type). RowList (k :: Type) -> TypeExpr (Row (k :: Type))
+Union :: forall (k :: Type). Row (k :: Type) -> Row (k :: Type) -> TypeExpr (Row (k :: Type))
+Nub :: forall (k :: Type). Row (k :: Type) -> TypeExpr (Row (k :: Type))
+UnionAndNubRowLists ::
+  forall (k :: Type). RowList (k :: Type) -> RowList (k :: Type) -> TypeExpr (RowList (k :: Type))
+
+Synonyms
+type NaturalTransformation f g = forall (a :: (t3 :: Type)).
+  (f :: (t3 :: Type) -> Type) (a :: (t3 :: Type)) -> (g :: (t3 :: Type) -> Type) (a :: (t3 :: Type))
+type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
+type EFFECT r = ( effect :: Effect | (r :: Row (Type -> Type)) )
+type STATE s r = ( state :: State (s :: Type) | (r :: Row (Type -> Type)) )
+type READER a r = ( reader :: Reader (a :: Type) | (r :: Row (Type -> Type)) )
+
+Classes
+class forall (k :: Type) (a :: Row (k :: Type)) (b :: Row (k :: Type)) (c :: Row (k :: Type)). SafeUnion @(k :: Type) (a :: Row (k :: Type)) (b :: Row (k :: Type)) (c :: Row (k :: Type))
+class forall (k :: Type) (expr :: TypeExpr (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr (k :: Type)) (result :: (k :: Type))
+class forall (k :: Type) (list :: RowList (k :: Type)) (row :: Row (k :: Type)). ListToRow @(k :: Type) (list :: RowList (k :: Type)) (row :: Row (k :: Type))
+
+Instances
+instance forall (t29 :: Type) (t27 :: Row (t29 :: Type)) (t28 :: RowList (t29 :: Type)).
+  RowToList @(t29 :: Type) (t27 :: Row (t29 :: Type)) (t28 :: RowList (t29 :: Type)) =>
+  Eval @(RowList (t29 :: Type))
+    (FromRow @(t29 :: Type) (t27 :: Row (t29 :: Type)))
+    (t28 :: RowList (t29 :: Type))
+instance forall (t33 :: Type). ListToRow @(t33 :: Type) (Nil @(t33 :: Type)) ()
+instance forall (t40 :: Type) (t35 :: Symbol) (t36 :: (t40 :: Type)) (t39 :: Row (t40 :: Type))
+  (t38 :: Row (t40 :: Type)) (t37 :: RowList (t40 :: Type)).
+  Cons @(t40 :: Type)
+    (t35 :: Symbol)
+    (t36 :: (t40 :: Type))
+    (t39 :: Row (t40 :: Type))
+    (t38 :: Row (t40 :: Type)) =>
+  ListToRow @(t40 :: Type) (t37 :: RowList (t40 :: Type)) (t39 :: Row (t40 :: Type)) =>
+  ListToRow @(t40 :: Type)
+    (Cons @(t40 :: Type) (t35 :: Symbol) (t36 :: (t40 :: Type)) (t37 :: RowList (t40 :: Type)))
+    (t38 :: Row (t40 :: Type))
+instance forall (t49 :: Type) (t47 :: RowList (t49 :: Type)) (t48 :: Row (t49 :: Type)).
+  ListToRow @(t49 :: Type) (t47 :: RowList (t49 :: Type)) (t48 :: Row (t49 :: Type)) =>
+  Eval @(Row (t49 :: Type))
+    (ToRow @(t49 :: Type) (t47 :: RowList (t49 :: Type)))
+    (t48 :: Row (t49 :: Type))
+instance forall (t56 :: Type) (t53 :: Row (t56 :: Type)) (t54 :: Row (t56 :: Type))
+  (t55 :: Row (t56 :: Type)).
+  Union @(t56 :: Type)
+    (t53 :: Row (t56 :: Type))
+    (t54 :: Row (t56 :: Type))
+    (t55 :: Row (t56 :: Type)) =>
+  Eval @(Row (t56 :: Type))
+    (Union @(t56 :: Type) (t53 :: Row (t56 :: Type)) (t54 :: Row (t56 :: Type)))
+    (t55 :: Row (t56 :: Type))
+instance forall (t63 :: Type) (t61 :: Row (t63 :: Type)) (t62 :: Row (t63 :: Type)).
+  Nub @(t63 :: Type) (t61 :: Row (t63 :: Type)) (t62 :: Row (t63 :: Type)) =>
+  Eval @(Row (t63 :: Type))
+    (Nub @(t63 :: Type) (t61 :: Row (t63 :: Type)))
+    (t62 :: Row (t63 :: Type))
+instance forall (t74 :: Type) (t67 :: RowList (t74 :: Type)) (t70 :: Row (t74 :: Type))
+  (t68 :: RowList (t74 :: Type)) (t71 :: Row (t74 :: Type)) (t72 :: Row (t74 :: Type))
+  (t73 :: Row (t74 :: Type)) (t69 :: RowList (t74 :: Type)).
+  Eval @(Row (t74 :: Type))
+    (ToRow @(t74 :: Type) (t67 :: RowList (t74 :: Type)))
+    (t70 :: Row (t74 :: Type)) =>
+  Eval @(Row (t74 :: Type))
+    (ToRow @(t74 :: Type) (t68 :: RowList (t74 :: Type)))
+    (t71 :: Row (t74 :: Type)) =>
+  Eval @(Row (t74 :: Type))
+    (Union @(t74 :: Type) (t70 :: Row (t74 :: Type)) (t71 :: Row (t74 :: Type)))
+    (t72 :: Row (t74 :: Type)) =>
+  Eval @(Row (t74 :: Type))
+    (Nub @(t74 :: Type) (t72 :: Row (t74 :: Type)))
+    (t73 :: Row (t74 :: Type)) =>
+  Eval @(RowList (t74 :: Type))
+    (FromRow @(t74 :: Type) (t73 :: Row (t74 :: Type)))
+    (t69 :: RowList (t74 :: Type)) =>
+  Eval @(RowList (t74 :: Type))
+    (UnionAndNubRowLists @(t74 :: Type)
+      (t67 :: RowList (t74 :: Type))
+      (t68 :: RowList (t74 :: Type)))
+    (t69 :: RowList (t74 :: Type))
+instance forall (t89 :: Type) (t83 :: Row (t89 :: Type)) (t86 :: RowList (t89 :: Type))
+  (t84 :: Row (t89 :: Type)) (t87 :: RowList (t89 :: Type)) (t88 :: RowList (t89 :: Type))
+  (t85 :: Row (t89 :: Type)).
+  Eval @(RowList (t89 :: Type))
+    (FromRow @(t89 :: Type) (t83 :: Row (t89 :: Type)))
+    (t86 :: RowList (t89 :: Type)) =>
+  Eval @(RowList (t89 :: Type))
+    (FromRow @(t89 :: Type) (t84 :: Row (t89 :: Type)))
+    (t87 :: RowList (t89 :: Type)) =>
+  Eval @(RowList (t89 :: Type))
+    (UnionAndNubRowLists @(t89 :: Type)
+      (t86 :: RowList (t89 :: Type))
+      (t87 :: RowList (t89 :: Type)))
+    (t88 :: RowList (t89 :: Type)) =>
+  Eval @(Row (t89 :: Type))
+    (ToRow @(t89 :: Type) (t88 :: RowList (t89 :: Type)))
+    (t85 :: Row (t89 :: Type)) =>
+  SafeUnion @(t89 :: Type)
+    (t83 :: Row (t89 :: Type))
+    (t84 :: Row (t89 :: Type))
+    (t85 :: Row (t89 :: Type))
+
+Roles
+Run = [Nominal, Nominal]
+Unit = []
+Effect = [Nominal]
+State = [Nominal, Nominal]
+Reader = [Nominal, Nominal]
+TypeExpr = [Nominal]
+FromRow = [Nominal]
+ToRow = [Nominal]
+Union = [Nominal, Nominal]
+Nub = [Nominal]
+UnionAndNubRowLists = [Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1778700540_instance_subgoal_apart_compare/Main.purs
+++ b/tests-integration/fixtures/checking/1778700540_instance_subgoal_apart_compare/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Prim.Int (class Compare)
+import Prim.Ordering (GT, LT)
+import Type.Proxy (Proxy(..))
+
+class Pick :: Int -> Type -> Constraint
+class Pick index result | index -> result
+
+instance Compare index 1 LT => Pick index String
+else instance Compare index 1 GT => Pick index Int
+
+pick :: forall index result. Pick index result => Proxy index -> Proxy result
+pick _ = Proxy
+
+test :: Proxy Int
+test = pick (Proxy :: Proxy 2)
+
+testInferred = pick (Proxy :: Proxy 2)

--- a/tests-integration/fixtures/checking/1778700540_instance_subgoal_apart_compare/Main.snap
+++ b/tests-integration/fixtures/checking/1778700540_instance_subgoal_apart_compare/Main.snap
@@ -1,0 +1,22 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+pick ::
+  forall (index :: Int) (result :: Type).
+    Pick (index :: Int) (result :: Type) =>
+    Proxy @Int (index :: Int) -> Proxy @Type (result :: Type)
+test :: Proxy @Type Int
+testInferred :: Proxy @Type Int
+
+Types
+Pick :: Int -> Type -> Constraint
+
+Classes
+class forall (index :: Int) (result :: Type). Pick (index :: Int) (result :: Type)
+
+Instances
+instance forall (t2 :: Int). Compare (t2 :: Int) 1 LT => Pick (t2 :: Int) String
+instance forall (t4 :: Int). Compare (t4 :: Int) 1 GT => Pick (t4 :: Int) Int

--- a/tests-integration/fixtures/checking/1778701380_pick_max_compare_eval/Main.purs
+++ b/tests-integration/fixtures/checking/1778701380_pick_max_compare_eval/Main.purs
@@ -1,0 +1,55 @@
+module Main where
+
+import Prim.Int (class Compare)
+import Prim.Ordering (LT)
+import Prim.Boolean (False, True)
+import Type.Proxy (Proxy(..))
+
+foreign import data TypeExpr :: forall k. k -> Type
+
+foreign import data Eq :: forall a. a -> a -> TypeExpr Boolean
+
+infix 4 type Eq as ==
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+
+instance Eval (Eq a a) True
+else instance Eval (Eq a b) False
+
+class If :: forall k. Boolean -> k -> k -> k -> Constraint
+class If bool onTrue onFalse output | bool onTrue onFalse -> output
+instance If True onTrue onFalse onTrue
+else instance If False onTrue onFalse onFalse
+
+foreign import data NoDoc :: Type
+foreign import data Doc :: Type -> Type
+foreign import data Stub :: Type
+foreign import data Base64 :: Type
+
+class IntOf :: forall k. k -> Int -> Constraint
+class IntOf k int | k -> int
+
+instance IntOf NoDoc 0
+instance IntOf (Doc Stub) 1
+instance IntOf (Doc Base64) 2
+
+class PickMax :: forall k. k -> k -> k -> Constraint
+class PickMax a b c | a b -> c
+
+instance
+  ( IntOf a ia
+  , IntOf b ib
+  , Compare ia ib ord
+  , Eval (LT == ord) isLess
+  , If isLess b a c
+  ) =>
+  PickMax a b c
+
+pickMax :: forall a b c. PickMax a b c => Proxy a -> Proxy b -> Proxy c
+pickMax _ _ = Proxy
+
+test :: Proxy (Doc Base64)
+test = pickMax (Proxy :: Proxy (Doc Base64)) (Proxy :: Proxy (Doc Stub))
+
+testInferred = pickMax (Proxy :: Proxy (Doc Base64)) (Proxy :: Proxy (Doc Stub))

--- a/tests-integration/fixtures/checking/1778701380_pick_max_compare_eval/Main.snap
+++ b/tests-integration/fixtures/checking/1778701380_pick_max_compare_eval/Main.snap
@@ -1,0 +1,70 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+pickMax ::
+  forall (t61 :: Type) (a :: (t61 :: Type)) (b :: (t61 :: Type)) (c :: (t61 :: Type)).
+    PickMax @(t61 :: Type) (a :: (t61 :: Type)) (b :: (t61 :: Type)) (c :: (t61 :: Type)) =>
+    Proxy @(t61 :: Type) (a :: (t61 :: Type)) ->
+    Proxy @(t61 :: Type) (b :: (t61 :: Type)) ->
+    Proxy @(t61 :: Type) (c :: (t61 :: Type))
+test :: Proxy @Type (Doc Base64)
+testInferred :: Proxy @Type (Doc Base64)
+
+Types
+TypeExpr :: forall (k :: Type). (k :: Type) -> Type
+Eq :: forall (a :: Type). (a :: Type) -> (a :: Type) -> TypeExpr @Type Boolean
+== :: forall (a :: Type). (a :: Type) -> (a :: Type) -> TypeExpr @Type Boolean
+Eval :: forall (k :: Type). TypeExpr @Type (k :: Type) -> (k :: Type) -> Constraint
+If :: forall (k :: Type). Boolean -> (k :: Type) -> (k :: Type) -> (k :: Type) -> Constraint
+NoDoc :: Type
+Doc :: Type -> Type
+Stub :: Type
+Base64 :: Type
+IntOf :: forall (k :: Type). (k :: Type) -> Int -> Constraint
+PickMax :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type) -> Constraint
+
+Classes
+class forall (k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type))
+class forall (k :: Type) (bool :: Boolean) (onTrue :: (k :: Type)) (onFalse :: (k :: Type)) (output :: (k :: Type)). If @(k :: Type)
+  (bool :: Boolean)
+  (onTrue :: (k :: Type))
+  (onFalse :: (k :: Type))
+  (output :: (k :: Type))
+class forall (k :: Type) (k :: (k :: Type)) (int :: Int). IntOf @(k :: Type) (k :: (k :: Type)) (int :: Int)
+class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)). PickMax @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type))
+
+Instances
+instance forall (t18 :: Type) (t17 :: (t18 :: Type)).
+  Eval @Boolean (Eq @(t18 :: Type) (t17 :: (t18 :: Type)) (t17 :: (t18 :: Type))) True
+instance forall (t23 :: Type) (t21 :: (t23 :: Type)) (t22 :: (t23 :: Type)).
+  Eval @Boolean (Eq @(t23 :: Type) (t21 :: (t23 :: Type)) (t22 :: (t23 :: Type))) False
+instance forall (t29 :: Type) (t27 :: (t29 :: Type)) (t28 :: (t29 :: Type)).
+  If @(t29 :: Type) True (t27 :: (t29 :: Type)) (t28 :: (t29 :: Type)) (t27 :: (t29 :: Type))
+instance forall (t35 :: Type) (t33 :: (t35 :: Type)) (t34 :: (t35 :: Type)).
+  If @(t35 :: Type) False (t33 :: (t35 :: Type)) (t34 :: (t35 :: Type)) (t34 :: (t35 :: Type))
+instance IntOf @Type NoDoc 0
+instance IntOf @Type (Doc Stub) 1
+instance IntOf @Type (Doc Base64) 2
+instance forall (t46 :: Type) (t39 :: (t46 :: Type)) (t42 :: Int) (t40 :: (t46 :: Type)) (t43 :: Int)
+  (t44 :: Ordering) (t45 :: Boolean) (t41 :: (t46 :: Type)).
+  IntOf @(t46 :: Type) (t39 :: (t46 :: Type)) (t42 :: Int) =>
+  IntOf @(t46 :: Type) (t40 :: (t46 :: Type)) (t43 :: Int) =>
+  Compare (t42 :: Int) (t43 :: Int) (t44 :: Ordering) =>
+  Eval @Boolean (Eq @Ordering LT (t44 :: Ordering)) (t45 :: Boolean) =>
+  If @(t46 :: Type)
+    (t45 :: Boolean)
+    (t40 :: (t46 :: Type))
+    (t39 :: (t46 :: Type))
+    (t41 :: (t46 :: Type)) =>
+  PickMax @(t46 :: Type) (t39 :: (t46 :: Type)) (t40 :: (t46 :: Type)) (t41 :: (t46 :: Type))
+
+Roles
+TypeExpr = [Nominal]
+Eq = [Nominal, Nominal]
+NoDoc = []
+Doc = [Nominal]
+Stub = []
+Base64 = []

--- a/tests-integration/fixtures/checking/1778701500_pick_max_record_fold_order/Main.purs
+++ b/tests-integration/fixtures/checking/1778701500_pick_max_record_fold_order/Main.purs
@@ -1,0 +1,99 @@
+module Main where
+
+import Prim.Int (class Add, class Compare)
+import Prim.Ordering (LT)
+import Prim.Row as Row
+import Prim.RowList as RL
+import Prim.Boolean (False, True)
+import Type.Proxy (Proxy(..))
+
+foreign import data TypeExpr :: forall k. k -> Type
+foreign import data Eq :: forall a. a -> a -> TypeExpr Boolean
+infix 4 type Eq as ==
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+instance Eval (Eq a a) True
+else instance Eval (Eq a b) False
+
+class If :: forall k. Boolean -> k -> k -> k -> Constraint
+class If bool onTrue onFalse output | bool onTrue onFalse -> output
+instance If True onTrue onFalse onTrue
+else instance If False onTrue onFalse onFalse
+
+data CodecsArgsKind
+foreign import data CA :: DocKind -> KeysKind -> CodecsArgsKind
+data DocKind
+foreign import data NoDoc :: DocKind
+foreign import data Doc :: AttachmentKind -> DocKind
+data AttachmentKind
+foreign import data Stub :: AttachmentKind
+foreign import data Base64 :: AttachmentKind
+data KeysKind
+foreign import data NoKeys :: KeysKind
+
+foreign import data O :: Type -> CodecsArgsKind -> Type
+foreign import data Opts :: Type
+
+class IntOf :: forall k. k -> Int -> Constraint
+class IntOf k int | k -> int
+instance IntOf NoDoc 0
+instance IntOf Stub 0
+instance IntOf Base64 1
+instance (IntOf dk i1, Add 1 i1 i2) => IntOf (Doc dk) i2
+
+class PickMax :: forall k. k -> k -> k -> Constraint
+class PickMax a b c | a b -> c
+instance
+  ( IntOf a ia
+  , IntOf b ib
+  , Compare ia ib ord
+  , Eval (LT == ord) isLess
+  , If isLess b a c
+  ) =>
+  PickMax a b c
+
+data BuildO = BuildO
+
+class FoldingWithIndex f i x y z | f i x y -> z
+class HFoldlWithIndex f x a b | f x a -> b
+
+instance
+  PickMax dk1 (Doc Base64) dk2 =>
+  FoldingWithIndex BuildO (Proxy "attachments") (O Opts (CA dk1 kk)) (Proxy True) (O Opts (CA dk2 kk))
+
+instance
+  PickMax dk1 (Doc Stub) dk2 =>
+  FoldingWithIndex BuildO (Proxy "includeDocs") (O Opts (CA dk1 kk)) (Proxy True) (O Opts (CA dk2 kk))
+
+instance
+  ( FoldingWithIndex f (Proxy sym) x (Proxy y) z
+  , HFoldlWithIndex f z (Proxy rl) b
+  ) =>
+  HFoldlWithIndex f x (Proxy (RL.Cons sym y rl)) b
+
+instance HFoldlWithIndex f x (Proxy RL.Nil) x
+
+class FoldlRecord f x (rl :: RL.RowList Type) (r :: Row Type) b | f x rl -> b, rl -> r
+instance
+  ( Row.Cons sym a r' r
+  , FoldingWithIndex f (Proxy sym) x a z
+  , FoldlRecord f z rl r b
+  ) =>
+  FoldlRecord f x (RL.Cons sym a rl) r b
+instance FoldlRecord f x RL.Nil r x
+
+class Build config args | config -> args
+instance
+  ( RL.RowToList r rl
+  , FoldlRecord BuildO (O Opts (CA NoDoc NoKeys)) rl r args
+  ) =>
+  Build { | r } args
+
+build :: forall config args. Build config args => config -> Proxy args
+build _ = Proxy
+
+test :: Proxy (O Opts (CA (Doc Base64) NoKeys))
+test = build { includeDocs: Proxy @True, attachments: Proxy @True }
+
+testInferred = build { includeDocs: Proxy @True, attachments: Proxy @True }

--- a/tests-integration/fixtures/checking/1778701500_pick_max_record_fold_order/Main.snap
+++ b/tests-integration/fixtures/checking/1778701500_pick_max_record_fold_order/Main.snap
@@ -1,0 +1,204 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+BuildO :: BuildO
+build ::
+  forall (t185 :: Type) (config :: Type) (args :: (t185 :: Type)).
+    Build @Type @(t185 :: Type) (config :: Type) (args :: (t185 :: Type)) =>
+    (config :: Type) -> Proxy @(t185 :: Type) (args :: (t185 :: Type))
+test :: Proxy @Type (O Opts (CA (Doc Base64) NoKeys))
+testInferred :: Proxy @Type (O Opts (CA (Doc Base64) NoKeys))
+
+Types
+TypeExpr :: forall (k :: Type). (k :: Type) -> Type
+Eq :: forall (a :: Type). (a :: Type) -> (a :: Type) -> TypeExpr @Type Boolean
+== :: forall (a :: Type). (a :: Type) -> (a :: Type) -> TypeExpr @Type Boolean
+Eval :: forall (k :: Type). TypeExpr @Type (k :: Type) -> (k :: Type) -> Constraint
+If :: forall (k :: Type). Boolean -> (k :: Type) -> (k :: Type) -> (k :: Type) -> Constraint
+CodecsArgsKind :: Type
+CA :: DocKind -> KeysKind -> CodecsArgsKind
+DocKind :: Type
+NoDoc :: DocKind
+Doc :: AttachmentKind -> DocKind
+AttachmentKind :: Type
+Stub :: AttachmentKind
+Base64 :: AttachmentKind
+KeysKind :: Type
+NoKeys :: KeysKind
+O :: Type -> CodecsArgsKind -> Type
+Opts :: Type
+IntOf :: forall (k :: Type). (k :: Type) -> Int -> Constraint
+PickMax :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type) -> Constraint
+BuildO :: Type
+FoldingWithIndex ::
+  forall (t26 :: Type) (t25 :: Type) (t24 :: Type) (t23 :: Type) (t22 :: Type).
+    (t26 :: Type) -> (t25 :: Type) -> (t24 :: Type) -> (t23 :: Type) -> (t22 :: Type) -> Constraint
+HFoldlWithIndex ::
+  forall (t34 :: Type) (t33 :: Type) (t32 :: Type) (t31 :: Type).
+    (t34 :: Type) -> (t33 :: Type) -> (t32 :: Type) -> (t31 :: Type) -> Constraint
+FoldlRecord ::
+  forall (t42 :: Type) (t41 :: Type) (t40 :: Type).
+    (t42 :: Type) -> (t41 :: Type) -> RowList Type -> Row Type -> (t40 :: Type) -> Constraint
+Build :: forall (t46 :: Type) (t45 :: Type). (t46 :: Type) -> (t45 :: Type) -> Constraint
+
+Classes
+class forall (k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type))
+class forall (k :: Type) (bool :: Boolean) (onTrue :: (k :: Type)) (onFalse :: (k :: Type)) (output :: (k :: Type)). If @(k :: Type)
+  (bool :: Boolean)
+  (onTrue :: (k :: Type))
+  (onFalse :: (k :: Type))
+  (output :: (k :: Type))
+class forall (k :: Type) (k :: (k :: Type)) (int :: Int). IntOf @(k :: Type) (k :: (k :: Type)) (int :: Int)
+class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)). PickMax @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type))
+class forall (t26 :: Type) (t25 :: Type) (t24 :: Type) (t23 :: Type) (t22 :: Type) (f :: (t26 :: Type)) (i :: (t25 :: Type)) (x :: (t24 :: Type)) (y :: (t23 :: Type)) (z :: (t22 :: Type)). FoldingWithIndex @(t26 :: Type) @(t25 :: Type) @(t24 :: Type) @(t23 :: Type) @(t22 :: Type)
+  (f :: (t26 :: Type))
+  (i :: (t25 :: Type))
+  (x :: (t24 :: Type))
+  (y :: (t23 :: Type))
+  (z :: (t22 :: Type))
+class forall (t34 :: Type) (t33 :: Type) (t32 :: Type) (t31 :: Type) (f :: (t34 :: Type)) (x :: (t33 :: Type)) (a :: (t32 :: Type)) (b :: (t31 :: Type)). HFoldlWithIndex @(t34 :: Type) @(t33 :: Type) @(t32 :: Type) @(t31 :: Type)
+  (f :: (t34 :: Type))
+  (x :: (t33 :: Type))
+  (a :: (t32 :: Type))
+  (b :: (t31 :: Type))
+class forall (t42 :: Type) (t41 :: Type) (t40 :: Type) (f :: (t42 :: Type)) (x :: (t41 :: Type)) (rl :: RowList Type) (r :: Row Type) (b :: (t40 :: Type)). FoldlRecord @(t42 :: Type) @(t41 :: Type) @(t40 :: Type)
+  (f :: (t42 :: Type))
+  (x :: (t41 :: Type))
+  (rl :: RowList Type)
+  (r :: Row Type)
+  (b :: (t40 :: Type))
+class forall (t46 :: Type) (t45 :: Type) (config :: (t46 :: Type)) (args :: (t45 :: Type)). Build @(t46 :: Type) @(t45 :: Type) (config :: (t46 :: Type)) (args :: (t45 :: Type))
+
+Instances
+instance forall (t48 :: Type) (t47 :: (t48 :: Type)).
+  Eval @Boolean (Eq @(t48 :: Type) (t47 :: (t48 :: Type)) (t47 :: (t48 :: Type))) True
+instance forall (t53 :: Type) (t51 :: (t53 :: Type)) (t52 :: (t53 :: Type)).
+  Eval @Boolean (Eq @(t53 :: Type) (t51 :: (t53 :: Type)) (t52 :: (t53 :: Type))) False
+instance forall (t59 :: Type) (t57 :: (t59 :: Type)) (t58 :: (t59 :: Type)).
+  If @(t59 :: Type) True (t57 :: (t59 :: Type)) (t58 :: (t59 :: Type)) (t57 :: (t59 :: Type))
+instance forall (t65 :: Type) (t63 :: (t65 :: Type)) (t64 :: (t65 :: Type)).
+  If @(t65 :: Type) False (t63 :: (t65 :: Type)) (t64 :: (t65 :: Type)) (t64 :: (t65 :: Type))
+instance IntOf @DocKind NoDoc 0
+instance IntOf @AttachmentKind Stub 0
+instance IntOf @AttachmentKind Base64 1
+instance forall (t69 :: AttachmentKind) (t71 :: Int) (t70 :: Int).
+  IntOf @AttachmentKind (t69 :: AttachmentKind) (t71 :: Int) =>
+  Add 1 (t71 :: Int) (t70 :: Int) =>
+  IntOf @DocKind (Doc (t69 :: AttachmentKind)) (t70 :: Int)
+instance forall (t82 :: Type) (t75 :: (t82 :: Type)) (t78 :: Int) (t76 :: (t82 :: Type)) (t79 :: Int)
+  (t80 :: Ordering) (t81 :: Boolean) (t77 :: (t82 :: Type)).
+  IntOf @(t82 :: Type) (t75 :: (t82 :: Type)) (t78 :: Int) =>
+  IntOf @(t82 :: Type) (t76 :: (t82 :: Type)) (t79 :: Int) =>
+  Compare (t78 :: Int) (t79 :: Int) (t80 :: Ordering) =>
+  Eval @Boolean (Eq @Ordering LT (t80 :: Ordering)) (t81 :: Boolean) =>
+  If @(t82 :: Type)
+    (t81 :: Boolean)
+    (t76 :: (t82 :: Type))
+    (t75 :: (t82 :: Type))
+    (t77 :: (t82 :: Type)) =>
+  PickMax @(t82 :: Type) (t75 :: (t82 :: Type)) (t76 :: (t82 :: Type)) (t77 :: (t82 :: Type))
+instance forall (t91 :: DocKind) (t93 :: DocKind) (t92 :: KeysKind).
+  PickMax @DocKind (t91 :: DocKind) (Doc Base64) (t93 :: DocKind) =>
+  FoldingWithIndex @Type @Type @Type @Type @Type
+    BuildO
+    (Proxy @Symbol "attachments")
+    (O Opts (CA (t91 :: DocKind) (t92 :: KeysKind)))
+    (Proxy @Boolean True)
+    (O Opts (CA (t93 :: DocKind) (t92 :: KeysKind)))
+instance forall (t97 :: DocKind) (t99 :: DocKind) (t98 :: KeysKind).
+  PickMax @DocKind (t97 :: DocKind) (Doc Stub) (t99 :: DocKind) =>
+  FoldingWithIndex @Type @Type @Type @Type @Type
+    BuildO
+    (Proxy @Symbol "includeDocs")
+    (O Opts (CA (t97 :: DocKind) (t98 :: KeysKind)))
+    (Proxy @Boolean True)
+    (O Opts (CA (t99 :: DocKind) (t98 :: KeysKind)))
+instance forall (t114 :: Type) (t113 :: Type) (t112 :: Type) (t103 :: (t114 :: Type)) (t105 :: Symbol)
+  (t104 :: (t113 :: Type)) (t111 :: Type) (t106 :: (t111 :: Type)) (t109 :: (t112 :: Type))
+  (t110 :: Type) (t107 :: RowList (t111 :: Type)) (t108 :: (t110 :: Type)).
+  FoldingWithIndex @(t114 :: Type) @Type @(t113 :: Type) @Type @(t112 :: Type)
+    (t103 :: (t114 :: Type))
+    (Proxy @Symbol (t105 :: Symbol))
+    (t104 :: (t113 :: Type))
+    (Proxy @(t111 :: Type) (t106 :: (t111 :: Type)))
+    (t109 :: (t112 :: Type)) =>
+  HFoldlWithIndex @(t114 :: Type) @(t112 :: Type) @Type @(t110 :: Type)
+    (t103 :: (t114 :: Type))
+    (t109 :: (t112 :: Type))
+    (Proxy @(RowList (t111 :: Type)) (t107 :: RowList (t111 :: Type)))
+    (t108 :: (t110 :: Type)) =>
+  HFoldlWithIndex @(t114 :: Type) @(t113 :: Type) @Type @(t110 :: Type)
+    (t103 :: (t114 :: Type))
+    (t104 :: (t113 :: Type))
+    (Proxy @(RowList (t111 :: Type))
+      (Cons @(t111 :: Type)
+        (t105 :: Symbol)
+        (t106 :: (t111 :: Type))
+        (t107 :: RowList (t111 :: Type))))
+    (t108 :: (t110 :: Type))
+instance forall (t131 :: Type) (t130 :: Type) (t127 :: (t131 :: Type)) (t128 :: (t130 :: Type))
+  (t129 :: Type).
+  HFoldlWithIndex @(t131 :: Type) @(t130 :: Type) @Type @(t130 :: Type)
+    (t127 :: (t131 :: Type))
+    (t128 :: (t130 :: Type))
+    (Proxy @(RowList (t129 :: Type)) (Nil @(t129 :: Type)))
+    (t128 :: (t130 :: Type))
+instance forall (t139 :: Symbol) (t140 :: Type) (t144 :: Row Type) (t142 :: Row Type) (t149 :: Type)
+  (t148 :: Type) (t147 :: Type) (t137 :: (t149 :: Type)) (t138 :: (t148 :: Type))
+  (t145 :: (t147 :: Type)) (t146 :: Type) (t141 :: RowList Type) (t143 :: (t146 :: Type)).
+  Cons @Type (t139 :: Symbol) (t140 :: Type) (t144 :: Row Type) (t142 :: Row Type) =>
+  FoldingWithIndex @(t149 :: Type) @Type @(t148 :: Type) @Type @(t147 :: Type)
+    (t137 :: (t149 :: Type))
+    (Proxy @Symbol (t139 :: Symbol))
+    (t138 :: (t148 :: Type))
+    (t140 :: Type)
+    (t145 :: (t147 :: Type)) =>
+  FoldlRecord @(t149 :: Type) @(t147 :: Type) @(t146 :: Type)
+    (t137 :: (t149 :: Type))
+    (t145 :: (t147 :: Type))
+    (t141 :: RowList Type)
+    (t142 :: Row Type)
+    (t143 :: (t146 :: Type)) =>
+  FoldlRecord @(t149 :: Type) @(t148 :: Type) @(t146 :: Type)
+    (t137 :: (t149 :: Type))
+    (t138 :: (t148 :: Type))
+    (Cons @Type (t139 :: Symbol) (t140 :: Type) (t141 :: RowList Type))
+    (t142 :: Row Type)
+    (t143 :: (t146 :: Type))
+instance forall (t167 :: Type) (t166 :: Type) (t163 :: (t167 :: Type)) (t164 :: (t166 :: Type))
+  (t165 :: Row Type).
+  FoldlRecord @(t167 :: Type) @(t166 :: Type) @(t166 :: Type)
+    (t163 :: (t167 :: Type))
+    (t164 :: (t166 :: Type))
+    (Nil @Type)
+    (t165 :: Row Type)
+    (t164 :: (t166 :: Type))
+instance forall (t173 :: Row Type) (t175 :: RowList Type) (t176 :: Type) (t174 :: (t176 :: Type)).
+  RowToList @Type (t173 :: Row Type) (t175 :: RowList Type) =>
+  FoldlRecord @Type @Type @(t176 :: Type)
+    BuildO
+    (O Opts (CA NoDoc NoKeys))
+    (t175 :: RowList Type)
+    (t173 :: Row Type)
+    (t174 :: (t176 :: Type)) =>
+  Build @Type @(t176 :: Type) {| (t173 :: Row Type) } (t174 :: (t176 :: Type))
+
+Roles
+TypeExpr = [Nominal]
+Eq = [Nominal, Nominal]
+CodecsArgsKind = []
+CA = [Nominal, Nominal]
+DocKind = []
+NoDoc = []
+Doc = [Nominal]
+AttachmentKind = []
+Stub = []
+Base64 = []
+KeysKind = []
+NoKeys = []
+O = [Nominal, Nominal]
+Opts = []
+BuildO = []

--- a/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.purs
+++ b/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+import Prim.Boolean (False, True)
+import Type.Proxy (Proxy(..))
+
+foreign import data TypeExpr :: forall k. k -> Type
+foreign import data NotEq :: Boolean -> Boolean -> TypeExpr Boolean
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+
+instance Eval (NotEq a a) False
+else instance Eval (NotEq a b) True
+
+class IsBoolean :: Boolean -> Constraint
+class IsBoolean bool
+
+instance IsBoolean True
+instance IsBoolean False
+
+foreign import reflectBoolean :: forall bool. IsBoolean bool => Proxy bool -> Boolean
+
+test :: forall x. IsBoolean x => Eval (NotEq False True) x => Boolean
+test = reflectBoolean (Proxy @x)

--- a/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/checking/1778701560_eval_given_visible_type_application/Main.snap
@@ -1,0 +1,32 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+reflectBoolean ::
+  forall (bool :: Boolean).
+    IsBoolean (bool :: Boolean) => Proxy @Boolean (bool :: Boolean) -> Boolean
+test ::
+  forall (x :: Boolean).
+    IsBoolean (x :: Boolean) => Eval @Boolean (NotEq False True) (x :: Boolean) => Boolean
+
+Types
+TypeExpr :: forall (k :: Type). (k :: Type) -> Type
+NotEq :: Boolean -> Boolean -> TypeExpr @Type Boolean
+Eval :: forall (k :: Type). TypeExpr @Type (k :: Type) -> (k :: Type) -> Constraint
+IsBoolean :: Boolean -> Constraint
+
+Classes
+class forall (k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type))
+class forall (bool :: Boolean). IsBoolean (bool :: Boolean)
+
+Instances
+instance forall (t5 :: Boolean). Eval @Boolean (NotEq (t5 :: Boolean) (t5 :: Boolean)) False
+instance forall (t7 :: Boolean) (t8 :: Boolean). Eval @Boolean (NotEq (t7 :: Boolean) (t8 :: Boolean)) True
+instance IsBoolean True
+instance IsBoolean False
+
+Roles
+TypeExpr = [Nominal]
+NotEq = [Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1778720160_example_function_fundep/Main.purs
+++ b/tests-integration/fixtures/checking/1778720160_example_function_fundep/Main.purs
@@ -1,0 +1,29 @@
+module Main where
+
+foreign import data Aff :: Type -> Type
+foreign import data Spec :: (Type -> Type) -> Type -> Type
+foreign import data Unit :: Type
+foreign import data Error :: Type
+
+class MonadThrow e m
+instance MonadThrow Error Aff
+
+class Example t arg m | t -> arg, t -> m where
+  evaluateExample :: t -> Unit
+
+instance Example (arg -> m Unit) arg m where
+  evaluateExample _ = unit
+
+else instance Example (m Unit) Unit m where
+  evaluateExample _ = unit
+
+foreign import unit :: Unit
+foreign import shouldEqual :: forall m. MonadThrow Error m => Int -> Int -> m Unit
+
+it :: forall t arg g. Example t arg g => String -> t -> Spec g arg
+it _ _ = spec
+
+foreign import spec :: forall g a. Spec g a
+
+test :: Spec Aff Int
+test = it "returns correct total" \res -> shouldEqual res 4

--- a/tests-integration/fixtures/checking/1778720160_example_function_fundep/Main.snap
+++ b/tests-integration/fixtures/checking/1778720160_example_function_fundep/Main.snap
@@ -1,0 +1,53 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+evaluateExample ::
+  forall (t8 :: Type) (t7 :: Type) (@t :: Type) (@arg :: (t8 :: Type)) (@m :: (t7 :: Type)).
+    Example @(t8 :: Type) @(t7 :: Type) (t :: Type) (arg :: (t8 :: Type)) (m :: (t7 :: Type)) =>
+    (t :: Type) -> Unit
+unit :: Unit
+shouldEqual ::
+  forall (m :: Type -> Type).
+    MonadThrow @Type @(Type -> Type) Error (m :: Type -> Type) =>
+    Int -> Int -> (m :: Type -> Type) Unit
+it ::
+  forall (t :: Type) (arg :: Type) (g :: Type -> Type).
+    Example @Type @(Type -> Type) (t :: Type) (arg :: Type) (g :: Type -> Type) =>
+    String -> (t :: Type) -> Spec (g :: Type -> Type) (arg :: Type)
+spec :: forall (g :: Type -> Type) (a :: Type). Spec (g :: Type -> Type) (a :: Type)
+test :: Spec Aff Int
+
+Types
+Aff :: Type -> Type
+Spec :: (Type -> Type) -> Type -> Type
+Unit :: Type
+Error :: Type
+MonadThrow :: forall (t3 :: Type) (t2 :: Type). (t3 :: Type) -> (t2 :: Type) -> Constraint
+Example :: forall (t8 :: Type) (t7 :: Type). Type -> (t8 :: Type) -> (t7 :: Type) -> Constraint
+
+Classes
+class forall (t3 :: Type) (t2 :: Type) (e :: (t3 :: Type)) (m :: (t2 :: Type)). MonadThrow @(t3 :: Type) @(t2 :: Type) (e :: (t3 :: Type)) (m :: (t2 :: Type))
+class forall (t8 :: Type) (t7 :: Type) (t :: Type) (arg :: (t8 :: Type)) (m :: (t7 :: Type)). Example @(t8 :: Type) @(t7 :: Type) (t :: Type) (arg :: (t8 :: Type)) (m :: (t7 :: Type))
+  evaluateExample ::
+  forall (t8 :: Type) (t7 :: Type) (@t :: Type) (@arg :: (t8 :: Type)) (@m :: (t7 :: Type)).
+    Example @(t8 :: Type) @(t7 :: Type) (t :: Type) (arg :: (t8 :: Type)) (m :: (t7 :: Type)) =>
+    (t :: Type) -> Unit
+
+Instances
+instance MonadThrow @Type @(Type -> Type) Error Aff
+instance forall (t9 :: Type) (t10 :: Type -> Type).
+  Example @Type @(Type -> Type)
+    ((t9 :: Type) -> (t10 :: Type -> Type) Unit)
+    (t9 :: Type)
+    (t10 :: Type -> Type)
+instance forall (t13 :: Type -> Type).
+  Example @Type @(Type -> Type) ((t13 :: Type -> Type) Unit) Unit (t13 :: Type -> Type)
+
+Roles
+Aff = [Nominal]
+Spec = [Nominal, Nominal]
+Unit = []
+Error = []

--- a/tests-integration/fixtures/checking/1778723460_pick_max_attachment_codec_binary/Main.purs
+++ b/tests-integration/fixtures/checking/1778723460_pick_max_attachment_codec_binary/Main.purs
@@ -1,0 +1,119 @@
+module Main where
+
+import Prim.Int (class Add, class Compare)
+import Prim.Ordering (LT)
+import Prim.Row as Row
+import Prim.RowList as RL
+import Prim.Boolean (False, True)
+import Type.Proxy (Proxy(..))
+
+foreign import data TypeExpr :: forall k. k -> Type
+foreign import data Eq :: forall a. a -> a -> TypeExpr Boolean
+infix 4 type Eq as ==
+
+class Eval :: forall k. TypeExpr k -> k -> Constraint
+class Eval expr result | expr -> result
+instance Eval (Eq a a) True
+else instance Eval (Eq a b) False
+
+class If :: forall k. Boolean -> k -> k -> k -> Constraint
+class If bool onTrue onFalse output | bool onTrue onFalse -> output
+instance If True onTrue onFalse onTrue
+else instance If False onTrue onFalse onFalse
+
+data CodecsArgsKind
+foreign import data CA :: DocKind -> KeysKind -> CodecsArgsKind
+data DocKind
+foreign import data NoDoc :: DocKind
+foreign import data Doc :: AttachmentKind -> DocKind
+data AttachmentKind
+foreign import data Stub :: AttachmentKind
+foreign import data Base64 :: AttachmentKind
+foreign import data Blob :: AttachmentKind
+data KeysKind
+foreign import data NoKeys :: KeysKind
+
+foreign import data O :: Type -> CodecsArgsKind -> Type
+foreign import data Opts :: Type
+foreign import data Res :: Type -> Type
+foreign import data StubAttachment :: Type
+foreign import data Base64Attachment :: Type
+foreign import data BlobAttachment :: Type
+
+class IntOf :: forall k. k -> Int -> Constraint
+class IntOf k int | k -> int
+instance IntOf NoDoc 0
+instance IntOf Stub 0
+instance IntOf Base64 1
+instance IntOf Blob 2
+instance (IntOf dk i1, Add 1 i1 i2) => IntOf (Doc dk) i2
+
+class PickMax :: forall k. k -> k -> k -> Constraint
+class PickMax a b c | a b -> c
+instance
+  ( IntOf a ia
+  , IntOf b ib
+  , Compare ia ib ord
+  , Eval (LT == ord) isLess
+  , If isLess b a c
+  ) =>
+  PickMax a b c
+
+class IsJAttachmentCodec :: AttachmentKind -> Type -> Constraint
+class IsJAttachmentCodec dk attachment | dk -> attachment
+instance IsJAttachmentCodec Stub StubAttachment
+instance IsJAttachmentCodec Base64 Base64Attachment
+instance IsJAttachmentCodec Blob BlobAttachment
+
+class IsCodec :: CodecsArgsKind -> Type -> Constraint
+class IsCodec dak a | dak -> a
+instance IsJAttachmentCodec a attachment => IsCodec (CA (Doc a) NoKeys) (Res attachment)
+
+data BuildO = BuildO
+
+class FoldingWithIndex f i x y z | f i x y -> z
+class HFoldlWithIndex f x a b | f x a -> b
+
+instance
+  PickMax dk1 (Doc Base64) dk2 =>
+  FoldingWithIndex BuildO (Proxy "attachments") (O Opts (CA dk1 kk)) (Proxy True) (O Opts (CA dk2 kk))
+
+instance
+  PickMax dk1 (Doc Blob) dk2 =>
+  FoldingWithIndex BuildO (Proxy "binary") (O Opts (CA dk1 kk)) (Proxy True) (O Opts (CA dk2 kk))
+
+instance
+  PickMax dk1 (Doc Stub) dk2 =>
+  FoldingWithIndex BuildO (Proxy "includeDocs") (O Opts (CA dk1 kk)) (Proxy True) (O Opts (CA dk2 kk))
+
+instance
+  ( FoldingWithIndex f (Proxy sym) x (Proxy y) z
+  , HFoldlWithIndex f z (Proxy rl) b
+  ) =>
+  HFoldlWithIndex f x (Proxy (RL.Cons sym y rl)) b
+
+instance HFoldlWithIndex f x (Proxy RL.Nil) x
+
+class FoldlRecord f x (rl :: RL.RowList Type) (r :: Row Type) b | f x rl -> b, rl -> r
+instance
+  ( Row.Cons sym a r' r
+  , FoldingWithIndex f (Proxy sym) x a z
+  , FoldlRecord f z rl r b
+  ) =>
+  FoldlRecord f x (RL.Cons sym a rl) r b
+instance FoldlRecord f x RL.Nil r x
+
+class Build config args | config -> args
+instance
+  ( RL.RowToList r rl
+  , FoldlRecord BuildO (O Opts (CA NoDoc NoKeys)) rl r (O Opts args)
+  ) =>
+  Build { | r } args
+
+allDocs :: forall config args a. Build config args => IsCodec args a => config -> Proxy a
+allDocs _ = Proxy
+
+test :: Proxy (Res BlobAttachment)
+test = allDocs { includeDocs: Proxy @True, attachments: Proxy @True, binary: Proxy @True }
+
+testInferred = allDocs { includeDocs: Proxy @True, attachments: Proxy @True, binary: Proxy @True }

--- a/tests-integration/fixtures/checking/1778723460_pick_max_attachment_codec_binary/Main.snap
+++ b/tests-integration/fixtures/checking/1778723460_pick_max_attachment_codec_binary/Main.snap
@@ -1,0 +1,234 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+BuildO :: BuildO
+allDocs ::
+  forall (config :: Type) (args :: CodecsArgsKind) (a :: Type).
+    Build @Type @CodecsArgsKind (config :: Type) (args :: CodecsArgsKind) =>
+    IsCodec (args :: CodecsArgsKind) (a :: Type) =>
+    (config :: Type) -> Proxy @Type (a :: Type)
+test :: Proxy @Type (Res BlobAttachment)
+testInferred :: Proxy @Type (Res BlobAttachment)
+
+Types
+TypeExpr :: forall (k :: Type). (k :: Type) -> Type
+Eq :: forall (a :: Type). (a :: Type) -> (a :: Type) -> TypeExpr @Type Boolean
+== :: forall (a :: Type). (a :: Type) -> (a :: Type) -> TypeExpr @Type Boolean
+Eval :: forall (k :: Type). TypeExpr @Type (k :: Type) -> (k :: Type) -> Constraint
+If :: forall (k :: Type). Boolean -> (k :: Type) -> (k :: Type) -> (k :: Type) -> Constraint
+CodecsArgsKind :: Type
+CA :: DocKind -> KeysKind -> CodecsArgsKind
+DocKind :: Type
+NoDoc :: DocKind
+Doc :: AttachmentKind -> DocKind
+AttachmentKind :: Type
+Stub :: AttachmentKind
+Base64 :: AttachmentKind
+Blob :: AttachmentKind
+KeysKind :: Type
+NoKeys :: KeysKind
+O :: Type -> CodecsArgsKind -> Type
+Opts :: Type
+Res :: Type -> Type
+StubAttachment :: Type
+Base64Attachment :: Type
+BlobAttachment :: Type
+IntOf :: forall (k :: Type). (k :: Type) -> Int -> Constraint
+PickMax :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type) -> Constraint
+IsJAttachmentCodec :: AttachmentKind -> Type -> Constraint
+IsCodec :: CodecsArgsKind -> Type -> Constraint
+BuildO :: Type
+FoldingWithIndex ::
+  forall (t30 :: Type) (t29 :: Type) (t28 :: Type) (t27 :: Type) (t26 :: Type).
+    (t30 :: Type) -> (t29 :: Type) -> (t28 :: Type) -> (t27 :: Type) -> (t26 :: Type) -> Constraint
+HFoldlWithIndex ::
+  forall (t38 :: Type) (t37 :: Type) (t36 :: Type) (t35 :: Type).
+    (t38 :: Type) -> (t37 :: Type) -> (t36 :: Type) -> (t35 :: Type) -> Constraint
+FoldlRecord ::
+  forall (t46 :: Type) (t45 :: Type) (t44 :: Type).
+    (t46 :: Type) -> (t45 :: Type) -> RowList Type -> Row Type -> (t44 :: Type) -> Constraint
+Build :: forall (t50 :: Type) (t49 :: Type). (t50 :: Type) -> (t49 :: Type) -> Constraint
+
+Classes
+class forall (k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type)). Eval @(k :: Type) (expr :: TypeExpr @Type (k :: Type)) (result :: (k :: Type))
+class forall (k :: Type) (bool :: Boolean) (onTrue :: (k :: Type)) (onFalse :: (k :: Type)) (output :: (k :: Type)). If @(k :: Type)
+  (bool :: Boolean)
+  (onTrue :: (k :: Type))
+  (onFalse :: (k :: Type))
+  (output :: (k :: Type))
+class forall (k :: Type) (k :: (k :: Type)) (int :: Int). IntOf @(k :: Type) (k :: (k :: Type)) (int :: Int)
+class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)). PickMax @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type))
+class forall (dk :: AttachmentKind) (attachment :: Type). IsJAttachmentCodec (dk :: AttachmentKind) (attachment :: Type)
+class forall (dak :: CodecsArgsKind) (a :: Type). IsCodec (dak :: CodecsArgsKind) (a :: Type)
+class forall (t30 :: Type) (t29 :: Type) (t28 :: Type) (t27 :: Type) (t26 :: Type) (f :: (t30 :: Type)) (i :: (t29 :: Type)) (x :: (t28 :: Type)) (y :: (t27 :: Type)) (z :: (t26 :: Type)). FoldingWithIndex @(t30 :: Type) @(t29 :: Type) @(t28 :: Type) @(t27 :: Type) @(t26 :: Type)
+  (f :: (t30 :: Type))
+  (i :: (t29 :: Type))
+  (x :: (t28 :: Type))
+  (y :: (t27 :: Type))
+  (z :: (t26 :: Type))
+class forall (t38 :: Type) (t37 :: Type) (t36 :: Type) (t35 :: Type) (f :: (t38 :: Type)) (x :: (t37 :: Type)) (a :: (t36 :: Type)) (b :: (t35 :: Type)). HFoldlWithIndex @(t38 :: Type) @(t37 :: Type) @(t36 :: Type) @(t35 :: Type)
+  (f :: (t38 :: Type))
+  (x :: (t37 :: Type))
+  (a :: (t36 :: Type))
+  (b :: (t35 :: Type))
+class forall (t46 :: Type) (t45 :: Type) (t44 :: Type) (f :: (t46 :: Type)) (x :: (t45 :: Type)) (rl :: RowList Type) (r :: Row Type) (b :: (t44 :: Type)). FoldlRecord @(t46 :: Type) @(t45 :: Type) @(t44 :: Type)
+  (f :: (t46 :: Type))
+  (x :: (t45 :: Type))
+  (rl :: RowList Type)
+  (r :: Row Type)
+  (b :: (t44 :: Type))
+class forall (t50 :: Type) (t49 :: Type) (config :: (t50 :: Type)) (args :: (t49 :: Type)). Build @(t50 :: Type) @(t49 :: Type) (config :: (t50 :: Type)) (args :: (t49 :: Type))
+
+Instances
+instance forall (t52 :: Type) (t51 :: (t52 :: Type)).
+  Eval @Boolean (Eq @(t52 :: Type) (t51 :: (t52 :: Type)) (t51 :: (t52 :: Type))) True
+instance forall (t57 :: Type) (t55 :: (t57 :: Type)) (t56 :: (t57 :: Type)).
+  Eval @Boolean (Eq @(t57 :: Type) (t55 :: (t57 :: Type)) (t56 :: (t57 :: Type))) False
+instance forall (t63 :: Type) (t61 :: (t63 :: Type)) (t62 :: (t63 :: Type)).
+  If @(t63 :: Type) True (t61 :: (t63 :: Type)) (t62 :: (t63 :: Type)) (t61 :: (t63 :: Type))
+instance forall (t69 :: Type) (t67 :: (t69 :: Type)) (t68 :: (t69 :: Type)).
+  If @(t69 :: Type) False (t67 :: (t69 :: Type)) (t68 :: (t69 :: Type)) (t68 :: (t69 :: Type))
+instance IntOf @DocKind NoDoc 0
+instance IntOf @AttachmentKind Stub 0
+instance IntOf @AttachmentKind Base64 1
+instance IntOf @AttachmentKind Blob 2
+instance forall (t73 :: AttachmentKind) (t75 :: Int) (t74 :: Int).
+  IntOf @AttachmentKind (t73 :: AttachmentKind) (t75 :: Int) =>
+  Add 1 (t75 :: Int) (t74 :: Int) =>
+  IntOf @DocKind (Doc (t73 :: AttachmentKind)) (t74 :: Int)
+instance forall (t86 :: Type) (t79 :: (t86 :: Type)) (t82 :: Int) (t80 :: (t86 :: Type)) (t83 :: Int)
+  (t84 :: Ordering) (t85 :: Boolean) (t81 :: (t86 :: Type)).
+  IntOf @(t86 :: Type) (t79 :: (t86 :: Type)) (t82 :: Int) =>
+  IntOf @(t86 :: Type) (t80 :: (t86 :: Type)) (t83 :: Int) =>
+  Compare (t82 :: Int) (t83 :: Int) (t84 :: Ordering) =>
+  Eval @Boolean (Eq @Ordering LT (t84 :: Ordering)) (t85 :: Boolean) =>
+  If @(t86 :: Type)
+    (t85 :: Boolean)
+    (t80 :: (t86 :: Type))
+    (t79 :: (t86 :: Type))
+    (t81 :: (t86 :: Type)) =>
+  PickMax @(t86 :: Type) (t79 :: (t86 :: Type)) (t80 :: (t86 :: Type)) (t81 :: (t86 :: Type))
+instance IsJAttachmentCodec Stub StubAttachment
+instance IsJAttachmentCodec Base64 Base64Attachment
+instance IsJAttachmentCodec Blob BlobAttachment
+instance forall (t95 :: AttachmentKind) (t96 :: Type).
+  IsJAttachmentCodec (t95 :: AttachmentKind) (t96 :: Type) =>
+  IsCodec (CA (Doc (t95 :: AttachmentKind)) NoKeys) (Res (t96 :: Type))
+instance forall (t99 :: DocKind) (t101 :: DocKind) (t100 :: KeysKind).
+  PickMax @DocKind (t99 :: DocKind) (Doc Base64) (t101 :: DocKind) =>
+  FoldingWithIndex @Type @Type @Type @Type @Type
+    BuildO
+    (Proxy @Symbol "attachments")
+    (O Opts (CA (t99 :: DocKind) (t100 :: KeysKind)))
+    (Proxy @Boolean True)
+    (O Opts (CA (t101 :: DocKind) (t100 :: KeysKind)))
+instance forall (t105 :: DocKind) (t107 :: DocKind) (t106 :: KeysKind).
+  PickMax @DocKind (t105 :: DocKind) (Doc Blob) (t107 :: DocKind) =>
+  FoldingWithIndex @Type @Type @Type @Type @Type
+    BuildO
+    (Proxy @Symbol "binary")
+    (O Opts (CA (t105 :: DocKind) (t106 :: KeysKind)))
+    (Proxy @Boolean True)
+    (O Opts (CA (t107 :: DocKind) (t106 :: KeysKind)))
+instance forall (t111 :: DocKind) (t113 :: DocKind) (t112 :: KeysKind).
+  PickMax @DocKind (t111 :: DocKind) (Doc Stub) (t113 :: DocKind) =>
+  FoldingWithIndex @Type @Type @Type @Type @Type
+    BuildO
+    (Proxy @Symbol "includeDocs")
+    (O Opts (CA (t111 :: DocKind) (t112 :: KeysKind)))
+    (Proxy @Boolean True)
+    (O Opts (CA (t113 :: DocKind) (t112 :: KeysKind)))
+instance forall (t128 :: Type) (t127 :: Type) (t126 :: Type) (t117 :: (t128 :: Type)) (t119 :: Symbol)
+  (t118 :: (t127 :: Type)) (t125 :: Type) (t120 :: (t125 :: Type)) (t123 :: (t126 :: Type))
+  (t124 :: Type) (t121 :: RowList (t125 :: Type)) (t122 :: (t124 :: Type)).
+  FoldingWithIndex @(t128 :: Type) @Type @(t127 :: Type) @Type @(t126 :: Type)
+    (t117 :: (t128 :: Type))
+    (Proxy @Symbol (t119 :: Symbol))
+    (t118 :: (t127 :: Type))
+    (Proxy @(t125 :: Type) (t120 :: (t125 :: Type)))
+    (t123 :: (t126 :: Type)) =>
+  HFoldlWithIndex @(t128 :: Type) @(t126 :: Type) @Type @(t124 :: Type)
+    (t117 :: (t128 :: Type))
+    (t123 :: (t126 :: Type))
+    (Proxy @(RowList (t125 :: Type)) (t121 :: RowList (t125 :: Type)))
+    (t122 :: (t124 :: Type)) =>
+  HFoldlWithIndex @(t128 :: Type) @(t127 :: Type) @Type @(t124 :: Type)
+    (t117 :: (t128 :: Type))
+    (t118 :: (t127 :: Type))
+    (Proxy @(RowList (t125 :: Type))
+      (Cons @(t125 :: Type)
+        (t119 :: Symbol)
+        (t120 :: (t125 :: Type))
+        (t121 :: RowList (t125 :: Type))))
+    (t122 :: (t124 :: Type))
+instance forall (t145 :: Type) (t144 :: Type) (t141 :: (t145 :: Type)) (t142 :: (t144 :: Type))
+  (t143 :: Type).
+  HFoldlWithIndex @(t145 :: Type) @(t144 :: Type) @Type @(t144 :: Type)
+    (t141 :: (t145 :: Type))
+    (t142 :: (t144 :: Type))
+    (Proxy @(RowList (t143 :: Type)) (Nil @(t143 :: Type)))
+    (t142 :: (t144 :: Type))
+instance forall (t153 :: Symbol) (t154 :: Type) (t158 :: Row Type) (t156 :: Row Type) (t163 :: Type)
+  (t162 :: Type) (t161 :: Type) (t151 :: (t163 :: Type)) (t152 :: (t162 :: Type))
+  (t159 :: (t161 :: Type)) (t160 :: Type) (t155 :: RowList Type) (t157 :: (t160 :: Type)).
+  Cons @Type (t153 :: Symbol) (t154 :: Type) (t158 :: Row Type) (t156 :: Row Type) =>
+  FoldingWithIndex @(t163 :: Type) @Type @(t162 :: Type) @Type @(t161 :: Type)
+    (t151 :: (t163 :: Type))
+    (Proxy @Symbol (t153 :: Symbol))
+    (t152 :: (t162 :: Type))
+    (t154 :: Type)
+    (t159 :: (t161 :: Type)) =>
+  FoldlRecord @(t163 :: Type) @(t161 :: Type) @(t160 :: Type)
+    (t151 :: (t163 :: Type))
+    (t159 :: (t161 :: Type))
+    (t155 :: RowList Type)
+    (t156 :: Row Type)
+    (t157 :: (t160 :: Type)) =>
+  FoldlRecord @(t163 :: Type) @(t162 :: Type) @(t160 :: Type)
+    (t151 :: (t163 :: Type))
+    (t152 :: (t162 :: Type))
+    (Cons @Type (t153 :: Symbol) (t154 :: Type) (t155 :: RowList Type))
+    (t156 :: Row Type)
+    (t157 :: (t160 :: Type))
+instance forall (t181 :: Type) (t180 :: Type) (t177 :: (t181 :: Type)) (t178 :: (t180 :: Type))
+  (t179 :: Row Type).
+  FoldlRecord @(t181 :: Type) @(t180 :: Type) @(t180 :: Type)
+    (t177 :: (t181 :: Type))
+    (t178 :: (t180 :: Type))
+    (Nil @Type)
+    (t179 :: Row Type)
+    (t178 :: (t180 :: Type))
+instance forall (t187 :: Row Type) (t189 :: RowList Type) (t188 :: CodecsArgsKind).
+  RowToList @Type (t187 :: Row Type) (t189 :: RowList Type) =>
+  FoldlRecord @Type @Type @Type
+    BuildO
+    (O Opts (CA NoDoc NoKeys))
+    (t189 :: RowList Type)
+    (t187 :: Row Type)
+    (O Opts (t188 :: CodecsArgsKind)) =>
+  Build @Type @CodecsArgsKind {| (t187 :: Row Type) } (t188 :: CodecsArgsKind)
+
+Roles
+TypeExpr = [Nominal]
+Eq = [Nominal, Nominal]
+CodecsArgsKind = []
+CA = [Nominal, Nominal]
+DocKind = []
+NoDoc = []
+Doc = [Nominal]
+AttachmentKind = []
+Stub = []
+Base64 = []
+Blob = []
+KeysKind = []
+NoKeys = []
+O = [Nominal, Nominal]
+Opts = []
+Res = [Nominal]
+StubAttachment = []
+Base64Attachment = []
+BlobAttachment = []
+BuildO = []

--- a/tests-integration/fixtures/checking/1778805900_recursive_instance_chain_candidate_constraint/Main.purs
+++ b/tests-integration/fixtures/checking/1778805900_recursive_instance_chain_candidate_constraint/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+data Unit = Unit
+
+class Resolve :: Type -> Constraint
+class Resolve a where
+  resolve :: Proxy a -> Unit
+
+instance recursiveResolve :: Resolve a => Resolve a where
+  resolve _ = Unit
+else instance resolveInt :: Resolve Int where
+  resolve _ = Unit

--- a/tests-integration/fixtures/checking/1778805900_recursive_instance_chain_candidate_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1778805900_recursive_instance_chain_candidate_constraint/Main.snap
@@ -1,0 +1,25 @@
+---
+source: target/debug/build/tests-integration-35f6ccefceed9daa/out/checking_generated.rs
+expression: report
+---
+Terms
+Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Unit :: Unit
+resolve :: forall (@a :: Type). Resolve (a :: Type) => Proxy @Type (a :: Type) -> Unit
+
+Types
+Proxy :: forall (k :: Type). (k :: Type) -> Type
+Unit :: Type
+Resolve :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Resolve (a :: Type)
+  resolve :: forall (@a :: Type). Resolve (a :: Type) => Proxy @Type (a :: Type) -> Unit
+
+Instances
+instance forall (t3 :: Type). Resolve (t3 :: Type) => Resolve (t3 :: Type)
+instance Resolve Int
+
+Roles
+Proxy = [Phantom]
+Unit = []


### PR DESCRIPTION
# checking: backtrack instance-chain subgoals and bound recursive probes

Base branch: `pr/checking-row-fundep-givens`

## Review Order

This PR is stacked on `pr/checking-row-fundep-givens` and should be reviewed after that PR.

Base branch for review: `pr/checking-row-fundep-givens`

It is otherwise independent from `pr/checking-operator-expected-results`; both branches can be reviewed after the row-fundep/givens PR is understood.

## Summary

- Backtrack instance-chain candidate probing when nested subgoals are unsatisfiable.
- Refine else-candidate blocking so candidates are blocked only by unknown match results, not by known-apart or known-unsatisfiable subgoals.
- Bound recursive instance probes to avoid infinite recursion while preserving the ability to reject impossible candidates.

## Motivation

These fixes address several false positives from real PureScript project code involving overlapping/else instances, type-level comparison, row folds, and derived codec-like instance chains. The analyzer was either selecting the wrong else branch too early, keeping an impossible candidate alive, or recursively probing the same candidate shape without a useful bound.

The common concern is candidate probing: it needs transactional state, precise blocking semantics, and recursion protection. Failed nested probes should not leak solver state, known-unsatisfiable subgoals should reject a candidate, and recursive probes need a bound.

## Motivating Example

For overlapping instances, a candidate with an impossible nested subgoal should be rejected so the valid else candidate can be considered:

```purescript
class Pick a b result | a b -> result

instance pickSame :: Compare a a EQ => Pick a a a
else instance pickFallback :: Pick a b b

choose :: forall a b result. Pick a b result => Proxy a -> Proxy b -> Proxy result
choose _ _ = Proxy
```

Before this change, the checker could keep an impossible candidate alive, block on the wrong condition, or recursively reprobe the same candidate shape.

## Implementation Notes

- Adds canonical/probe state needed to recognize repeated recursive instance probes.
- Uses checkpoint/restore behavior while testing nested candidate constraints so failed probes do not leak solver state.
- Rejects candidates with unsatisfiable nested subgoals instead of leaving them ambiguous.
- Keeps else-instance blocking focused on genuinely unknown match results.
- This branch is stacked on `pr/checking-row-fundep-givens` because it shares the constraint matching/given infrastructure introduced there.

## Tests

Added fixtures:

- `1778700540_instance_subgoal_apart_compare`
- `1778701380_pick_max_compare_eval`
- `1778701500_pick_max_record_fold_order`
- `1778720160_example_function_fundep`
- `1778723460_pick_max_attachment_codec_binary`
- `1778805900_recursive_instance_chain_candidate_constraint`

Validation run locally:

```bash
cargo check -p checking --tests
```
