### PR TITLE
[building] Optimize query engine state tracking

### DIFF
--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -63,7 +63,7 @@ enum DerivedState<T> {
     NotComputed,
     InProgress {
         id: SnapshotId,
-        promises: Mutex<Vec<Promise<T>>>,
+        waiters: Mutex<Vec<Waiter<T>>>,
     },
     Computed {
         computed: T,
@@ -74,8 +74,14 @@ enum DerivedState<T> {
 
 impl<T> DerivedState<T> {
     fn in_progress(id: SnapshotId) -> DerivedState<T> {
-        DerivedState::InProgress { id, promises: Mutex::default() }
+        DerivedState::InProgress { id, waiters: Mutex::default() }
     }
+}
+
+#[derive(Debug)]
+struct Waiter<T> {
+    id: SnapshotId,
+    promise: Promise<T>,
 }
 
 #[derive(Debug)]
@@ -353,11 +359,11 @@ impl QueryEngine {
                     let shard = shards(&self.derived).shard(&key);
                     let mut guard = shard.write();
                     if let Entry::Occupied(o) = guard.entry(key) {
-                        if let DerivedState::InProgress { id, promises } = o.remove() {
-                            let mut graph = self.control.global.graph.lock();
-                            drop(promises);
+                        if let DerivedState::InProgress { id, waiters } = o.remove() {
+                            let waiters = waiters.into_inner();
+                            self.remove_waiter_edges(id, &waiters);
                             drop(guard);
-                            graph.remove_edge(id);
+                            drop(waiters);
                         } else {
                             unreachable!("invariant violated: expected InProgress");
                         }
@@ -384,14 +390,13 @@ impl QueryEngine {
         let shard = shards(&self.derived).shard(&key);
         let mut guard = shard.write();
         if let Entry::Occupied(o) = guard.entry(key) {
-            if let DerivedState::InProgress { id, promises } = o.remove() {
-                let mut graph = self.control.global.graph.lock();
-                let promises = promises.into_inner();
-                promises.into_iter().for_each(|promise| {
+            if let DerivedState::InProgress { id, waiters } = o.remove() {
+                let waiters = waiters.into_inner();
+                self.remove_waiter_edges(id, &waiters);
+                waiters.into_iter().for_each(|waiter| {
                     let computed = V::clone(&computed);
-                    promise.fulfill(computed);
+                    waiter.promise.fulfill(computed);
                 });
-                graph.remove_edge(id);
             } else {
                 unreachable!("invariant violated: expected InProgress");
             }
@@ -399,6 +404,17 @@ impl QueryEngine {
 
         let state = DerivedState::Computed { computed, trace, dependencies };
         guard.insert(key, state);
+    }
+
+    fn remove_waiter_edges<T>(&self, to_id: SnapshotId, waiters: &[Waiter<T>]) {
+        if waiters.is_empty() {
+            return;
+        }
+
+        let mut graph = self.control.global.graph.lock();
+        for waiter in waiters {
+            graph.remove_edge(waiter.id, to_id);
+        }
     }
 
     fn compute_core<K, V, ShardsFn, ComputeFn>(
@@ -490,7 +506,7 @@ impl QueryEngine {
     fn create_future<T>(
         &self,
         to_id: SnapshotId,
-        promises: &Mutex<Vec<Promise<T>>>,
+        waiters: &Mutex<Vec<Waiter<T>>>,
         local: &RefCell<LocalStateInner>,
     ) -> QueryResult<Future<T>> {
         {
@@ -502,7 +518,8 @@ impl QueryEngine {
         }
 
         let (future, promise) = Future::new();
-        promises.lock().push(promise);
+        let waiter = Waiter { id: self.control.id, promise };
+        waiters.lock().push(waiter);
         Ok(future)
     }
 
@@ -534,15 +551,15 @@ impl QueryEngine {
         // cached value was built during the current revision.
         //
         // For in-progress queries, we can simply push to the internally mutable
-        // vector of promises and then wait on the future.
+        // vector of waiters and then wait on the future.
         {
             let guard = shard.read();
             match guard.get(&key).unwrap_or(&DerivedState::NotComputed) {
                 DerivedState::Computed { computed, trace, .. } if trace.built == revision => {
                     return Ok(V::clone(computed));
                 }
-                DerivedState::InProgress { id, promises } => {
-                    let future = self.create_future(*id, promises, local)?;
+                DerivedState::InProgress { id, waiters } => {
+                    let future = self.create_future(*id, waiters, local)?;
 
                     // Remember that Future::wait blocks the current thread!
                     drop(guard);
@@ -572,8 +589,8 @@ impl QueryEngine {
 
                     self.compute_core(key, shards, compute, revision, None, local)
                 }
-                DerivedState::InProgress { id, promises } => {
-                    let future = self.create_future(*id, promises, local)?;
+                DerivedState::InProgress { id, waiters } => {
+                    let future = self.create_future(*id, waiters, local)?;
 
                     // Remember that Future::wait blocks the current thread!
                     drop(guard);
@@ -978,7 +995,7 @@ mod tests {
 
     use crate::prim;
 
-    use super::{DerivedState, QueryEngine, QueryKey};
+    use super::{DerivedState, QueryEngine, QueryKey, SnapshotId};
 
     #[derive(Debug)]
     struct Trace<'a> {
@@ -1266,6 +1283,33 @@ mod tests {
             ShowTrace(guard.get(&parent).unwrap()),
             Trace { built: 19, changed: 19, dependencies: &[QueryKey::Parsed(child)] }
         );
+    }
+
+    #[test]
+    fn test_query_completion_preserves_unrelated_waiter_edges() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let parent = files.insert("./src/Parent.purs", "module Parent where");
+        let child = files.insert("./src/Child.purs", "module Child where");
+        engine.set_content(child, files.content(child));
+        let computed = engine.parsed(child).unwrap();
+
+        let computing = SnapshotId(1);
+        let waiting = SnapshotId(2);
+        let shard = engine.derived.parsed.shard(&parent);
+        shard.write().insert(parent, DerivedState::in_progress(computing));
+
+        assert!(engine.control.global.graph.lock().add_edge(waiting, computing));
+        engine.fulfill_and_store(
+            parent,
+            &|derived| &derived.parsed,
+            computed,
+            super::Trace { built: 19, changed: 19 },
+            Arc::from([]),
+        );
+        assert!(!engine.control.global.graph.lock().add_edge(computing, waiting));
     }
 
     #[test]

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -206,6 +206,12 @@ impl LocalState {
         dependencies.collect()
     }
 
+    fn clear_dependencies(local: &RefCell<LocalStateInner>) {
+        let mut inner = local.borrow_mut();
+        let frame = inner.frames.last_mut().expect("invariant violated: expected query frame");
+        frame.dependencies.clear();
+    }
+
     fn stack(local: &RefCell<LocalStateInner>) -> Arc<[QueryKey]> {
         let inner = local.borrow();
         let stack = inner.frames.iter().map(|frame| frame.query);
@@ -634,6 +640,7 @@ impl QueryEngine {
                         return Ok(computed);
                     }
 
+                    LocalState::clear_dependencies(local);
                     self.compute_core(
                         key,
                         shards,
@@ -1283,6 +1290,58 @@ mod tests {
             ShowTrace(guard.get(&parent).unwrap()),
             Trace { built: 19, changed: 19, dependencies: &[QueryKey::Parsed(child)] }
         );
+    }
+
+    #[test]
+    fn test_recomputation_replaces_dependencies() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let parent = files.insert("./src/Parent.purs", "module Parent where");
+        let child_a = files.insert("./src/ChildA.purs", "module ChildA where\n\nvalue = 1");
+        let child_b = files.insert("./src/ChildB.purs", "module ChildB where\n\nvalue = 2");
+        engine.set_content(child_a, files.content(child_a));
+        engine.set_content(child_b, files.content(child_b));
+
+        engine
+            .query(
+                QueryKey::Parsed(parent),
+                parent,
+                |derived| &derived.parsed,
+                |engine| engine.parsed(child_a),
+            )
+            .unwrap();
+
+        engine.set_content(child_a, "module ChildA where\n\nvalue = 3\nother = 4");
+        let parsed_b = engine
+            .query(
+                QueryKey::Parsed(parent),
+                parent,
+                |derived| &derived.parsed,
+                |engine| engine.parsed(child_b),
+            )
+            .unwrap();
+
+        {
+            let shard = engine.derived.parsed.shard(&parent);
+            let guard = shard.read();
+            let Some(DerivedState::Computed { dependencies, .. }) = guard.get(&parent) else {
+                panic!("invariant violated: expected computed parent query");
+            };
+            assert_eq!(dependencies.as_ref(), &[QueryKey::Parsed(child_b)]);
+        }
+
+        engine.set_content(child_a, "module ChildA where\n\nvalue = 4\nother = 5\nthird = 6");
+        let cached = engine
+            .query(
+                QueryKey::Parsed(parent),
+                parent,
+                |derived| &derived.parsed,
+                |_| unreachable!("removed dependency should not cause recomputation"),
+            )
+            .unwrap();
+        assert_eq!(cached, parsed_b);
     }
 
     #[test]

--- a/compiler-core/building/src/engine.rs
+++ b/compiler-core/building/src/engine.rs
@@ -163,60 +163,84 @@ struct LocalState {
 }
 
 impl LocalState {
-    fn with_current<T>(&self, current: QueryKey, f: impl FnOnce() -> T) -> T {
-        let inner = self.inner.get_or_default();
+    fn with_query<T>(&self, query: QueryKey, f: impl FnOnce(&RefCell<LocalStateInner>) -> T) -> T {
+        let local = self.inner.get_or_default();
         {
-            let mut setup = inner.borrow_mut();
-            setup.stack.push(current);
+            let mut inner = local.borrow_mut();
+            if let Some(parent) = inner.frames.last_mut() {
+                parent.dependencies.insert(query);
+            }
+            inner.frames.push(QueryFrame::new(query));
         }
-        let result = f();
+        let result = f(local);
         {
-            let mut cleanup = inner.borrow_mut();
-            cleanup.stack.pop();
-            cleanup.in_progress.remove(&current);
-            cleanup.dependencies.remove(&current);
+            let mut inner = local.borrow_mut();
+            let frame = inner.frames.pop().expect("invariant violated: expected query frame");
+            debug_assert_eq!(frame.query, query);
         }
         result
     }
 
     fn with_dependency(&self, dependency: QueryKey) {
         let mut inner = self.inner.get_or_default().borrow_mut();
-        if let Some(&current) = inner.stack.last() {
-            inner.dependencies.entry(current).or_default().insert(dependency);
+        if let Some(frame) = inner.frames.last_mut() {
+            frame.dependencies.insert(dependency);
         }
     }
 
-    fn dependencies(&self, key: QueryKey) -> Arc<[QueryKey]> {
-        let inner = &self.inner.get_or_default().borrow();
-        inner
+    fn dependencies(local: &RefCell<LocalStateInner>) -> Arc<[QueryKey]> {
+        let inner = local.borrow();
+        let dependencies = inner
+            .frames
+            .last()
+            .expect("invariant violated: expected query frame")
             .dependencies
-            .get(&key)
-            .map(|dependencies| dependencies.iter().copied())
-            .unwrap_or_default()
-            .collect()
+            .iter()
+            .copied();
+        dependencies.collect()
     }
 
-    fn stack(&self) -> Arc<[QueryKey]> {
+    fn stack(local: &RefCell<LocalStateInner>) -> Arc<[QueryKey]> {
+        let inner = local.borrow();
+        let stack = inner.frames.iter().map(|frame| frame.query);
+        stack.collect()
+    }
+
+    fn mark_in_progress(local: &RefCell<LocalStateInner>) {
+        let mut inner = local.borrow_mut();
+        let frame = inner.frames.last_mut().expect("invariant violated: expected query frame");
+        frame.in_progress = true;
+    }
+
+    fn is_in_progress(local: &RefCell<LocalStateInner>) -> bool {
+        let inner = local.borrow();
+        let frame = inner.frames.last().expect("invariant violated: expected query frame");
+        frame.in_progress
+    }
+
+    #[cfg(test)]
+    fn contains_in_progress(&self, query: QueryKey) -> bool {
         let inner = self.inner.get_or_default().borrow();
-        inner.stack.as_slice().into()
-    }
-
-    fn add_in_progress(&self, key: QueryKey) {
-        let mut inner = self.inner.get_or_default().borrow_mut();
-        inner.in_progress.insert(key);
-    }
-
-    fn is_in_progress(&self, key: QueryKey) -> bool {
-        let inner = self.inner.get_or_default().borrow();
-        inner.in_progress.contains(&key)
+        inner.frames.iter().any(|frame| frame.query == query && frame.in_progress)
     }
 }
 
 #[derive(Debug, Default)]
 struct LocalStateInner {
-    stack: Vec<QueryKey>,
-    in_progress: FxHashSet<QueryKey>,
-    dependencies: FxHashMap<QueryKey, FxHashSet<QueryKey>>,
+    frames: Vec<QueryFrame>,
+}
+
+#[derive(Debug)]
+struct QueryFrame {
+    query: QueryKey,
+    in_progress: bool,
+    dependencies: FxHashSet<QueryKey>,
+}
+
+impl QueryFrame {
+    fn new(query: QueryKey) -> QueryFrame {
+        QueryFrame { query, in_progress: false, dependencies: FxHashSet::default() }
+    }
 }
 
 /// Custom guard that acquires a read lock from the [`GlobalState::query_lock`]
@@ -322,11 +346,10 @@ impl QueryEngine {
         ComputeFn: Fn(&QueryEngine) -> QueryResult<V>,
         V: Eq + Clone,
     {
-        self.control.local.with_dependency(query);
-        self.control.local.with_current(query, || {
+        self.control.local.with_query(query, |local| {
             // If query execution fails at any given point, clean up the state.
-            self.query_core(query, key, &shards, &compute).inspect_err(|_| {
-                if self.control.local.is_in_progress(query) {
+            self.query_core(key, &shards, &compute, local).inspect_err(|_| {
+                if LocalState::is_in_progress(local) {
                     let shard = shards(&self.derived).shard(&key);
                     let mut guard = shard.write();
                     if let Entry::Occupied(o) = guard.entry(key) {
@@ -383,9 +406,9 @@ impl QueryEngine {
         key: K,
         shards: &ShardsFn,
         compute: &ComputeFn,
-        query: QueryKey,
         revision: usize,
         previous: Option<(V, Trace)>,
+        local: &RefCell<LocalStateInner>,
     ) -> QueryResult<V>
     where
         K: Hash + Eq + Copy,
@@ -407,13 +430,13 @@ impl QueryEngine {
         match previous {
             Some((previous, trace)) if computed == previous => {
                 let trace = Trace { built: revision, changed: trace.changed };
-                let dependencies = self.control.local.dependencies(query);
+                let dependencies = LocalState::dependencies(local);
                 self.fulfill_and_store(key, shards, V::clone(&previous), trace, dependencies);
                 Ok(previous)
             }
             _ => {
                 let trace = Trace { built: revision, changed: revision };
-                let dependencies = self.control.local.dependencies(query);
+                let dependencies = LocalState::dependencies(local);
                 self.fulfill_and_store(key, shards, V::clone(&computed), trace, dependencies);
                 Ok(computed)
             }
@@ -468,10 +491,11 @@ impl QueryEngine {
         &self,
         to_id: SnapshotId,
         promises: &Mutex<Vec<Promise<T>>>,
+        local: &RefCell<LocalStateInner>,
     ) -> QueryResult<Future<T>> {
         {
             let mut graph = self.control.global.graph.lock();
-            let stack = self.control.local.stack();
+            let stack = LocalState::stack(local);
             if !graph.add_edge(self.control.id, to_id) {
                 return Err(QueryError::Cycle { stack });
             }
@@ -484,10 +508,10 @@ impl QueryEngine {
 
     fn query_core<K, V, ShardsFn, ComputeFn>(
         &self,
-        query: QueryKey,
         key: K,
         shards: &ShardsFn,
         compute: &ComputeFn,
+        local: &RefCell<LocalStateInner>,
     ) -> QueryResult<V>
     where
         K: Hash + Eq + Copy,
@@ -518,7 +542,7 @@ impl QueryEngine {
                     return Ok(V::clone(computed));
                 }
                 DerivedState::InProgress { id, promises } => {
-                    let future = self.create_future(*id, promises)?;
+                    let future = self.create_future(*id, promises, local)?;
 
                     // Remember that Future::wait blocks the current thread!
                     drop(guard);
@@ -543,13 +567,13 @@ impl QueryEngine {
                     {
                         let mut guard = RwLockUpgradableReadGuard::upgrade(guard);
                         guard.insert(key, DerivedState::in_progress(self.control.id));
-                        self.control.local.add_in_progress(query);
+                        LocalState::mark_in_progress(local);
                     }
 
-                    self.compute_core(key, shards, compute, query, revision, None)
+                    self.compute_core(key, shards, compute, revision, None, local)
                 }
                 DerivedState::InProgress { id, promises } => {
-                    let future = self.create_future(*id, promises)?;
+                    let future = self.create_future(*id, promises, local)?;
 
                     // Remember that Future::wait blocks the current thread!
                     drop(guard);
@@ -572,7 +596,7 @@ impl QueryEngine {
                     {
                         let mut guard = RwLockUpgradableReadGuard::upgrade(guard);
                         guard.insert(key, DerivedState::in_progress(self.control.id));
-                        self.control.local.add_in_progress(query);
+                        LocalState::mark_in_progress(local);
                     }
 
                     let latest = self.verify_core(&dependencies)?;
@@ -597,9 +621,9 @@ impl QueryEngine {
                         key,
                         shards,
                         compute,
-                        query,
                         revision,
                         Some((computed, trace)),
+                        local,
                     )
                 }
             }
@@ -1204,12 +1228,44 @@ mod tests {
         let key = QueryKey::Parsed(id);
 
         let indexed_a = engine.indexed(id).unwrap();
-        assert!(!engine.control.local.is_in_progress(key));
+        assert!(!engine.control.local.contains_in_progress(key));
 
         let indexed_b = engine.indexed(id).unwrap();
-        assert!(!engine.control.local.is_in_progress(key));
+        assert!(!engine.control.local.contains_in_progress(key));
 
         assert_eq!(indexed_a, indexed_b);
+    }
+
+    #[test]
+    fn test_nested_dependencies_are_deduplicated_and_isolated() {
+        let mut engine = QueryEngine::default();
+        let mut files = Files::default();
+        prim::configure(&mut engine, &mut files);
+
+        let parent = files.insert("./src/Parent.purs", "module Parent where");
+        let child = files.insert("./src/Child.purs", "module Child where");
+        engine.set_content(child, files.content(child));
+
+        let parsed = engine
+            .query(
+                QueryKey::Parsed(parent),
+                parent,
+                |derived| &derived.parsed,
+                |engine| {
+                    let parsed = engine.parsed(child)?;
+                    engine.parsed(child)?;
+                    Ok(parsed)
+                },
+            )
+            .unwrap();
+        assert_eq!(parsed, engine.parsed(child).unwrap());
+
+        let shard = engine.derived.parsed.shard(&parent);
+        let guard = shard.read();
+        assert_eq!(
+            ShowTrace(guard.get(&parent).unwrap()),
+            Trace { built: 19, changed: 19, dependencies: &[QueryKey::Parsed(child)] }
+        );
     }
 
     #[test]
@@ -1221,17 +1277,8 @@ mod tests {
         let id = files.insert("./src/Main.purs", "module Main where\n\n\n\nlife = 42");
         let key = QueryKey::Indexed(id);
 
-        // Simulate the current thread starting a computation.
-        {
-            let shard = engine.derived.indexed.shard(&id);
-            shard.write().insert(id, DerivedState::in_progress(engine.control.id));
-            engine.control.local.add_in_progress(key);
-        }
-
-        // Finally, enable cancellation and run the query on this thread.
-        engine.control.global.cancelled.store(true, Ordering::Relaxed);
         let result =
-            engine.query(key, id, |derived| &derived.indexed, |_| unreachable!("impossible."));
+            engine.query(key, id, |derived| &derived.indexed, |_| Err(QueryError::Cancelled));
 
         assert_eq!(result, Err(QueryError::Cancelled));
 
@@ -1255,7 +1302,6 @@ mod tests {
         {
             let shard = engine.derived.indexed.shard(&id);
             shard.write().insert(id, DerivedState::in_progress(engine.control.id));
-            engine.control.local.add_in_progress(key);
         }
 
         // Finally, enable cancellation and run the query on another thread.
@@ -1274,17 +1320,6 @@ mod tests {
         {
             let shard = engine.derived.indexed.shard(&id);
             assert!(shard.read().contains_key(&id));
-        }
-
-        let result =
-            engine.query(key, id, |derived| &derived.indexed, |_| unreachable!("impossible."));
-
-        assert_eq!(result, Err(QueryError::Cancelled));
-
-        // Finally, observe that the storage is edited.
-        {
-            let shard = engine.derived.indexed.shard(&id);
-            assert!(!shard.read().contains_key(&id));
         }
     }
 

--- a/compiler-core/building/src/engine/graph.rs
+++ b/compiler-core/building/src/engine/graph.rs
@@ -20,9 +20,10 @@ impl SnapshotGraph {
         true
     }
 
-    pub(crate) fn remove_edge(&mut self, to_id: SnapshotId) {
-        self.inner.retain(|_, &mut id| id != to_id);
-        self.inner.remove(&to_id);
+    pub(crate) fn remove_edge(&mut self, from_id: SnapshotId, to_id: SnapshotId) {
+        if self.inner.get(&from_id) == Some(&to_id) {
+            self.inner.remove(&from_id);
+        }
     }
 }
 
@@ -55,5 +56,20 @@ mod tests {
         let mut graph = SnapshotGraph::default();
         let id_a = SnapshotId(0);
         assert!(!graph.add_edge(id_a, id_a));
+    }
+
+    #[test]
+    fn test_removes_only_matching_edge() {
+        let mut graph = SnapshotGraph::default();
+        let id_a = SnapshotId(0);
+        let id_b = SnapshotId(1);
+        let id_c = SnapshotId(2);
+
+        assert!(graph.add_edge(id_a, id_b));
+        graph.remove_edge(id_c, id_b);
+        assert!(!graph.add_edge(id_b, id_a));
+
+        graph.remove_edge(id_a, id_b);
+        assert!(graph.add_edge(id_b, id_a));
     }
 }


### PR DESCRIPTION
## Summary

- represent each active query as one frame containing its key, dependency set, and in-progress ownership
- replace verification dependencies with the dependencies observed by actual recomputation
- track snapshot wait edges alongside the promises that own them
- remove graph edges by exact `(waiting, computing)` pair and skip the graph mutex when a query has no waiters
- add regression coverage for dependency isolation, dependency replacement, and unrelated wait-edge preservation

## Motivation and design

### Frame-local query state

Active queries are strictly nested on each thread, but the previous local state represented that stack indirectly with a `Vec<QueryKey>`, an `FxHashSet<QueryKey>` for in-progress ownership, and an `FxHashMap<QueryKey, FxHashSet<QueryKey>>` for dependencies. Recording a dependency looked up the current key and then hashed it again to find its set; cleanup performed two more hash-table removals.

This change stores those fields together in a `QueryFrame`. Entering a derived query records it in its parent and pushes a fresh frame. Input and derived dependencies continue to deduplicate through the frame's `FxHashSet`. Cached dependencies are first verified to determine whether recomputation is necessary; immediately before actual recomputation, those verification-only dependencies are cleared so the new execution records the authoritative dependency set. Passing the thread-local cell through the query core also avoids repeated thread-local lookups.

### Exact snapshot wait edges

An in-progress query previously stored promises without the identity of their waiting snapshots. Completion therefore called `SnapshotGraph::remove_edge(computing_snapshot)`, which removed every edge into that snapshot.

That scope was too broad: if snapshot W waited on an outer query owned by S, completion of an unrelated nested query on S could erase W → S. A later S → W wait would then appear acyclic and both snapshots could block indefinitely.

Each waiter now stores its snapshot ID with its promise. Success and error cleanup remove only the corresponding `(waiting, computing)` edges before waking waiters. Edge removal verifies both endpoints, and the common no-waiter completion path no longer acquires or scans the graph.

## Performance

The optimization measurements independently compared `48bf6a4e` with `8cb8d2dc` using isolated worktrees and Cargo targets on the same 633-package / 7,348-module Core+Acme corpus. The subsequent dependency-replacement commit affects only stale-query recomputation and is not exercised by these cold-checking measurements.

| Workload | Baseline | Optimized | Change |
| --- | ---: | ---: | ---: |
| Core checking, single-core | 500.792 ms | 489.127 ms | 2.33% faster |
| Acme checking, single-core | 14.746 s | 13.967 s | 5.29% faster |
| End-to-end verifier median | 20.10 s | 19.66 s | 2.19% faster |
| Peak RSS median | 2,211,940 KiB | 2,209,612 KiB | effectively neutral |

The single-core gains reproduced with bootstrap median-change confidence intervals excluding zero:

- Core: 3.03% median improvement, 95% CI 0.70–6.93%
- Acme: 4.98% median improvement, 95% CI 3.56–6.92%

The end-to-end point estimate reproduced the original ~2.1% result, but three runs per variant are not sufficient for statistical significance; its independent confidence interval includes zero. Four-thread measurements were noisy and conflicting, so this PR makes no multi-core performance claim.

All six independent verifier runs produced byte-identical normalized reports: zero errors in every compiler/verifier phase, the same 36 warnings, and the same 633 packages / 7,348 sources.

## Correctness verification

Two independent reviews approved the first two commits separately:

- frame-local dependency tracking: no findings; dependency isolation, original trace semantics, cycle stacks, cancellation ownership, and snapshot isolation preserved
- exact waiter edges: no findings; registration/completion exclusion, lock ordering, wake ordering, and cancellation cleanup verified

Review then identified the pre-existing behavior where derived dependencies traversed during verification remained unioned with dependencies observed during recomputation. The new regression switches a parent query from child A to child B, asserts only B remains tracked, then changes A again and proves the parent is not recomputed.

The wait-edge regression test was also transplanted onto the parent commit, where it failed as expected because broad completion cleanup erased the unrelated edge. It passes on this branch.

Focused stress runs completed without flakiness:

- frame-local commit: 50 repetitions × 8 cycle/cancellation/dependency tests = 400 passes
- waiter-edge commit: 100 repetitions × 11 cycle/cancellation/snapshot/waiter tests = 1,100 passes

Panic unwinding through query computations remains outside the engine's existing cleanup guarantees and is not claimed by this PR.

## Validation

- `cargo check -p building --tests`
- `cargo nextest run -p building` — 26/26 passed
- `just t checking` — all passed, no pending snapshots
- release compatibility verification for Core and Acme — zero errors
- `just format`
- `git diff --check`