### PR TITLE
[checking] Implement overlapping instance checks

### DIFF
--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -1,25 +1,40 @@
 //! Implements searching for instance chains.
 
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{IndexedModule, InstanceChainId, TypeItemId};
+use indexing::{
+    DeriveId, IndexedModule, InstanceChainId, InstanceId, TermItemId, TermItemKind, TypeItemId,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
-use crate::core::constraint::CanonicalConstraintId;
+use crate::core::constraint::{CanonicalConstraint, CanonicalConstraintId};
 use crate::core::fd::{get_all_determined, get_functional_dependencies};
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
-use crate::core::{CheckedInstance, KindOrType, Type, TypeId, normalise};
+use crate::core::{CheckedInstance, KindOrType, Type, TypeId, constraint, normalise, toolkit};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 use crate::{CheckedModule, ExternalQueries};
 
+pub type InstanceChainKey = (FileId, InstanceChainId);
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum InstanceCandidateOrigin {
+    Instance(FileId, InstanceId),
+    Derive(FileId, DeriveId),
+}
+
 /// A candidate found for a constraint.
+#[derive(Clone, Copy)]
 pub struct InstanceCandidate {
     /// The syntactic ID for the instance chain.
-    pub id: Option<InstanceChainId>,
+    pub chain: Option<InstanceChainKey>,
     /// The position of the instance in the chain.
     pub position: u32,
+    /// The provenance of the instance candidate.
+    pub origin: InstanceCandidateOrigin,
     /// Type information about the instance.
     pub instance: CheckedInstance,
 }
@@ -33,6 +48,133 @@ pub struct InstanceCandidate {
 pub struct InstanceChains {
     pub chains: Vec<Vec<InstanceCandidate>>,
     pub blocking: Vec<u32>,
+}
+
+pub fn validate_declared_instance_overlap<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    item_id: TermItemId,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let Some((origin, instance)) = declared_instance_candidate(state, context, item_id) else {
+        return Ok(());
+    };
+
+    let Some(OverlappingDeclaredCandidates { matches, wanted }) =
+        collect_overlapping_declared_candidates(state, context, origin, instance)?
+    else {
+        return Ok(());
+    };
+
+    let Some(current_position) = context
+        .indexed
+        .items
+        .iter_terms()
+        .position(|(candidate_item_id, _)| candidate_item_id == item_id)
+    else {
+        return Ok(());
+    };
+
+    let overlap = matches.iter().any(|candidate| {
+        should_report_overlap(context, candidate.origin, origin, current_position)
+    });
+
+    if overlap {
+        let constraint = state.canonicals.type_id(context, wanted);
+        let instances = matches.iter().map(|candidate| candidate.instance.signature).collect();
+        state.insert_error(ErrorKind::OverlappingInstances { constraint, instances });
+    }
+
+    Ok(())
+}
+
+fn declared_instance_candidate<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    item_id: TermItemId,
+) -> Option<(InstanceCandidateOrigin, CheckedInstance)>
+where
+    Q: ExternalQueries,
+{
+    match context.indexed.items[item_id].kind {
+        TermItemKind::Instance { id } => {
+            let instance = state.checked.lookup_instance(id)?;
+            let origin = InstanceCandidateOrigin::Instance(context.id, id);
+            Some((origin, instance))
+        }
+        TermItemKind::Derive { id } => {
+            let instance = state.checked.lookup_derived(id)?;
+            let origin = InstanceCandidateOrigin::Derive(context.id, id);
+            Some((origin, instance))
+        }
+        _ => None,
+    }
+}
+
+struct OverlappingDeclaredCandidates {
+    matches: Vec<InstanceCandidate>,
+    wanted: CanonicalConstraintId,
+}
+
+fn collect_overlapping_declared_candidates<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    origin: InstanceCandidateOrigin,
+    instance: CheckedInstance,
+) -> QueryResult<Option<OverlappingDeclaredCandidates>>
+where
+    Q: ExternalQueries,
+{
+    // An instance head is the dual of a constraint; we synthesise it here to reuse
+    // [`collect_instance_chains`]'s file-scoped enumeration, which scopes modules
+    // by walking the head's type constructors, not by matching against candidates.
+    let wanted = {
+        let Some(toolkit::InstanceInfo { arguments, .. }) =
+            toolkit::instance_info(state, context, instance.signature, instance.resolution)?
+        else {
+            return Ok(None);
+        };
+        let (file_id, type_id) = instance.resolution;
+        let arguments = Arc::from(arguments);
+        state.canonicals.intern(CanonicalConstraint { file_id, type_id, arguments })
+    };
+
+    let search = collect_instance_chains(state, context, wanted)?;
+    let current_chain = instance_candidate_chain(context, origin);
+
+    fn is_chain_sibling(
+        candidate: InstanceCandidate,
+        current_chain: Option<InstanceChainKey>,
+        origin: InstanceCandidateOrigin,
+    ) -> bool {
+        if let (Some(candidate_chain), Some(current_chain)) = (candidate.chain, current_chain) {
+            candidate_chain == current_chain && candidate.origin != origin
+        } else {
+            false
+        }
+    }
+
+    let mut matches = vec![];
+    'chain: for chain in search.chains {
+        for candidate in chain {
+            if is_chain_sibling(candidate, current_chain, origin) {
+                continue;
+            }
+            if constraint::matching::declared_instances_overlap(
+                state,
+                context,
+                instance,
+                candidate.instance,
+            )? {
+                matches.push(candidate);
+                continue 'chain;
+            }
+        }
+    }
+
+    Ok(Some(OverlappingDeclaredCandidates { matches, wanted }))
 }
 
 /// Collects [`InstanceCandidate`]s for a given constraint.
