### PR TITLE
[checking] Fix kind-polymorphic row synonym tails

### DIFF
--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -297,7 +297,8 @@ where
         }
 
         lowering::TypeKind::Record { items, tail } => {
-            let (row_type, row_kind) = infer_row_kind(state, context, items, tail)?;
+            let (row_type, row_kind) =
+                infer_row_kind(state, context, items, tail, EmptyRowTail::Check)?;
             unification::subtype(state, context, row_kind, context.prim.row_type)?;
 
             let t = context.intern_application(context.prim.record, row_type);
@@ -306,7 +307,9 @@ where
             Ok((t, k))
         }
 
-        lowering::TypeKind::Row { items, tail } => infer_row_kind(state, context, items, tail),
+        lowering::TypeKind::Row { items, tail } => {
+            infer_row_kind(state, context, items, tail, EmptyRowTail::Infer)
+        }
 
         lowering::TypeKind::Parenthesized { parenthesized } => {
             if let Some(parenthesized) = parenthesized {
@@ -403,23 +406,33 @@ where
     Ok((result_type, result_kind))
 }
 
+#[derive(Clone, Copy)]
+enum EmptyRowTail {
+    Check,
+    Infer,
+}
+
 fn infer_row_kind<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     items: &Arc<[lowering::TypeRowItem]>,
     tail: &Option<lowering::TypeId>,
+    empty_tail: EmptyRowTail,
 ) -> QueryResult<(TypeId, TypeId)>
 where
     Q: ExternalQueries,
 {
+    let field_kind = state.fresh_unification(context.queries, context.prim.t);
+    let row_kind = context.intern_application(context.prim.row, field_kind);
+
     if items.is_empty()
         && let Some(tail) = tail
     {
-        return infer_kind(state, context, *tail);
+        return match empty_tail {
+            EmptyRowTail::Check => check_kind(state, context, *tail, row_kind),
+            EmptyRowTail::Infer => infer_kind(state, context, *tail),
+        };
     }
-
-    let field_kind = state.fresh_unification(context.queries, context.prim.t);
-    let row_kind = context.intern_application(context.prim.row, field_kind);
 
     let fields = items.iter().map(|item| {
         let label = item.name.clone().unwrap_or(MISSING_NAME);
@@ -436,8 +449,7 @@ where
     let fields = fields.collect::<QueryResult<Vec<_>>>()?;
 
     let tail = if let Some(tail) = tail {
-        let (tail_type, tail_kind) = infer_kind(state, context, *tail)?;
-        unification::subtype(state, context, tail_kind, row_kind)?;
+        let (tail_type, _) = check_kind(state, context, *tail, row_kind)?;
         Some(tail_type)
     } else {
         None

--- a/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.purs
+++ b/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+type Optional :: forall k. Row k
+type Optional = ()
+
+type All =
+  ( value :: Int
+  | Optional
+  )
+
+defaultOptions :: { | Optional }
+defaultOptions = {}
+
+class ConvertOptions defaults provided all
+
+instance
+  ConvertOptions
+    { | Optional }
+    { | provided }
+    { | All }

--- a/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
+++ b/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
@@ -1,0 +1,40 @@
+---
+source: target/debug/build/tests-integration-6275ac7a2b26d932/out/checking_generated.rs
+assertion_line: 28
+expression: report
+---
+Terms
+defaultOptions :: {| Optional }
+
+Types
+Optional :: forall (k :: Type). Row (k :: Type)
+All :: Row Type
+ConvertOptions ::
+  forall (t6 :: Type) (t5 :: Type) (t4 :: Type).
+    (t6 :: Type) -> (t5 :: Type) -> (t4 :: Type) -> Constraint
+
+Synonyms
+type Optional = ()
+type All = ( value :: Int | Optional )
+
+Classes
+class forall (t6 :: Type) (t5 :: Type) (t4 :: Type) (defaults :: (t6 :: Type)) (provided :: (t5 :: Type)) (all :: (t4 :: Type)). ConvertOptions @(t6 :: Type) @(t5 :: Type) @(t4 :: Type)
+  (defaults :: (t6 :: Type))
+  (provided :: (t5 :: Type))
+  (all :: (t4 :: Type))
+
+Instances
+instance forall (t7 :: Row Type).
+  ConvertOptions @Type @Type @Type {| Optional } {| (t7 :: Row Type) } {| All }
+
+Diagnostics
+error[CannotUnify]: Cannot unify '()' with 'Optional'
+  --> 12:18..12:20
+   |
+12 | defaultOptions = {}
+   |                  ^~
+error[CannotUnify]: Cannot unify '{}' with '{| Optional }'
+  --> 12:18..12:20
+   |
+12 | defaultOptions = {}
+   |                  ^~

--- a/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
+++ b/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 28
 expression: report
 ---
 Terms
-defaultOptions :: {| Optional }
+defaultOptions :: {| Optional @Type }
 
 Types
 Optional :: forall (k :: Type). Row (k :: Type)
@@ -15,7 +15,7 @@ ConvertOptions ::
 
 Synonyms
 type Optional = ()
-type All = ( value :: Int | Optional )
+type All = ( value :: Int | Optional @Type )
 
 Classes
 class forall (t6 :: Type) (t5 :: Type) (t4 :: Type) (defaults :: (t6 :: Type)) (provided :: (t5 :: Type)) (all :: (t4 :: Type)). ConvertOptions @(t6 :: Type) @(t5 :: Type) @(t4 :: Type)
@@ -25,16 +25,4 @@ class forall (t6 :: Type) (t5 :: Type) (t4 :: Type) (defaults :: (t6 :: Type)) (
 
 Instances
 instance forall (t7 :: Row Type).
-  ConvertOptions @Type @Type @Type {| Optional } {| (t7 :: Row Type) } {| All }
-
-Diagnostics
-error[CannotUnify]: Cannot unify '()' with 'Optional'
-  --> 12:18..12:20
-   |
-12 | defaultOptions = {}
-   |                  ^~
-error[CannotUnify]: Cannot unify '{}' with '{| Optional }'
-  --> 12:18..12:20
-   |
-12 | defaultOptions = {}
-   |                  ^~
+  ConvertOptions @Type @Type @Type {| Optional @Type } {| (t7 :: Row Type) } {| All }


### PR DESCRIPTION
Fixes a bug in the type checker where kind-polymorphic type synonyms in row tails do not receive kind applications. See the failing test case commit for an example.