### PR TITLE
[checking] Use row kind inference in Prim.Union

### DIFF
--- a/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
@@ -187,7 +187,9 @@ where
         // `Union ( a :: A, b :: B | t ) ( c :: C ) ( | u )` solves `u ~ ( a :: A, b :: B | f )`,
         // plus the remaining `Union ( | t ) ( c :: C ) ( | f )` constraint.
         (Some(RowView::Open { fields: left_fields, tail }), Some(_), _) => {
-            let fresh = state.fresh_unification(context.queries, context.prim.row_type);
+            let row_kind = infer_row_constraint_kind(state, context, arguments)?;
+            let fresh_kind = context.intern_application(context.prim.row, row_kind);
+            let fresh = state.fresh_unification(context.queries, fresh_kind);
             let result = context.intern_row(left_fields.iter().cloned(), Some(fresh));
 
             let constraint = make_prim_row_constraint(

--- a/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_row.rs
@@ -24,18 +24,18 @@ fn make_prim_row_constraint<Q>(
 where
     Q: ExternalQueries,
 {
-    let row_kind = infer_row_constraint_kind(state, context, arguments)?;
+    let row_element_kind = infer_prim_row_element_kind(state, context, arguments)?;
 
     let constructor =
         context.queries.intern_type(Type::Constructor(context.prim_row.file_id, class_id));
-    let mut constraint = context.intern_kind_application(constructor, row_kind);
-    for &argument in arguments {
-        constraint = context.intern_application(constraint, argument);
-    }
-    Ok(constraint)
+
+    Ok(arguments.iter().copied().fold(
+        context.intern_kind_application(constructor, row_element_kind),
+        |application, argument| context.intern_application(application, argument),
+    ))
 }
 
-fn infer_row_constraint_kind<Q>(
+fn infer_prim_row_element_kind<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     arguments: &[TypeId],
@@ -47,10 +47,12 @@ where
         let argument_kind = types::elaborate_kind(state, context, argument)?;
         let argument_kind = normalise::expand(state, context, argument_kind)?;
 
-        if let Type::Application(row_constructor, row_kind) = context.lookup_type(argument_kind) {
+        if let Type::Application(row_constructor, row_element_kind) =
+            context.lookup_type(argument_kind)
+        {
             let row_constructor = normalise::expand(state, context, row_constructor)?;
             if row_constructor == context.prim.row {
-                return Ok(row_kind);
+                return Ok(row_element_kind);
             }
         }
     }
@@ -187,8 +189,9 @@ where
         // `Union ( a :: A, b :: B | t ) ( c :: C ) ( | u )` solves `u ~ ( a :: A, b :: B | f )`,
         // plus the remaining `Union ( | t ) ( c :: C ) ( | f )` constraint.
         (Some(RowView::Open { fields: left_fields, tail }), Some(_), _) => {
-            let row_kind = infer_row_constraint_kind(state, context, arguments)?;
-            let fresh_kind = context.intern_application(context.prim.row, row_kind);
+            let row_element_kind = infer_prim_row_element_kind(state, context, arguments)?;
+            let fresh_kind = context.intern_application(context.prim.row, row_element_kind);
+
             let fresh = state.fresh_unification(context.queries, fresh_kind);
             let result = context.intern_row(left_fields.iter().cloned(), Some(fresh));
 

--- a/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.purs
+++ b/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Prim.Row as Row
+import Type.Proxy (Proxy(..))
+
+foreign import data Effect :: Type -> Type
+
+openLeftHigherKinded
+  :: forall tail output
+   . Row.Union (effect :: Effect | tail) () output
+  => Proxy output
+openLeftHigherKinded = Proxy
+
+forceSolve
+  :: forall tail output
+   . Row.Union tail () output
+  => { openLeftHigherKinded :: Proxy (effect :: Effect | output) }
+forceSolve =
+  { openLeftHigherKinded }

--- a/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+openLeftHigherKinded ::
+  forall (tail :: Row (Type -> Type)) (output :: Row (Type -> Type)).
+    Union @(Type -> Type)
+      ( effect :: Effect | (tail :: Row (Type -> Type)) )
+      ()
+      (output :: Row (Type -> Type)) =>
+    Proxy @(Row (Type -> Type)) (output :: Row (Type -> Type))
+forceSolve ::
+  forall (tail :: Row (Type -> Type)) (output :: Row (Type -> Type)).
+    Union @(Type -> Type) (tail :: Row (Type -> Type)) () (output :: Row (Type -> Type)) =>
+    { openLeftHigherKinded ::
+        Proxy @(Row (Type -> Type)) ( effect :: Effect | (output :: Row (Type -> Type)) )
+    }
+
+Types
+Effect :: Type -> Type
+
+Roles
+Effect = [Nominal]
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Type' with 'Type -> Type'
+  --> 14:1..17:67
+   |
+14 | forceSolve
+   | ^~~~~~~~~~
+error[CannotUnify]: Cannot unify 'Row Type' with 'Row (Type -> Type)'
+  --> 14:1..17:67
+   |
+14 | forceSolve
+   | ^~~~~~~~~~

--- a/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.snap
@@ -23,15 +23,3 @@ Effect :: Type -> Type
 
 Roles
 Effect = [Nominal]
-
-Diagnostics
-error[CannotUnify]: Cannot unify 'Type' with 'Type -> Type'
-  --> 14:1..17:67
-   |
-14 | forceSolve
-   | ^~~~~~~~~~
-error[CannotUnify]: Cannot unify 'Row Type' with 'Row (Type -> Type)'
-  --> 14:1..17:67
-   |
-14 | forceSolve
-   | ^~~~~~~~~~


### PR DESCRIPTION
Supersedes #122, fixes an issue in Prim.Union where kinds are `Type` instead of being inferred, leading to errors when the row is `Type -> Type` instead.