### PR TITLE
[indexing] Reduce name and stable lookup overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
 name = "indexing"
 version = "0.1.0"
 dependencies = [
+ "hashbrown 0.17.1",
  "insta",
  "itertools 0.14.0",
  "la-arena",

--- a/compiler-core/indexing/Cargo.toml
+++ b/compiler-core/indexing/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+hashbrown = "0.17.1"
 itertools = "0.14.0"
 la-arena = "0.3.1"
 paste = "1.0.15"

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -7,11 +7,12 @@ pub use error::*;
 pub use items::*;
 pub use source::*;
 
-use std::collections::hash_map::Entry;
-use std::ops;
+use std::hash::BuildHasher;
+use std::{fmt, ops};
 
+use hashbrown::HashTable;
 use la_arena::Arena;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use smol_str::SmolStr;
 use stabilizing::StabilizedModule;
 use syntax::{SyntaxNodePtr, cst};
@@ -97,15 +98,28 @@ pub struct IndexedNames {
     pub types: NameIndex<TypeItemId>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
 pub struct NameIndex<ItemId> {
-    first: FxHashMap<SmolStr, ItemId>,
+    first: HashTable<usize>,
     entries: Vec<(SmolStr, ItemId)>,
 }
 
+impl<ItemId: fmt::Debug> fmt::Debug for NameIndex<ItemId> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("NameIndex").field("entries", &self.entries).finish()
+    }
+}
+
+impl<ItemId: PartialEq> PartialEq for NameIndex<ItemId> {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+    }
+}
+
+impl<ItemId: Eq> Eq for NameIndex<ItemId> {}
+
 impl<ItemId> Default for NameIndex<ItemId> {
     fn default() -> Self {
-        NameIndex { first: FxHashMap::default(), entries: Vec::default() }
+        NameIndex { first: HashTable::default(), entries: Vec::default() }
     }
 }
 
