### PR TITLE
[parsing] Optimize lexer and parser throughput

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v rustup >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+fi
+
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
+rustup toolchain install stable --profile minimal
+rustup toolchain install nightly --profile minimal --component rustfmt
+rustup default stable
+
+if ! command -v cargo-binstall >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -LsSf \
+    https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+fi
+
+cargo binstall --no-confirm just cargo-nextest

--- a/.agents/setup
+++ b/.agents/setup
@@ -13,7 +13,8 @@ rustup default stable
 
 if ! command -v cargo-binstall >/dev/null 2>&1; then
   curl --proto '=https' --tlsv1.2 -LsSf \
-    https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    https://raw.githubusercontent.com/cargo-bins/cargo-binstall/aaa84a43aec4955a42c5ffc65d258961e39f276e/install-from-binstall-release.sh \
+    | BINSTALL_VERSION=1.19.1 bash
 fi
 
 cargo binstall --no-confirm just cargo-nextest

--- a/compiler-core/lexing/src/categories.rs
+++ b/compiler-core/lexing/src/categories.rs
@@ -10,15 +10,23 @@ pub(super) trait LexerCategories {
 
 impl LexerCategories for char {
     fn is_lower_start(self) -> bool {
-        self.is_letter_lowercase() || self == '_'
+        if self.is_ascii() {
+            self.is_ascii_lowercase() || self == '_'
+        } else {
+            self.is_letter_lowercase()
+        }
     }
 
     fn is_upper_start(self) -> bool {
-        self.is_letter_uppercase()
+        if self.is_ascii() { self.is_ascii_uppercase() } else { self.is_letter_uppercase() }
     }
 
     fn is_name(self) -> bool {
-        self.is_alphanumeric() || self == '_' || self == '\''
+        if self.is_ascii() {
+            self.is_ascii_alphanumeric() || self == '_' || self == '\''
+        } else {
+            self.is_alphanumeric()
+        }
     }
 
     fn is_operator(self) -> bool {

--- a/compiler-core/lexing/src/layout.rs
+++ b/compiler-core/lexing/src/layout.rs
@@ -54,7 +54,7 @@ impl<'s> Layout<'s> {
     pub(super) fn new(lexed: &'s Lexed<'s>) -> Layout<'s> {
         let index = 0;
         let stack = vec![(Position { line: 1, column: 1 }, Delimiter::Root)];
-        let output = vec![];
+        let output = Vec::with_capacity(lexed.len());
         Layout { lexed, index, stack, output }
     }
 
@@ -64,10 +64,11 @@ impl<'s> Layout<'s> {
 
     pub(super) fn take_token(&mut self) {
         let token = self.lexed.kind(self.index);
-        let qualifier = self.lexed.qualifier(self.index);
-        let position = self.lexed.position(self.index);
-        let next = self.lexed.position(self.index + 1);
-        self.insert(token, qualifier, position, next);
+        let info = self.lexed.info(self.index);
+        let qualified = info.annotation < info.qualifier;
+        let position = info.position;
+        let next = self.lexed.info(self.index + 1).position;
+        self.insert(token, qualified, position, next);
         self.index += 1;
     }
 
@@ -83,21 +84,15 @@ impl<'s> Layout<'s> {
 }
 
 impl<'s> Layout<'s> {
-    fn insert(
-        &mut self,
-        token: SyntaxKind,
-        qualifier: Option<&'s str>,
-        position: Position,
-        next: Position,
-    ) {
-        Insert::new(self, token, qualifier, position, next).invoke();
+    fn insert(&mut self, token: SyntaxKind, qualified: bool, position: Position, next: Position) {
+        Insert::new(self, token, qualified, position, next).invoke();
     }
 }
 
 struct Insert<'l, 's> {
     layout: &'l mut Layout<'s>,
     token: SyntaxKind,
-    qualifier: Option<&'s str>,
+    qualified: bool,
     position: Position,
     next: Position,
 }
@@ -106,16 +101,16 @@ impl<'l, 's> Insert<'l, 's> {
     fn new(
         layout: &'l mut Layout<'s>,
         token: SyntaxKind,
-        qualifier: Option<&'s str>,
+        qualified: bool,
         position: Position,
         next: Position,
     ) -> Insert<'l, 's> {
-        Insert { layout, token, qualifier, position, next }
+        Insert { layout, token, qualified, position, next }
     }
 
     fn invoke(&mut self) {
         match self.token {
-            SyntaxKind::DATA if self.qualifier.is_none() => {
+            SyntaxKind::DATA if !self.qualified => {
                 self.insert_default();
                 if self.is_top_declaration(self.position) {
                     self.push_stack(self.position, Delimiter::TopDecl);
@@ -124,7 +119,7 @@ impl<'l, 's> Insert<'l, 's> {
                 }
             }
 
-            SyntaxKind::CLASS if self.qualifier.is_none() => {
+            SyntaxKind::CLASS if !self.qualified => {
                 self.insert_default();
                 if self.is_top_declaration(self.position) {
                     self.push_stack(self.position, Delimiter::TopDeclHead);
@@ -133,7 +128,7 @@ impl<'l, 's> Insert<'l, 's> {
                 }
             }
 
-            SyntaxKind::WHERE if self.qualifier.is_none() => match &self.layout.stack[..] {
+            SyntaxKind::WHERE if !self.qualified => match &self.layout.stack[..] {
                 [.., (_, Delimiter::TopDeclHead)] => {
                     self.pop_stack();
                     self.insert_token(self.token);
@@ -150,7 +145,7 @@ impl<'l, 's> Insert<'l, 's> {
                 }
             },
 
-            SyntaxKind::IN if self.qualifier.is_none() => {
+            SyntaxKind::IN if !self.qualified => {
                 let collapse = self.collapse(Insert::in_p);
                 match collapse.preview(self.layout) {
                     [.., (_, Delimiter::Ado), (_, Delimiter::LetStmt)] => {
@@ -174,7 +169,7 @@ impl<'l, 's> Insert<'l, 's> {
                 }
             }
 
-            SyntaxKind::LET if self.qualifier.is_none() => {
+            SyntaxKind::LET if !self.qualified => {
                 self.insert_keyword_property(|this| match &this.layout.stack[..] {
                     [.., (position, Delimiter::Do)] if position.column == this.position.column => {
                         this.insert_start(Delimiter::LetStmt);
@@ -200,13 +195,13 @@ impl<'l, 's> Insert<'l, 's> {
                 });
             }
 
-            SyntaxKind::CASE if self.qualifier.is_none() => {
+            SyntaxKind::CASE if !self.qualified => {
                 self.insert_keyword_property(|this| {
                     this.push_stack(this.position, Delimiter::Case);
                 });
             }
 
-            SyntaxKind::OF if self.qualifier.is_none() => {
+            SyntaxKind::OF if !self.qualified => {
                 let collapse = self.collapse(Insert::indented_p);
                 match collapse.preview(self.layout) {
                     [.., (_, Delimiter::Case)] => {
@@ -223,13 +218,13 @@ impl<'l, 's> Insert<'l, 's> {
                 }
             }
 
-            SyntaxKind::IF if self.qualifier.is_none() => {
+            SyntaxKind::IF if !self.qualified => {
                 self.insert_keyword_property(|this| {
                     this.push_stack(this.position, Delimiter::If);
                 });
             }
 
-            SyntaxKind::THEN if self.qualifier.is_none() => {
+            SyntaxKind::THEN if !self.qualified => {
                 let collapse = self.collapse(Insert::indented_p);
                 match collapse.preview(self.layout) {
                     [.., (_, Delimiter::If)] => {
@@ -245,7 +240,7 @@ impl<'l, 's> Insert<'l, 's> {
                 }
             }
 
-            SyntaxKind::ELSE if self.qualifier.is_none() => {
+            SyntaxKind::ELSE if !self.qualified => {
                 let collapse = self.collapse(Insert::indented_p);
                 match collapse.preview(self.layout) {
                     [.., (_, Delimiter::Then)] => {
@@ -397,7 +392,7 @@ impl<'l, 's> Insert<'l, 's> {
                 self.pop_stack_if(|delimiter| delimiter == Delimiter::Property);
             }
 
-            _ if LOWER.contains(self.token) && self.qualifier.is_none() => {
+            _ if LOWER.contains(self.token) && !self.qualified => {
                 self.insert_default();
                 self.pop_stack_if(|delimiter| delimiter == Delimiter::Property);
             }

--- a/compiler-core/lexing/src/lexed.rs
+++ b/compiler-core/lexing/src/lexed.rs
@@ -77,8 +77,9 @@ pub(super) struct LexedBuilder<'s> {
 
 impl<'s> LexedBuilder<'s> {
     pub(super) fn new(source: &'s str) -> LexedBuilder<'s> {
-        let kinds = vec![];
-        let infos = vec![];
+        let capacity = source.len() / 4;
+        let kinds = Vec::with_capacity(capacity);
+        let infos = Vec::with_capacity(capacity);
         let errors = vec![];
         LexedBuilder { source, kinds, infos, errors }
     }

--- a/compiler-core/parsing/src/builder.rs
+++ b/compiler-core/parsing/src/builder.rs
@@ -12,8 +12,14 @@ pub(crate) enum Output {
     Annotate,
     Qualify,
     Token { kind: SyntaxKind },
-    Error { message: Arc<str> },
+    Error { message: ParserError },
     Finish,
+}
+
+#[derive(Debug)]
+pub(crate) enum ParserError {
+    Message(&'static str),
+    Expected(SyntaxKind),
 }
 
 struct Builder<'l, 's> {
@@ -116,7 +122,10 @@ pub(crate) fn build(lexed: &Lexed<'_>, output: Vec<Output>) -> (ParsedModule, Ve
             Output::Annotate => builder.annotate(),
             Output::Qualify => builder.qualify(),
             Output::Token { kind } => builder.token(kind),
-            Output::Error { message } => builder.error(message),
+            Output::Error { message: ParserError::Message(message) } => builder.error(message),
+            Output::Error { message: ParserError::Expected(kind) } => {
+                builder.error(format!("Expected {kind:?}"));
+            }
             Output::Finish => builder.finish(),
         }
     }

--- a/compiler-core/parsing/src/parser.rs
+++ b/compiler-core/parsing/src/parser.rs
@@ -6,18 +6,17 @@ mod names;
 mod types;
 
 use std::cell::Cell;
-use std::mem;
-use std::sync::Arc;
 
 use drop_bomb::DropBomb;
 use syntax::{SyntaxKind, TokenSet};
 
-use crate::builder::Output;
+use crate::builder::{Output, ParserError};
 
 pub(crate) struct Parser<'t> {
     index: usize,
     tokens: &'t [SyntaxKind],
     output: Vec<Output>,
+    errors: usize,
     fuel: Cell<u16>,
 }
 
@@ -26,9 +25,10 @@ type Rule = fn(&mut Parser);
 impl<'t> Parser<'t> {
     pub(crate) fn new(tokens: &'t [SyntaxKind]) -> Parser<'t> {
         let index = 0;
-        let output = vec![];
+        let output = Vec::with_capacity(tokens.len());
+        let errors = 0;
         let fuel = Cell::new(u16::MAX);
-        Parser { index, tokens, output, fuel }
+        Parser { index, tokens, output, errors, fuel }
     }
 
     pub(crate) fn finish(self) -> Vec<Output> {
@@ -67,68 +67,56 @@ impl<'t> Parser<'t> {
 
     fn optional(&mut self, rule: Rule) {
         let initial_index = self.index;
-        let initial_output = mem::take(&mut self.output);
+        let initial_output = self.output.len();
+        let initial_errors = self.errors;
 
         rule(self);
 
-        let index = mem::replace(&mut self.index, initial_index);
-        let mut output = mem::replace(&mut self.output, initial_output);
-        let finished = output.iter().all(|event| !matches!(event, Output::Error { .. }));
-
-        if finished {
-            self.index = index;
-            self.output.append(&mut output);
+        if self.errors != initial_errors {
+            self.index = initial_index;
+            self.output.truncate(initial_output);
+            self.errors = initial_errors;
         }
-    }
-
-    fn lookahead(&mut self, rule: Rule) -> bool {
-        let initial_index = self.index;
-        let initial_output = mem::take(&mut self.output);
-
-        rule(self);
-
-        let _ = mem::replace(&mut self.index, initial_index);
-        let output = mem::replace(&mut self.output, initial_output);
-
-        output.iter().all(|event| !matches!(event, Output::Error { .. }))
     }
 
     fn alternative(&mut self, rules: impl IntoIterator<Item = Rule>) {
         let initial_index = self.index;
-        let initial_output = mem::take(&mut self.output);
+        let initial_output = self.output.len();
+        let initial_errors = self.errors;
 
         let mut fallback = None;
-        let mut selected = None;
 
         for rule in rules.into_iter() {
             rule(self);
 
-            let index = mem::replace(&mut self.index, initial_index);
-            let output = mem::take(&mut self.output);
-            let finished = output.iter().all(|event| !matches!(event, Output::Error { .. }));
-
-            if finished {
-                selected = Some((index, output));
-                break;
-            } else if fallback.is_none() {
-                fallback = Some((index, output));
-                continue;
+            if self.errors == initial_errors {
+                return;
             }
+
+            if fallback.is_none() {
+                let output = self.output.drain(initial_output..).collect();
+                fallback = Some((self.index, self.errors, output));
+            } else {
+                self.output.truncate(initial_output);
+            }
+
+            self.index = initial_index;
+            self.errors = initial_errors;
         }
 
-        let (index, mut output) =
-            selected.or(fallback).expect("invariant violated: at least one branch");
-
+        let (index, errors, mut output) =
+            fallback.expect("invariant violated: at least one branch");
         self.index = index;
-        self.output = initial_output;
+        self.errors = errors;
         self.output.append(&mut output);
     }
 
-    fn error(&mut self, message: impl Into<Arc<str>>) {
-        self.output.push(Output::Error { message: message.into() });
+    fn error(&mut self, message: &'static str) {
+        self.errors += 1;
+        self.output.push(Output::Error { message: ParserError::Message(message) });
     }
 
-    fn error_recover(&mut self, message: impl Into<Arc<str>>) {
+    fn error_recover(&mut self, message: &'static str) {
         let mut marker = self.start();
         self.error(message);
         self.consume();
@@ -141,6 +129,14 @@ impl<'t> Parser<'t> {
 
     fn at_next(&self, kind: SyntaxKind) -> bool {
         self.nth(1) == kind
+    }
+
+    fn nth_at(&self, index: usize, kind: SyntaxKind) -> bool {
+        self.nth(index) == kind
+    }
+
+    fn nth_at_in(&self, index: usize, set: TokenSet) -> bool {
+        set.contains(self.nth(index))
     }
 
     fn at_eof(&self) -> bool {
@@ -163,6 +159,7 @@ impl<'t> Parser<'t> {
         if !self.at_in(set) {
             return false;
         }
+        self.fuel.set(u16::MAX);
         self.index += 1;
         self.output.push(Output::Token { kind });
         true
@@ -172,11 +169,12 @@ impl<'t> Parser<'t> {
         if self.eat(kind) {
             return true;
         }
-        self.error(format!("Expected {kind:?}"));
+        self.errors += 1;
+        self.output.push(Output::Error { message: ParserError::Expected(kind) });
         false
     }
 
-    fn expect_in(&mut self, set: TokenSet, kind: SyntaxKind, message: &str) -> bool {
+    fn expect_in(&mut self, set: TokenSet, kind: SyntaxKind, message: &'static str) -> bool {
         if self.eat_in(set, kind) {
             return true;
         }
@@ -383,7 +381,7 @@ fn type_items(p: &mut Parser) {
 fn imports_and_statements(p: &mut Parser) {
     let mut imports = p.start();
 
-    let recover_until_end = |p: &mut Parser, m: &str| {
+    let recover_until_end = |p: &mut Parser, m: &'static str| {
         let mut e = None;
         while !p.at(SyntaxKind::LAYOUT_SEPARATOR) && !p.at(SyntaxKind::LAYOUT_END) && !p.at_eof() {
             if e.is_none() {
@@ -616,18 +614,18 @@ fn role_or_synonym_signature_or_equation(p: &mut Parser) {
     }
 }
 
-fn is_class_signature(p: &mut Parser) {
-    p.expect(SyntaxKind::CLASS);
-    p.expect(SyntaxKind::UPPER);
-    p.expect(SyntaxKind::DOUBLE_COLON);
-}
-
 fn class_signature_or_declaration(p: &mut Parser) {
-    if p.lookahead(is_class_signature) {
+    if is_class_signature(p) {
         class_signature(p);
     } else {
         class_declaration(p);
     }
+}
+
+fn is_class_signature(p: &Parser) -> bool {
+    p.nth_at(0, SyntaxKind::CLASS)
+        && p.nth_at(1, SyntaxKind::UPPER)
+        && p.nth_at(2, SyntaxKind::DOUBLE_COLON)
 }
 
 fn class_signature(p: &mut Parser) {
@@ -740,7 +738,7 @@ fn class_functional_dependency(p: &mut Parser) {
 fn class_statements(p: &mut Parser) {
     let mut m = p.start();
     p.expect(SyntaxKind::LAYOUT_START);
-    let recover_until_end = |p: &mut Parser, m: &str| {
+    let recover_until_end = |p: &mut Parser, m: &'static str| {
         let mut e = None;
         while !p.at(SyntaxKind::LAYOUT_SEPARATOR) && !p.at(SyntaxKind::LAYOUT_END) && !p.at_eof() {
             if e.is_none() {
@@ -847,7 +845,7 @@ fn instance_head(p: &mut Parser) {
 fn instance_statements(p: &mut Parser) {
     let mut m = p.start();
     p.expect(SyntaxKind::LAYOUT_START);
-    let recover_until_end = |p: &mut Parser, m: &str| {
+    let recover_until_end = |p: &mut Parser, m: &'static str| {
         let mut e = None;
         while !p.at(SyntaxKind::LAYOUT_SEPARATOR) && !p.at(SyntaxKind::LAYOUT_END) && !p.at_eof() {
             if e.is_none() {

--- a/compiler-core/parsing/src/parser/binding.rs
+++ b/compiler-core/parsing/src/parser/binding.rs
@@ -8,7 +8,7 @@ const LET_BINDING_START: TokenSet = TokenSet::new(&[SyntaxKind::LOWER])
 
 pub(super) fn let_binding_statements(p: &mut Parser) {
     let mut m = p.start();
-    let recover_until_end = |p: &mut Parser, m: &str| {
+    let recover_until_end = |p: &mut Parser, m: &'static str| {
         let mut e = None;
         while !p.at(SyntaxKind::LAYOUT_SEPARATOR) && !p.at(SyntaxKind::LAYOUT_END) && !p.at_eof() {
             if e.is_none() {

--- a/compiler-core/parsing/src/parser/expressions.rs
+++ b/compiler-core/parsing/src/parser/expressions.rs
@@ -213,7 +213,7 @@ fn case_trunk(p: &mut Parser) {
 
 fn case_branches(p: &mut Parser) {
     let mut m = p.start();
-    let recover_until_end = |p: &mut Parser, m: &str| {
+    let recover_until_end = |p: &mut Parser, m: &'static str| {
         let mut e = None;
         while !p.at(SyntaxKind::LAYOUT_SEPARATOR) && !p.at(SyntaxKind::LAYOUT_END) && !p.at_eof() {
             if e.is_none() {
@@ -281,7 +281,7 @@ fn expression_do(p: &mut Parser, mut m: NodeMarker) {
 
 fn do_statements(p: &mut Parser) {
     let mut m = p.start();
-    let recover_until_end = |p: &mut Parser, m: &str| {
+    let recover_until_end = |p: &mut Parser, m: &'static str| {
         let mut e = None;
         while !p.at(SyntaxKind::LAYOUT_SEPARATOR) && !p.at(SyntaxKind::LAYOUT_END) && !p.at_eof() {
             if e.is_none() {
@@ -347,7 +347,7 @@ fn expression_ado(p: &mut Parser, mut m: NodeMarker) {
 fn expression_6(p: &mut Parser) {
     let mut m = p.start();
     expression_7(p);
-    if p.lookahead(is_record_update) {
+    if is_record_update(p) {
         record_updates(p);
         m.end(p, SyntaxKind::ExpressionRecordUpdate);
     } else {
@@ -355,12 +355,10 @@ fn expression_6(p: &mut Parser) {
     }
 }
 
-fn is_record_update(p: &mut Parser) {
-    p.expect(SyntaxKind::LEFT_CURLY);
-    names::label(p);
-    if !p.eat(SyntaxKind::EQUAL) && !p.eat(SyntaxKind::LEFT_CURLY) {
-        p.error("Expected EQUAL or LEFT_CURLY");
-    }
+fn is_record_update(p: &Parser) -> bool {
+    p.nth_at(0, SyntaxKind::LEFT_CURLY)
+        && p.nth_at_in(1, names::RECORD_LABEL)
+        && (p.nth_at(2, SyntaxKind::EQUAL) || p.nth_at(2, SyntaxKind::LEFT_CURLY))
 }
 
 fn record_updates(p: &mut Parser) {

--- a/compiler-core/parsing/src/parser/types.rs
+++ b/compiler-core/parsing/src/parser/types.rs
@@ -177,42 +177,27 @@ fn type_variable_binding(p: &mut Parser) {
     m.end(p, SyntaxKind::TypeVariableBinding);
 }
 
-fn at_type_row_empty(p: &mut Parser) {
-    p.expect(SyntaxKind::LEFT_PARENTHESIS);
-    p.expect(SyntaxKind::RIGHT_PARENTHESIS);
-}
-
-fn at_type_row_tail(p: &mut Parser) {
-    p.expect(SyntaxKind::LEFT_PARENTHESIS);
-    p.expect(SyntaxKind::PIPE);
-}
-
-fn at_type_row(p: &mut Parser) {
-    p.expect(SyntaxKind::LEFT_PARENTHESIS);
-    if !p.at_in(names::RECORD_LABEL) {
-        return p.error("Expecting RECORD_LABEL");
-    } else {
-        p.consume();
-    }
-    p.expect(SyntaxKind::DOUBLE_COLON);
-}
-
-fn at_type_variable_kinded(p: &mut Parser) {
-    p.expect(SyntaxKind::LEFT_PARENTHESIS);
-    p.expect(SyntaxKind::LEFT_PARENTHESIS);
-    p.expect_in(names::LOWER, SyntaxKind::LOWER, "Expected LOWER");
-    p.expect(SyntaxKind::RIGHT_PARENTHESIS);
-    p.expect(SyntaxKind::DOUBLE_COLON);
-}
-
 fn type_parenthesis(p: &mut Parser) {
-    if p.lookahead(at_type_row_empty) || p.lookahead(at_type_row_tail) || p.lookahead(at_type_row) {
+    if is_type_row(p) {
         type_row(p);
-    } else if p.lookahead(at_type_variable_kinded) {
+    } else if is_kinded_type_variable(p) {
         type_kinded_variable(p);
     } else {
         type_parenthesized(p);
     }
+}
+
+fn is_type_row(p: &Parser) -> bool {
+    p.nth_at(1, SyntaxKind::RIGHT_PARENTHESIS)
+        || p.nth_at(1, SyntaxKind::PIPE)
+        || (p.nth_at_in(1, names::RECORD_LABEL) && p.nth_at(2, SyntaxKind::DOUBLE_COLON))
+}
+
+fn is_kinded_type_variable(p: &Parser) -> bool {
+    p.nth_at(1, SyntaxKind::LEFT_PARENTHESIS)
+        && p.nth_at_in(2, names::LOWER)
+        && p.nth_at(3, SyntaxKind::RIGHT_PARENTHESIS)
+        && p.nth_at(4, SyntaxKind::DOUBLE_COLON)
 }
 
 fn type_kinded_variable(p: &mut Parser) {

--- a/tests-compatibility/benches/parsing.rs
+++ b/tests-compatibility/benches/parsing.rs
@@ -2,15 +2,70 @@ use std::fs;
 use std::hint::black_box;
 use std::sync::Arc;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use rayon::prelude::*;
 use tests_compatibility::all_source_files;
+use walkdir::WalkDir;
+
+fn source_files() -> (&'static str, Arc<[String]>) {
+    let mut paths = all_source_files();
+    let corpus = if paths.is_empty() {
+        let fixtures = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests-integration/fixtures");
+        paths.extend(WalkDir::new(fixtures).into_iter().filter_map(|entry| {
+            let path = entry.expect("failed to walk integration fixture corpus").into_path();
+            (path.extension().is_some_and(|extension| extension == "purs")).then_some(path)
+        }));
+        "integration-fixtures"
+    } else {
+        "compatibility-cache"
+    };
+
+    let files: Arc<[_]> = paths
+        .iter()
+        .map(|path| {
+            fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+        })
+        .collect();
+    assert!(!files.is_empty(), "benchmark corpus is empty");
+
+    (corpus, files)
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut g = c.benchmark_group("parsing");
+    let (corpus, files) = source_files();
+    let bytes = files.iter().map(String::len).sum::<usize>() as u64;
+    assert!(bytes > 0, "benchmark corpus contains no source text");
+    let lexed: Arc<[_]> = files.iter().map(|file| lexing::lex(file)).collect();
+    let tokens: Arc<[_]> = lexed.iter().map(lexing::layout).collect();
 
-    let files: Arc<[String]> =
-        all_source_files().iter().filter_map(|file| fs::read_to_string(file).ok()).collect();
+    let mut g = c.benchmark_group(format!("parsing/{corpus}"));
+    g.sample_size(10);
+    g.throughput(Throughput::Bytes(bytes));
+
+    g.bench_function("lex-single-core", |b| {
+        b.iter(|| {
+            files.iter().for_each(|file| {
+                black_box(lexing::lex(black_box(file)));
+            });
+        })
+    });
+
+    g.bench_function("layout-single-core", |b| {
+        b.iter(|| {
+            lexed.iter().for_each(|lexed| {
+                black_box(lexing::layout(black_box(lexed)));
+            });
+        })
+    });
+
+    g.bench_function("parse-prelexed-single-core", |b| {
+        b.iter(|| {
+            lexed.iter().zip(tokens.iter()).for_each(|(lexed, tokens)| {
+                black_box(parsing::parse(black_box(lexed), black_box(tokens)));
+            });
+        })
+    });
 
     let files = Arc::clone(&files);
     g.bench_function("parse-single-core", |b| {


### PR DESCRIPTION
## Intent

Reduce the cost of lexing, layout insertion, and parsing without changing lexical classification, CST shape, diagnostics, or malformed-input recovery. The changes focus on allocation and speculative parsing costs observed in the existing package-set benchmark, while adding phase-isolated measurements so future work can distinguish lexer, layout, and parser effects.

## Changes

- add an idempotent `.agents/setup` for stable Rust, nightly rustfmt, Just, and cargo-nextest, using cargo-binstall for binary tools
- extend the compatibility parsing benchmark with isolated lex, layout, pre-lexed parse, and end-to-end cases
  - label whether the compatibility cache or integration fixtures are being measured
  - reject empty or unreadable corpora instead of silently timing empty loops
  - report byte throughput and use a practical sample size for the full package set
- fast-path ASCII identifier classification while retaining the existing Unicode-category fallback
- preallocate lexer metadata, layout output, and parser events
- avoid constructing qualifier slices when layout only needs qualified/unqualified state
- make optional and alternative parser rules append transactionally to the existing event buffer, retaining the first failed alternative for recovery
- replace speculative grammar lookahead with named token predicates
- defer parser diagnostic allocation and expected-token formatting until CST construction

## Performance

Measured single-core over the prepared compatibility corpus of 633 packages, 7,348 PureScript files, and 26.3 MB of source:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Lex + layout + parse | 1.6772 s | 1.2496 s | ~25.5% faster |

The final end-to-end throughput is approximately 20.0 MiB/s. Isolated measurements also showed approximately 15.4% improvement to pre-lexed `parsing::parse` from direct token lookahead and approximately 4.9% improvement to layout from reduced metadata work.

## Verification

- `cargo check -p lexing --tests`
- `cargo check -p parsing --tests`
- `cargo check -p tests-compatibility --bench parsing`
- `cargo nextest run -p lexing -p parsing` (468 passed)
- package-set compatibility tests:
  - `test_parse_package_set`
  - `test_parallel_parse_package_set`
  - `test_cst_id_package_set`
  - `test_index_package_set`
- `just format --check`
