### PR TITLE
[ls] Implement negotiation for position encodings

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -1,3 +1,4 @@
+pub mod capabilities;
 pub mod error;
 pub mod event;
 pub mod extension;
@@ -9,6 +10,7 @@ use std::sync::Arc;
 use std::{env, fs, mem, process};
 
 use analyzer::completion::SuggestionsCache;
+use analyzer::position::PositionEncoding;
 use analyzer::symbols::WorkspaceSymbolsCache;
 use analyzer::{Files, QueryEngine, prim};
 use async_lsp::client_monitor::ClientProcessMonitorLayer;
@@ -28,6 +30,7 @@ use tower::ServiceBuilder;
 use walkdir::WalkDir;
 
 use crate::cli;
+use crate::lsp::capabilities::negotiate_position_encoding;
 use crate::lsp::error::{AnalyzerResultExt, LspError};
 
 pub struct State {
@@ -41,6 +44,7 @@ pub struct State {
     pub suggestions_cache: Arc<RwLock<SuggestionsCache>>,
 
     pub root: Option<PathBuf>,
+    pub position_encoding: PositionEncoding,
 }
 
 impl State {
@@ -58,8 +62,18 @@ impl State {
         let suggestions_cache = Arc::new(RwLock::new(suggestions_cache));
 
         let root = None;
+        let position_encoding = PositionEncoding::Utf16;
 
-        State { config, client, engine, files, workspace_symbols_cache, suggestions_cache, root }
+        State {
+            config,
+            client,
+            engine,
+            files,
+            workspace_symbols_cache,
+            suggestions_cache,
+            root,
+            position_encoding,
+        }
     }
 
     fn spawn<T>(&self, f: impl FnOnce(StateSnapshot) -> T + Send + 'static) -> task::JoinHandle<T>
@@ -72,6 +86,7 @@ impl State {
             files: Arc::clone(&self.files),
             workspace_symbols_cache: Arc::clone(&self.workspace_symbols_cache),
             suggestions_cache: Arc::clone(&self.suggestions_cache),
+            position_encoding: self.position_encoding,
         };
         task::spawn_blocking(move || f(snapshot))
     }
@@ -93,6 +108,7 @@ struct StateSnapshot {
     files: Arc<RwLock<Files>>,
     workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     suggestions_cache: Arc<RwLock<SuggestionsCache>>,
+    position_encoding: PositionEncoding,
 }
 
 impl StateSnapshot {
@@ -108,6 +124,9 @@ fn initialize(
     state: &mut State,
     p: extension::CustomInitializeParams,
 ) -> impl Future<Output = Result<InitializeResult, ResponseError>> + use<> {
+    let position_encoding = negotiate_position_encoding(&p.initialize_params);
+    state.position_encoding = position_encoding;
+
     state.root = p
         .initialize_params
         .workspace_folders
@@ -142,11 +161,11 @@ fn initialize(
                     TextDocumentSyncOptions {
                         open_close: Some(true),
                         change: Some(TextDocumentSyncKind::FULL),
-                        // Clients may not send didSave unless we advertise it.
                         save: Some(TextDocumentSyncSaveOptions::Supported(true)),
                         ..TextDocumentSyncOptions::default()
                     },
                 )),
+                position_encoding: Some(PositionEncodingKind::from(position_encoding)),
                 ..ServerCapabilities::default()
             },
         })
