### PR TITLE
[checking] Implement holes for terms and types

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -160,6 +160,12 @@ fn initialize(
                         label_details_support: Some(true),
                     }),
                 }),
+                code_action_provider: Some(CodeActionProviderCapability::Options(
+                    CodeActionOptions {
+                        code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+                        ..CodeActionOptions::default()
+                    },
+                )),
                 definition_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
@@ -314,6 +320,22 @@ fn hover(snapshot: StateSnapshot, p: HoverParams) -> Result<Option<Hover>, LspEr
 
     let result = snapshot
         .with_language_context(|context| analyzer::hover::implementation(context, uri, position));
+
+    result.on_non_fatal(None)
+}
+
+fn code_action(
+    snapshot: StateSnapshot,
+    p: CodeActionParams,
+) -> Result<Option<CodeActionResponse>, LspError> {
+    let _span = tracing::info_span!("code_action").entered();
+    let uri = p.text_document.uri;
+    let range = p.range;
+    let action_context = p.context;
+
+    let result = snapshot.with_language_context(|context| {
+        analyzer::code_action::implementation(context, uri, range, action_context)
+    });
 
     result.on_non_fatal(None)
 }
@@ -520,6 +542,7 @@ pub async fn start(config: Arc<cli::Config>) {
             .request::<extension::CustomInitialize, _>(initialize)
             .request_snapshot::<request::GotoDefinition>(definition)
             .request_snapshot::<request::HoverRequest>(hover)
+            .request_snapshot::<request::CodeActionRequest>(code_action)
             .request_snapshot::<request::Completion>(completion)
             .request_snapshot::<request::ResolveCompletionItem>(resolve_completion_item)
             .request_snapshot::<request::References>(references)

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -2,11 +2,12 @@ use std::mem;
 use std::sync::Arc;
 
 use building_types::QueryResult;
+use smol_str::SmolStr;
 
 use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::{Type, TypeId};
-use crate::error::{CheckingError, ErrorKind};
+use crate::error::{CheckingError, ErrorKind, HoleBinding, holes};
 use crate::state::CheckState;
 use crate::{ExternalQueries, OperatorBranchTypes};
 
@@ -112,6 +113,19 @@ where
             let t2 = zonk(state, context, t2)?;
             ErrorKind::CannotUnify { t1, t2 }
         }
+        ErrorKind::TermHole { type_id, bindings } => {
+            let type_id = zonk(state, context, type_id)?;
+            let bindings = zonk_hole_bindings(state, context, &bindings)?;
+            let bindings = holes::refine_bindings(state, context, type_id, bindings)?;
+            ErrorKind::TermHole { type_id, bindings }
+        }
+        ErrorKind::TypeHole { type_id, kind_id, bindings } => {
+            let type_id = zonk(state, context, type_id)?;
+            let kind_id = zonk(state, context, kind_id)?;
+            let bindings = zonk_hole_bindings(state, context, &bindings)?;
+            let bindings = holes::refine_bindings(state, context, kind_id, bindings)?;
+            ErrorKind::TypeHole { type_id, kind_id, bindings }
+        }
         ErrorKind::InstanceHeadLabeledRow { class_file, class_item, position, type_id } => {
             let type_id = zonk(state, context, type_id)?;
             ErrorKind::InstanceHeadLabeledRow { class_file, class_item, position, type_id }
@@ -170,6 +184,22 @@ where
         | ErrorKind::PropertyIsMissing { .. }
         | ErrorKind::AdditionalProperty { .. }) => kind,
     })
+}
+
+fn zonk_hole_bindings<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    bindings: &[HoleBinding],
+) -> QueryResult<Vec<HoleBinding>>
+where
+    Q: ExternalQueries,
+{
+    let bindings = bindings.iter().map(|binding| {
+        let name = SmolStr::clone(&binding.name);
+        let type_id = zonk(state, context, binding.type_id)?;
+        Ok(HoleBinding { name, type_id })
+    });
+    bindings.collect()
 }
 
 fn zonk_operator_branch<Q>(

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -7,9 +7,10 @@ use smol_str::SmolStr;
 use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::{Type, TypeId};
-use crate::error::{CheckingError, ErrorKind, HoleBinding, holes};
+use crate::error::{CheckingError, ErrorKind};
+use crate::holes::{HoleBinding, TermHole, TypeHole};
 use crate::state::CheckState;
-use crate::{ExternalQueries, OperatorBranchTypes};
+use crate::{ExternalQueries, OperatorBranchTypes, holes};
 
 struct Zonk;
 
@@ -71,6 +72,32 @@ where
     Ok(())
 }
 
+pub fn zonk_holes<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    for (source_term, hole) in mem::take(&mut state.checked.holes.terms) {
+        let type_id = zonk(state, context, hole.type_id)?;
+        let bindings = zonk_hole_bindings(state, context, &hole.bindings)?;
+        let bindings = holes::refine_bindings(state, context, type_id, bindings)?;
+
+        let hole = TermHole { type_id, bindings };
+        state.checked.holes.terms.insert(source_term, hole);
+    }
+
+    for (source_type, hole) in mem::take(&mut state.checked.holes.types) {
+        let type_id = zonk(state, context, hole.type_id)?;
+        let kind_id = zonk(state, context, hole.kind_id)?;
+        let bindings = zonk_hole_bindings(state, context, &hole.bindings)?;
+        let bindings = holes::refine_bindings(state, context, kind_id, bindings)?;
+
+        let hole = TypeHole { type_id, kind_id, bindings };
+        state.checked.holes.types.insert(source_type, hole);
+    }
+
+    Ok(())
+}
+
 pub fn zonk_errors<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
 where
     Q: ExternalQueries,
@@ -113,19 +140,6 @@ where
             let t2 = zonk(state, context, t2)?;
             ErrorKind::CannotUnify { t1, t2 }
         }
