### PR TITLE
[agents] Install Rust formatting and linting components

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -7,7 +7,7 @@ fi
 
 export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
 
-rustup toolchain install stable --profile minimal
+rustup toolchain install stable --profile minimal --component clippy,rustfmt
 rustup toolchain install nightly --profile minimal --component rustfmt
 rustup default stable
 


### PR DESCRIPTION
## Summary

- install Clippy and rustfmt with the stable Rust toolchain
- install nightly Rust with rustfmt for the repository's import-formatting recipe
- keep stable Rust as the default toolchain

## Verification

- `just fix`
- `just format`