@@ -247,16 +266,32 @@ fn definition(
     let _span = tracing::info_span!("definition").entered();
     let uri = p.text_document_position_params.text_document.uri;
     let position = p.text_document_position_params.position;
-    analyzer::definition::implementation(&snapshot.engine, &snapshot.files(), uri, position)
-        .on_non_fatal(None)
+
+    let result = analyzer::definition::implementation(
+        &snapshot.engine,
+        &snapshot.files(),
+        uri,
+        position,
+        snapshot.position_encoding,
+    );
+
+    result.on_non_fatal(None)
 }
 
 fn hover(snapshot: StateSnapshot, p: HoverParams) -> Result<Option<Hover>, LspError> {
     let _span = tracing::info_span!("hover").entered();
     let uri = p.text_document_position_params.text_document.uri;
     let position = p.text_document_position_params.position;
-    analyzer::hover::implementation(&snapshot.engine, &snapshot.files(), uri, position)
-        .on_non_fatal(None)
+
+    let result = analyzer::hover::implementation(
+        &snapshot.engine,
+        &snapshot.files(),
+        uri,
+        position,
+        snapshot.position_encoding,
+    );
+
+    result.on_non_fatal(None)
 }
 
 fn completion(
@@ -269,14 +304,16 @@ fn completion(
 
     let mut cache = snapshot.suggestions_cache.write();
 
-    analyzer::completion::implementation(
+    let result = analyzer::completion::implementation(
         &snapshot.engine,
         &snapshot.files(),
         &mut cache,
         uri,
         position,
-    )
-    .on_non_fatal(None)
+        snapshot.position_encoding,
+    );
+
+    result.on_non_fatal(None)
 }
 
 fn resolve_completion_item(
@@ -295,8 +332,16 @@ fn references(
     let _span = tracing::info_span!("references").entered();
     let uri = p.text_document_position.text_document.uri;
     let position = p.text_document_position.position;
-    analyzer::references::implementation(&snapshot.engine, &snapshot.files(), uri, position)
-        .on_non_fatal(None)
+
+    let result = analyzer::references::implementation(
+        &snapshot.engine,
+        &snapshot.files(),
+        uri,
+        position,
+        snapshot.position_encoding,
+    );
+
+    result.on_non_fatal(None)
 }
 
 fn workspace_symbols(
@@ -306,8 +351,16 @@ fn workspace_symbols(
     let _span = tracing::info_span!("workspace_symbols").entered();
 
     let mut cache = snapshot.workspace_symbols_cache.write();
-    analyzer::symbols::workspace(&snapshot.engine, &snapshot.files(), &mut cache, &p.query)
-        .on_non_fatal(None)
+
+    let result = analyzer::symbols::workspace(
+        &snapshot.engine,
+        &snapshot.files(),
+        &mut cache,
+        &p.query,
+        snapshot.position_encoding,
+    );
+
+    result.on_non_fatal(None)
 }
 
 fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), LspError> {

--- a/compiler-bin/src/lsp/capabilities.rs
+++ b/compiler-bin/src/lsp/capabilities.rs
@@ -1,0 +1,79 @@
+use analyzer::position::PositionEncoding;
+use async_lsp::lsp_types::{InitializeParams, PositionEncodingKind};
+
+pub fn negotiate_position_encoding(params: &InitializeParams) -> PositionEncoding {
+    let Some(encodings) = params
+        .capabilities
+        .general
+        .as_ref()
+        .and_then(|general| general.position_encodings.as_ref())
+    else {
+        return PositionEncoding::Utf16;
+    };
+
+    if encodings.contains(&PositionEncodingKind::UTF8) {
+        PositionEncoding::Utf8
+    } else if encodings.contains(&PositionEncodingKind::UTF16) {
+        PositionEncoding::Utf16
+    } else if encodings.contains(&PositionEncodingKind::UTF32) {
+        PositionEncoding::Utf32
+    } else {
+        PositionEncoding::Utf16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_lsp::lsp_types::{ClientCapabilities, GeneralClientCapabilities};
+
+    use super::*;
+
+    fn params(position_encodings: Option<Vec<PositionEncodingKind>>) -> InitializeParams {
+        InitializeParams {
+            capabilities: ClientCapabilities {
+                general: Some(GeneralClientCapabilities {
+                    position_encodings,
+                    ..GeneralClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+            ..InitializeParams::default()
+        }
+    }
+
+    #[test]
+    fn defaults_to_utf16_without_client_preference() {
+        let params = InitializeParams::default();
+
+        let encoding = negotiate_position_encoding(&params);
+        assert_eq!(encoding, PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn prefers_utf8_when_available() {
+        let params = params(Some(vec![
+            PositionEncodingKind::UTF32,
+            PositionEncodingKind::UTF16,
+            PositionEncodingKind::UTF8,
+        ]));
+
+        let encoding = negotiate_position_encoding(&params);
+        assert_eq!(encoding, PositionEncoding::Utf8);
+    }
+
+    #[test]
+    fn falls_back_to_utf16_before_utf32() {
+        let params = params(Some(vec![PositionEncodingKind::UTF32, PositionEncodingKind::UTF16]));
+
+        let encoding = negotiate_position_encoding(&params);
+        assert_eq!(encoding, PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn supports_utf32_when_it_is_the_only_known_option() {
+        let params = params(Some(vec![PositionEncodingKind::UTF32]));
+
+        let encoding = negotiate_position_encoding(&params);
+        assert_eq!(encoding, PositionEncoding::Utf32);
+    }
+}

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -1,4 +1,4 @@
-use analyzer::{common, locate};
+use analyzer::{common, position};
 use async_lsp::LanguageClient;
 use async_lsp::lsp_types::*;
 use diagnostics::{DiagnosticsContext, ToDiagnostics};
@@ -67,7 +67,10 @@ fn collect_diagnostics_core(
         all_diagnostics.extend(error.to_diagnostics(&context));
     }
 
-    let to_position = |offset: u32| locate::offset_to_position(&content, TextSize::from(offset));
+    let to_position = |offset: u32| {
+        let position = position::offset_to_utf8_position(&content, TextSize::from(offset))?;
+        position::utf8_position_to_protocol(&content, position, snapshot.position_encoding)
+    };
 
     let diagnostics = all_diagnostics
         .iter()

--- a/compiler-core/diagnostics/src/render.rs
+++ b/compiler-core/diagnostics/src/render.rs
@@ -1,11 +1,17 @@
 use itertools::Itertools;
-use line_index::{LineCol, LineIndex};
+use line_index::{LineCol, LineIndex, WideEncoding};
 use lsp_types::{
     DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Position, Range,
 };
 use rowan::TextSize;
 
 use crate::{Diagnostic, Severity, Span};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DisplayPosition {
+    line: u32,
+    column: u32,
+}
 
 pub fn format_text(diagnostics: &[Diagnostic]) -> String {
     let mut output = String::new();
@@ -57,9 +63,9 @@ fn span_location(
     content: &str,
     span: Span,
 ) -> Option<((u32, u32), (u32, u32))> {
-    let start = offset_to_position(line_index, content, TextSize::from(span.start))?;
-    let end = offset_to_position(line_index, content, TextSize::from(span.end))?;
-    Some(((start.line, start.character), (end.line, end.character)))
+    let start = offset_to_display_position(line_index, content, TextSize::from(span.start))?;
+    let end = offset_to_display_position(line_index, content, TextSize::from(span.end))?;
+    Some(((start.line, start.column), (end.line, end.column)))
 }
 
 pub fn format_rustc(diagnostics: &[Diagnostic], content: &str) -> String {
@@ -159,27 +165,49 @@ fn format_rustc_inner(diagnostics: &[Diagnostic], content: &str, path: Option<&s
     output
 }
 
-fn offset_to_position(line_index: &LineIndex, content: &str, offset: TextSize) -> Option<Position> {
+fn offset_to_display_position(
+    line_index: &LineIndex,
+    content: &str,
+    offset: TextSize,
+) -> Option<DisplayPosition> {
     let LineCol { line, col } = line_index.line_col(offset);
 
     let line_text_range = line_index.line(line)?;
     let line_content = &content[line_text_range];
 
     let until_col = &line_content[..col as usize];
-    let character = until_col.chars().count() as u32;
+    let column = until_col.chars().count() as u32;
 
-    Some(Position { line, character })
+    Some(DisplayPosition { line, column })
+}
+
+fn offset_to_lsp_position(
+    line_index: &LineIndex,
+    offset: TextSize,
+    encoding: &lsp_types::PositionEncodingKind,
+) -> Option<Position> {
+    let line_col = line_index.try_line_col(offset)?;
+    let character = if encoding == &lsp_types::PositionEncodingKind::UTF8 {
+        line_col.col
+    } else if encoding == &lsp_types::PositionEncodingKind::UTF32 {
+        line_index.to_wide(WideEncoding::Utf32, line_col)?.col
+    } else {
+        line_index.to_wide(WideEncoding::Utf16, line_col)?.col
+    };
+
+    Some(Position { line: line_col.line, character })
 }
 
 pub fn to_lsp_diagnostic(
     diagnostic: &Diagnostic,
     content: &str,
     uri: &lsp_types::Url,
+    encoding: &lsp_types::PositionEncodingKind,
 ) -> Option<lsp_types::Diagnostic> {
     let line_index = LineIndex::new(content);
 
     let to_position =
-        |offset: u32| offset_to_position(&line_index, content, TextSize::from(offset));
+        |offset: u32| offset_to_lsp_position(&line_index, TextSize::from(offset), encoding);
 
     let primary = diagnostic.primary;
     let start = to_position(primary.start)?;

--- a/compiler-lsp/analyzer/src/common.rs
+++ b/compiler-lsp/analyzer/src/common.rs
@@ -4,13 +4,15 @@ use files::{FileId, Files};
 use indexing::{TermItemId, TypeItemId};
 use syntax::{SyntaxNode, SyntaxNodePtr};
 
-use crate::{AnalyzerError, locate};
+use crate::position::{PositionEncoding, Utf8Range};
+use crate::{AnalyzerError, locate, position};
 
 pub fn file_term_location(
     engine: &QueryEngine,
     uri: Url,
     file_id: FileId,
     term_id: TermItemId,
+    encoding: PositionEncoding,
 ) -> Result<Location, AnalyzerError> {
     let content = engine.content(file_id);
     let (parsed, _) = engine.parsed(file_id)?;
@@ -22,6 +24,8 @@ pub fn file_term_location(
     let pointers = indexed.term_item_ptr(&stabilized, term_id);
 
     let range = pointers_range(&content, root, pointers)?;
+    let range = position::utf8_range_to_protocol(&content, range, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
     Ok(Location { uri, range })
 }
 
@@ -30,6 +34,7 @@ pub fn file_type_location(
     uri: Url,
     file_id: FileId,
     type_id: TypeItemId,
+    encoding: PositionEncoding,
 ) -> Result<Location, AnalyzerError> {
     let content = engine.content(file_id);
     let (parsed, _) = engine.parsed(file_id)?;
@@ -41,6 +46,8 @@ pub fn file_type_location(
     let pointers = indexed.type_item_ptr(&stabilized, type_id);
 
     let range = pointers_range(&content, root, pointers)?;
+    let range = position::utf8_range_to_protocol(&content, range, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
 
     Ok(Location { uri, range })
 }
@@ -61,9 +68,9 @@ pub fn pointers_range(
     content: &str,
     root: SyntaxNode,
     pointers: impl Iterator<Item = SyntaxNodePtr>,
-) -> Result<Range, AnalyzerError> {
+) -> Result<Utf8Range, AnalyzerError> {
     pointers
         .filter_map(|ptr| locate::syntax_range(content, &root, &ptr))
-        .reduce(|start, end| Range { start: start.start, end: end.end })
+        .reduce(|start, end| Utf8Range { start: start.start, end: end.end })
         .ok_or(AnalyzerError::NonFatal)
 }

--- a/compiler-lsp/analyzer/src/completion.rs
+++ b/compiler-lsp/analyzer/src/completion.rs
@@ -24,7 +24,8 @@ use sources::{
 };
 use syntax::SyntaxKind;
 
-use crate::{AnalyzerError, locate};
+use crate::position::PositionEncoding;
+use crate::{AnalyzerError, position};
 
 #[derive(Clone, Default)]
 pub struct SuggestionsCacheEntry {
@@ -42,6 +43,7 @@ pub fn implementation(
     cache: &mut SuggestionsCache,
     uri: Url,
     position: Position,
+    encoding: PositionEncoding,
 ) -> Result<Option<CompletionResponse>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
@@ -50,9 +52,12 @@ pub fn implementation(
 
     let prim_id = engine.prim_id();
     let content = engine.content(current_file);
+    let position = position::protocol_position_to_utf8(&content, position, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
     let (parsed, _) = engine.parsed(current_file)?;
 
-    let offset = locate::position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
+    let offset =
+        position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
 
     let node = parsed.syntax_node();
     let token = node.token_at_offset(offset);
@@ -70,7 +75,7 @@ pub fn implementation(
     };
 
     let semantics = CursorSemantics::new(&content, position);
-    let (text, range) = CursorText::new(&content, &token);
+    let (text, range) = CursorText::new(&content, &token, encoding);
 
     let stabilized = engine.stabilized(current_file)?;
     let resolved = engine.resolved(current_file)?;
@@ -86,6 +91,7 @@ pub fn implementation(
         resolved: &resolved,
         prim_id,
         prim_resolved: &prim_resolved,
+        encoding,
         semantics,
         text,
         range,

--- a/compiler-lsp/analyzer/src/completion/edit.rs
+++ b/compiler-lsp/analyzer/src/completion/edit.rs
@@ -9,7 +9,7 @@ use rowan::ast::AstNode;
 use smol_str::{SmolStrBuilder, ToSmolStr};
 
 use crate::completion::Context;
-use crate::locate;
+use crate::{locate, position};
 
 fn import_item<F, G>(
     context: &Context,
@@ -79,7 +79,9 @@ where
 
         let import_range = {
             let ptr = ptr.syntax_node_ptr();
-            locate::syntax_range(context.content, &root, &ptr)
+            locate::syntax_range(context.content, &root, &ptr).and_then(|range| {
+                position::utf8_range_to_protocol(context.content, range, context.encoding)
+            })
         };
 
         (Some(import_text), import_range)

--- a/compiler-lsp/analyzer/src/completion/prelude.rs
+++ b/compiler-lsp/analyzer/src/completion/prelude.rs
@@ -9,7 +9,8 @@ use smol_str::SmolStr;
 use stabilizing::StabilizedModule;
 use syntax::{SyntaxKind, SyntaxToken, cst};
 
-use crate::{AnalyzerError, locate};
+use crate::position::{PositionEncoding, Utf8Position};
+use crate::{AnalyzerError, position};
 
 pub struct Context<'c, 'a> {
     pub engine: &'c QueryEngine,
@@ -24,6 +25,7 @@ pub struct Context<'c, 'a> {
     pub prim_id: FileId,
     pub prim_resolved: &'a ResolvedModule,
 
+    pub encoding: PositionEncoding,
     pub semantics: CursorSemantics,
     pub text: CursorText,
     pub range: Option<Range>,
@@ -41,11 +43,12 @@ impl Context<'_, '_> {
             |cst| Some(cst.syntax().text_range()),
         )?;
 
-        let mut position = locate::offset_to_position(self.content, range.end())?;
+        let mut position = position::offset_to_utf8_position(self.content, range.end())?;
 
         position.line += 1;
-        position.character = 0;
+        position.column = 0;
 
+        let position = position::utf8_position_to_protocol(self.content, position, self.encoding)?;
         Some(Range::new(position, position))
     }
 
@@ -108,7 +111,7 @@ pub enum CursorSemantics {
 const COMPLETION_MARKER: &str = "Z'PureScript'Z";
 
 impl CursorSemantics {
-    pub fn new(content: &str, position: Position) -> CursorSemantics {
+    pub fn new(content: &str, position: Utf8Position) -> CursorSemantics {
         // We insert a placeholder identifier at the current position of the
         // text cursor. This is done as an effort to produce as valid of a
         // parse tree as possible before we perform further analysis.
@@ -124,7 +127,7 @@ impl CursorSemantics {
         //
         // component = Halogen.Z'PureScript'Z
 
-        let Some(offset) = locate::position_to_offset(content, position) else {
+        let Some(offset) = position::utf8_position_to_offset(content, position) else {
             return CursorSemantics::General;
         };
 
@@ -183,14 +186,22 @@ pub enum CursorText {
 }
 
 impl CursorText {
-    pub fn new(content: &str, token: &SyntaxToken) -> (CursorText, Option<Range>) {
-        CursorText::of_qualified(content, token)
-            .or_else(|| CursorText::of_qualifier(content, token))
-            .or_else(|| CursorText::of_module_name(content, token))
+    pub fn new(
+        content: &str,
+        token: &SyntaxToken,
+        encoding: PositionEncoding,
+    ) -> (CursorText, Option<Range>) {
+        CursorText::of_qualified(content, token, encoding)
+            .or_else(|| CursorText::of_qualifier(content, token, encoding))
+            .or_else(|| CursorText::of_module_name(content, token, encoding))
             .unwrap_or((CursorText::None, None))
     }
 
-    fn of_qualified(content: &str, token: &SyntaxToken) -> Option<(CursorText, Option<Range>)> {
+    fn of_qualified(
+        content: &str,
+        token: &SyntaxToken,
+        encoding: PositionEncoding,
+    ) -> Option<(CursorText, Option<Range>)> {
         token.parent_ancestors().find_map(|node| {
             let qualified = cst::QualifiedName::cast(node)?;
 
@@ -227,7 +238,8 @@ impl CursorText {
                 (None, None) => None,
             };
 
-            let range = range.and_then(|range| locate::text_range_to_range(content, range));
+            let range =
+                range.and_then(|range| position::text_range_to_protocol(content, range, encoding));
             let text = match (prefix, name) {
                 (None, None) => CursorText::None,
                 (Some(p), None) => CursorText::Prefix(p),
@@ -239,7 +251,11 @@ impl CursorText {
         })
     }
 
-    fn of_qualifier(content: &str, token: &SyntaxToken) -> Option<(CursorText, Option<Range>)> {
+    fn of_qualifier(
+        content: &str,
+        token: &SyntaxToken,
+        encoding: PositionEncoding,
+    ) -> Option<(CursorText, Option<Range>)> {
         token.parent_ancestors().find_map(|node| {
             let qualifier = cst::Qualifier::cast(node)?;
             let token = qualifier.text()?;
@@ -248,7 +264,7 @@ impl CursorText {
             let prefix = SmolStr::new(prefix);
 
             let range = token.text_range();
-            let range = locate::text_range_to_range(content, range)?;
+            let range = position::text_range_to_protocol(content, range, encoding)?;
 
             let range = Some(range);
             let text = CursorText::Prefix(prefix);
@@ -257,7 +273,11 @@ impl CursorText {
         })
     }
 
-    fn of_module_name(content: &str, token: &SyntaxToken) -> Option<(CursorText, Option<Range>)> {
+    fn of_module_name(
+        content: &str,
+        token: &SyntaxToken,
+        encoding: PositionEncoding,
+    ) -> Option<(CursorText, Option<Range>)> {
         token.parent_ancestors().find_map(|node| {
             let module_name = cst::ModuleName::cast(node)?;
 
@@ -276,7 +296,8 @@ impl CursorText {
                 (None, None) => None,
             };
 
-            let range = range.map(|range| locate::text_range_to_range(content, range))?;
+            let range =
+                range.map(|range| position::text_range_to_protocol(content, range, encoding))?;
             let text = match (prefix, name) {
                 (None, None) => CursorText::None,
                 (Some(p), None) => CursorText::Prefix(p),

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -13,57 +13,63 @@ use smol_str::ToSmolStr;
 use syntax::{SyntaxNode, SyntaxNodePtr, cst};
 
 use crate::extract::AnnotationSyntaxRange;
-use crate::{AnalyzerError, common, locate};
+use crate::position::{PositionEncoding, Utf8Range};
+use crate::{AnalyzerError, common, locate, position};
 
 pub fn implementation(
     engine: &QueryEngine,
     files: &Files,
     uri: Url,
     position: Position,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
         files.id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
+    let content = engine.content(current_file);
+    let position = position::protocol_position_to_utf8(&content, position, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
+
     let located = locate::locate(engine, current_file, position)?;
 
     match located {
         locate::Located::ModuleName(module_name) => {
-            definition_module_name(engine, files, current_file, module_name)
+            definition_module_name(engine, files, current_file, module_name, encoding)
         }
         locate::Located::ImportItem(import_id) => {
-            definition_import(engine, files, current_file, import_id)
+            definition_import(engine, files, current_file, import_id, encoding)
         }
         locate::Located::Binder(binder_id) => {
-            definition_binder(engine, files, current_file, binder_id)
+            definition_binder(engine, files, current_file, binder_id, encoding)
         }
         locate::Located::Expression(expression_id) => {
-            definition_expression(engine, files, uri, current_file, expression_id)
+            definition_expression(engine, files, uri, current_file, expression_id, encoding)
         }
         locate::Located::Type(type_id) => {
-            definition_type(engine, files, uri, current_file, type_id)
+            definition_type(engine, files, uri, current_file, type_id, encoding)
         }
         locate::Located::TermOperator(operator_id) => {
             let lowered = engine.lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
-            definition_file_term(engine, files, f_id, t_id)
+            definition_file_term(engine, files, f_id, t_id, encoding)
         }
         locate::Located::TypeOperator(operator_id) => {
             let lowered = engine.lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
-            definition_file_type(engine, files, f_id, t_id)
+            definition_file_type(engine, files, f_id, t_id, encoding)
         }
         locate::Located::TermItem(term_id) => {
-            definition_file_term(engine, files, current_file, term_id)
+            definition_file_term(engine, files, current_file, term_id, encoding)
         }
         locate::Located::TypeItem(type_id) => {
-            definition_file_type(engine, files, current_file, type_id)
+            definition_file_type(engine, files, current_file, type_id, encoding)
         }
         locate::Located::LetBinding(let_id) => {
-            definition_let_binding(engine, files, current_file, let_id)
+            definition_let_binding(engine, files, current_file, let_id, encoding)
         }
         locate::Located::Pun(_) => Ok(None),
         locate::Located::Nothing => Ok(None),
@@ -75,6 +81,7 @@ fn definition_module_name(
     files: &Files,
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let (parsed, _) = engine.parsed(current_file)?;
 
@@ -91,13 +98,9 @@ fn definition_module_name(
 
     let range = root.text_range();
 
-    let range_start =
-        locate::offset_to_position(&content, range.start()).ok_or(AnalyzerError::NonFatal)?;
-    let range_end =
-        locate::offset_to_position(&content, range.end()).ok_or(AnalyzerError::NonFatal)?;
-
     let uri = common::file_uri(engine, files, module_id)?;
-    let range = Range { start: range_start, end: range_end };
+    let range = position::text_range_to_protocol(&content, range, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
 
     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
 }
@@ -107,6 +110,7 @@ fn definition_import(
     files: &Files,
     current_file: FileId,
     import_id: ImportItemId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
@@ -131,7 +135,7 @@ fn definition_import(
         let name = name.trim_start_matches("(").trim_end_matches(")");
         let (f_id, t_id) =
             import_resolved.exports.lookup_term(name).ok_or(AnalyzerError::NonFatal)?;
-        definition_file_term(engine, files, f_id, t_id)
+        definition_file_term(engine, files, f_id, t_id, encoding)
     };
 
     let goto_type = |engine: &QueryEngine, files: &Files, name: &str| {
@@ -141,7 +145,7 @@ fn definition_import(
             .lookup_type(name)
             .or_else(|| import_resolved.exports.lookup_class(name))
             .ok_or(AnalyzerError::NonFatal)?;
-        definition_file_type(engine, files, f_id, t_id)
+        definition_file_type(engine, files, f_id, t_id, encoding)
     };
 
     let goto_class = |engine: &QueryEngine, files: &Files, name: &str| {
@@ -151,7 +155,7 @@ fn definition_import(
             .lookup_class(name)
             .or_else(|| import_resolved.exports.lookup_type(name))
             .ok_or(AnalyzerError::NonFatal)?;
-        definition_file_type(engine, files, f_id, t_id)
+        definition_file_type(engine, files, f_id, t_id, encoding)
     };
 
     match node {
@@ -188,13 +192,14 @@ fn definition_binder(
     files: &Files,
     current_file: FileId,
     binder_id: BinderId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
     let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         BinderKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            definition_file_term(engine, files, *f_id, *t_id)
+            definition_file_term(engine, files, *f_id, *t_id, encoding)
         }
         _ => Ok(None),
     }
@@ -206,6 +211,7 @@ fn definition_expression(
     uri: Url,
     current_file: FileId,
     expression_id: ExpressionId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
@@ -218,7 +224,7 @@ fn definition_expression(
     match kind {
         ExpressionKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            definition_file_term(engine, files, *f_id, *t_id)
+            definition_file_term(engine, files, *f_id, *t_id, encoding)
         }
         ExpressionKind::Variable { resolution, .. } => {
             let resolution = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -227,6 +233,8 @@ fn definition_expression(
                     let root = parsed.syntax_node();
                     let ptr = stabilized.syntax_ptr(*id).ok_or(AnalyzerError::NonFatal)?;
                     let range = locate::syntax_range(&content, &root, &ptr)
+                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(&content, range, encoding)
                         .ok_or(AnalyzerError::NonFatal)?;
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
@@ -250,7 +258,9 @@ fn definition_expression(
 
                     let range = signature
                         .chain(equations)
-                        .reduce(|start, end| Range { start: start.start, end: end.end })
+                        .reduce(|start, end| Utf8Range { start: start.start, end: end.end })
+                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(&content, range, encoding)
                         .ok_or(AnalyzerError::NonFatal)?;
 
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
@@ -260,22 +270,28 @@ fn definition_expression(
                     let ptr = stabilized.syntax_ptr(*id).ok_or(AnalyzerError::NonFatal)?;
                     let range = record_pun_name_range(&content, &root, &ptr)
                         .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(&content, range, encoding)
+                        .ok_or(AnalyzerError::NonFatal)?;
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
                 TermVariableResolution::Reference(f_id, t_id) => {
-                    definition_file_term(engine, files, *f_id, *t_id)
+                    definition_file_term(engine, files, *f_id, *t_id, encoding)
                 }
             }
         }
         ExpressionKind::OperatorName { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            definition_file_term(engine, files, *f_id, *t_id)
+            definition_file_term(engine, files, *f_id, *t_id, encoding)
         }
         _ => Ok(None),
     }
 }
 
-fn record_pun_name_range(content: &str, root: &SyntaxNode, ptr: &SyntaxNodePtr) -> Option<Range> {
+fn record_pun_name_range(
+    content: &str,
+    root: &SyntaxNode,
+    ptr: &SyntaxNodePtr,
+) -> Option<Utf8Range> {
     let node = ptr.try_to_node(root)?;
     let pun = cst::RecordPun::cast(node)?;
 
@@ -283,7 +299,7 @@ fn record_pun_name_range(content: &str, root: &SyntaxNode, ptr: &SyntaxNodePtr) 
     let name = name.syntax();
     let range = AnnotationSyntaxRange::from_node(name).syntax?;
 
-    locate::text_range_to_range(content, range)
+    position::text_range_to_utf8_range(content, range)
 }
 
 fn definition_type(
@@ -292,6 +308,7 @@ fn definition_type(
     uri: Url,
     current_file: FileId,
     type_id: TypeId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
@@ -302,11 +319,11 @@ fn definition_type(
     match kind {
         TypeKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            definition_file_type(engine, files, *f_id, *t_id)
+            definition_file_type(engine, files, *f_id, *t_id, encoding)
         }
         TypeKind::Operator { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            definition_file_type(engine, files, *f_id, *t_id)
+            definition_file_type(engine, files, *f_id, *t_id, encoding)
         }
         TypeKind::Variable { resolution, .. } => {
             let resolution = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -318,6 +335,8 @@ fn definition_type(
                         .ok_or(AnalyzerError::NonFatal)?
                         .syntax_node_ptr();
                     let range = locate::syntax_range(&content, &root, &ptr)
+                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(&content, range, encoding)
                         .ok_or(AnalyzerError::NonFatal)?;
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
@@ -333,9 +352,10 @@ fn definition_file_term(
     files: &Files,
     file_id: FileId,
     term_id: TermItemId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let uri = common::file_uri(engine, files, file_id)?;
-    let location = common::file_term_location(engine, uri, file_id, term_id)?;
+    let location = common::file_term_location(engine, uri, file_id, term_id, encoding)?;
     Ok(Some(GotoDefinitionResponse::Scalar(location)))
 }
 
@@ -344,9 +364,10 @@ fn definition_file_type(
     files: &Files,
     file_id: FileId,
     type_id: TypeItemId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let uri = common::file_uri(engine, files, file_id)?;
-    let location = common::file_type_location(engine, uri, file_id, type_id)?;
+    let location = common::file_type_location(engine, uri, file_id, type_id, encoding)?;
     Ok(Some(GotoDefinitionResponse::Scalar(location)))
 }
 
@@ -355,6 +376,7 @@ fn definition_let_binding(
     files: &Files,
     file_id: FileId,
     let_id: LetBindingNameGroupId,
+    encoding: PositionEncoding,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let content = engine.content(file_id);
     let (parsed, _) = engine.parsed(file_id)?;
@@ -371,6 +393,8 @@ fn definition_let_binding(
 
     let pointers = iter::chain(signature, equations);
     let range = common::pointers_range(&content, root, pointers)?;
+    let range = position::utf8_range_to_protocol(&content, range, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
 
     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
 }

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -10,19 +10,25 @@ use rowan::ast::{AstNode, AstPtr};
 use smol_str::ToSmolStr;
 use syntax::{SyntaxNode, cst};
 
-use crate::extract::{self, AnnotationSyntaxRange};
-use crate::{AnalyzerError, locate};
+use crate::extract::AnnotationSyntaxRange;
+use crate::position::PositionEncoding;
+use crate::{AnalyzerError, extract, locate, position};
 
 pub fn implementation(
     engine: &QueryEngine,
     files: &Files,
     uri: Url,
     position: Position,
+    encoding: PositionEncoding,
 ) -> Result<Option<Hover>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
         files.id(uri).ok_or(AnalyzerError::NonFatal)?
     };
+
+    let content = engine.content(current_file);
+    let position = position::protocol_position_to_utf8(&content, position, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
 
     let located = locate::locate(engine, current_file, position)?;
 

--- a/compiler-lsp/analyzer/src/lib.rs
+++ b/compiler-lsp/analyzer/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod extract;
 pub mod hover;
 pub mod locate;
+pub mod position;
 pub mod references;
 pub mod symbols;
 

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -1,82 +1,24 @@
 //! Abstractions for identifying syntax at a given location.
 
-use async_lsp::lsp_types::*;
 use building::QueryEngine;
 use files::FileId;
 use indexing::{ImportItemId, IndexedModule, TermItemId, TypeItemId};
-use line_index::{LineCol, LineIndex};
 use lowering::{
     BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordPunId, TermOperatorId,
     TypeId, TypeOperatorId,
 };
+use rowan::TokenAtOffset;
 use rowan::ast::{AstNode, AstPtr};
-use rowan::{TextRange, TextSize, TokenAtOffset};
 use stabilizing::StabilizedModule;
 use syntax::{SyntaxNode, SyntaxNodePtr, SyntaxToken, cst};
 
-use crate::AnalyzerError;
 use crate::extract::AnnotationSyntaxRange;
+use crate::position::{Utf8Position, Utf8Range};
+use crate::{AnalyzerError, position};
 
-pub fn position_to_offset(content: &str, position: Position) -> Option<TextSize> {
-    let line_index = LineIndex::new(content);
-
-    let line_range = line_index.line(position.line)?;
-    let line_content = content[line_range].trim_end_matches(['\n', '\r']);
-
-    let line = position.line;
-    let col = if line_content.is_empty() {
-        0
-    } else {
-        let last_column = || line_content.len() as u32;
-        line_content
-            .char_indices()
-            .nth(position.character as usize)
-            .map(|(column, _)| column as u32)
-            .unwrap_or_else(last_column)
-    };
-
-    let line_col = LineCol { line, col };
-    line_index.offset(line_col)
-}
-
-pub fn offset_to_position(content: &str, offset: TextSize) -> Option<Position> {
-    let line_index = LineIndex::new(content);
-
-    let LineCol { line, col } = line_index.line_col(offset);
-
-    let line_text_range = line_index.line(line)?;
-    let line_content = &content[line_text_range];
-
-    let until_col = &line_content[..col as usize];
-    let character = until_col.chars().count() as u32;
-
-    Some(Position { line, character })
-}
-
-pub fn text_range_to_range(content: &str, range: TextRange) -> Option<Range> {
-    let line_index = LineIndex::new(content);
-
-    let calculate = |offset: TextSize| {
-        let LineCol { line, col } = line_index.line_col(offset);
-
-        let line_text_range = line_index.line(line)?;
-        let line_content = &content[line_text_range];
-
-        let until_col = &line_content[..col as usize];
-        let character = until_col.chars().count() as u32;
-
-        Some(Position { line, character })
-    };
-
-    let start = calculate(range.start())?;
-    let end = calculate(range.end())?;
-
-    Some(Range { start, end })
-}
-
-pub fn syntax_range(content: &str, root: &SyntaxNode, ptr: &SyntaxNodePtr) -> Option<Range> {
+pub fn syntax_range(content: &str, root: &SyntaxNode, ptr: &SyntaxNodePtr) -> Option<Utf8Range> {
     let range = AnnotationSyntaxRange::from_ptr(root, ptr);
-    range.syntax.and_then(|range| text_range_to_range(content, range))
+    range.syntax.and_then(|range| position::text_range_to_utf8_range(content, range))
 }
 
 type ModuleNamePtr = AstPtr<cst::ModuleName>;
@@ -100,7 +42,7 @@ pub enum Located {
 pub fn locate(
     engine: &QueryEngine,
     id: FileId,
-    position: Position,
+    position: Utf8Position,
 ) -> Result<Located, AnalyzerError> {
     let content = engine.content(id);
 
@@ -109,7 +51,7 @@ pub fn locate(
     let indexed = engine.indexed(id)?;
     let lowered = engine.lowered(id)?;
 
-    let Some(offset) = position_to_offset(&content, position) else {
+    let Some(offset) = position::utf8_position_to_offset(&content, position) else {
         return Ok(Located::Nothing);
     };
 

--- a/compiler-lsp/analyzer/src/locate/tests.rs
+++ b/compiler-lsp/analyzer/src/locate/tests.rs
@@ -1,75 +1,74 @@
-use async_lsp::lsp_types::Position;
 use rowan::TextSize;
 
-use crate::locate::position_to_offset;
+use crate::position::{Utf8Position, utf8_position_to_offset};
 
 #[test]
 fn zero_on_blank_line() {
     let content = "";
-    let position = Position::new(0, 0);
+    let position = Utf8Position { line: 0, column: 0 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(0)));
 }
 
 #[test]
 fn zero_or_lf_line() {
     let content = "\n";
-    let position = Position::new(0, 0);
+    let position = Utf8Position { line: 0, column: 0 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(0)));
 }
 
 #[test]
 fn zero_or_crlf_line() {
     let content = "\r\n";
-    let position = Position::new(0, 0);
+    let position = Utf8Position { line: 0, column: 0 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(0)));
 }
 
 #[test]
 fn last_on_line() {
     let content = "abcdef";
-    let position = Position::new(0, 6);
+    let position = Utf8Position { line: 0, column: 6 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(6)));
 }
 
 #[test]
 fn last_on_line_clamp() {
     let content = "abcdef";
-    let position = Position::new(0, 600);
+    let position = Utf8Position { line: 0, column: 600 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(6)));
 }
 
 #[test]
 fn last_on_lf_line() {
     let content = "abcdef\n";
-    let position = Position::new(0, 6);
+    let position = Utf8Position { line: 0, column: 6 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(6)));
 }
 
 #[test]
 fn last_on_crlf_line_clamp() {
     let content = "abcdef\r\n";
-    let position = Position::new(0, 600);
+    let position = Utf8Position { line: 0, column: 600 };
 
-    let offset = position_to_offset(content, position);
+    let offset = utf8_position_to_offset(content, position);
     assert_eq!(offset, Some(TextSize::new(6)));
 }
 
 mod text_range_to_range {
     use rowan::{TextRange, TextSize};
 
-    use crate::locate::{position_to_offset, text_range_to_range};
+    use crate::position::{text_range_to_utf8_range, utf8_position_to_offset};
 
     /// Extracts a slice from `content` using `_` anchors to mark
     /// the start and end. The content is returned with the anchors
@@ -97,20 +96,20 @@ mod text_range_to_range {
     fn format_test_case(input: &str) -> String {
         let (content, range) = extract_range(input);
 
-        let lsp_range = text_range_to_range(&content, range).unwrap();
+        let utf8_range = text_range_to_utf8_range(&content, range).unwrap();
         let text_range = {
-            let start = position_to_offset(&content, lsp_range.start).unwrap();
-            let end = position_to_offset(&content, lsp_range.end).unwrap();
+            let start = utf8_position_to_offset(&content, utf8_range.start).unwrap();
+            let end = utf8_position_to_offset(&content, utf8_range.end).unwrap();
             TextRange::new(start, end)
         };
 
         format!(
             "Content: {}\nRange: {}:{} -> {}:{}\nRoundtrip: {}",
             &content[range],
-            lsp_range.start.line,
-            lsp_range.start.character,
-            lsp_range.end.line,
-            lsp_range.end.character,
+            utf8_range.start.line,
+            utf8_range.start.column,
+            utf8_range.end.line,
+            utf8_range.end.column,
             range == text_range,
         )
     }
@@ -137,7 +136,7 @@ mod text_range_to_range {
     fn unicode_full() {
         insta::assert_snapshot!(format_test_case("_content ∷ Type_"), @r"
         Content: content ∷ Type
-        Range: 0:0 -> 0:14
+        Range: 0:0 -> 0:16
         Roundtrip: true
         ");
     }
@@ -146,7 +145,7 @@ mod text_range_to_range {
     fn unicode_partial() {
         insta::assert_snapshot!(format_test_case("content _∷ Type_"), @r"
         Content: ∷ Type
-        Range: 0:8 -> 0:14
+        Range: 0:8 -> 0:16
         Roundtrip: true
         ");
     }
@@ -155,7 +154,7 @@ mod text_range_to_range {
     fn unicode_ending() {
         insta::assert_snapshot!(format_test_case("_content ∷_ Type"), @r"
         Content: content ∷
-        Range: 0:0 -> 0:9
+        Range: 0:0 -> 0:11
         Roundtrip: true
         ");
     }
@@ -173,7 +172,7 @@ mod text_range_to_range {
     fn emoji_single() {
         insta::assert_snapshot!(format_test_case("hello _😀_ world"), @r"
         Content: 😀
-        Range: 0:6 -> 0:7
+        Range: 0:6 -> 0:10
         Roundtrip: true
         ");
     }
@@ -182,7 +181,7 @@ mod text_range_to_range {
     fn emoji_multiple() {
         insta::assert_snapshot!(format_test_case("_🎉🎊🎈_"), @r"
         Content: 🎉🎊🎈
-        Range: 0:0 -> 0:3
+        Range: 0:0 -> 0:12
         Roundtrip: true
         ");
     }
@@ -241,7 +240,7 @@ mod text_range_to_range {
         insta::assert_snapshot!(format_test_case("type _∷ Type\nvalue ∷_ Int\ndata ∷ Data"), @r"
         Content: ∷ Type
         value ∷
-        Range: 0:5 -> 1:7
+        Range: 0:5 -> 1:9
         Roundtrip: true
         ");
     }

--- a/compiler-lsp/analyzer/src/position.rs
+++ b/compiler-lsp/analyzer/src/position.rs
@@ -1,0 +1,195 @@
+use async_lsp::lsp_types;
+use line_index::{LineCol, LineIndex, WideEncoding, WideLineCol};
+use rowan::{TextRange, TextSize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PositionEncoding {
+    Utf8,
+    Utf16,
+    Utf32,
+}
+
+impl PositionEncoding {
+    fn wide(self) -> Option<WideEncoding> {
+        WideEncoding::try_from(self).ok()
+    }
+}
+
+impl TryFrom<PositionEncoding> for WideEncoding {
+    type Error = ();
+
+    fn try_from(encoding: PositionEncoding) -> Result<WideEncoding, ()> {
+        match encoding {
+            PositionEncoding::Utf8 => Err(()),
+            PositionEncoding::Utf16 => Ok(WideEncoding::Utf16),
+            PositionEncoding::Utf32 => Ok(WideEncoding::Utf32),
+        }
+    }
+}
+
+impl From<PositionEncoding> for lsp_types::PositionEncodingKind {
+    fn from(encoding: PositionEncoding) -> lsp_types::PositionEncodingKind {
+        match encoding {
+            PositionEncoding::Utf8 => lsp_types::PositionEncodingKind::UTF8,
+            PositionEncoding::Utf16 => lsp_types::PositionEncodingKind::UTF16,
+            PositionEncoding::Utf32 => lsp_types::PositionEncodingKind::UTF32,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Utf8Position {
+    pub line: u32,
+    pub column: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Utf8Range {
+    pub start: Utf8Position,
+    pub end: Utf8Position,
+}
+
+pub fn protocol_position_to_utf8(
+    content: &str,
+    position: lsp_types::Position,
+    encoding: PositionEncoding,
+) -> Option<Utf8Position> {
+    let line_index = LineIndex::new(content);
+    let line_col = match encoding.wide() {
+        None => LineCol { line: position.line, col: position.character },
+        Some(encoding) => line_index
+            .to_utf8(encoding, WideLineCol { line: position.line, col: position.character })?,
+    };
+
+    let position = Utf8Position { line: line_col.line, column: line_col.col };
+    let offset = utf8_position_to_offset(content, position)?;
+    offset_to_utf8_position(content, offset)
+}
+
+pub fn utf8_position_to_protocol(
+    content: &str,
+    position: Utf8Position,
+    encoding: PositionEncoding,
+) -> Option<lsp_types::Position> {
+    let line_index = LineIndex::new(content);
+    let line_col = LineCol { line: position.line, col: position.column };
+
+    let offset = line_index.offset(line_col)?;
+    line_index.try_line_col(offset)?;
+
+    let position = match encoding.wide() {
+        None => lsp_types::Position { line: line_col.line, character: line_col.col },
+        Some(encoding) => {
+            let line_col = line_index.to_wide(encoding, line_col)?;
+            lsp_types::Position { line: line_col.line, character: line_col.col }
+        }
+    };
+
+    Some(position)
+}
+
+pub fn utf8_range_to_protocol(
+    content: &str,
+    range: Utf8Range,
+    encoding: PositionEncoding,
+) -> Option<lsp_types::Range> {
+    let start = utf8_position_to_protocol(content, range.start, encoding)?;
+    let end = utf8_position_to_protocol(content, range.end, encoding)?;
+    Some(lsp_types::Range { start, end })
+}
+
+pub fn utf8_position_to_offset(content: &str, position: Utf8Position) -> Option<TextSize> {
+    let line_index = LineIndex::new(content);
+
+    let line_range = line_index.line(position.line)?;
+    let line_content = content[line_range].trim_end_matches(['\n', '\r']);
+
+    let column = if line_content.is_empty() {
+        0
+    } else if position.column > line_content.len() as u32 {
+        line_content.len() as u32
+    } else {
+        line_content.get(position.column as usize..)?;
+        position.column
+    };
+
+    let line_col = LineCol { line: position.line, col: column };
+    let offset = line_index.offset(line_col)?;
+    line_index.try_line_col(offset)?;
+    Some(offset)
+}
+
+pub fn offset_to_utf8_position(content: &str, offset: TextSize) -> Option<Utf8Position> {
+    let line_index = LineIndex::new(content);
+    let LineCol { line, col } = line_index.try_line_col(offset)?;
+    Some(Utf8Position { line, column: col })
+}
+
+pub fn text_range_to_utf8_range(content: &str, range: TextRange) -> Option<Utf8Range> {
+    let start = offset_to_utf8_position(content, range.start())?;
+    let end = offset_to_utf8_position(content, range.end())?;
+    Some(Utf8Range { start, end })
+}
+
+pub fn text_range_to_protocol(
+    content: &str,
+    range: TextRange,
+    encoding: PositionEncoding,
+) -> Option<lsp_types::Range> {
+    let range = text_range_to_utf8_range(content, range)?;
+    utf8_range_to_protocol(content, range, encoding)
+}
+
+#[cfg(test)]
+mod tests {
+    use async_lsp::lsp_types::Position;
+    use rowan::TextSize;
+
+    use super::{
+        PositionEncoding, Utf8Position, offset_to_utf8_position, protocol_position_to_utf8,
+        utf8_position_to_offset, utf8_position_to_protocol,
+    };
+
+    #[test]
+    fn utf16_protocol_position_maps_to_utf8_column() {
+        let content = "a😀b";
+        let position = Position::new(0, 3);
+
+        let position =
+            protocol_position_to_utf8(content, position, PositionEncoding::Utf16).unwrap();
+        assert_eq!(position, Utf8Position { line: 0, column: 5 });
+
+        let offset = utf8_position_to_offset(content, position);
+        assert_eq!(offset, Some(TextSize::new(5)));
+    }
+
+    #[test]
+    fn utf32_protocol_position_maps_to_utf8_column() {
+        let content = "a😀b";
+        let position = Position::new(0, 2);
+
+        let position =
+            protocol_position_to_utf8(content, position, PositionEncoding::Utf32).unwrap();
+        assert_eq!(position, Utf8Position { line: 0, column: 5 });
+    }
+
+    #[test]
+    fn utf8_position_maps_to_utf16_protocol_position() {
+        let content = "a😀b";
+        let position = offset_to_utf8_position(content, TextSize::new(5)).unwrap();
+
+        let position =
+            utf8_position_to_protocol(content, position, PositionEncoding::Utf16).unwrap();
+        assert_eq!(position, Position::new(0, 3));
+    }
+
+    #[test]
+    fn protocol_position_past_line_end_clamps_to_same_line() {
+        let content = "abc\ndef";
+        let position = Position::new(0, 99);
+
+        let position =
+            protocol_position_to_utf8(content, position, PositionEncoding::Utf16).unwrap();
+        assert_eq!(position, Utf8Position { line: 0, column: 3 });
+    }
+}

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -14,54 +14,64 @@ use smol_str::ToSmolStr;
 use stabilizing::{AstId, StabilizedModule};
 use syntax::{PureScript, cst};
 
-use crate::{AnalyzerError, common, locate};
+use crate::position::PositionEncoding;
+use crate::{AnalyzerError, common, locate, position};
 
 pub fn implementation(
     engine: &QueryEngine,
     files: &Files,
     uri: Url,
     position: Position,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
         files.id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
+    let content = engine.content(current_file);
+    let position = position::protocol_position_to_utf8(&content, position, encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
+
     let located = locate::locate(engine, current_file, position)?;
 
     match located {
         locate::Located::ModuleName(module_name) => {
-            references_module_name(engine, files, current_file, module_name)
+            references_module_name(engine, files, current_file, module_name, encoding)
         }
         locate::Located::ImportItem(import_id) => {
-            references_import(engine, files, current_file, import_id)
+            references_import(engine, files, current_file, import_id, encoding)
         }
         locate::Located::Binder(binder_id) => {
-            references_binder(engine, files, current_file, binder_id)
+            references_binder(engine, files, current_file, binder_id, encoding)
         }
         locate::Located::Expression(expression_id) => {
-            references_expression(engine, files, current_file, expression_id)
+            references_expression(engine, files, current_file, expression_id, encoding)
         }
-        locate::Located::Type(type_id) => references_type(engine, files, current_file, type_id),
+        locate::Located::Type(type_id) => {
+            references_type(engine, files, current_file, type_id, encoding)
+        }
         locate::Located::TermOperator(operator_id) => {
             let lowered = engine.lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
-            references_file_term(engine, files, current_file, f_id, t_id)
+            references_file_term(engine, files, current_file, f_id, t_id, encoding)
         }
         locate::Located::TypeOperator(operator_id) => {
             let lowered = engine.lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
-            references_file_type(engine, files, current_file, f_id, t_id)
+            references_file_type(engine, files, current_file, f_id, t_id, encoding)
         }
         locate::Located::TermItem(term_id) => {
-            references_file_term(engine, files, current_file, current_file, term_id)
+            references_file_term(engine, files, current_file, current_file, term_id, encoding)
         }
         locate::Located::TypeItem(type_id) => {
-            references_file_type(engine, files, current_file, current_file, type_id)
+            references_file_type(engine, files, current_file, current_file, type_id, encoding)
         }
-        locate::Located::LetBinding(let_id) => references_let(engine, files, current_file, let_id),
+        locate::Located::LetBinding(let_id) => {
+            references_let(engine, files, current_file, let_id, encoding)
+        }
         locate::Located::Pun(_) => Ok(None),
         locate::Located::Nothing => Ok(None),
     }
@@ -72,6 +82,7 @@ fn references_module_name(
     files: &Files,
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let (parsed, _) = engine.parsed(current_file)?;
 
@@ -94,6 +105,8 @@ fn references_module_name(
         let stabilized = engine.stabilized(candidate_id)?;
         let ptr = stabilized.syntax_ptr(import_id).ok_or(AnalyzerError::NonFatal)?;
         let range = locate::syntax_range(&content, &root, &ptr).ok_or(AnalyzerError::NonFatal)?;
+        let range = position::utf8_range_to_protocol(&content, range, encoding)
+            .ok_or(AnalyzerError::NonFatal)?;
 
         locations.push(Location { uri, range });
     }
@@ -106,6 +119,7 @@ fn references_import(
     files: &Files,
     current_file: FileId,
     import_id: ImportItemId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
@@ -130,7 +144,7 @@ fn references_import(
         let name = name.trim_start_matches("(").trim_end_matches(")");
         let (f_id, t_id) =
             import_resolved.exports.lookup_term(name).ok_or(AnalyzerError::NonFatal)?;
-        references_file_term(engine, files, current_file, f_id, t_id)
+        references_file_term(engine, files, current_file, f_id, t_id, encoding)
     };
 
     let references_type = |engine: &QueryEngine, files: &Files, name: &str| {
@@ -140,7 +154,7 @@ fn references_import(
             .lookup_type(name)
             .or_else(|| import_resolved.exports.lookup_class(name))
             .ok_or(AnalyzerError::NonFatal)?;
-        references_file_type(engine, files, current_file, f_id, t_id)
+        references_file_type(engine, files, current_file, f_id, t_id, encoding)
     };
 
     let references_class = |engine: &QueryEngine, files: &Files, name: &str| {
@@ -150,7 +164,7 @@ fn references_import(
             .lookup_class(name)
             .or_else(|| import_resolved.exports.lookup_type(name))
             .ok_or(AnalyzerError::NonFatal)?;
-        references_file_type(engine, files, current_file, f_id, t_id)
+        references_file_type(engine, files, current_file, f_id, t_id, encoding)
     };
 
     match node {
@@ -187,13 +201,14 @@ fn references_binder(
     files: &Files,
     current_file: FileId,
     binder_id: BinderId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
     let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         lowering::BinderKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            references_file_term(engine, files, current_file, *f_id, *t_id)
+            references_file_term(engine, files, current_file, *f_id, *t_id, encoding)
         }
         _ => Ok(None),
     }
@@ -204,13 +219,14 @@ fn references_expression(
     files: &Files,
     current_file: FileId,
     expression_id: ExpressionId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
     let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         ExpressionKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            references_file_term(engine, files, current_file, *f_id, *t_id)
+            references_file_term(engine, files, current_file, *f_id, *t_id, encoding)
         }
         ExpressionKind::Variable { resolution, .. } => {
             let resolution = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -219,13 +235,13 @@ fn references_expression(
                 TermVariableResolution::Let(_) => Ok(None),
                 TermVariableResolution::RecordPun(_) => Ok(None),
                 TermVariableResolution::Reference(f_id, t_id) => {
-                    references_file_term(engine, files, current_file, *f_id, *t_id)
+                    references_file_term(engine, files, current_file, *f_id, *t_id, encoding)
                 }
             }
         }
         ExpressionKind::OperatorName { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            references_file_term(engine, files, current_file, *f_id, *t_id)
+            references_file_term(engine, files, current_file, *f_id, *t_id, encoding)
         }
         _ => Ok(None),
     }
@@ -236,17 +252,18 @@ fn references_type(
     files: &Files,
     current_file: FileId,
     type_id: TypeId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
     let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         TypeKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            references_file_type(engine, files, current_file, *f_id, *t_id)
+            references_file_type(engine, files, current_file, *f_id, *t_id, encoding)
         }
         TypeKind::Operator { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
-            references_file_type(engine, files, current_file, *f_id, *t_id)
+            references_file_type(engine, files, current_file, *f_id, *t_id, encoding)
         }
         _ => Ok(None),
     }
@@ -257,13 +274,15 @@ fn id_range<T>(
     parsed: &ParsedModule,
     stabilized: &StabilizedModule,
     item_id: AstId<T>,
+    encoding: PositionEncoding,
 ) -> Option<Range>
 where
     T: AstNode<Language = PureScript>,
 {
     let root = parsed.syntax_node();
     let ptr = stabilized.syntax_ptr(item_id)?;
-    locate::syntax_range(content, &root, &ptr)
+    let range = locate::syntax_range(content, &root, &ptr)?;
+    position::utf8_range_to_protocol(content, range, encoding)
 }
 
 fn references_file_term(
@@ -272,6 +291,7 @@ fn references_file_term(
     current_file: FileId,
     file_id: FileId,
     term_id: TermItemId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let candidates = probe_term_references(engine, files, current_file, file_id, term_id)?;
 
@@ -289,21 +309,21 @@ fn references_file_term(
             if let ExpressionKind::Constructor { resolution: Some((f_id, t_id)) } = expr_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(&content, &parsed, &stabilized, expr_id)
+                let range = id_range(&content, &parsed, &stabilized, expr_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             } else if let ExpressionKind::OperatorName { resolution: Some((f_id, t_id)) } =
                 expr_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(&content, &parsed, &stabilized, expr_id)
+                let range = id_range(&content, &parsed, &stabilized, expr_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             } else if let ExpressionKind::Variable { resolution: Some(resolution) } = expr_kind
                 && let TermVariableResolution::Reference(f_id, t_id) = resolution
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(&content, &parsed, &stabilized, expr_id)
+                let range = id_range(&content, &parsed, &stabilized, expr_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
@@ -313,7 +333,7 @@ fn references_file_term(
             if let BinderKind::Constructor { resolution: Some((f_id, t_id)), .. } = binder_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(&content, &parsed, &stabilized, binder_id)
+                let range = id_range(&content, &parsed, &stabilized, binder_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
@@ -321,7 +341,7 @@ fn references_file_term(
 
         for (operator_id, f_id, t_id) in lowered.info.iter_term_operator() {
             if (f_id, t_id) == (file_id, term_id) {
-                let range = id_range(&content, &parsed, &stabilized, operator_id)
+                let range = id_range(&content, &parsed, &stabilized, operator_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
@@ -337,6 +357,7 @@ fn references_file_type(
     current_file: FileId,
     file_id: FileId,
     type_id: TypeItemId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let candidates = probe_type_references(engine, files, current_file, file_id, type_id)?;
 
@@ -354,14 +375,14 @@ fn references_file_type(
             if let TypeKind::Constructor { resolution: Some((f_id, t_id)) } = ty_kind
                 && (*f_id, *t_id) == (file_id, type_id)
             {
-                let range = id_range(&content, &parsed, &stabilized, ty_id)
+                let range = id_range(&content, &parsed, &stabilized, ty_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
             if let TypeKind::Operator { resolution: Some((f_id, t_id)) } = ty_kind
                 && (*f_id, *t_id) == (file_id, type_id)
             {
-                let range = id_range(&content, &parsed, &stabilized, ty_id)
+                let range = id_range(&content, &parsed, &stabilized, ty_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
@@ -369,7 +390,7 @@ fn references_file_type(
 
         for (operator_id, f_id, t_id) in lowered.info.iter_type_operator() {
             if (f_id, t_id) == (file_id, type_id) {
-                let range = id_range(&content, &parsed, &stabilized, operator_id)
+                let range = id_range(&content, &parsed, &stabilized, operator_id, encoding)
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
@@ -468,6 +489,7 @@ fn references_let(
     files: &Files,
     current_file: FileId,
     let_id: LetBindingNameGroupId,
+    encoding: PositionEncoding,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let uri = common::file_uri(engine, files, current_file)?;
 
@@ -487,7 +509,7 @@ fn references_let(
             && *candidate_id == let_id
         {
             let uri = Url::clone(&uri);
-            let range = id_range(&content, &parsed, &stabilized, expression_id)
+            let range = id_range(&content, &parsed, &stabilized, expression_id, encoding)
                 .ok_or(AnalyzerError::NonFatal)?;
             locations.push(Location { uri, range });
         }

--- a/compiler-lsp/analyzer/src/symbols.rs
+++ b/compiler-lsp/analyzer/src/symbols.rs
@@ -5,6 +5,7 @@ use building::QueryEngine;
 use files::Files;
 use radix_trie::Trie;
 
+use crate::position::PositionEncoding;
 use crate::{AnalyzerError, common};
 
 pub fn workspace(
@@ -12,6 +13,7 @@ pub fn workspace(
     files: &Files,
     cache: &mut WorkspaceSymbolsCache,
     query: &str,
+    encoding: PositionEncoding,
 ) -> Result<Option<WorkspaceSymbolResponse>, AnalyzerError> {
     if query.is_empty() {
         return Ok(None);
@@ -35,7 +37,7 @@ pub fn workspace(
         }
     } else {
         tracing::debug!("Initialising cache for '{query}'");
-        let filtered_symbols = build_symbol_list(engine, files, &query)?;
+        let filtered_symbols = build_symbol_list(engine, files, &query, encoding)?;
         Arc::new(filtered_symbols)
     };
 
@@ -55,6 +57,7 @@ fn build_symbol_list(
     engine: &QueryEngine,
     files: &Files,
     query: &str,
+    encoding: PositionEncoding,
 ) -> Result<Vec<SymbolInformation>, AnalyzerError> {
     let mut symbols = vec![];
 
@@ -66,7 +69,8 @@ fn build_symbol_list(
             if !name.to_lowercase().starts_with(query) {
                 continue;
             }
-            let location = common::file_term_location(engine, uri.clone(), file_id, term_id)?;
+            let location =
+                common::file_term_location(engine, uri.clone(), file_id, term_id, encoding)?;
             symbols.push(SymbolInformation {
                 name: name.to_string(),
                 kind: SymbolKind::FUNCTION,
@@ -82,7 +86,8 @@ fn build_symbol_list(
             if !name.to_lowercase().starts_with(query) {
                 continue;
             }
-            let location = common::file_type_location(engine, uri.clone(), file_id, type_id)?;
+            let location =
+                common::file_type_location(engine, uri.clone(), file_id, type_id, encoding)?;
             symbols.push(SymbolInformation {
                 name: name.to_string(),
                 kind: SymbolKind::CLASS,
@@ -98,7 +103,8 @@ fn build_symbol_list(
             if !name.to_lowercase().starts_with(query) {
                 continue;
             }
-            let location = common::file_type_location(engine, uri.clone(), file_id, type_id)?;
+            let location =
+                common::file_type_location(engine, uri.clone(), file_id, type_id, encoding)?;
             symbols.push(SymbolInformation {
                 name: name.to_string(),
                 kind: SymbolKind::CLASS,

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use analyzer::{QueryEngine, locate};
+use analyzer::{QueryEngine, position};
 use checking::core::pretty as pretty2;
 use checking::{ExternalQueries, core as core2};
 use diagnostics::{DiagnosticsContext, ToDiagnostics, format_rustc};
@@ -18,8 +18,8 @@ macro_rules! pos {
     ($content:expr, $stabilized:expr, $id:expr) => {{
         let cst = $stabilized.ast_ptr($id).unwrap();
         let range = cst.syntax_node_ptr().text_range();
-        let p = locate::offset_to_position($content, range.start()).unwrap();
-        format!("{}:{}", p.line, p.character)
+        let p = position::offset_to_utf8_position($content, range.start()).unwrap();
+        format!("{}:{}", p.line, p.column)
     }};
 }
 
@@ -349,9 +349,9 @@ fn write_term_resolution(
     let cst = stabilized.ast_ptr(expression_id).unwrap();
     let node = cst.syntax_node_ptr().to_node(module.syntax());
     let text = node.text().to_string();
-    let position = locate::offset_to_position(content, node.text_range().start()).unwrap();
+    let position = position::offset_to_utf8_position(content, node.text_range().start()).unwrap();
 
-    writeln!(out, "{}@{}:{}", text.trim(), position.line, position.character).unwrap();
+    writeln!(out, "{}@{}:{}", text.trim(), position.line, position.column).unwrap();
 
     match resolution {
         Some(TermVariableResolution::Binder(id)) => {

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -3,6 +3,7 @@ pub mod render;
 use std::fmt::Write;
 
 use analyzer::completion::SuggestionsCache;
+use analyzer::position::PositionEncoding;
 use analyzer::{QueryEngine, prim};
 use async_lsp::lsp_types::{
     CompletionItemKind, CompletionList, CompletionResponse, GotoDefinitionResponse, HoverContents,
@@ -119,6 +120,8 @@ fn dispatch_cursor(
     cursor: CursorKind,
     uri: Url,
 ) {
+    let encoding = PositionEncoding::Utf16;
+
     let render_location = |location: Location| -> String {
         format!(
             "{} @ {}:{}..{}:{}",
@@ -133,7 +136,7 @@ fn dispatch_cursor(
     match cursor {
         CursorKind::GotoDefinition => {
             if let Ok(Some(response)) =
-                analyzer::definition::implementation(engine, files, uri, position)
+                analyzer::definition::implementation(engine, files, uri, position, encoding)
             {
                 match response {
                     GotoDefinitionResponse::Scalar(location) => {
@@ -152,7 +155,7 @@ fn dispatch_cursor(
         }
         CursorKind::Hover => {
             if let Ok(Some(response)) =
-                analyzer::hover::implementation(engine, files, uri, position)
+                analyzer::hover::implementation(engine, files, uri, position, encoding)
             {
                 let convert = |marked: MarkedString| -> String {
                     match marked {
@@ -194,7 +197,7 @@ fn dispatch_cursor(
         }
         CursorKind::Completion | CursorKind::CompletionCached => {
             if let Ok(Some(response)) =
-                analyzer::completion::implementation(engine, files, cache, uri, position)
+                analyzer::completion::implementation(engine, files, cache, uri, position, encoding)
             {
                 match response {
                     CompletionResponse::Array(items)
@@ -230,7 +233,7 @@ fn dispatch_cursor(
         }
         CursorKind::References => {
             if let Ok(Some(location)) =
-                analyzer::references::implementation(engine, files, uri, position)
+                analyzer::references::implementation(engine, files, uri, position, encoding)
             {
                 let location = location.into_iter().map(render_location).join("\n");
                 writeln!(result, "{location}").unwrap();


### PR DESCRIPTION
The language server was written under the incorrect assumption that lsp_types::Position was UTF-8 encoded. This implements client-server negotiation for position encodings, and the analyzer::position module for internal UTF-8 treatment.