### PR TITLE
[checking] Include kind unification in instance matching

### DIFF
--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -12,6 +12,7 @@ use crate::core::fd::{Fd, compute_closure, get_all_determined, get_functional_de
 use crate::core::substitute::SubstituteName;
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
 use crate::core::{KindOrType, Name, RowField, RowTypeId, Type, TypeId, normalise, toolkit};
+use crate::source::types;
 use crate::state::CheckState;
 
 #[derive(PartialEq, Eq)]
@@ -636,6 +637,8 @@ where
         &declared_arguments,
     )? {
         MatchType::Match { bindings } => {
+            let matched_names: FxHashSet<_> = bindings.iter().map(|(name, _)| *name).collect();
+
             let mut substitution = FxHashMap::default();
             for &(name, bound) in &bindings {
                 substitution.entry(name).or_insert(bound);
@@ -651,6 +654,21 @@ where
             }
 
             let mut unifications = vec![];
+
+            for binder in &declared.binders {
+                if !matched_names.contains(&binder.name) {
+                    continue;
+                }
+
+                let expected_kind =
+                    SubstituteName::many(state, context, &substitution, binder.kind)?;
+
+                let actual_kind =
+                    types::elaborate_kind(state, context, substitution[&binder.name])?;
+
+                unifications.push((actual_kind, expected_kind));
+            }
+
             for (wanted, declared) in iter::zip(wanted_arguments, declared_arguments) {
                 let wanted = SubstituteName::many(state, context, &substitution, wanted)?;
                 let declared = SubstituteName::many(state, context, &substitution, declared)?;

--- a/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.purs
+++ b/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+import Prim.Ordering
+import Prim.Int
+import Type.Proxy
+
+class Pick a b result | a b -> result
+
+instance pickSame :: Compare a a EQ => Pick a a a
+else instance pickFallback :: Pick a b b
+
+choose :: forall a b result. Pick a b result => Proxy a -> Proxy b -> Proxy result
+choose _ _ = Proxy
+
+x = choose (Proxy @Int) (Proxy @Int)

--- a/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
@@ -35,3 +35,10 @@ instance forall (t :: Type) (t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type)
     (t2 :: (t :: Type))
     (t3 :: (t1 :: Type))
     (t3 :: (t1 :: Type))
+
+Diagnostics
+error[CannotUnify]: Cannot unify 'Type' with 'Int'
+  --> 15:1..15:37
+   |
+15 | x = choose (Proxy @Int) (Proxy @Int)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+choose ::
+  forall (t :: Type) (t1 :: Type) (t2 :: Type) (a :: (t :: Type)) (b :: (t1 :: Type))
+    (result :: (t2 :: Type)).
+    Pick @(t :: Type) @(t1 :: Type) @(t2 :: Type)
+      (a :: (t :: Type))
+      (b :: (t1 :: Type))
+      (result :: (t2 :: Type)) =>
+    Proxy @(t :: Type) (a :: (t :: Type)) ->
+    Proxy @(t1 :: Type) (b :: (t1 :: Type)) ->
+    Proxy @(t2 :: Type) (result :: (t2 :: Type))
+x :: Proxy @Type Int
+
+Types
+Pick ::
+  forall (t :: Type) (t1 :: Type) (t2 :: Type).
+    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> Constraint
+
+Classes
+class forall (t :: Type) (t1 :: Type) (t2 :: Type) (a :: (t :: Type)) (b :: (t1 :: Type)) (result :: (t2 :: Type)). Pick @(t :: Type) @(t1 :: Type) @(t2 :: Type)
+  (a :: (t :: Type))
+  (b :: (t1 :: Type))
+  (result :: (t2 :: Type))
+
+Instances
+instance forall (t :: Int).
+  Compare (t :: Int) (t :: Int) EQ => Pick @Int @Int @Int (t :: Int) (t :: Int) (t :: Int)
+instance forall (t :: Type) (t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type)).
+  Pick @(t :: Type) @(t1 :: Type) @(t1 :: Type)
+    (t2 :: (t :: Type))
+    (t3 :: (t1 :: Type))
+    (t3 :: (t1 :: Type))


### PR DESCRIPTION
Adds kind unifications in declared instance matching sourced from substitutions. This is consistent with the original compiler.