### PR TITLE
[checking] Use subtyping for instance member signatures

### DIFF
--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -297,8 +297,15 @@ where
                 types::check_kind(state, context, signature_id, context.prim.t)?;
 
             if let Some(class_member_type) = class_member_type {
-                let unified =
-                    unification::unify(state, context, signature_member_type, class_member_type)?;
+                let unified = state.with_implication(|state| {
+                    let class_member_type =
+                        normalise::normalise(state, context, class_member_type)?;
+                    let class_member_type =
+                        toolkit::skolemise_forall(state, context, class_member_type)?;
+                    let class_member_type =
+                        toolkit::collect_givens(state, context, class_member_type)?;
+                    unification::subtype(state, context, signature_member_type, class_member_type)
+                })?;
                 if !unified {
                     let expected = state.pretty_id(context, class_member_type)?;
                     let actual = state.pretty_id(context, signature_member_type)?;

--- a/tests-integration/fixtures/checking/1772475900_instance_member_signature_mismatch/Main.snap
+++ b/tests-integration/fixtures/checking/1772475900_instance_member_signature_mismatch/Main.snap
@@ -22,11 +22,6 @@ error[CannotUnify]: Cannot unify 'Int' with 'String'
   |
 7 | instance Show Int where
   | ^~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Int -> Int' with 'Int -> String'
-  --> 7:1..9:13
-  |
-7 | instance Show Int where
-  | ^~~~~~~~~~~~~~~~~~~~~~~
 error[InstanceMemberTypeMismatch]: Instance member type mismatch: expected 'Int -> String', got 'Int -> Int'
   --> 7:1..9:13
   |

--- a/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.purs
+++ b/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.purs
@@ -1,0 +1,32 @@
+module Main where
+
+import Data.Functor (class Functor)
+
+class Transform :: ((Type -> Type) -> Type -> Type) -> Constraint
+class Transform t where
+  lift :: forall f a. Functor f => f a -> t f a
+
+data Wrap :: (Type -> Type) -> Type -> Type
+data Wrap f a = Wrap (f a)
+
+instance Transform Wrap where
+  lift :: forall f a. f a -> Wrap f a
+  lift = Wrap
+
+class Render a where
+  render :: a -> String
+
+class Renderer t where
+  renderer :: forall a. Render a => a -> t
+
+instance Renderer String where
+  renderer :: forall a. Render a => a -> String
+  renderer = render
+
+class TransformPlain :: ((Type -> Type) -> Type -> Type) -> Constraint
+class TransformPlain t where
+  liftPlain :: forall f a. f a -> t f a
+
+instance TransformPlain Wrap where
+  liftPlain :: forall f a. Functor f => f a -> Wrap f a
+  liftPlain = Wrap

--- a/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
+++ b/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
@@ -60,60 +60,7 @@ Roles
 Wrap = [Representational, Nominal]
 
 Diagnostics
-error[CannotUnify]: Cannot unify '(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'Functor (f :: Type -> Type) =>
-(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 12:1..14:14
-   |
-12 | instance Transform Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'forall (a :: Type). (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (a :: Type).
-  Functor (f :: Type -> Type) =>
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 12:1..14:14
-   |
-12 | instance Transform Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'forall (f :: Type -> Type) (a :: Type).
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (f :: Type -> Type) (a :: Type).
-  Functor (f :: Type -> Type) =>
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 12:1..14:14
-   |
-12 | instance Transform Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[InstanceMemberTypeMismatch]: Instance member type mismatch: expected 'forall (f :: Type -> Type) (a :: Type).
-  Functor (f :: Type -> Type) =>
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)', got 'forall (f :: Type -> Type) (a :: Type).
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 12:1..14:14
-   |
-12 | instance Transform Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Functor (f :: Type -> Type) =>
-(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with '(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 30:1..32:19
-   |
-30 | instance TransformPlain Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'forall (a :: Type).
-  Functor (f :: Type -> Type) =>
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (a :: Type). (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 30:1..32:19
-   |
-30 | instance TransformPlain Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotUnify]: Cannot unify 'forall (f :: Type -> Type) (a :: Type).
-  Functor (f :: Type -> Type) =>
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (f :: Type -> Type) (a :: Type).
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
-  --> 30:1..32:19
-   |
-30 | instance TransformPlain Wrap where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[InstanceMemberTypeMismatch]: Instance member type mismatch: expected 'forall (f :: Type -> Type) (a :: Type).
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)', got 'forall (f :: Type -> Type) (a :: Type).
-  Functor (f :: Type -> Type) =>
-  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
   --> 30:1..32:19
    |
 30 | instance TransformPlain Wrap where

--- a/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
+++ b/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
@@ -1,0 +1,120 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+lift ::
+  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+    Transform (t :: (Type -> Type) -> Type -> Type) =>
+    Functor (f :: Type -> Type) =>
+    (f :: Type -> Type) (a :: Type) ->
+    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+Wrap ::
+  forall (@f :: Type -> Type) (@a :: Type).
+    (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)
+render :: forall (@a :: Type). Render (a :: Type) => (a :: Type) -> String
+renderer ::
+  forall (@t :: Type) (a :: Type).
+    Renderer (t :: Type) => Render (a :: Type) => (a :: Type) -> (t :: Type)
+liftPlain ::
+  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+    TransformPlain (t :: (Type -> Type) -> Type -> Type) =>
+    (f :: Type -> Type) (a :: Type) ->
+    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+
+Types
+Transform :: ((Type -> Type) -> Type -> Type) -> Constraint
+Wrap :: (Type -> Type) -> Type -> Type
+Render :: Type -> Constraint
+Renderer :: Type -> Constraint
+TransformPlain :: ((Type -> Type) -> Type -> Type) -> Constraint
+
+Classes
+class forall (t :: (Type -> Type) -> Type -> Type). Transform (t :: (Type -> Type) -> Type -> Type)
+  lift ::
+  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+    Transform (t :: (Type -> Type) -> Type -> Type) =>
+    Functor (f :: Type -> Type) =>
+    (f :: Type -> Type) (a :: Type) ->
+    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+class forall (a :: Type). Render (a :: Type)
+  render :: forall (@a :: Type). Render (a :: Type) => (a :: Type) -> String
+class forall (t :: Type). Renderer (t :: Type)
+  renderer ::
+  forall (@t :: Type) (a :: Type).
+    Renderer (t :: Type) => Render (a :: Type) => (a :: Type) -> (t :: Type)
+class forall (t :: (Type -> Type) -> Type -> Type). TransformPlain (t :: (Type -> Type) -> Type -> Type)
+  liftPlain ::
+  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+    TransformPlain (t :: (Type -> Type) -> Type -> Type) =>
+    (f :: Type -> Type) (a :: Type) ->
+    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+
+Instances
+instance Transform Wrap
+instance Renderer String
+instance TransformPlain Wrap
+
+Roles
+Wrap = [Representational, Nominal]
+
+Diagnostics
+error[CannotUnify]: Cannot unify '(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'Functor (f :: Type -> Type) =>
+(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 12:1..14:14
+   |
+12 | instance Transform Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'forall (a :: Type). (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (a :: Type).
+  Functor (f :: Type -> Type) =>
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 12:1..14:14
+   |
+12 | instance Transform Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'forall (f :: Type -> Type) (a :: Type).
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (f :: Type -> Type) (a :: Type).
+  Functor (f :: Type -> Type) =>
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 12:1..14:14
+   |
+12 | instance Transform Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[InstanceMemberTypeMismatch]: Instance member type mismatch: expected 'forall (f :: Type -> Type) (a :: Type).
+  Functor (f :: Type -> Type) =>
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)', got 'forall (f :: Type -> Type) (a :: Type).
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 12:1..14:14
+   |
+12 | instance Transform Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Functor (f :: Type -> Type) =>
+(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with '(f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 30:1..32:19
+   |
+30 | instance TransformPlain Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'forall (a :: Type).
+  Functor (f :: Type -> Type) =>
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (a :: Type). (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 30:1..32:19
+   |
+30 | instance TransformPlain Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotUnify]: Cannot unify 'forall (f :: Type -> Type) (a :: Type).
+  Functor (f :: Type -> Type) =>
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)' with 'forall (f :: Type -> Type) (a :: Type).
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 30:1..32:19
+   |
+30 | instance TransformPlain Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[InstanceMemberTypeMismatch]: Instance member type mismatch: expected 'forall (f :: Type -> Type) (a :: Type).
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)', got 'forall (f :: Type -> Type) (a :: Type).
+  Functor (f :: Type -> Type) =>
+  (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)'
+  --> 30:1..32:19
+   |
+30 | instance TransformPlain Wrap where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This changes the checking rule for instance member signatures to use subtyping instead of unification; this enables constraint weakening in instance member signatures. Note that in code generation, the class member signature still dictates which implicit arguments must be passed into the member implementation.