@@ -57,10 +199,11 @@ where
 
     let mut instances = vec![];
 
-    for &file_id in &files {
+    for file_id in files {
         if file_id == context.id {
             collect_instances_from_checked(
                 &mut instances,
+                file_id,
                 &state.checked,
                 &context.indexed,
                 constraint.file_id,
@@ -71,6 +214,7 @@ where
             let indexed = context.queries.indexed(file_id)?;
             collect_instances_from_checked(
                 &mut instances,
+                file_id,
                 &checked,
                 &indexed,
                 constraint.file_id,
@@ -79,14 +223,14 @@ where
         }
     }
 
-    type Grouped = FxHashMap<InstanceChainId, Vec<InstanceCandidate>>;
+    type Grouped = FxHashMap<InstanceChainKey, Vec<InstanceCandidate>>;
 
     let mut grouped = Grouped::default();
     let mut chains = vec![];
 
     for instance in instances {
-        if let Some(id) = instance.id {
-            grouped.entry(id).or_default().push(instance);
+        if let Some(chain) = instance.chain {
+            grouped.entry(chain).or_default().push(instance);
         } else {
             chains.push(vec![instance]);
         }
@@ -97,35 +241,101 @@ where
         chains.push(chain);
     }
 
+    chains.sort_by_key(|chain| {
+        chain
+            .first()
+            .map(|instance| (instance.chain, instance.position, instance.instance.signature))
+    });
+
     Ok(InstanceChains { chains, blocking })
+}
+
+fn instance_candidate_chain<Q>(
+    context: &CheckContext<Q>,
+    origin: InstanceCandidateOrigin,
+) -> Option<InstanceChainKey>
+where
+    Q: ExternalQueries,
+{
+    let InstanceCandidateOrigin::Instance(file_id, instance_id) = origin else {
+        return None;
+    };
+
+    if file_id != context.id {
+        return None;
+    }
+
+    context.indexed.pairs.instance_chain_id(instance_id).map(|chain_id| (file_id, chain_id))
+}
+
+fn instance_candidate_position<Q>(
+    context: &CheckContext<Q>,
+    origin: InstanceCandidateOrigin,
+) -> Option<usize>
+where
+    Q: ExternalQueries,
+{
+    context.indexed.items.iter_terms().position(|(_, item)| match (origin, &item.kind) {
+        (InstanceCandidateOrigin::Instance(file_id, origin_id), TermItemKind::Instance { id }) => {
+            file_id == context.id && origin_id == *id
+        }
+        (InstanceCandidateOrigin::Derive(file_id, origin_id), TermItemKind::Derive { id }) => {
+            file_id == context.id && origin_id == *id
+        }
+        _ => false,
+    })
+}
+
+fn should_report_overlap<Q>(
+    context: &CheckContext<Q>,
+    candidate: InstanceCandidateOrigin,
+    origin: InstanceCandidateOrigin,
+    origin_position: usize,
+) -> bool
+where
+    Q: ExternalQueries,
+{
+    if candidate == origin {
+        return false;
+    }
+
+    let Some(candidate_position) = instance_candidate_position(context, candidate) else {
+        return true;
+    };
+
+    candidate_position < origin_position
 }
 
 fn collect_instances_from_checked(
     output: &mut Vec<InstanceCandidate>,
+    file_id: FileId,
     checked: &CheckedModule,
     indexed: &IndexedModule,
     class_file: FileId,
     class_id: TypeItemId,
 ) {
-    output.extend(
-        checked
-            .instances
-            .iter()
-            .filter(|(_, instance)| instance.resolution == (class_file, class_id))
-            .map(|(&id, &instance)| InstanceCandidate {
-                id: indexed.pairs.instance_chain_id(id),
-                position: indexed.pairs.instance_chain_position(id).unwrap_or(0),
-                instance,
-            }),
-    );
+    let instances = checked
+        .instances
+        .iter()
+        .filter(|(_, instance)| instance.resolution == (class_file, class_id))
+        .map(|(&id, &instance)| {
+            let chain = indexed.pairs.instance_chain_id(id).map(|chain_id| (file_id, chain_id));
+            let position = indexed.pairs.instance_chain_position(id).unwrap_or(0);
+            let origin = InstanceCandidateOrigin::Instance(file_id, id);
+            InstanceCandidate { chain, position, origin, instance }
+        });
 
-    output.extend(
-        checked
-            .derived
-            .values()
-            .filter(|instance| instance.resolution == (class_file, class_id))
-            .map(|&instance| InstanceCandidate { id: None, position: 0, instance }),
-    );
+    let derived = checked
+        .derived
+        .iter()
+        .filter(|(_, instance)| instance.resolution == (class_file, class_id))
+        .map(|(&id, &instance)| {
+            let origin = InstanceCandidateOrigin::Derive(file_id, id);
+            InstanceCandidate { chain: None, position: 0, origin, instance }
+        });
+
+    output.extend(instances);
+    output.extend(derived);
 }
 
 pub fn validate_rows<Q>(

--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -8,10 +8,14 @@ use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::constraint::instances::InstanceCandidate;
 use crate::core::constraint::{CanonicalConstraintId, canonical};
-use crate::core::fd::{Fd, compute_closure, get_all_determined, get_functional_dependencies};
+use crate::core::fd::{
+    Fd, compute_closure, compute_covering_sets, get_all_determined, get_functional_dependencies,
+};
 use crate::core::substitute::SubstituteName;
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
-use crate::core::{KindOrType, Name, RowField, RowTypeId, Type, TypeId, normalise, toolkit};
+use crate::core::{
+    CheckedInstance, KindOrType, Name, RowField, RowTypeId, Type, TypeId, normalise, toolkit,
+};
 use crate::source::types;
 use crate::state::CheckState;
 
@@ -616,17 +620,8 @@ where
     let functional_dependencies =
         get_functional_dependencies(state, context, wanted.file_id, wanted.type_id)?;
 
-    let wanted_arguments = wanted
-        .arguments
-        .iter()
-        .filter_map(|argument| if let KindOrType::Type(id) = argument { Some(*id) } else { None })
-        .collect_vec();
-
-    let declared_arguments = declared
-        .arguments
-        .iter()
-        .filter_map(|argument| if let KindOrType::Type(id) = argument { Some(*id) } else { None })
-        .collect_vec();
+    let wanted_arguments = type_arguments(&wanted.arguments);
+    let declared_arguments = type_arguments(&declared.arguments);
 
     match match_instance(
         state,
@@ -640,7 +635,7 @@ where
             let matched_names: FxHashSet<_> = bindings.iter().map(|(name, _)| *name).collect();
 
             let mut substitution = FxHashMap::default();
-            for &(name, bound) in &bindings {
+            for (name, bound) in bindings {
                 substitution.entry(name).or_insert(bound);
             }
 
@@ -654,18 +649,14 @@ where
             }
 
             let mut unifications = vec![];
-
             for binder in &declared.binders {
                 if !matched_names.contains(&binder.name) {
                     continue;
                 }
-
                 let expected_kind =
                     SubstituteName::many(state, context, &substitution, binder.kind)?;
-
                 let actual_kind =
                     types::elaborate_kind(state, context, substitution[&binder.name])?;
-
                 unifications.push((actual_kind, expected_kind));
             }
 
@@ -687,5 +678,179 @@ where
         }
         MatchType::Apart => Ok(MatchInstance::Apart),
         MatchType::Stuck { stuck, skolem } => Ok(MatchInstance::Stuck { stuck, skolem }),
+    }
+}
+
+pub fn declared_instances_overlap<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    left: CheckedInstance,
+    right: CheckedInstance,
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    if left.resolution != right.resolution {
+        return Ok(false);
+    }
+
+    let (file_id, type_id) = left.resolution;
+
+    let Some(left) = toolkit::instance_info(state, context, left.signature, left.resolution)?
+    else {
+        return Ok(false);
+    };
+    let Some(right) = toolkit::instance_info(state, context, right.signature, right.resolution)?
+    else {
+        return Ok(false);
+    };
+
+    let left_arguments = type_arguments(&left.arguments);
+    let right_arguments = type_arguments(&right.arguments);
+
+    if left_arguments.len() != right_arguments.len() {
+        return Ok(false);
+    }
+
+    let functional_dependencies = get_functional_dependencies(state, context, file_id, type_id)?;
+    let covering_sets = compute_covering_sets(&functional_dependencies, left_arguments.len());
+
+    Ok(!instances_are_apart(state, context, &covering_sets, &left_arguments, &right_arguments)?)
+}
+
+fn type_arguments(arguments: &[KindOrType]) -> Vec<TypeId> {
+    arguments
+        .iter()
+        .filter_map(|argument| if let KindOrType::Type(id) = argument { Some(*id) } else { None })
+        .collect_vec()
+}
+
+fn instances_are_apart<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    covering_sets: &[FxHashSet<usize>],
+    left_arguments: &[TypeId],
+    right_arguments: &[TypeId],
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    for covering_set in covering_sets {
+        let mut covering_set_is_apart = false;
+
+        for &position in covering_set {
+            if types_apart(
+                state,
+                context,
+                left_arguments[position],
+                right_arguments[position],
+                false,
+            )?
+            .is_apart()
+            {
+                covering_set_is_apart = true;
+                break;
+            }
+        }
+
+        if !covering_set_is_apart {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn types_apart<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    left: TypeId,
+    right: TypeId,
+    comparing_kind_argument: bool,
+) -> QueryResult<MatchType>
+where
+    Q: ExternalQueries,
+{
+    // Declaration-time overlap checking follows PureScript's conservative
+    // head-apartness approximation rather than solver unification. In
+    // particular, kinded applications may be separated by their explicit
+    // kind arguments even when their value-level arguments could still unify;
+    // any remaining ambiguity is reported at instance-search sites.
+    let left = normalise::expand(state, context, left)?;
+    let right = normalise::expand(state, context, right)?;
+
+    let left_core = context.lookup_type(left);
+    let right_core = context.lookup_type(right);
+
+    match (left_core, right_core) {
+        (Type::Kinded(left, _), _) => {
+            types_apart(state, context, left, right, comparing_kind_argument)
+        }
+        (_, Type::Kinded(right, _)) => {
+            types_apart(state, context, left, right, comparing_kind_argument)
+        }
+
+        (Type::Rigid(_, _, _), Type::Rigid(_, _, _))
+        | (Type::Unification(_), Type::Unification(_)) => Ok(MatchType::Match { bindings: vec![] }),
+
+        (Type::Rigid(_, _, _) | Type::Unification(_), _)
+        | (_, Type::Rigid(_, _, _) | Type::Unification(_)) => Ok(if comparing_kind_argument {
+            MatchType::Apart
+        } else {
+            MatchType::Match { bindings: vec![] }
+        }),
+
+        (Type::Constructor(left_file, left_item), Type::Constructor(right_file, right_item)) => {
+            Ok(if (left_file, left_item) != (right_file, right_item) {
+                MatchType::Apart
+            } else {
+                MatchType::Match { bindings: vec![] }
+            })
+        }
+
+        (Type::String(_, left), Type::String(_, right)) => {
+            Ok(if left != right { MatchType::Apart } else { MatchType::Match { bindings: vec![] } })
+        }
+        (Type::Integer(left), Type::Integer(right)) => {
+            Ok(if left != right { MatchType::Apart } else { MatchType::Match { bindings: vec![] } })
+        }
+
+        (
+            Type::Application(left_function, left_argument),
+            Type::Application(right_function, right_argument),
+        ) => Ok(types_apart(state, context, left_function, right_function, false)?
+            .combine(types_apart(state, context, left_argument, right_argument, false)?)),
+
+        (Type::Application(_, _), Type::Function(right_argument, right_result)) => {
+            let right = context.intern_function_application(right_argument, right_result);
+            types_apart(state, context, left, right, comparing_kind_argument)
+        }
+
+        (Type::Function(left_argument, left_result), Type::Application(_, _)) => {
+            let left = context.intern_function_application(left_argument, left_result);
+            types_apart(state, context, left, right, comparing_kind_argument)
+        }
+
+        (
+            Type::KindApplication(left_function, left_argument),
+            Type::KindApplication(right_function, right_argument),
+        ) => Ok(types_apart(state, context, left_function, right_function, false)?
+            .combine(types_apart(state, context, left_argument, right_argument, true)?)),
+
+        (
+            Type::Function(left_argument, left_result),
+            Type::Function(right_argument, right_result),
+        ) => Ok(types_apart(state, context, left_argument, right_argument, false)?
+            .combine(types_apart(state, context, left_result, right_result, false)?)),
+
+        (Type::Row(left), Type::Row(right)) => compare_row_types_with(
+            state,
+            context,
+            left,
+            right,
+            &mut |state, context, left, right| types_apart(state, context, left, right, false),
+        ),
+
+        (_, _) => Ok(MatchType::Apart),
     }
 }

--- a/compiler-core/checking/src/core/fd.rs
+++ b/compiler-core/checking/src/core/fd.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::TypeItemId;
+use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use crate::context::CheckContext;
@@ -81,13 +82,51 @@ pub fn compute_closure(
     }
 }
 
+pub fn compute_covering_sets(
+    functional_dependencies: &[Fd],
+    argument_count: usize,
+) -> Vec<FxHashSet<usize>> {
+    let all_argument_positions: FxHashSet<_> = (0..argument_count).collect();
+
+    let all_covering_sets =
+        argument_position_subsets(argument_count).into_iter().filter(|argument_positions| {
+            let determined_positions = compute_closure(functional_dependencies, argument_positions);
+            determined_positions == all_argument_positions
+        });
+
+    let all_covering_sets = all_covering_sets.collect_vec();
+
+    let mut minimal_covering_sets = all_covering_sets.clone();
+    minimal_covering_sets.retain(|covering_set| {
+        !all_covering_sets.iter().any(|other_covering_set| {
+            other_covering_set != covering_set && other_covering_set.is_subset(covering_set)
+        })
+    });
+
+    minimal_covering_sets
+}
+
+fn argument_position_subsets(argument_count: usize) -> Vec<FxHashSet<usize>> {
+    let mut subsets = vec![FxHashSet::default()];
+
+    for argument_position in (0..argument_count).rev() {
+        for index in 0..subsets.len() {
+            let mut subset = subsets[index].clone();
+            subset.insert(argument_position);
+            subsets.push(subset);
+        }
+    }
+
+    subsets
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_no_fundeps() {
-        let initial: FxHashSet<usize> = [0, 1].into_iter().collect();
+        let initial = FxHashSet::from_iter([0, 1]);
         let result = compute_closure(&[], &initial);
         assert_eq!(result, initial);
     }
@@ -95,46 +134,46 @@ mod tests {
     #[test]
     fn test_single_fundep() {
         let fundeps = vec![Fd::new([0], [1])];
-        let initial: FxHashSet<usize> = [0].into_iter().collect();
+        let initial = FxHashSet::from_iter([0]);
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [0, 1].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0, 1]));
     }
 
     #[test]
     fn test_fundep_not_triggered() {
         let fundeps = vec![Fd::new([0], [1])];
-        let initial: FxHashSet<usize> = [1].into_iter().collect();
+        let initial = FxHashSet::from_iter([1]);
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [1].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([1]));
     }
 
     #[test]
     fn test_transitive_fundeps() {
         let fundeps = vec![Fd::new([0], [1]), Fd::new([1], [2])];
-        let initial: FxHashSet<usize> = [0].into_iter().collect();
+        let initial = FxHashSet::from_iter([0]);
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [0, 1, 2].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0, 1, 2]));
     }
 
     #[test]
     fn test_multi_determiner() {
         let fundeps = vec![Fd::new([0, 1], [2])];
 
-        let initial: FxHashSet<usize> = [0].into_iter().collect();
+        let initial = FxHashSet::from_iter([0]);
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [0].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0]));
 
