### PR TITLE
[checking] Inline interner operations

### DIFF
--- a/compiler-core/checking/src/interners.rs
+++ b/compiler-core/checking/src/interners.rs
@@ -11,34 +11,42 @@ pub struct CoreInterners {
 }
 
 impl CoreInterners {
+    #[inline]
     pub fn intern_type(&self, t: Type) -> TypeId {
         self.types.intern(t)
     }
 
+    #[inline]
     pub fn lookup_type(&self, id: TypeId) -> Type {
         self.types[id].clone()
     }
 
+    #[inline]
     pub fn intern_forall_binder(&self, b: ForallBinder) -> ForallBinderId {
         self.forall_binders.intern(b)
     }
 
+    #[inline]
     pub fn lookup_forall_binder(&self, id: ForallBinderId) -> ForallBinder {
         self.forall_binders[id]
     }
 
+    #[inline]
     pub fn intern_row_type(&self, r: RowType) -> RowTypeId {
         self.row_types.intern(r)
     }
 
+    #[inline]
     pub fn lookup_row_type(&self, id: RowTypeId) -> RowType {
         self.row_types[id].clone()
     }
 
+    #[inline]
     pub fn intern_smol_str(&self, s: SmolStr) -> crate::core::SmolStrId {
         self.smol_strs.intern(s)
     }
 
+    #[inline]
     pub fn lookup_smol_str(&self, id: crate::core::SmolStrId) -> SmolStr {
         self.smol_strs[id].clone()
     }


### PR DESCRIPTION
## Summary

Inline the checking interner's small public operations so calls from the building crate can be optimized across the crate boundary.

This is stacked on #175.

## Motivation

A `perf` profile of the prepared single-core checking benchmark attributed 9.25% of sampled CPU time to `CoreInterners::lookup_type`. These methods are small wrappers around the parallel interners, but without an inline hint the common lookup and clone path remained behind a cross-crate call boundary.

The change adds `#[inline]` to the type, forall-binder, row-type, and string intern/lookup operations. It does not change interner storage, identity, synchronization, or checking semantics.

I also evaluated targeted constraint wakeups and allocation-reusing instance matching. Their combined Acme result was statistically unchanged (`+0.33%`, `p = 0.33`), so those changes were discarded rather than included speculatively.

## Performance

The benchmark uses the full prepared compatibility corpus (633 packages, 7,348 PureScript files) and a `QueryEngine` with parsing, stabilizing, indexing, resolving, lowering, grouping, bracketing, and sectioning pre-warmed. The checked cache remains cold. Runs were pinned to CPU 0 and compared with Criterion against the #175 baseline.

| Corpus | #175 baseline | This branch | Change |
| --- | ---: | ---: | ---: |
| Core | 479.68 ms | 452.17 ms | **-6.12%** |
| Acme | 13.778 s | 13.110 s | **-4.85%** |

Criterion confidence intervals:

- Core: `-7.87% .. -4.28%`, `p = 0.00`
- Acme: `-5.93% .. -3.47%`, `p = 0.00`

## Verification

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (20 passed)
- `just t checking` (all fixtures passed, no pending snapshots)
- `just format`
- `git diff --check`