-        ErrorKind::TermHole { type_id, bindings } => {
-            let type_id = zonk(state, context, type_id)?;
-            let bindings = zonk_hole_bindings(state, context, &bindings)?;
-            let bindings = holes::refine_bindings(state, context, type_id, bindings)?;
-            ErrorKind::TermHole { type_id, bindings }
-        }
-        ErrorKind::TypeHole { type_id, kind_id, bindings } => {
-            let type_id = zonk(state, context, type_id)?;
-            let kind_id = zonk(state, context, kind_id)?;
-            let bindings = zonk_hole_bindings(state, context, &bindings)?;
-            let bindings = holes::refine_bindings(state, context, kind_id, bindings)?;
-            ErrorKind::TypeHole { type_id, kind_id, bindings }
-        }
         ErrorKind::InstanceHeadLabeledRow { class_file, class_item, position, type_id } => {
             let type_id = zonk(state, context, type_id)?;
             ErrorKind::InstanceHeadLabeledRow { class_file, class_item, position, type_id }
@@ -167,6 +181,8 @@ where
         | ErrorKind::DeriveMissingFunctor
         | ErrorKind::EmptyAdoBlock
         | ErrorKind::EmptyDoBlock
+        | ErrorKind::TermHole { .. }
+        | ErrorKind::TypeHole { .. }
         | ErrorKind::InvalidFinalBind
         | ErrorKind::InvalidFinalLet
         | ErrorKind::InstanceHeadMismatch { .. }

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -1,10 +1,18 @@
 //! Implements the errors emitted by the type checker.
 
+pub mod holes;
+
 use std::sync::Arc;
 
 use smol_str::SmolStr;
 
 use crate::core::{SmolStrId, TypeId};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoleBinding {
+    pub name: SmolStr,
+    pub type_id: TypeId,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCrumb {
@@ -67,6 +75,15 @@ pub enum ErrorKind {
     DeriveMissingFunctor,
     EmptyAdoBlock,
     EmptyDoBlock,
+    TermHole {
+        type_id: TypeId,
+        bindings: Arc<[HoleBinding]>,
+    },
+    TypeHole {
+        type_id: TypeId,
+        kind_id: TypeId,
+        bindings: Arc<[HoleBinding]>,
+    },
     InvalidFinalBind,
     InvalidFinalLet,
     InstanceHeadMismatch {

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -1,18 +1,10 @@
 //! Implements the errors emitted by the type checker.
 
-pub mod holes;
-
 use std::sync::Arc;
 
 use smol_str::SmolStr;
 
 use crate::core::{SmolStrId, TypeId};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HoleBinding {
-    pub name: SmolStr,
-    pub type_id: TypeId,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCrumb {
@@ -76,13 +68,10 @@ pub enum ErrorKind {
     EmptyAdoBlock,
     EmptyDoBlock,
     TermHole {
-        type_id: TypeId,
-        bindings: Arc<[HoleBinding]>,
+        source_term: lowering::ExpressionId,
     },
     TypeHole {
-        type_id: TypeId,
-        kind_id: TypeId,
-        bindings: Arc<[HoleBinding]>,
+        source_type: lowering::TypeId,
     },
     InvalidFinalBind,
     InvalidFinalLet,

--- a/compiler-core/checking/src/error/holes.rs
+++ b/compiler-core/checking/src/error/holes.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use rustc_hash::FxHashSet;
+
+use crate::ExternalQueries;
+use crate::context::CheckContext;
+use crate::core::constraint::matching::{self, MatchType};
+use crate::core::{TypeId, toolkit};
+use crate::state::CheckState;
+
+use super::HoleBinding;
+
+pub fn refine_bindings<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    expected: TypeId,
+    mut bindings: Vec<HoleBinding>,
+) -> QueryResult<Arc<[HoleBinding]>>
+where
+    Q: ExternalQueries,
+{
+    bindings.sort_by(|left, right| left.name.cmp(&right.name));
+    let expected = toolkit::without_constraints(state, context, expected)?;
+
+    let mut relevant = vec![];
+    for binding in &bindings {
+        if binding_matches(state, context, binding.type_id, expected)? {
+            relevant.push(HoleBinding::clone(binding));
+        }
+    }
+
+    let selected = if relevant.is_empty() { bindings } else { relevant };
+    Ok(Arc::from(selected))
+}
+
+fn binding_matches<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    candidate: TypeId,
+    expected: TypeId,
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    let inspected = toolkit::inspect_quantified(state, context, candidate)?;
+    let candidate = toolkit::without_constraints(state, context, inspected.quantified)?;
+
+    let pattern = inspected.binders.iter().map(|binder| binder.name);
+    let pattern = pattern.collect::<FxHashSet<_>>();
+
+    let matched = matching::types_match(state, context, &pattern, expected, candidate)?;
+    let MatchType::Match { bindings } = matched else { return Ok(false) };
+
+    Ok(matching::verify_substitution(state, context, bindings)?.is_match())
+}

--- a/compiler-core/checking/src/holes.rs
+++ b/compiler-core/checking/src/holes.rs
@@ -2,14 +2,33 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use rustc_hash::FxHashSet;
+use smol_str::SmolStr;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::constraint::matching::{self, MatchType};
+use crate::core::constraint::matching;
+use crate::core::constraint::matching::MatchType;
 use crate::core::{TypeId, toolkit};
 use crate::state::CheckState;
 
-use super::HoleBinding;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoleBinding {
+    pub name: SmolStr,
+    pub type_id: TypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TermHole {
+    pub type_id: TypeId,
+    pub bindings: Arc<[HoleBinding]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeHole {
+    pub type_id: TypeId,
+    pub kind_id: TypeId,
+    pub bindings: Arc<[HoleBinding]>,
+}
 
 pub fn refine_bindings<Q>(
     state: &mut CheckState,

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod error;
+pub mod holes;
 pub mod implication;
 pub mod safety;
 pub mod source;
@@ -25,6 +26,7 @@ use crate::core::{
     RowType, RowTypeId, SmolStrId,
 };
 use crate::error::CheckingError;
+use crate::holes::{TermHole, TypeHole};
 
 pub trait ExternalQueries:
     QueryProxy<
@@ -63,8 +65,15 @@ pub struct CheckedModule {
     pub derived: FxHashMap<DeriveId, CheckedInstance>,
     pub roles: FxHashMap<TypeItemId, Arc<[Role]>>,
     pub nodes: CheckedNodes,
+    pub holes: CheckedHoles,
     pub errors: Vec<CheckingError>,
     pub names: FxHashMap<Name, SmolStrId>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct CheckedHoles {
+    pub terms: FxHashMap<lowering::ExpressionId, TermHole>,
+    pub types: FxHashMap<lowering::TypeId, TypeHole>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -119,6 +128,14 @@ impl CheckedModule {
 
     pub fn lookup_name(&self, name: Name) -> Option<SmolStrId> {
         self.names.get(&name).copied()
+    }
+
+    pub fn lookup_term_hole(&self, id: lowering::ExpressionId) -> Option<&TermHole> {
+        self.holes.terms.get(&id)
+    }
+
+    pub fn lookup_type_hole(&self, id: lowering::TypeId) -> Option<&TypeHole> {
+        self.holes.types.get(&id)
     }
 }
 
@@ -186,6 +203,7 @@ fn check_source(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<
     source::check_type_items(&mut state, &context)?;
     source::check_term_items(&mut state, &context)?;
     core::zonk::zonk_nodes(&mut state, &context)?;
+    core::zonk::zonk_holes(&mut state, &context)?;
     core::zonk::zonk_errors(&mut state, &context)?;
 
     Ok(state.checked)

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -7,13 +7,18 @@ pub mod form_let;
 pub mod forms;
 pub mod guarded;
 
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use itertools::Itertools;
+use lowering::GraphNode;
+use rustc_hash::FxHashSet;
+use smol_str::SmolStr;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, normalise, toolkit, unification};
-use crate::error::ErrorCrumb;
+use crate::error::{ErrorCrumb, ErrorKind, HoleBinding};
 use crate::source::{operator, types};
 use crate::state::CheckState;
 
@@ -311,7 +316,12 @@ where
 
         lowering::ExpressionKind::Hole => {
             let kind = state.fresh_unification(context.queries, context.prim.t);
-            Ok(state.fresh_unification(context.queries, kind))
+            let type_id = state.fresh_unification(context.queries, kind);
+
+            let bindings = term_hole_bindings(state, context, expression);
+            state.insert_error(ErrorKind::TermHole { type_id, bindings });
+
+            Ok(type_id)
         }
 
         lowering::ExpressionKind::String => Ok(context.prim.string),
@@ -348,4 +358,66 @@ where
             collections::infer_record_update(state, context, record, updates)
         }
     }
+}
+
+fn term_hole_bindings<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
+) -> Arc<[HoleBinding]>
+where
+    Q: ExternalQueries,
+{
+    let Some(scope_node) = context.lowered.nodes.expression_node(expression) else {
+        return Arc::from([]);
+    };
+
+    let mut seen = FxHashSet::default();
+    let mut result = vec![];
+
+    for (_, node) in context.lowered.graph.traverse(scope_node) {
+        match node {
+            GraphNode::Binder { binders, puns, .. } => {
+                let mut binders = binders.iter().collect_vec();
+                binders.sort_by_key(|(name, _)| *name);
+
+                for (name, binder_id) in binders {
+                    if seen.insert(name)
+                        && let Some(type_id) = state.checked.nodes.lookup_binder(*binder_id)
+                    {
+                        let name = SmolStr::clone(name);
+                        result.push(HoleBinding { name, type_id });
+                    }
+                }
+
+                let mut puns = puns.iter().collect_vec();
+                puns.sort_by_key(|(name, _)| *name);
+
+                for (name, pun_id) in puns {
+                    if seen.insert(name)
+                        && let Some(type_id) = state.checked.nodes.lookup_pun(*pun_id)
+                    {
+                        let name = SmolStr::clone(name);
+                        result.push(HoleBinding { name, type_id });
+                    }
+                }
+            }
+            GraphNode::Let { bindings, .. } => {
+                let mut bindings = bindings.iter().collect_vec();
+                bindings.sort_by_key(|(name, _)| *name);
+
+                for (name, let_id) in bindings {
+                    if seen.insert(name)
+                        && let Some(type_id) = state.checked.nodes.lookup_let(*let_id)
+                    {
+                        let name = SmolStr::clone(name);
+                        result.push(HoleBinding { name, type_id });
+                    }
+                }
+            }
+            GraphNode::Forall { .. } | GraphNode::Implicit { .. } => {}
+        }
+    }
+
+    Arc::from(result)
 }

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -10,6 +10,8 @@ pub mod guarded;
 use std::sync::Arc;
 
 use building_types::QueryResult;
+use files::FileId;
+use indexing::{ImportKind, TermItemId};
 use itertools::Itertools;
 use lowering::GraphNode;
 use rustc_hash::FxHashSet;
@@ -319,7 +321,7 @@ where
             let kind = state.fresh_unification(context.queries, context.prim.t);
             let type_id = state.fresh_unification(context.queries, kind);
 
-            let bindings = term_hole_bindings(state, context, expression);
+            let bindings = term_hole_bindings(state, context, expression)?;
             state.checked.holes.terms.insert(expression, TermHole { type_id, bindings });
             state.insert_error(ErrorKind::TermHole { source_term: expression });
 
@@ -366,17 +368,30 @@ fn term_hole_bindings<Q>(
     state: &CheckState,
     context: &CheckContext<Q>,
     expression: lowering::ExpressionId,
-) -> Arc<[HoleBinding]>
+) -> QueryResult<Arc<[HoleBinding]>>
 where
     Q: ExternalQueries,
 {
-    let Some(scope_node) = context.lowered.nodes.expression_node(expression) else {
-        return Arc::from([]);
-    };
-
     let mut seen = FxHashSet::default();
     let mut result = vec![];
 
+    if let Some(scope_node) = context.lowered.nodes.expression_node(expression) {
+        collect_graph_term_hole_bindings(state, context, scope_node, &mut seen, &mut result);
+    }
+
+    collect_resolved_term_hole_bindings(state, context, &mut seen, &mut result)?;
+    Ok(Arc::from(result))
+}
+
+fn collect_graph_term_hole_bindings<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    scope_node: lowering::GraphNodeId,
+    seen: &mut FxHashSet<SmolStr>,
+    result: &mut Vec<HoleBinding>,
+) where
+    Q: ExternalQueries,
+{
     for (_, node) in context.lowered.graph.traverse(scope_node) {
         match node {
             GraphNode::Binder { binders, puns, .. } => {
@@ -384,7 +399,7 @@ where
                 binders.sort_by_key(|(name, _)| *name);
 
                 for (name, binder_id) in binders {
-                    if seen.insert(name)
+                    if seen.insert(SmolStr::clone(name))
                         && let Some(type_id) = state.checked.nodes.lookup_binder(*binder_id)
                     {
                         let name = SmolStr::clone(name);
@@ -396,7 +411,7 @@ where
                 puns.sort_by_key(|(name, _)| *name);
 
                 for (name, pun_id) in puns {
-                    if seen.insert(name)
+                    if seen.insert(SmolStr::clone(name))
                         && let Some(type_id) = state.checked.nodes.lookup_pun(*pun_id)
                     {
                         let name = SmolStr::clone(name);
@@ -409,7 +424,7 @@ where
                 bindings.sort_by_key(|(name, _)| *name);
 
                 for (name, let_id) in bindings {
-                    if seen.insert(name)
+                    if seen.insert(SmolStr::clone(name))
                         && let Some(type_id) = state.checked.nodes.lookup_let(*let_id)
                     {
                         let name = SmolStr::clone(name);
@@ -420,6 +435,73 @@ where
             GraphNode::Forall { .. } | GraphNode::Implicit { .. } => {}
         }
     }
+}
 
-    Arc::from(result)
+fn collect_resolved_term_hole_bindings<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    seen: &mut FxHashSet<SmolStr>,
+    result: &mut Vec<HoleBinding>,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    for (name, file_id, term_id) in context.resolved.locals.iter_terms() {
+        collect_resolved_term_hole_binding(state, context, name, file_id, term_id, seen, result)?;
+    }
+
+    for import in context.resolved.unqualified.values().flatten() {
+        let visible_terms =
+            import.iter_terms().filter(|(_, _, _, kind)| !matches!(kind, ImportKind::Hidden));
+
+        for (name, file_id, term_id, _) in visible_terms {
+            collect_resolved_term_hole_binding(
+                state, context, name, file_id, term_id, seen, result,
+            )?;
+        }
+    }
+
+    if !context.resolved.unqualified.contains_key("Prim") {
+        for (name, file_id, term_id) in context.prim_resolved.exports.iter_terms() {
+            collect_resolved_term_hole_binding(
+                state, context, name, file_id, term_id, seen, result,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_resolved_term_hole_binding<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    name: &SmolStr,
+    file_id: FileId,
+    term_id: TermItemId,
+    seen: &mut FxHashSet<SmolStr>,
+    result: &mut Vec<HoleBinding>,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    if seen.contains(name) {
+        return Ok(());
+    }
+
+    let Some((resolved_file_id, resolved_term_id)) =
+        context.resolved.lookup_term(&context.prim_resolved, None, name)
+    else {
+        return Ok(());
+    };
+
+    if (resolved_file_id, resolved_term_id) != (file_id, term_id) {
+        return Ok(());
+    }
+
+    let type_id = toolkit::lookup_file_term(state, context, resolved_file_id, resolved_term_id)?;
+    let name = SmolStr::clone(name);
+    seen.insert(SmolStr::clone(&name));
+    result.push(HoleBinding { name, type_id });
+
+    Ok(())
 }

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -18,7 +18,8 @@ use smol_str::SmolStr;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, normalise, toolkit, unification};
-use crate::error::{ErrorCrumb, ErrorKind, HoleBinding};
+use crate::error::{ErrorCrumb, ErrorKind};
+use crate::holes::{HoleBinding, TermHole};
 use crate::source::{operator, types};
 use crate::state::CheckState;
 
@@ -319,7 +320,8 @@ where
             let type_id = state.fresh_unification(context.queries, kind);
 
             let bindings = term_hole_bindings(state, context, expression);
-            state.insert_error(ErrorKind::TermHole { type_id, bindings });
+            state.checked.holes.terms.insert(expression, TermHole { type_id, bindings });
+            state.insert_error(ErrorKind::TermHole { source_term: expression });
 
             Ok(type_id)
         }

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -13,7 +13,8 @@ use smol_str::SmolStr;
 use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
 use crate::core::{ForallBinder, RowField, Type, TypeId, normalise, toolkit, unification};
-use crate::error::{ErrorCrumb, ErrorKind, HoleBinding};
+use crate::error::{ErrorCrumb, ErrorKind};
+use crate::holes::{HoleBinding, TypeHole};
 use crate::source::{operator, synonym};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -192,7 +193,8 @@ where
             let type_id = state.fresh_unification(context.queries, kind_id);
 
             let bindings = type_hole_bindings(state, context, id);
-            state.insert_error(ErrorKind::TypeHole { type_id, kind_id, bindings });
+            state.checked.holes.types.insert(id, TypeHole { type_id, kind_id, bindings });
+            state.insert_error(ErrorKind::TypeHole { source_type: id });
 
             Ok((type_id, kind_id))
         }

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -5,12 +5,15 @@ pub mod application;
 use std::sync::Arc;
 
 use building_types::QueryResult;
+use itertools::Itertools;
+use lowering::GraphNode;
+use rustc_hash::FxHashSet;
 use smol_str::SmolStr;
 
 use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
 use crate::core::{ForallBinder, RowField, Type, TypeId, normalise, toolkit, unification};
-use crate::error::ErrorCrumb;
+use crate::error::{ErrorCrumb, ErrorKind, HoleBinding};
 use crate::source::{operator, synonym};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -185,9 +188,13 @@ where
         }
 
         lowering::TypeKind::Hole => {
-            let k = state.fresh_unification(context.queries, context.prim.t);
-            let t = state.fresh_unification(context.queries, k);
-            Ok((t, k))
+            let kind_id = state.fresh_unification(context.queries, context.prim.t);
+            let type_id = state.fresh_unification(context.queries, kind_id);
+
+            let bindings = type_hole_bindings(state, context, id);
+            state.insert_error(ErrorKind::TypeHole { type_id, kind_id, bindings });
+
+            Ok((type_id, kind_id))
         }
 
         lowering::TypeKind::Integer { value } => {
@@ -320,6 +327,99 @@ where
                 Ok(unknown("missing parenthesized"))
             }
         }
+    }
+}
+
+fn type_hole_bindings<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    source_type: lowering::TypeId,
+) -> Arc<[HoleBinding]>
+where
+    Q: ExternalQueries,
+{
+    let mut seen: FxHashSet<&SmolStr> = FxHashSet::default();
+    let mut result = vec![];
+
+    if let Some(scope_node) = context.lowered.nodes.type_node(source_type) {
+        collect_graph_type_bindings(state, context, scope_node, &mut seen, &mut result);
+    }
+
+    Arc::from(result)
+}
+
+fn collect_graph_type_bindings<'a, Q>(
+    state: &CheckState,
+    context: &'a CheckContext<Q>,
+    scope_node: lowering::GraphNodeId,
+    seen: &mut FxHashSet<&'a SmolStr>,
+    result: &mut Vec<HoleBinding>,
+) where
+    Q: ExternalQueries,
+{
+    for (node_id, node) in context.lowered.graph.traverse(scope_node) {
+        match node {
+            GraphNode::Forall { bindings, .. } => {
+                let mut bindings = bindings.iter().collect_vec();
+                bindings.sort_by_key(|(name, _)| *name);
+
+                for (name, binding_id) in bindings {
+                    collect_forall_binding(state, name, *binding_id, seen, result);
+                }
+            }
+            GraphNode::Implicit { bindings, .. } => {
+                let mut entries = bindings.iter_indexed().collect_vec();
+                entries.sort_by_key(|(name, _)| *name);
+
+                for (name, binding_id) in entries {
+                    collect_implicit_binding(state, node_id, name, binding_id, seen, result);
+                }
+            }
+            GraphNode::Binder { .. } | GraphNode::Let { .. } => {}
+        }
+    }
+}
+
+fn collect_forall_binding<'a>(
+    state: &CheckState,
+    name: &'a SmolStr,
+    binding_id: lowering::TypeVariableBindingId,
+    seen: &mut FxHashSet<&'a SmolStr>,
+    result: &mut Vec<HoleBinding>,
+) {
+    let Some(type_id) = state
+        .checked
+        .nodes
+        .lookup_forall_binding(binding_id)
+        .or_else(|| state.bindings.lookup_forall(binding_id).map(|(_, kind)| kind))
+    else {
+        return;
+    };
+
+    if seen.insert(name) {
+        result.push(HoleBinding { name: SmolStr::clone(name), type_id });
+    }
+}
+
+fn collect_implicit_binding<'a>(
+    state: &CheckState,
+    node_id: lowering::GraphNodeId,
+    name: &'a SmolStr,
+    binding_id: lowering::ImplicitBindingId,
+    seen: &mut FxHashSet<&'a SmolStr>,
+    result: &mut Vec<HoleBinding>,
+) {
+    let Some(type_id) = state
+        .checked
+        .nodes
+        .lookup_implicit_binding(node_id, binding_id)
+        .or_else(|| state.bindings.lookup_implicit(node_id, binding_id).map(|(_, kind)| kind))
+    else {
+        return;
+    };
+
+    if seen.insert(name) {
+        result.push(HoleBinding { name: SmolStr::clone(name), type_id });
     }
 }
 

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -1,4 +1,5 @@
-use checking::error::{CheckingError, ErrorKind, HoleBinding};
+use checking::error::{CheckingError, ErrorKind};
+use checking::holes::HoleBinding;
 use indexing::{IndexingError, TypeItemKind};
 use itertools::Itertools;
 use lowering::LoweringError;
@@ -267,24 +268,32 @@ impl ToDiagnostics for CheckingError {
             ErrorKind::EmptyDoBlock => {
                 (Severity::Error, "EmptyDoBlock", "Empty do block".to_string())
             }
-            ErrorKind::TermHole { type_id, .. } => {
+            ErrorKind::TermHole { source_term } => {
                 let name = context.text_of(span).trim();
-                let type_id = render_type(*type_id);
-                (
-                    Severity::Error,
-                    "TermHole",
-                    format!("Hole '{name}' has inferred type: {type_id}"),
-                )
+                if let Some(hole) = context.checked.lookup_term_hole(*source_term) {
+                    let type_id = render_type(hole.type_id);
+                    (
+                        Severity::Error,
+                        "TermHole",
+                        format!("Hole '{name}' has inferred type: {type_id}"),
+                    )
+                } else {
+                    (Severity::Error, "TermHole", format!("Hole '{name}' has unknown type"))
+                }
             }
-            ErrorKind::TypeHole { type_id, kind_id, .. } => {
+            ErrorKind::TypeHole { source_type } => {
                 let name = context.text_of(span).trim();
-                let type_id = render_type(*type_id);
-                let kind = render_type(*kind_id);
-                (
-                    Severity::Error,
-                    "TypeHole",
-                    format!("Type hole '{name}' has inferred type: {type_id} :: {kind}"),
-                )
+                if let Some(hole) = context.checked.lookup_type_hole(*source_type) {
+                    let type_id = render_type(hole.type_id);
+                    let kind = render_type(hole.kind_id);
+                    (
+                        Severity::Error,
+                        "TypeHole",
+                        format!("Type hole '{name}' has inferred type: {type_id} :: {kind}"),
+                    )
+                } else {
+                    (Severity::Error, "TypeHole", format!("Type hole '{name}' has unknown kind"))
+                }
             }
             ErrorKind::InvalidFinalBind => (
                 Severity::Warning,
@@ -449,10 +458,18 @@ impl ToDiagnostics for CheckingError {
             }
         }
 
-        if let ErrorKind::TermHole { bindings, .. } | ErrorKind::TypeHole { bindings, .. } =
-            &self.kind
-        {
-            diagnostic = attach_hole_binding_trivia(diagnostic, context, bindings);
+        match &self.kind {
+            ErrorKind::TermHole { source_term } => {
+                if let Some(hole) = context.checked.lookup_term_hole(*source_term) {
+                    diagnostic = attach_hole_binding_trivia(diagnostic, context, &hole.bindings);
+                }
+            }
+            ErrorKind::TypeHole { source_type } => {
+                if let Some(hole) = context.checked.lookup_type_hole(*source_type) {
+                    diagnostic = attach_hole_binding_trivia(diagnostic, context, &hole.bindings);
+                }
+            }
+            _ => {}
         }
 
         vec![diagnostic]

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -1,4 +1,4 @@
-use checking::error::{CheckingError, ErrorKind};
+use checking::error::{CheckingError, ErrorKind, HoleBinding};
 use indexing::{IndexingError, TypeItemKind};
 use itertools::Itertools;
 use lowering::LoweringError;
@@ -267,6 +267,25 @@ impl ToDiagnostics for CheckingError {
             ErrorKind::EmptyDoBlock => {
                 (Severity::Error, "EmptyDoBlock", "Empty do block".to_string())
             }
+            ErrorKind::TermHole { type_id, .. } => {
+                let name = context.text_of(span).trim();
+                let type_id = render_type(*type_id);
+                (
+                    Severity::Error,
+                    "TermHole",
+                    format!("Hole '{name}' has inferred type: {type_id}"),
+                )
+            }
+            ErrorKind::TypeHole { type_id, kind_id, .. } => {
+                let name = context.text_of(span).trim();
+                let type_id = render_type(*type_id);
+                let kind = render_type(*kind_id);
+                (
+                    Severity::Error,
+                    "TypeHole",
+                    format!("Type hole '{name}' has inferred type: {type_id} :: {kind}"),
+                )
+            }
             ErrorKind::InvalidFinalBind => (
                 Severity::Warning,
                 "InvalidFinalBind",
@@ -430,6 +449,33 @@ impl ToDiagnostics for CheckingError {
             }
         }
 
+        if let ErrorKind::TermHole { bindings, .. } | ErrorKind::TypeHole { bindings, .. } =
+            &self.kind
+        {
+            diagnostic = attach_hole_binding_trivia(diagnostic, context, bindings);
+        }
+
         vec![diagnostic]
     }
+}
+
+const MAX_HOLE_BINDINGS: usize = 5;
+
+fn attach_hole_binding_trivia<Q>(
+    mut diagnostic: Diagnostic,
+    context: &DiagnosticsContext<'_, Q>,
+    bindings: &[HoleBinding],
+) -> Diagnostic
+where
+    Q: ExternalQueries,
+{
+    diagnostic.trivia.reserve(bindings.len().min(MAX_HOLE_BINDINGS));
+
+    for binding in bindings.iter().take(MAX_HOLE_BINDINGS) {
+        let type_id = context.render_type(binding.type_id);
+        let trivia = format!("{} :: {type_id} is in scope", binding.name);
+        diagnostic = diagnostic.with_trivia(trivia);
+    }
+
+    diagnostic
 }

--- a/compiler-core/lowering/src/scope.rs
+++ b/compiler-core/lowering/src/scope.rs
@@ -85,27 +85,38 @@ pub struct ImplicitBindings {
 pub type ImplicitBindingId = Idx<SmolStr>;
 
 impl ImplicitBindings {
+    fn binding_id(index: usize) -> ImplicitBindingId {
+        Idx::from_raw(RawIdx::from_u32(index as u32))
+    }
+
     pub(crate) fn bind(&mut self, name: &str, id: TypeId) -> ImplicitBindingId {
         let name = SmolStr::from(name);
         let entry = self.inner.entry(name);
         let index = entry.index();
         entry.or_default().push(id);
-        Idx::from_raw(RawIdx::from_u32(index as u32))
+        ImplicitBindings::binding_id(index)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&str, &[TypeId])> {
         self.inner.iter().map(|(name, id)| (name.as_str(), id.as_slice()))
     }
 
+    pub fn iter_indexed(&self) -> impl Iterator<Item = (&SmolStr, ImplicitBindingId)> + '_ {
+        self.inner.iter().enumerate().map(|(index, (name, _))| {
+            let binding_id = ImplicitBindings::binding_id(index);
+            (name, binding_id)
+        })
+    }
+
     pub fn get(&self, name: &str) -> Option<ImplicitBindingId> {
         let (index, _, _) = self.inner.get_full(name)?;
-        Some(Idx::from_raw(RawIdx::from_u32(index as u32)))
+        Some(ImplicitBindings::binding_id(index))
     }
 
     pub fn get_index(&self, index: ImplicitBindingId) -> Option<(&str, &[TypeId])> {
         let index = index.into_raw().into_u32() as usize;
-        let (name, ids) = self.inner.get_index(index)?;
-        Some((name, ids))
+        let (name, id) = self.inner.get_index(index)?;
+        Some((name, id))
     }
 }
 

--- a/compiler-lsp/analyzer/src/code_action.rs
+++ b/compiler-lsp/analyzer/src/code_action.rs
@@ -1,0 +1,99 @@
+mod holes;
+
+use std::collections::HashMap;
+
+use async_lsp::lsp_types::*;
+use files::FileId;
+use lowering::{ExpressionId, TypeId};
+
+use crate::{AnalyzerError, LanguageContext, locate, position};
+
+pub fn implementation(
+    language: &LanguageContext,
+    uri: Url,
+    range: Range,
+    action_context: CodeActionContext,
+) -> Result<Option<CodeActionResponse>, AnalyzerError> {
+    let file = {
+        let uri = uri.as_str();
+        language.files.id(uri).ok_or(AnalyzerError::NonFatal)?
+    };
+
+    let content = language.engine.content(file);
+    let position = position::protocol_position_to_utf8(&content, range.start, language.encoding)
+        .ok_or(AnalyzerError::NonFatal)?;
+
+    let located = locate::locate(language.engine, file, position)?;
+    let kinds = RequestedCodeActionKinds { only: action_context.only.as_deref() };
+    let request = CodeActionRequest { language, uri: &uri, file, kinds, located };
+
+    let mut actions = vec![];
+    holes::collect(&request, &mut actions)?;
+
+    let has_actions = !actions.is_empty();
+    Ok(has_actions.then_some(actions))
+}
+
+pub struct CodeActionRequest<'request, 'language> {
+    pub language: &'request LanguageContext<'language>,
+    pub uri: &'request Url,
+    pub file: FileId,
+    pub kinds: RequestedCodeActionKinds<'request>,
+    pub located: locate::Located,
+}
+
+#[derive(Clone, Copy)]
+pub struct RequestedCodeActionKinds<'a> {
+    only: Option<&'a [CodeActionKind]>,
+}
+
+impl RequestedCodeActionKinds<'_> {
+    pub fn includes(&self, action_kind: &CodeActionKind) -> bool {
+        let Some(only) = self.only else { return true };
+        only.iter().any(|kind| code_action_kind_matches(kind, action_kind))
+    }
+}
+
+fn code_action_kind_matches(requested: &CodeActionKind, action_kind: &CodeActionKind) -> bool {
+    let requested = requested.as_str();
+    let action_kind = action_kind.as_str();
+
+    let Some(suffix) = action_kind.strip_prefix(requested) else { return false };
+    suffix.is_empty() || suffix.starts_with('.')
+}
+
+pub fn workspace_edit(uri: &Url, edits: Vec<TextEdit>) -> WorkspaceEdit {
+    let mut changes = HashMap::default();
+
+    let uri = Url::clone(uri);
+    changes.insert(uri, edits);
+
+    WorkspaceEdit { changes: Some(changes), ..WorkspaceEdit::default() }
+}
+
+pub fn expression_range(
+    request: &CodeActionRequest,
+    expression_id: ExpressionId,
+) -> Result<Range, AnalyzerError> {
+    let content = request.language.engine.content(request.file);
+    let (parsed, _) = request.language.engine.parsed(request.file)?;
+    let stabilized = request.language.engine.stabilized(request.file)?;
+
+    let range = locate::id_range(&content, &parsed, &stabilized, expression_id)
+        .ok_or(AnalyzerError::NonFatal)?;
+
+    position::utf8_range_to_protocol(&content, range, request.language.encoding)
+        .ok_or(AnalyzerError::NonFatal)
+}
+
+pub fn type_range(request: &CodeActionRequest, type_id: TypeId) -> Result<Range, AnalyzerError> {
+    let content = request.language.engine.content(request.file);
+    let (parsed, _) = request.language.engine.parsed(request.file)?;
+    let stabilized = request.language.engine.stabilized(request.file)?;
+
+    let range =
+        locate::id_range(&content, &parsed, &stabilized, type_id).ok_or(AnalyzerError::NonFatal)?;
+
+    position::utf8_range_to_protocol(&content, range, request.language.encoding)
+        .ok_or(AnalyzerError::NonFatal)
+}

--- a/compiler-lsp/analyzer/src/code_action/holes.rs
+++ b/compiler-lsp/analyzer/src/code_action/holes.rs
@@ -1,0 +1,52 @@
+use async_lsp::lsp_types::*;
+use checking::holes::HoleBinding;
+
+use crate::code_action::{CodeActionRequest, expression_range, type_range, workspace_edit};
+use crate::{AnalyzerError, locate};
+
+pub fn collect(
+    request: &CodeActionRequest,
+    actions: &mut Vec<CodeActionOrCommand>,
+) -> Result<(), AnalyzerError> {
+    if !request.kinds.includes(&CodeActionKind::QUICKFIX) {
+        return Ok(());
+    }
+
+    let checked = request.language.engine.checked(request.file)?;
+    match &request.located {
+        locate::Located::Expression(expression_id) => {
+            let Some(hole) = checked.lookup_term_hole(*expression_id) else { return Ok(()) };
+
+            let range = expression_range(request, *expression_id)?;
+            collect_binding_actions(request, range, &hole.bindings, actions);
+        }
+        locate::Located::Type(type_id) => {
+            let Some(hole) = checked.lookup_type_hole(*type_id) else { return Ok(()) };
+
+            let range = type_range(request, *type_id)?;
+            collect_binding_actions(request, range, &hole.bindings, actions);
+        }
+        _ => (),
+    }
+
+    Ok(())
+}
+
+fn collect_binding_actions(
+    request: &CodeActionRequest,
+    range: Range,
+    bindings: &[HoleBinding],
+    actions: &mut Vec<CodeActionOrCommand>,
+) {
+    for binding in bindings {
+        let name = binding.name.to_string();
+        let title = format!("Replace hole with '{name}'");
+
+        actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+            title,
+            kind: Some(CodeActionKind::QUICKFIX),
+            edit: Some(workspace_edit(request.uri, vec![TextEdit { range, new_text: name }])),
+            ..CodeAction::default()
+        }));
+    }
+}

--- a/compiler-lsp/analyzer/src/lib.rs
+++ b/compiler-lsp/analyzer/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod code_action;
 pub mod common;
 pub mod completion;
 pub mod context;

--- a/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
+++ b/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
@@ -7,3 +7,10 @@ Terms
 hole :: forall (t :: Type). (t :: Type)
 
 Types
+
+Diagnostics
+error[TermHole]: Hole '?hole' has inferred type: (t :: Type)
+  --> 3:8..3:13
+  |
+3 | hole = ?hole
+  |        ^~~~~

--- a/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
+++ b/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
@@ -14,3 +14,4 @@ error[TermHole]: Hole '?hole' has inferred type: (t :: Type)
   |
 3 | hole = ?hole
   |        ^~~~~
+  trivia: hole :: (t :: Type) is in scope

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.purs
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+termHole :: Int -> Int
+termHole argument =
+  let
+    localInt :: Int
+    localInt = argument
+
+    localString :: String
+    localString = "not relevant"
+  in
+    ?term
+
+type TypeHole a = ?type :: Type

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.purs
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.purs
@@ -12,3 +12,13 @@ termHole argument =
     ?term
 
 type TypeHole a = ?type :: Type
+
+recordPunHole :: { punInt :: Int, punString :: String } -> Int
+recordPunHole { punInt, punString } = ?pun
+
+class InstanceTypeHole implicit where
+  instanceTypeHoleMember :: implicit -> implicit
+
+instance InstanceTypeHole implicit where
+  instanceTypeHoleMember :: ?implicit -> implicit
+  instanceTypeHoleMember value = value

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -5,12 +5,26 @@ expression: report
 ---
 Terms
 termHole :: Int -> Int
+recordPunHole :: { punInt :: Int, punString :: String } -> Int
+instanceTypeHoleMember ::
+  forall (@implicit :: Type).
+    InstanceTypeHole (implicit :: Type) => (implicit :: Type) -> (implicit :: Type)
 
 Types
 TypeHole :: forall (t :: Type). (t :: Type) -> Type
+InstanceTypeHole :: Type -> Constraint
 
 Synonyms
 type TypeHole a = ?3
+
+Classes
+class forall (implicit :: Type). InstanceTypeHole (implicit :: Type)
+  instanceTypeHoleMember ::
+  forall (@implicit :: Type).
+    InstanceTypeHole (implicit :: Type) => (implicit :: Type) -> (implicit :: Type)
+
+Instances
+instance forall (t :: Type). InstanceTypeHole (t :: Type)
 
 Diagnostics
 error[TypeHole]: Type hole '?type' has inferred type: ?3 :: Type
@@ -26,3 +40,15 @@ error[TermHole]: Hole '?term' has inferred type: Int
    |     ^~~~~
   trivia: argument :: Int is in scope
   trivia: localInt :: Int is in scope
+error[TermHole]: Hole '?pun' has inferred type: Int
+  --> 17:39..17:43
+   |
+17 | recordPunHole { punInt, punString } = ?pun
+   |                                       ^~~~
+  trivia: punInt :: Int is in scope
+error[TypeHole]: Type hole '?implicit' has inferred type: (t1 :: Type) :: Type
+  --> 23:29..23:38
+   |
+23 |   instanceTypeHoleMember :: ?implicit -> implicit
+   |                             ^~~~~~~~~
+  trivia: implicit :: Type is in scope

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+termHole :: Int -> Int
+
+Types
+TypeHole :: forall (t :: Type). (t :: Type) -> Type
+
+Synonyms
+type TypeHole a = ?3

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -11,3 +11,18 @@ TypeHole :: forall (t :: Type). (t :: Type) -> Type
 
 Synonyms
 type TypeHole a = ?3
+
+Diagnostics
+error[TypeHole]: Type hole '?type' has inferred type: ?3 :: Type
+  --> 14:19..14:24
+   |
+14 | type TypeHole a = ?type :: Type
+   |                   ^~~~~
+  trivia: a :: (t :: Type) is in scope
+error[TermHole]: Hole '?term' has inferred type: Int
+  --> 12:5..12:10
+   |
+12 |     ?term
+   |     ^~~~~
+  trivia: argument :: Int is in scope
+  trivia: localInt :: Int is in scope

--- a/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Lib.purs
+++ b/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Lib.purs
@@ -1,0 +1,6 @@
+module Lib where
+
+data ImportedOption = ImportedYes | ImportedNo
+
+importedOption :: ImportedOption
+importedOption = ImportedYes

--- a/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.purs
+++ b/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Lib
+
+data Option = Yes | No
+
+localOption :: Option
+localOption = Yes
+
+option :: Option
+option = ?help
+
+imported :: ImportedOption
+imported = ?imported
+
+class Select a where
+  select :: a -> Option
+
+method :: forall a. Select a => a -> Option
+method = ?method

--- a/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
+++ b/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
@@ -29,13 +29,23 @@ error[TermHole]: Hole '?help' has inferred type: Option
    |
 11 | option = ?help
    |          ^~~~~
+  trivia: No :: Option is in scope
+  trivia: Yes :: Option is in scope
+  trivia: localOption :: Option is in scope
+  trivia: option :: Option is in scope
 error[TermHole]: Hole '?imported' has inferred type: ImportedOption
   --> 14:12..14:21
    |
 14 | imported = ?imported
    |            ^~~~~~~~~
+  trivia: ImportedNo :: ImportedOption is in scope
+  trivia: ImportedYes :: ImportedOption is in scope
+  trivia: imported :: ImportedOption is in scope
+  trivia: importedOption :: ImportedOption is in scope
 error[TermHole]: Hole '?method' has inferred type: (a :: Type) -> Option
   --> 20:10..20:17
    |
 20 | method = ?method
    |          ^~~~~~~
+  trivia: method :: forall (a1 :: Type). Select (a1 :: Type) => (a1 :: Type) -> Option is in scope
+  trivia: select :: forall (@a2 :: Type). Select (a2 :: Type) => (a2 :: Type) -> Option is in scope

--- a/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
+++ b/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Yes :: Option
+No :: Option
+localOption :: Option
+option :: Option
+imported :: ImportedOption
+select :: forall (@a :: Type). Select (a :: Type) => (a :: Type) -> Option
+method :: forall (a :: Type). Select (a :: Type) => (a :: Type) -> Option
+
+Types
+Option :: Type
+Select :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Select (a :: Type)
+  select :: forall (@a :: Type). Select (a :: Type) => (a :: Type) -> Option
+
+Roles
+Option = []
+
+Diagnostics
+error[TermHole]: Hole '?help' has inferred type: Option
+  --> 11:10..11:15
+   |
+11 | option = ?help
+   |          ^~~~~
+error[TermHole]: Hole '?imported' has inferred type: ImportedOption
+  --> 14:12..14:21
+   |
+14 | imported = ?imported
+   |            ^~~~~~~~~
+error[TermHole]: Hole '?method' has inferred type: (a :: Type) -> Option
+  --> 20:10..20:17
+   |
+20 | method = ?method
+   |          ^~~~~~~

--- a/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Lib.purs
+++ b/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Lib.purs
@@ -1,0 +1,9 @@
+module Lib where
+
+data Remote = Shared | RemoteOnly
+
+remoteValue :: Remote
+remoteValue = RemoteOnly
+
+shadowedValue :: Remote
+shadowedValue = RemoteOnly

--- a/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.purs
+++ b/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Lib
+
+data Local = Shared | LocalOnly
+
+localValue :: Local
+localValue = LocalOnly
+
+shadowedValue :: Local
+shadowedValue = LocalOnly
+
+local :: Local
+local = ?local
+
+remote :: Remote
+remote = ?remote
+
+binderShadow :: Local -> Remote
+binderShadow remoteValue = ?binder

--- a/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
+++ b/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Shared :: Local
+LocalOnly :: Local
+localValue :: Local
+shadowedValue :: Local
+local :: Local
+remote :: Remote
+binderShadow :: Local -> Remote
+
+Types
+Local :: Type
+
+Roles
+Local = []
+
+Diagnostics
+error[TermHole]: Hole '?local' has inferred type: Local
+  --> 14:9..14:15
+   |
+14 | local = ?local
+   |         ^~~~~~
+error[TermHole]: Hole '?remote' has inferred type: Remote
+  --> 17:10..17:17
+   |
+17 | remote = ?remote
+   |          ^~~~~~~
+error[TermHole]: Hole '?binder' has inferred type: Remote
+  --> 20:28..20:35
+   |
+20 | binderShadow remoteValue = ?binder
+   |                            ^~~~~~~
+  trivia: remoteValue :: Local is in scope

--- a/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
+++ b/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
@@ -24,14 +24,23 @@ error[TermHole]: Hole '?local' has inferred type: Local
    |
 14 | local = ?local
    |         ^~~~~~
+  trivia: LocalOnly :: Local is in scope
+  trivia: Shared :: Local is in scope
+  trivia: local :: Local is in scope
+  trivia: localValue :: Local is in scope
+  trivia: shadowedValue :: Local is in scope
 error[TermHole]: Hole '?remote' has inferred type: Remote
   --> 17:10..17:17
    |
 17 | remote = ?remote
    |          ^~~~~~~
+  trivia: RemoteOnly :: Remote is in scope
+  trivia: remote :: Remote is in scope
+  trivia: remoteValue :: Remote is in scope
 error[TermHole]: Hole '?binder' has inferred type: Remote
   --> 20:28..20:35
    |
 20 | binderShadow remoteValue = ?binder
    |                            ^~~~~~~
-  trivia: remoteValue :: Local is in scope
+  trivia: RemoteOnly :: Remote is in scope
+  trivia: remote :: Remote is in scope

--- a/tests-integration/fixtures/lsp/1781586060_code_action_typed_holes/Main.purs
+++ b/tests-integration/fixtures/lsp/1781586060_code_action_typed_holes/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+termHole :: Int -> Int
+termHole argument =
+  let
+    localInt :: Int
+    localInt = argument
+
+    localString :: String
+    localString = "not relevant"
+  in
+    ?term
+--  .
+
+type TypeHole a = ?type :: Type
+--                .
+
+data Choice = Yes | No
+
+constructorHole :: Choice
+constructorHole = ?constructor
+--                .

--- a/tests-integration/fixtures/lsp/1781586060_code_action_typed_holes/Main.snap
+++ b/tests-integration/fixtures/lsp/1781586060_code_action_typed_holes/Main.snap
@@ -1,0 +1,36 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 101
+expression: report
+---
+CodeAction at Position { line: 11, character: 4 }
+
+```
+    ?term
+--  .
+```
+
+Replace hole with 'argument' [quickfix] 11:4..11:9 => "argument"
+Replace hole with 'localInt' [quickfix] 11:4..11:9 => "localInt"
+
+
+CodeAction at Position { line: 14, character: 18 }
+
+```
+type TypeHole a = ?type :: Type
+--                .
+```
+
+Replace hole with 'a' [quickfix] 14:18..14:23 => "a"
+
+
+CodeAction at Position { line: 20, character: 18 }
+
+```
+constructorHole = ?constructor
+--                .
+```
+
+Replace hole with 'No' [quickfix] 20:18..20:30 => "No"
+Replace hole with 'Yes' [quickfix] 20:18..20:30 => "Yes"
+Replace hole with 'constructorHole' [quickfix] 20:18..20:30 => "constructorHole"

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -6,9 +6,11 @@ use analyzer::completion::SuggestionsCache;
 use analyzer::position::PositionEncoding;
 use analyzer::{QueryEngine, prim};
 use async_lsp::lsp_types::{
-    CompletionItemKind, CompletionList, CompletionResponse, DocumentHighlight,
-    DocumentSymbolResponse, GotoDefinitionResponse, HoverContents, LanguageString, Location,
-    MarkedString, Position, SymbolInformation, Url, WorkspaceSymbolResponse,
+    CodeActionContext, CodeActionKind, CodeActionOrCommand, CodeActionResponse,
+    CodeActionTriggerKind, CompletionItemKind, CompletionList, CompletionResponse,
+    DocumentHighlight, DocumentSymbolResponse, GotoDefinitionResponse, HoverContents,
+    LanguageString, Location, MarkedString, Position, Range, SymbolInformation, TextEdit, Url,
+    WorkspaceEdit, WorkspaceSymbolResponse,
 };
 use files::{FileId, Files};
 use itertools::Itertools;
@@ -26,10 +28,11 @@ enum CursorKind {
     References,
     DocumentHighlight,
     DocumentSymbols,
+    CodeAction,
 }
 
 impl CursorKind {
-    const CHARACTERS: &[char] = &['@', '$', '^', '~', '%', '!', '&'];
+    const CHARACTERS: &[char] = &['@', '$', '^', '~', '%', '!', '&', '.'];
 
     fn parse(text: &str) -> Option<CursorKind> {
         match text {
@@ -40,6 +43,7 @@ impl CursorKind {
             "%" => Some(CursorKind::References),
             "&" => Some(CursorKind::DocumentHighlight),
             "!" => Some(CursorKind::DocumentSymbols),
+            "." => Some(CursorKind::CodeAction),
             _ => None,
         }
     }
@@ -47,6 +51,11 @@ impl CursorKind {
     fn valid(c: char) -> bool {
         CursorKind::CHARACTERS.contains(&c)
     }
+}
+
+fn cursor_marker_line(line: &str) -> bool {
+    let Some(markers) = line.strip_prefix("--") else { return false };
+    markers.chars().all(|character| character.is_whitespace() || CursorKind::valid(character))
 }
 
 enum Request {
@@ -63,7 +72,7 @@ fn extract_cursors(content: &str) -> Vec<(usize, Request)> {
     for (index, text) in content.match_indices(CursorKind::valid) {
         let line_col = line_index.line_col(TextSize::new(index as u32));
         let line_range = line_index.line(line_col.line).unwrap();
-        if !content[line_range].starts_with("--") {
+        if !cursor_marker_line(&content[line_range]) {
             continue;
         }
 
@@ -182,6 +191,60 @@ fn render_location(location: Location) -> String {
     )
 }
 
+fn render_text_edit(edit: TextEdit) -> String {
+    format!(
+        "{}:{}..{}:{} => {:?}",
+        edit.range.start.line,
+        edit.range.start.character,
+        edit.range.end.line,
+        edit.range.end.character,
+        edit.new_text,
+    )
+}
+
+fn render_workspace_edit(edit: WorkspaceEdit) -> Vec<String> {
+    let mut result = vec![];
+
+    if let Some(changes) = edit.changes {
+        for edits in changes.into_values() {
+            result.extend(edits.into_iter().map(render_text_edit));
+        }
+    }
+
+    result.sort();
+    result
+}
+
+fn render_code_action_response(response: CodeActionResponse) -> String {
+    let mut result = vec![];
+
+    for action in response {
+        match action {
+            CodeActionOrCommand::CodeAction(action) => {
+                let kind = action.kind.as_ref().map(CodeActionKind::as_str).unwrap_or("<none>");
+
+                if let Some(edit) = action.edit {
+                    let edits = render_workspace_edit(edit);
+                    if edits.is_empty() {
+                        result.push(format!("{} [{kind}] <no edit>", action.title));
+                    } else {
+                        for edit in edits {
+                            result.push(format!("{} [{kind}] {edit}", action.title));
+                        }
+                    }
+                } else {
+                    result.push(format!("{} [{kind}] <no edit>", action.title));
+                }
+            }
+            CodeActionOrCommand::Command(command) => {
+                result.push(format!("{} [command:{}]", command.title, command.command));
+            }
+        }
+    }
+
+    if result.is_empty() { "<empty>".to_string() } else { result.join("\n") }
+}
+
 fn dispatch_cursor(
     result: &mut String,
     engine: &QueryEngine,
@@ -250,6 +313,22 @@ fn dispatch_cursor(
                         }
                     }
                 }
+            } else {
+                writeln!(result, "<empty>").unwrap();
+            }
+        }
+        CursorKind::CodeAction => {
+            let range = Range::new(position, position);
+            let action_context = CodeActionContext {
+                diagnostics: vec![],
+                only: Some(vec![CodeActionKind::QUICKFIX]),
+                trigger_kind: Some(CodeActionTriggerKind::INVOKED),
+            };
+
+            if let Ok(Some(response)) =
+                analyzer::code_action::implementation(&context, uri, range, action_context)
+            {
+                writeln!(result, "{}", render_code_action_response(response)).unwrap();
             } else {
                 writeln!(result, "<empty>").unwrap();
             }


### PR DESCRIPTION
Closes #72. Adds typed holes for terms and types. Suggested bindings are currently placed as diagnostics trivia, but I'll probably change this to something that can be usable by the language server.