-        let initial: FxHashSet<usize> = [0, 1].into_iter().collect();
+        let initial = FxHashSet::from_iter([0, 1]);
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [0, 1, 2].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0, 1, 2]));
     }
 
     #[test]
     fn test_multiple_determined() {
         let fundeps = vec![Fd::new([0], [1, 2])];
-        let initial: FxHashSet<usize> = [0].into_iter().collect();
+        let initial = FxHashSet::from_iter([0]);
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [0, 1, 2].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0, 1, 2]));
     }
 
     #[test]
@@ -142,7 +181,7 @@ mod tests {
         let fundeps = vec![Fd::new([], [0])];
         let initial: FxHashSet<usize> = FxHashSet::default();
         let result = compute_closure(&fundeps, &initial);
-        assert_eq!(result, [0].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0]));
     }
 
     #[test]
@@ -155,27 +194,57 @@ mod tests {
     fn test_all_determined_single_fundep() {
         let fundeps = vec![Fd::new([0], [1])];
         let result = get_all_determined(&fundeps);
-        assert_eq!(result, [1].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([1]));
     }
 
     #[test]
     fn test_all_determined_multiple_fundeps() {
         let fundeps = vec![Fd::new([0], [1]), Fd::new([1], [2])];
         let result = get_all_determined(&fundeps);
-        assert_eq!(result, [1, 2].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([1, 2]));
     }
 
     #[test]
     fn test_all_determined_overlapping() {
         let fundeps = vec![Fd::new([0], [1, 2]), Fd::new([3], [1])];
         let result = get_all_determined(&fundeps);
-        assert_eq!(result, [1, 2].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([1, 2]));
     }
 
     #[test]
     fn test_all_determined_empty_determiners() {
         let fundeps = vec![Fd::new([], [0])];
         let result = get_all_determined(&fundeps);
-        assert_eq!(result, [0].into_iter().collect());
+        assert_eq!(result, FxHashSet::from_iter([0]));
+    }
+
+    #[test]
+    fn test_covering_sets_no_fundeps() {
+        let result = compute_covering_sets(&[], 2);
+        assert_eq!(result, vec![FxHashSet::from_iter([0, 1])]);
+    }
+
+    #[test]
+    fn test_covering_sets_single_fundep() {
+        let fundeps = vec![Fd::new([0], [1])];
+        let result = compute_covering_sets(&fundeps, 2);
+        assert_eq!(result, vec![FxHashSet::from_iter([0])]);
+    }
+
+    #[test]
+    fn test_covering_sets_symmetric_fundeps() {
+        let fundeps = vec![Fd::new([0], [1]), Fd::new([1], [0])];
+        let result = compute_covering_sets(&fundeps, 2);
+
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&FxHashSet::from_iter([0])));
+        assert!(result.contains(&FxHashSet::from_iter([1])));
+    }
+
+    #[test]
+    fn test_covering_sets_empty_determiner() {
+        let fundeps = vec![Fd::new([], [0])];
+        let result = compute_covering_sets(&fundeps, 1);
+        assert_eq!(result, vec![FxHashSet::default()]);
     }
 }

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -171,6 +171,14 @@ where
             let constraint = zonk(state, context, constraint)?;
             ErrorKind::NoInstanceFound { given, constraint }
         }