@@ -114,7 +128,11 @@ where
     ItemId: Copy + Eq,
 {
     pub fn lookup(&self, name: &str) -> Option<ItemId> {
-        self.first.get(name).copied()
+        let hash = FxBuildHasher.hash_one(name);
+        self.first.find(hash, |&index| self.entries[index].0 == name).map(|&index| {
+            let (_, id) = &self.entries[index];
+            *id
+        })
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&SmolStr, ItemId)> {
@@ -122,19 +140,60 @@ where
     }
 
     pub(crate) fn insert(&mut self, name: SmolStr, id: ItemId) -> Option<ItemId> {
-        let existing = match self.first.entry(SmolStr::clone(&name)) {
-            Entry::Occupied(entry) => {
-                let id = entry.get();
-                Some(*id)
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(id);
-                None
-            }
-        };
+        let hash = FxBuildHasher.hash_one(name.as_str());
+        let existing =
+            self.first.find(hash, |&index| self.entries[index].0 == name).map(|&index| {
+                let (_, id) = &self.entries[index];
+                *id
+            });
 
         self.entries.push((name, id));
+
+        if existing.is_none() {
+            let index = self.entries.len() - 1;
+            self.first.insert_unique(hash, index, |&index| {
+                FxBuildHasher.hash_one(&self.entries[index].0)
+            });
+        }
+
         existing.filter(|existing| *existing != id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NameIndex;
+
+    #[test]
+    fn name_index_preserves_first_and_insertion_order() {
+        let mut index = NameIndex::default();
+
+        assert_eq!(index.insert("first".into(), 0), None);
+        assert_eq!(index.insert("second".into(), 1), None);
+        assert_eq!(index.insert("first".into(), 2), Some(0));
+        assert_eq!(index.insert("first".into(), 0), None);
+
+        assert_eq!(index.lookup("first"), Some(0));
+        assert_eq!(index.lookup("second"), Some(1));
+        assert_eq!(index.lookup("missing"), None);
+
+        let entries: Vec<_> = index.iter().map(|(name, id)| (name.as_str(), id)).collect();
+        assert_eq!(entries, [("first", 0), ("second", 1), ("first", 2), ("first", 0)]);
+    }
+
+    #[test]
+    fn name_index_preserves_lookups_when_growing() {
+        let mut index = NameIndex::default();
+
+        for id in 0..1024 {
+            let name = format!("name_{id}");
+            assert_eq!(index.insert(name.into(), id), None);
+        }
+
+        for id in 0..1024 {
+            let name = format!("name_{id}");
+            assert_eq!(index.lookup(&name), Some(id));
+        }
     }
 }
 

--- a/compiler-core/stabilizing/src/map.rs
+++ b/compiler-core/stabilizing/src/map.rs
@@ -38,11 +38,13 @@ impl StabilizedModule {
         self.table.insert_unique(hash, id, |&id| arena_hasher(&self.arena, id));
     }
 
+    #[inline]
     pub fn lookup_cst<N: AstNode<Language = PureScript>>(&self, cst: &N) -> Option<AstId<N>> {
         let ptr = AstPtr::new(cst);
         self.lookup_ptr(&ptr)
     }
 
+    #[inline]
     pub fn lookup_ptr<N: AstNode<Language = PureScript>>(
         &self,
         ptr: &AstPtr<N>,

--- a/tests-compatibility/Cargo.toml
+++ b/tests-compatibility/Cargo.toml
@@ -41,6 +41,10 @@ name = "parsing"
 harness = false
 
 [[bench]]
+name = "indexing"
+harness = false
+
+[[bench]]
 name = "checking_single_core"
 harness = false
 

--- a/tests-compatibility/benches/indexing.rs
+++ b/tests-compatibility/benches/indexing.rs
@@ -1,0 +1,76 @@
+use std::fs;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Duration;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use stabilizing::StabilizedModule;
+use syntax::cst;
+use tests_compatibility::all_source_files;
+use walkdir::WalkDir;
+
+struct PreparedModule {
+    cst: cst::Module,
+    stabilized: StabilizedModule,
+}
+
+fn prepared_modules() -> (&'static str, u64, Arc<[PreparedModule]>) {
+    let mut paths = all_source_files();
+    let corpus = if paths.is_empty() {
+        let fixtures = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests-integration/fixtures");
+        paths.extend(WalkDir::new(fixtures).into_iter().filter_map(|entry| {
+            let path = entry.expect("failed to walk integration fixture corpus").into_path();
+            (path.extension().is_some_and(|extension| extension == "purs")).then_some(path)
+        }));
+        "integration-fixtures"
+    } else {
+        "compatibility-cache"
+    };
+
+    assert!(!paths.is_empty(), "benchmark corpus is empty");
+
+    let mut bytes = 0;
+    let modules = paths
+        .iter()
+        .map(|path| {
+            let source = fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            bytes += source.len() as u64;
+
+            let lexed = lexing::lex(&source);
+            let tokens = lexing::layout(&lexed);
+            let (parsed, _) = parsing::parse(&lexed, &tokens);
+            let stabilized = stabilizing::stabilize_module(&parsed.syntax_node());
+            let cst = parsed.cst();
+
+            PreparedModule { cst, stabilized }
+        })
+        .collect();
+
+    assert!(bytes > 0, "benchmark corpus contains no source text");
+
+    (corpus, bytes, modules)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let (corpus, bytes, modules) = prepared_modules();
+
+    let mut group = c.benchmark_group(format!("indexing/{corpus}"));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+    group.throughput(Throughput::Bytes(bytes));
+
+    group.bench_function("index-prepared-single-core", |b| {
+        b.iter(|| {
+            modules.iter().for_each(|module| {
+                black_box(indexing::index_module(
+                    black_box(&module.cst),
+                    black_box(&module.stabilized),
+                ));
+            });
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## Intent

Reduce the indexing pass's table and stable-node lookup overhead without changing item IDs, duplicate handling, insertion order, exports, relationships, or diagnostics.

This PR is stacked on #173 so the benchmark can prepare CSTs with the optimized frontend while measuring `indexing::index_module` in isolation.

## Changes

- Add a corpus-labelled Criterion benchmark that prepares lexing, layout, parsing, and stabilization outside the timed loop, then indexes the same 633-package compatibility corpus on one core.
- Keep names in `NameIndex`'s ordered entries and store compact entry indices in its lookup table, rather than storing another `SmolStr` key and item ID in the table. First-wins lookup and complete insertion-order iteration remain unchanged and have focused growth/duplicate tests.
- Hint the optimizer to inline the profiled stable-CST lookup path used throughout indexing.

## Performance

Measured with the prepared compatibility corpus: 7,348 PureScript files, 26.3 MB of source, 10 Criterion samples, pinned to one CPU with `taskset -c 0`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Prepared single-core indexing | 168.66 ms | 166.50 ms | ~1.3% faster |
| Throughput | 148.48 MiB/s | 150.41 MiB/s | ~1.3% higher |

Criterion reported `p = 0.00`, but classified the result within its configured noise threshold. Unpinned runs varied materially, so this PR intentionally does not claim a larger improvement.

## Verification

- `cargo check -p indexing --tests`
- `cargo check -p stabilizing --tests`
- `cargo check -p tests-compatibility --bench indexing`
- `cargo nextest run -p indexing -p stabilizing`
- `just t resolving`
- `just t lowering`
- `just t checking`
- `just t lsp`
- `cargo nextest run -p tests-compatibility test_index_package_set`
- `just format --check`

All integration suites completed without pending snapshot changes. The package-set indexing test passed across the prepared 7,348-file corpus.
