### PR TITLE
[checking] Avoid elaboration when subtyping record fields

### DIFF
--- a/compiler-core/checking/src/core/unification.rs
+++ b/compiler-core/checking/src/core/unification.rs
@@ -236,7 +236,7 @@ where
             if let (Type::Row(t1_row_id), Type::Row(t2_row_id)) =
                 (t1_argument_core, t2_argument_core)
             {
-                subtype_rows::<P, Q>(state, context, t1_row_id, t2_row_id)
+                subtype_rows::<NonElaborating, Q>(state, context, t1_row_id, t2_row_id)
             } else {
                 unify(state, context, t1, t2)
             }

--- a/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.purs
+++ b/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+import Type.Proxy (Proxy(..))
+
+class Encode :: Type -> Type -> Constraint
+class Encode token a
+
+class RecordDef :: Type -> Row Type -> Constraint
+class RecordDef token row where
+  recordDef
+    :: { handle :: forall a. Encode token a => token -> Proxy a -> String }
+    -> token
+    -> Record row
+    -> String
+
+class RecordDefRowList :: Type -> Row Type -> Type -> Constraint
+class RecordDefRowList token row rowList where
+  recordDefRowList
+    :: { handle :: forall a. Encode token a => token -> Proxy a -> String }
+    -> token
+    -> Record row
+    -> Proxy rowList
+    -> String
+
+instance RecordDefRowList token row rowList => RecordDef token row where
+  recordDef interface token row =
+    recordDefRowList interface token row (Proxy :: _ rowList)

--- a/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
+++ b/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
@@ -61,15 +61,3 @@ Instances
 instance forall (t9 :: Type) (t10 :: Row Type) (t11 :: Type).
   RecordDefRowList (t9 :: Type) (t10 :: Row Type) (t11 :: Type) =>
   RecordDef (t9 :: Type) (t10 :: Row Type)
-
-Diagnostics
-error[CannotUnify]: Cannot unify '(t15 :: Type) -> Proxy @Type ?13 -> String' with 'Encode ?10 (a :: Type) => ?10 -> Proxy @Type (a :: Type) -> String'
-  --> 27:22..27:31
-   |
-27 |     recordDefRowList interface token row (Proxy :: _ rowList)
-   |                      ^~~~~~~~~
-error[NoInstanceFound]: No instance found for: Encode (t15 :: Type) ?13
-  --> 25:1..27:62
-   |
-25 | instance RecordDefRowList token row rowList => RecordDef token row where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
+++ b/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
@@ -1,0 +1,75 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+recordDef ::
+  forall (@token :: Type) (@row :: Row Type).
+    RecordDef (token :: Type) (row :: Row Type) =>
+    { handle ::
+        forall (a :: Type).
+          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+    } ->
+    (token :: Type) ->
+    {| (row :: Row Type) } ->
+    String
+recordDefRowList ::
+  forall (@token :: Type) (@row :: Row Type) (@rowList :: Type).
+    RecordDefRowList (token :: Type) (row :: Row Type) (rowList :: Type) =>
+    { handle ::
+        forall (a :: Type).
+          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+    } ->
+    (token :: Type) ->
+    {| (row :: Row Type) } ->
+    Proxy @Type (rowList :: Type) ->
+    String
+
+Types
+Encode :: Type -> Type -> Constraint
+RecordDef :: Type -> Row Type -> Constraint
+RecordDefRowList :: Type -> Row Type -> Type -> Constraint
+
+Classes
+class forall (token :: Type) (a :: Type). Encode (token :: Type) (a :: Type)
+class forall (token :: Type) (row :: Row Type). RecordDef (token :: Type) (row :: Row Type)
+  recordDef ::
+  forall (@token :: Type) (@row :: Row Type).
+    RecordDef (token :: Type) (row :: Row Type) =>
+    { handle ::
+        forall (a :: Type).
+          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+    } ->
+    (token :: Type) ->
+    {| (row :: Row Type) } ->
+    String
+class forall (token :: Type) (row :: Row Type) (rowList :: Type). RecordDefRowList (token :: Type) (row :: Row Type) (rowList :: Type)
+  recordDefRowList ::
+  forall (@token :: Type) (@row :: Row Type) (@rowList :: Type).
+    RecordDefRowList (token :: Type) (row :: Row Type) (rowList :: Type) =>
+    { handle ::
+        forall (a :: Type).
+          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+    } ->
+    (token :: Type) ->
+    {| (row :: Row Type) } ->
+    Proxy @Type (rowList :: Type) ->
+    String
+
+Instances
+instance forall (t9 :: Type) (t10 :: Row Type) (t11 :: Type).
+  RecordDefRowList (t9 :: Type) (t10 :: Row Type) (t11 :: Type) =>
+  RecordDef (t9 :: Type) (t10 :: Row Type)
+
+Diagnostics
+error[CannotUnify]: Cannot unify '(t15 :: Type) -> Proxy @Type ?13 -> String' with 'Encode ?10 (a :: Type) => ?10 -> Proxy @Type (a :: Type) -> String'
+  --> 27:22..27:31
+   |
+27 |     recordDefRowList interface token row (Proxy :: _ rowList)
+   |                      ^~~~~~~~~
+error[NoInstanceFound]: No instance found for: Encode (t15 :: Type) ?13
+  --> 25:1..27:62
+   |
+25 | instance RecordDefRowList token row rowList => RecordDef token row where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes a bug in record subtyping where record fields are incorrectly elaborated. Aligns with the checking rule in the original purescript/purescript compiler.