+        ErrorKind::OverlappingInstances { constraint, instances } => {
+            let constraint = zonk(state, context, constraint)?;
+            let instances = instances
+                .iter()
+                .map(|&instance| zonk(state, context, instance))
+                .collect::<QueryResult<Arc<[_]>>>()?;
+            ErrorKind::OverlappingInstances { constraint, instances }
+        }
         ErrorKind::NoVisibleTypeVariable { function_type } => {
             let function_type = zonk(state, context, function_type)?;
             ErrorKind::NoVisibleTypeVariable { function_type }

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -107,6 +107,10 @@ pub enum ErrorKind {
         given: Arc<[TypeId]>,
         constraint: TypeId,
     },
+    OverlappingInstances {
+        constraint: TypeId,
+        instances: Arc<[TypeId]>,
+    },
     NoVisibleTypeVariable {
         function_type: TypeId,
     },

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -35,6 +35,7 @@ where
 {
     check_instance_declarations(state, context)?;
     let derive_results = derive::check_derive_declarations(state, context)?;
+    check_overlapping_instance_declarations(state, context)?;
     check_value_groups(state, context)?;
     check_instance_members(state, context)?;
     derive::check_derive_members(state, context, &derive_results)?;
@@ -62,6 +63,24 @@ where
 
         for item in items {
             check_instance_declaration(state, context, item)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn check_overlapping_instance_declarations<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    for scc in &context.grouped.term_scc {
+        for &item_id in scc.as_slice() {
+            state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
+                constraint::instances::validate_declared_instance_overlap(state, context, item_id)
+            })?;
         }
     }
 

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -363,6 +363,11 @@ impl ToDiagnostics for CheckingError {
                 let message = format!("No instance found for: {constraint}");
                 (Severity::Error, "NoInstanceFound", message)
             }
+            ErrorKind::OverlappingInstances { constraint, .. } => {
+                let constraint = render_type(*constraint);
+                let message = format!("Overlapping type class instances found for: {constraint}");
+                (Severity::Error, "OverlappingInstances", message)
+            }
             ErrorKind::NoVisibleTypeVariable { function_type } => {
                 let message = render_type(*function_type);
                 (
@@ -459,6 +464,13 @@ impl ToDiagnostics for CheckingError {
         }
 
         match &self.kind {
+            ErrorKind::OverlappingInstances { instances, .. } => {
+                for &instance in instances.iter() {
+                    let instance = render_type(instance);
+                    let trivia = format!("{instance} is matching");
+                    diagnostic = diagnostic.with_trivia(trivia)
+                }
+            }
             ErrorKind::TermHole { source_term } => {
                 if let Some(hole) = context.checked.lookup_term_hole(*source_term) {
                     diagnostic = attach_hole_binding_trivia(diagnostic, context, &hole.bindings);

--- a/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
@@ -18,6 +18,13 @@ Roles
 Either = [Representational, Representational]
 
 Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: Eq (Either Int (t :: Type))
+  --> 9:1..9:34
+  |
+9 | derive instance Eq (Either Int b)
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: forall (t1 :: Type). Eq (t1 :: Type) => Eq (Either Int (t1 :: Type)) is matching
+  trivia: forall (t :: Type). Eq (Either Int (t :: Type)) is matching
 error[NoInstanceFound]: No instance found for: Eq (t :: Type)
   --> 9:1..9:34
   |

--- a/tests-integration/fixtures/checking/1779903960_overlapping/Main.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+class Test a where
+  test :: a -> a
+
+instance testRefl :: Test a where
+  test x = x
+
+instance testInt :: Test Int where
+  test _ = 0
+
+value :: Int
+value = test 1

--- a/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
@@ -17,3 +17,12 @@ class forall (a :: Type). Test (a :: Type)
 Instances
 instance forall (t :: Type). Test (t :: Type)
 instance Test Int
+
+Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: Test Int
+  --> 9:1..10:13
+  |
+9 | instance testInt :: Test Int where
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: forall (t :: Type). Test (t :: Type) is matching
+  trivia: Test Int is matching

--- a/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+value :: Int
+
+Types
+Test :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Test (a :: Type)
+  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+
+Instances
+instance forall (t :: Type). Test (t :: Type)
+instance Test Int

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+class Test a where
+  test :: a -> a
+
+instance testInt :: Test Int where
+  test _ = 0
+
+else instance testRefl :: Test a where
+  test x = x
+
+value :: Int
+value = test 1

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+value :: Int
+
+Types
+Test :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Test (a :: Type)
+  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+
+Instances
+instance Test Int
+instance forall (t :: Type). Test (t :: Type)

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Lib.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Lib.purs
@@ -1,0 +1,9 @@
+module Lib where
+
+class C a b where
+  test :: a -> b -> Int
+
+data X = X
+
+instance cxx :: C X a where
+  test _ _ = 0

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Lib
+
+data Y = Y
+
+instance cxy :: C X Y
+
+value :: Int
+value = test X Y

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Y :: Y
+value :: Int
+
+Types
+Y :: Type
+
+Instances
+instance C X Y
+
+Roles
+Y = []

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
@@ -15,3 +15,12 @@ instance C X Y
 
 Roles
 Y = []
+
+Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: C X Y
+  --> 7:1..7:22
+  |
+7 | instance cxy :: C X Y
+  | ^~~~~~~~~~~~~~~~~~~~~
+  trivia: forall (t :: Type). C X (t :: Type) is matching
+  trivia: C X Y is matching

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Test a where
+  test :: a -> a
+
+instance testRefl :: Test a where
+  test x = x
+
+instance testInt :: Test Int where
+  test _ = 0

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+
+Types
+Test :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Test (a :: Type)
+  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+
+Instances
+instance forall (t :: Type). Test (t :: Type)
+instance Test Int

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
@@ -16,3 +16,12 @@ class forall (a :: Type). Test (a :: Type)
 Instances
 instance forall (t :: Type). Test (t :: Type)
 instance Test Int
+
+Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: Test Int
+  --> 9:1..10:13
+  |
+9 | instance testInt :: Test Int where
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: forall (t :: Type). Test (t :: Type) is matching
+  trivia: Test Int is matching

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+class ShowP :: forall k. k -> Constraint
+class ShowP a where
+  showP :: Proxy a -> String
+
+instance showPFirst :: ShowP a where
+  showP _ = "first"
+
+instance showPSecond :: ShowP a where
+  showP _ = "second"
+
+value :: String
+value = showP (Proxy :: Proxy Int)

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+showP ::
+  forall (k :: Type) (@a :: (k :: Type)).
+    ShowP @(k :: Type) (a :: (k :: Type)) => Proxy @(k :: Type) (a :: (k :: Type)) -> String
+value :: String
+
+Types
+Proxy :: forall (k :: Type). (k :: Type) -> Type
+ShowP :: forall (k :: Type). (k :: Type) -> Constraint
+
+Classes
+class forall (k :: Type) (a :: (k :: Type)). ShowP @(k :: Type) (a :: (k :: Type))
+  showP ::
+  forall (k :: Type) (@a :: (k :: Type)).
+    ShowP @(k :: Type) (a :: (k :: Type)) => Proxy @(k :: Type) (a :: (k :: Type)) -> String
+
+Instances
+instance forall (t :: Type) (t1 :: (t :: Type)). ShowP @(t :: Type) (t1 :: (t :: Type))
+instance forall (t :: Type) (t1 :: (t :: Type)). ShowP @(t :: Type) (t1 :: (t :: Type))
+
+Roles
+Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
@@ -26,3 +26,12 @@ instance forall (t :: Type) (t1 :: (t :: Type)). ShowP @(t :: Type) (t1 :: (t ::
 
 Roles
 Proxy = [Phantom]
+
+Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: ShowP @(t :: Type) (t1 :: (t :: Type))
+  --> 13:1..14:21
+   |
+13 | instance showPSecond :: ShowP a where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: forall (t2 :: Type) (t3 :: (t2 :: Type)). ShowP @(t2 :: Type) (t3 :: (t2 :: Type)) is matching
+  trivia: forall (t :: Type) (t1 :: (t :: Type)). ShowP @(t :: Type) (t1 :: (t :: Type)) is matching

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.purs
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+class Convert a b | a -> b where
+  convert :: a -> b
+
+type Bar = String
+
+instance convertSB :: Convert String Bar where
+  convert s = s
+
+instance convertSS :: Convert String String where
+  convert s = s
+
+value :: String
+value = convert "value"

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+convert ::
+  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+value :: String
+
+Types
+Convert :: Type -> Type -> Constraint
+Bar :: Type
+
+Synonyms
+type Bar = String
+
+Classes
+class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
+  convert ::
+  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+
+Instances
+instance Convert String Bar
+instance Convert String String

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.purs
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Eq (class Eq)
+
+data Box = Box
+
+derive instance Eq Box
+
+instance eqBox :: Eq Box where
+  eq _ _ = true

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Box :: Box
+
+Types
+Box :: Type
+
+Instances
+instance Eq Box
+
+Derived
+derive Eq Box
+
+Roles
+Box = []

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
@@ -17,3 +17,12 @@ derive Eq Box
 
 Roles
 Box = []
+
+Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: Eq Box
+  --> 9:1..10:16
+  |
+9 | instance eqBox :: Eq Box where
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Eq Box is matching
+  trivia: Eq Box is matching

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.purs
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+data Pair a b = Pair a b
+
+class Test a where
+  test :: a -> Int
+
+instance testLeft :: Test (Pair a Int) where
+  test _ = 0
+
+instance testRight :: Test (Pair String b) where
+  test _ = 1

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
@@ -21,3 +21,12 @@ instance forall (t :: Type). Test (Pair String (t :: Type))
 
 Roles
 Pair = [Representational, Representational]
+
+Diagnostics
+error[OverlappingInstances]: Overlapping type class instances found for: Test (Pair String (t :: Type))
+  --> 11:1..12:13
+   |
+11 | instance testRight :: Test (Pair String b) where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: forall (t1 :: Type). Test (Pair (t1 :: Type) Int) is matching
+  trivia: forall (t :: Type). Test (Pair String (t :: Type)) is matching

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Pair :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Pair (a :: Type) (b :: Type)
+test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> Int
+
+Types
+Pair :: Type -> Type -> Type
+Test :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Test (a :: Type)
+  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> Int
+
+Instances
+instance forall (t :: Type). Test (Pair (t :: Type) Int)
+instance forall (t :: Type). Test (Pair String (t :: Type))
+
+Roles
+Pair = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.purs
+++ b/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Convert a b | a -> b where
+  convert :: a -> b
+
+instance convertSI :: Convert String Int where
+  convert _ = 0
+
+instance convertSB :: Convert String Boolean where
+  convert _ = true

--- a/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.snap
@@ -6,14 +6,9 @@ expression: report
 Terms
 convert ::
   forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-value :: String
 
 Types
 Convert :: Type -> Type -> Constraint
-Bar :: Type
-
-Synonyms
-type Bar = String
 
 Classes
 class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
@@ -21,14 +16,14 @@ class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
   forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
 
 Instances
-instance Convert String Bar
-instance Convert String String
+instance Convert String Int
+instance Convert String Boolean
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Convert String String
-  --> 11:1..12:16
-   |
-11 | instance convertSS :: Convert String String where
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Convert String Bar is matching
-  trivia: Convert String String is matching
+error[OverlappingInstances]: Overlapping type class instances found for: Convert String Boolean
+  --> 9:1..10:19
+  |
+9 | instance convertSB :: Convert String Boolean where
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Convert String Int is matching
+  trivia: Convert String Boolean is matching

--- a/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.purs
+++ b/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+foreign import data ResultA :: Type
+foreign import data ResultB :: Type
+
+data Inner :: forall left right. left -> right -> Type
+data Inner left right
+
+data Outer :: forall left right. left -> right -> Type
+data Outer left right
+
+class Test :: forall input. input -> Type -> Constraint
+class Test input output | input -> output
+
+instance Test (Outer left right) ResultA
+
+instance Test (Outer (Inner left right) other) ResultB

--- a/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.snap
+++ b/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types
+ResultA :: Type
+ResultB :: Type
+Inner :: forall (left :: Type) (right :: Type). (left :: Type) -> (right :: Type) -> Type
+Outer :: forall (left :: Type) (right :: Type). (left :: Type) -> (right :: Type) -> Type
+Test :: forall (input :: Type). (input :: Type) -> Type -> Constraint
+
+Classes
+class forall (input :: Type) (input1 :: (input :: Type)) (output :: Type). Test @(input :: Type) (input1 :: (input :: Type)) (output :: Type)
+
+Instances
+instance forall (t :: Type) (t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type)).
+  Test @Type (Outer @(t :: Type) @(t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type))) ResultA
+instance forall (t :: Type) (t1 :: Type) (t2 :: Type) (t3 :: (t1 :: Type)) (t4 :: (t2 :: Type))
+  (t5 :: (t :: Type)).
+  Test @Type
+    (Outer @Type @(t :: Type)
+      (Inner @(t1 :: Type) @(t2 :: Type) (t3 :: (t1 :: Type)) (t4 :: (t2 :: Type)))
+      (t5 :: (t :: Type)))
+    ResultB
+
+Roles
+ResultA = []
+ResultB = []
+Inner = [Phantom, Phantom]
+Outer = [Phantom, Phantom]


### PR DESCRIPTION
Implements checking for overlapping instances. Uses a covering set based approach with a new function types_apart with semantics that match the original compiler. `tests-compatibility` on acme passes.