### PR TITLE
[meta] Add verified release installers

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -1,0 +1,58 @@
+name: Installer Tests
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release tag to install
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to install, or latest
+        default: latest
+        required: true
+        type: string
+
+permissions:
+  attestations: read
+  contents: read
+
+jobs:
+  install:
+    name: Install on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Require GitHub attestation verification
+        shell: bash
+        run: gh attestation verify --help >/dev/null
+
+      - name: Install on Linux or macOS
+        if: runner.os != 'Windows'
+        env:
+          ALEXANDRITE_INSTALL_DIR: ${{ runner.temp }}/alexandrite/bin
+          ALEXANDRITE_VERSION: ${{ inputs.version }}
+        run: |
+          sh ./install.sh
+          "$ALEXANDRITE_INSTALL_DIR/purescript-alexandrite" --version
+
+      - name: Install on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          ALEXANDRITE_INSTALL_DIR: ${{ runner.temp }}\alexandrite\bin
+          ALEXANDRITE_VERSION: ${{ inputs.version }}
+        run: |
+          & ./install.ps1
+          & "$env:ALEXANDRITE_INSTALL_DIR\purescript-alexandrite.exe" --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Cargo Build & Release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags:
@@ -12,6 +9,8 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
       - uses: taiki-e/create-gh-release-action@v1
@@ -22,6 +21,10 @@ jobs:
     needs: create-release
     name: Build & Release
     runs-on: ${{ matrix.os }}
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     strategy:
       matrix:
         include:
@@ -48,6 +51,7 @@ jobs:
           target: ${{ matrix.target }}
       
       - name: Build and Release
+        id: release
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: purescript-analyzer,purescript-alexandrite
@@ -58,3 +62,17 @@ jobs:
           locked: true
           target: ${{ matrix.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest release archive
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.release.outputs.tar || steps.release.outputs.zip }}
+
+  test-installers:
+    needs: build-and-release
+    permissions:
+      attestations: read
+      contents: read
+    uses: ./.github/workflows/installers.yml
+    with:
+      version: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -16,3 +16,23 @@ to enable minimal recomputation across trivial formatting changes.
 
 The language server component implements core code intelligence features such as completion, jump to
 definition, hover information, find references, workspace symbol search, and diagnostics.
