### PR TITLE
[lowering/resolving] Reduce scope and class-member lookup overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2091,6 +2093,7 @@ version = "0.1.0"
 dependencies = [
  "building-types",
  "files",
+ "hashbrown 0.16.1",
  "indexing",
  "itertools 0.14.0",
  "lexing",

--- a/compiler-core/checking/src/interners.rs
+++ b/compiler-core/checking/src/interners.rs
@@ -11,34 +11,42 @@ pub struct CoreInterners {
 }
 
 impl CoreInterners {
+    #[inline]
     pub fn intern_type(&self, t: Type) -> TypeId {
         self.types.intern(t)
     }
 
+    #[inline]
     pub fn lookup_type(&self, id: TypeId) -> Type {
         self.types[id].clone()
     }
 
+    #[inline]
     pub fn intern_forall_binder(&self, b: ForallBinder) -> ForallBinderId {
         self.forall_binders.intern(b)
     }
 
+    #[inline]
     pub fn lookup_forall_binder(&self, id: ForallBinderId) -> ForallBinder {
         self.forall_binders[id]
     }
 
+    #[inline]
     pub fn intern_row_type(&self, r: RowType) -> RowTypeId {
         self.row_types.intern(r)
     }
 
+    #[inline]
     pub fn lookup_row_type(&self, id: RowTypeId) -> RowType {
         self.row_types[id].clone()
     }
 
+    #[inline]
     pub fn intern_smol_str(&self, s: SmolStr) -> crate::core::SmolStrId {
         self.smol_strs.intern(s)
     }
 
+    #[inline]
     pub fn lookup_smol_str(&self, id: crate::core::SmolStrId) -> SmolStr {
         self.smol_strs[id].clone()
     }

--- a/compiler-core/lowering/src/scope.rs
+++ b/compiler-core/lowering/src/scope.rs
@@ -11,7 +11,6 @@
 //! can be as easy as obtaining the type of a [`BinderId`].
 //!
 //! [scope graph]: https://pl.ewi.tudelft.nl/research/projects/scope-graphs/
-use std::collections::VecDeque;
 use std::ops;
 
 use files::FileId;
@@ -154,9 +153,7 @@ pub struct LoweringGraph {
 impl LoweringGraph {
     /// Initialise a traversal starting from a [`GraphNodeId`].
     pub fn traverse(&self, id: GraphNodeId) -> GraphIter<'_> {
-        let inner = &self.inner;
-        let queue = VecDeque::from([id]);
-        GraphIter { inner, queue }
+        GraphIter { inner: &self.inner, next: Some(id) }
     }
 }
 
@@ -197,24 +194,20 @@ impl LoweringGraphNodes {
 /// An iterator that traverses the [`LoweringGraph`].
 pub struct GraphIter<'a> {
     inner: &'a Arena<GraphNode>,
-    queue: VecDeque<GraphNodeId>,
+    next: Option<GraphNodeId>,
 }
 
 impl<'a> Iterator for GraphIter<'a> {
     type Item = (Idx<GraphNode>, &'a GraphNode);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let id = self.queue.pop_back()?;
+        let id = self.next?;
         let item = &self.inner[id];
-        match &item {
+        self.next = match item {
             GraphNode::Binder { parent, .. }
             | GraphNode::Forall { parent, .. }
             | GraphNode::Let { parent, .. }
-            | GraphNode::Implicit { parent, .. } => {
-                parent.map(|id| {
-                    self.queue.push_front(id);
-                });
-            }
+            | GraphNode::Implicit { parent, .. } => *parent,
         };
         Some((id, item))
     }

--- a/compiler-core/resolving/Cargo.toml
+++ b/compiler-core/resolving/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 building-types = { version = "0.1.0", path = "../building-types" }
 files = { version = "0.1.0", path = "../files" }
+hashbrown = "0.16.1"
 indexing = { version = "0.1.0", path = "../indexing" }
 rustc-hash = "2.1.2"
 smol_str = "0.3.4"

--- a/compiler-core/resolving/src/lib.rs
+++ b/compiler-core/resolving/src/lib.rs
@@ -5,9 +5,12 @@ pub use error::*;
 
 use building_types::{QueryProxy, QueryResult};
 use files::FileId;
+use hashbrown::HashTable;
 use indexing::{ImportId, ImportKind, IndexedModule, TermItemId, TypeItemId};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use smol_str::SmolStr;
+use std::fmt;
+use std::hash::BuildHasher;
 use std::sync::Arc;
 
 pub trait ExternalQueries:
@@ -15,10 +18,33 @@ pub trait ExternalQueries:
 {
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ResolvedClassMembers {
-    members: FxHashMap<(TypeItemId, SmolStr), (FileId, TermItemId)>,
+    index: HashTable<usize>,
+    members: Vec<(TypeItemId, SmolStr, FileId, TermItemId)>,
 }
+
+impl fmt::Debug for ResolvedClassMembers {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("ResolvedClassMembers").field("members", &self.members).finish()
+    }
+}
+
+impl Default for ResolvedClassMembers {
+    fn default() -> Self {
+        ResolvedClassMembers { index: HashTable::default(), members: Vec::default() }
+    }
+}
+
+impl PartialEq for ResolvedClassMembers {
+    fn eq(&self, other: &Self) -> bool {
+        self.members.len() == other.members.len()
+            && self.members.iter().all(|(class_id, name, file, term_id)| {
+                other.lookup(*class_id, name) == Some((*file, *term_id))
+            })
+    }
+}
+
+impl Eq for ResolvedClassMembers {}
 
 impl ResolvedClassMembers {
     pub fn insert(
@@ -28,26 +54,44 @@ impl ResolvedClassMembers {
         file: FileId,
         term_id: TermItemId,
     ) {
-        self.members.insert((class_id, name), (file, term_id));
+        let hash = FxBuildHasher.hash_one((class_id, name.as_str()));
+        if let Some(&index) = self.index.find(hash, |&index| {
+            let (existing_class_id, existing_name, _, _) = &self.members[index];
+            *existing_class_id == class_id && existing_name == &name
+        }) {
+            self.members[index] = (class_id, name, file, term_id);
+            return;
+        }
+
+        let index = self.members.len();
+        self.members.push((class_id, name, file, term_id));
+        self.index.insert_unique(hash, index, |&index| {
+            let (class_id, name, _, _) = &self.members[index];
+            FxBuildHasher.hash_one((class_id, name.as_str()))
+        });
     }
 
     pub fn lookup(&self, class_id: TypeItemId, name: &str) -> Option<(FileId, TermItemId)> {
-        let key = &(class_id, SmolStr::new(name));
-        self.members.get(key).copied()
+        let hash = FxBuildHasher.hash_one((class_id, name));
+        let &index = self.index.find(hash, |&index| {
+            let (existing_class_id, existing_name, _, _) = &self.members[index];
+            *existing_class_id == class_id && existing_name == name
+        })?;
+        let (_, _, file, term_id) = self.members[index];
+        Some((file, term_id))
     }
 
     pub fn class_members(
         &self,
         class_id: TypeItemId,
     ) -> impl Iterator<Item = (&SmolStr, FileId, TermItemId)> + '_ {
-        self.members
-            .iter()
-            .filter(move |((type_id, _), _)| *type_id == class_id)
-            .map(|((_, name), (file, id))| (name, *file, *id))
+        self.members.iter().filter_map(move |(type_id, name, file, id)| {
+            (*type_id == class_id).then_some((name, *file, *id))
+        })
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (TypeItemId, &SmolStr, FileId, TermItemId)> + '_ {
-        self.members.iter().map(|((class_id, name), (file, id))| (*class_id, name, *file, *id))
+        self.members.iter().map(|(class_id, name, file, id)| (*class_id, name, *file, *id))
     }
 }
 

--- a/tests-compatibility/Cargo.toml
+++ b/tests-compatibility/Cargo.toml
@@ -45,6 +45,10 @@ name = "indexing"
 harness = false
 
 [[bench]]
+name = "lowering_resolving"
+harness = false
+
+[[bench]]
 name = "checking_single_core"
 harness = false
 

--- a/tests-compatibility/benches/lowering_resolving.rs
+++ b/tests-compatibility/benches/lowering_resolving.rs
@@ -1,0 +1,105 @@
+use std::fs;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Duration;
+
+use building::QueryEngine;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use files::FileId;
+use indexing::IndexedModule;
+use resolving::ResolvedModule;
+use stabilizing::StabilizedModule;
+use syntax::cst;
+use tests_compatibility::{all_source_files, build_warmed_engine};
+
+struct PreparedLoweringModule {
+    file_id: FileId,
+    cst: cst::Module,
+    stabilized: Arc<StabilizedModule>,
+    indexed: Arc<IndexedModule>,
+    resolved: Arc<ResolvedModule>,
+}
+
+struct PreparedCorpus {
+    bytes: u64,
+    engine: QueryEngine,
+    modules: Arc<[PreparedLoweringModule]>,
+    prim: Arc<ResolvedModule>,
+}
+
+fn prepared_corpus() -> PreparedCorpus {
+    let paths = all_source_files();
+    assert!(
+        !paths.is_empty(),
+        "lowering and resolving benchmarks require the prepared compatibility corpus"
+    );
+
+    let mut bytes = 0;
+    let sources: Arc<[(String, String)]> = paths
+        .iter()
+        .map(|path| {
+            let source = fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            bytes += source.len() as u64;
+            (path.to_string_lossy().into_owned(), source)
+        })
+        .collect();
+    assert!(bytes > 0, "benchmark corpus contains no source text");
+
+    let warmed = build_warmed_engine(&sources);
+    let prim = warmed.engine.resolved(warmed.engine.prim_id()).expect("failed to resolve Prim");
+    let modules = warmed
+        .candidates
+        .iter()
+        .map(|&file_id| {
+            let (parsed, _) = warmed.engine.parsed(file_id).expect("failed to parse corpus module");
+            let stabilized =
+                warmed.engine.stabilized(file_id).expect("failed to stabilize corpus module");
+            let indexed = warmed.engine.indexed(file_id).expect("failed to index corpus module");
+            let resolved =
+                warmed.engine.resolved(file_id).expect("failed to resolve corpus module");
+            let cst = parsed.cst();
+            PreparedLoweringModule { file_id, cst, stabilized, indexed, resolved }
+        })
+        .collect();
+
+    PreparedCorpus { bytes, engine: warmed.engine, modules, prim }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let corpus = prepared_corpus();
+
+    let mut group = c.benchmark_group("lowering-resolving/compatibility-cache");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+    group.throughput(Throughput::Bytes(corpus.bytes));
+
+    group.bench_function("resolve-prepared-single-core", |b| {
+        b.iter(|| {
+            corpus.modules.iter().for_each(|module| {
+                black_box(
+                    resolving::resolve_module(black_box(&corpus.engine), black_box(module.file_id))
+                        .expect("failed to resolve corpus module"),
+                );
+            });
+        })
+    });
+
+    group.bench_function("lower-prepared-single-core", |b| {
+        b.iter(|| {
+            corpus.modules.iter().for_each(|module| {
+                black_box(lowering::lower_module(
+                    black_box(module.file_id),
+                    black_box(&module.cst),
+                    black_box(&corpus.prim),
+                    black_box(&module.stabilized),
+                    black_box(&module.indexed),
+                    black_box(&module.resolved),
+                ));
+            });
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## Intent

Reduce allocation and lookup overhead in lowering and resolving without changing lowered or resolved semantics. This is stacked on #174 so the benchmark prepares against the optimized indexing representation.

## Changes

- add a phase-isolated, single-core compatibility-corpus benchmark for `resolving::resolve_module` and `lowering::lower_module`
  - prepare parsing, stabilization, indexing, dependency resolution, and Prim outside the timed loop
  - call the resolver directly against a warmed `QueryEngine`, measuring resolver construction plus realistic cached `ExternalQueries` access rather than the top-level query cache
  - require the prepared compatibility corpus and fail on unreadable or empty input
- traverse lowering's single-parent scope graph with one `Option<GraphNodeId>` instead of allocating a `VecDeque` for each local lookup
- store resolved class-member payloads in insertion-order entries with compact `usize` hash-table values
  - preserve replacement behavior for duplicate `(class, name)` keys
  - preserve map-style, insertion-order-independent equality
  - avoid constructing a temporary `SmolStr` for borrowed class-member lookup

## Performance

Measured over the prepared compatibility corpus of 633 packages, 7,348 PureScript files, and 26.3 MB of source, with 10 Criterion samples pinned to one CPU using `taskset -c 0`.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Prepared lowering | 1.0604 s | 1.0312 s | ~2.8% faster |
| Lowering throughput | 23.62 MiB/s | 24.29 MiB/s | ~2.8% higher |
| Prepared resolving | 146.42 ms | 145.62 ms | ~0.5% faster trend |
| Resolving throughput | 171.04 MiB/s | 171.97 MiB/s | ~0.5% higher trend |

Criterion measured the lowering change at `[-3.37%, -2.06%]`, `p < 0.05`. Resolving is small relative to run-to-run noise: one pinned run measured `[-3.31%, -1.25%]`, `p < 0.05`, while two repeats centered around 0.4% faster and were not statistically significant. The resolving result is therefore presented as a trend, not a definitive throughput claim.

Two resolver alternatives were measured and dropped: nested per-class maps regressed by 3.03–5.11%, and replacing partition buffers with repeated filtered traversal regressed by 1.78–3.75%.

## Verification

- `cargo check -p lowering --tests`
- `cargo check -p resolving --tests`
- `cargo check -p tests-compatibility --bench lowering_resolving`
- `just t lowering`
- `just t resolving`
- `just t checking`
- `just t lsp`
- `just format --check`

All integration suites completed without pending snapshot changes.
