### PR TITLE
Fix clippy warnings

### DIFF
--- a/compiler-bin/src/docs/location.rs
+++ b/compiler-bin/src/docs/location.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use documentation::schema::Location;
 
@@ -22,7 +22,7 @@ pub fn package_reference_location(reference: &spago::PackageReference) -> Option
     };
 
     let reference = Some(rev.to_string());
-    let subdir = subdir.as_ref().map(path_to_string);
+    let subdir = subdir.as_deref().map(path_to_string);
 
     Some(location_from_git_url(url.as_str(), reference, subdir))
 }
@@ -71,6 +71,6 @@ fn github_repository_url(owner: &str, repository: &str) -> String {
     format!("https://github.com/{owner}/{repository}")
 }
 
-fn path_to_string(path: &PathBuf) -> String {
+fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }

--- a/compiler-core/documenting/src/annotation.rs
+++ b/compiler-core/documenting/src/annotation.rs
@@ -201,10 +201,9 @@ fn extract_annotation(text: &str) -> Option<String> {
     let lines = text.lines().filter_map(documentation_line_content);
 
     let mut lines = lines.peekable();
-    if let Some(line) = lines.next() {
+    {
+        let line = lines.next()?;
         annotation.push_str(line);
-    } else {
-        return None;
     }
 
     lines.for_each(|line| {

--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -1009,7 +1009,7 @@ fn index_module_export(state: &mut State, id: ExportItemId, cst: &cst::ExportMod
             //
             // import Data.Maybe as Maybe
             // ```
-            for (_, items) in state.imports.iter_mut() {
+            for items in state.imports.values_mut() {
                 let alias = items.alias.as_deref();
                 let name = items.name.as_deref();
 


### PR DESCRIPTION
## Summary

- accept borrowed paths and use `Option::as_deref` when converting package subdirectories
- simplify annotation extraction with `?`
- iterate directly over mutable import-map values

These are mechanical clippy fixes with no intended behavior changes.

## Testing

- `cargo clippy --workspace`