+
+## Installation
+
+On Linux and macOS:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://raw.githubusercontent.com/purefunctor/purescript-alexandrite/main/install.sh | sh
+```
+
+On Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/purefunctor/purescript-alexandrite/main/install.ps1 | iex
+```
+
+The installers verify the release's GitHub build-provenance attestation when
+[GitHub CLI](https://cli.github.com/) is available. They display a warning and continue when it is not
+installed. Set `ALEXANDRITE_VERSION` to a release tag or `ALEXANDRITE_INSTALL_DIR` to an installation
+directory to override the defaults.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,72 @@
+$ErrorActionPreference = "Stop"
+
+$Repository = "purefunctor/purescript-alexandrite"
+$Binary = "purescript-alexandrite.exe"
+$InstallDirectory = if ($env:ALEXANDRITE_INSTALL_DIR) {
+    $env:ALEXANDRITE_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA "Alexandrite\bin"
+}
+$Version = if ($env:ALEXANDRITE_VERSION) { $env:ALEXANDRITE_VERSION } else { "latest" }
+
+if (-not [Environment]::Is64BitOperatingSystem) {
+    throw "Alexandrite supports only 64-bit Windows"
+}
+
+if ($Version -eq "latest") {
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases/latest"
+    $Version = $Release.tag_name
+}
+
+if ($Version -notmatch '^v[0-9]') {
+    throw "Invalid release version: $Version"
+}
+
+$Target = "x86_64-pc-windows-msvc"
+$ArchiveName = "purescript-alexandrite-$Target.zip"
+$ArchiveUrl = "https://github.com/$Repository/releases/download/$Version/$ArchiveName"
+$TemporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("alexandrite-install-" + [guid]::NewGuid())
+$Archive = Join-Path $TemporaryDirectory $ArchiveName
+
+New-Item -ItemType Directory -Path $TemporaryDirectory | Out-Null
+try {
+    Write-Host "Downloading purescript-alexandrite $Version for $Target"
+    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $Archive
+
+    $GitHubAttestationsAvailable = if (Get-Command gh -ErrorAction SilentlyContinue) {
+        & gh attestation verify --help 2>$null | Out-Null
+        $LASTEXITCODE -eq 0
+    } else {
+        $false
+    }
+
+    if ($GitHubAttestationsAvailable) {
+        Write-Host "Verifying GitHub release attestation"
+        & gh attestation verify $Archive --repo $Repository | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "GitHub release attestation verification failed"
+        }
+    } else {
+        Write-Warning "A GitHub CLI with attestation support is not installed; release provenance was not verified."
+        Write-Warning "Install or update gh from https://cli.github.com/ to verify future installations."
+    }
+
+    Expand-Archive -LiteralPath $Archive -DestinationPath $TemporaryDirectory
+    $ExtractedBinary = Join-Path $TemporaryDirectory "purescript-alexandrite-$Target\$Binary"
+    if (-not (Test-Path -LiteralPath $ExtractedBinary -PathType Leaf)) {
+        throw "Release archive does not contain $Binary"
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallDirectory | Out-Null
+    $Destination = Join-Path $InstallDirectory $Binary
+    $InstallationFile = Join-Path $InstallDirectory (".alexandrite-install-" + [guid]::NewGuid() + ".exe")
+    Copy-Item -LiteralPath $ExtractedBinary -Destination $InstallationFile
+    Move-Item -Force -LiteralPath $InstallationFile -Destination $Destination
+
+    Write-Host "Installed $Version to $Destination"
+    if ($env:PATH.Split([IO.Path]::PathSeparator) -notcontains $InstallDirectory) {
+        Write-Host "Add $InstallDirectory to PATH to run purescript-alexandrite."
+    }
+} finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $TemporaryDirectory
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+set -eu
+
+repository="purefunctor/purescript-alexandrite"
+binary="purescript-alexandrite"
+install_directory="${ALEXANDRITE_INSTALL_DIR:-$HOME/.local/bin}"
+version="${ALEXANDRITE_VERSION:-latest}"
+
+fail() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+command -v curl >/dev/null 2>&1 || fail "curl is required to install $binary"
+command -v tar >/dev/null 2>&1 || fail "tar is required to install $binary"
+
+case "$(uname -s):$(uname -m)" in
+    Linux:x86_64 | Linux:amd64)
+        target="x86_64-unknown-linux-musl"
+        ;;
+    Darwin:x86_64 | Darwin:arm64)
+        target="universal-apple-darwin"
+        ;;
+    *)
+        fail "unsupported platform: $(uname -s) $(uname -m)"
+        ;;
+esac
+
+if [ "$version" = "latest" ]; then
+    release_url=$(curl --proto '=https' --tlsv1.2 -LsSf -o /dev/null \
+        -w '%{url_effective}' "https://github.com/$repository/releases/latest")
+    version=${release_url##*/}
+fi
+
+case "$version" in
+    v[0-9]*) ;;
+    *) fail "invalid release version: $version" ;;
+esac
+
+archive_name="$binary-$target.tar.gz"
+archive_url="https://github.com/$repository/releases/download/$version/$archive_name"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/alexandrite-install.XXXXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
+archive="$temporary_directory/$archive_name"
+
+printf 'Downloading %s %s for %s\n' "$binary" "$version" "$target"
+curl --proto '=https' --tlsv1.2 -LsSf --retry 3 --output "$archive" "$archive_url"
+
+if command -v gh >/dev/null 2>&1 && gh attestation verify --help >/dev/null 2>&1; then
+    printf 'Verifying GitHub release attestation\n'
+    gh attestation verify "$archive" --repo "$repository" >/dev/null || \
+        fail "GitHub release attestation verification failed"
+else
+    printf '%s\n' \
+        'warning: A GitHub CLI with attestation support is not installed; release provenance was not verified.' \
+        'warning: Install or update gh from https://cli.github.com/ to verify future installations.' >&2
+fi
+
+archive_directory="$binary-$target"
+archive_binary="$archive_directory/$binary"
+entry_count=$(tar -tzf "$archive" | grep -c "^$archive_binary$" || true)
+[ "$entry_count" -eq 1 ] || fail "release archive does not contain exactly one $binary executable"
+
+tar -xzf "$archive" -C "$temporary_directory" "$archive_binary"
+extracted_binary="$temporary_directory/$archive_binary"
+[ -f "$extracted_binary" ] && [ ! -L "$extracted_binary" ] || \
+    fail "release archive contains an invalid $binary executable"
+
+mkdir -p "$install_directory"
+destination="$install_directory/$binary"
+[ ! -L "$destination" ] || fail "refusing to replace symbolic link: $destination"
+installation_file=$(mktemp "$install_directory/.alexandrite-install.XXXXXXXX")
+trap 'rm -rf "$temporary_directory"; rm -f "$installation_file"' EXIT HUP INT TERM
+cp "$extracted_binary" "$installation_file"
+chmod 755 "$installation_file"
+mv -f "$installation_file" "$destination"
+
+printf 'Installed %s to %s\n' "$version" "$destination"
+case ":$PATH:" in
+    *":$install_directory:"*) ;;
+    *) printf 'Add %s to PATH to run %s.\n' "$install_directory" "$binary" ;;
+esac


### PR DESCRIPTION
## Summary

- add shell and PowerShell installers for the existing Linux, macOS, and Windows release archives
- verify GitHub build-provenance attestations when a compatible GitHub CLI is available, while warning when verification is unavailable
- attest release archives and exercise installation on all three platforms after each release

## Motivation

The language server needs a consistent installation path for users and for editor integrations such as alexandrite-vscode. The installers resolve an exact release, select a platform-specific archive, validate its expected contents, and install the binary atomically. Linux uses the static musl build to avoid coupling installation to the runner's glibc version.

## Verification

- installed release v0.0.12 end to end with the Linux musl archive
- confirmed the installed binary reports purescript-alexandrite 0.0.12
- checked install.sh with sh -n
- checked the diff with git diff --check
- added release-time installer tests for Ubuntu, macOS, and Windows

Existing releases predate artifact attestations. Attestation-backed installation starts with the first release produced by the updated workflow.