### PR TITLE
[checking] Reduce dependency lookup and overlap costs

### DIFF
--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -2,6 +2,7 @@
 //!
 //! See documentation for [`CheckContext`] for more information.
 
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use building_types::QueryResult;
@@ -10,14 +11,16 @@ use indexing::{IndexedModule, TermItemId, TypeItemId};
 use itertools::Itertools;
 use lowering::{GroupedModule, LoweredModule};
 use resolving::ResolvedModule;
+use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 use stabilizing::StabilizedModule;
 use sugar::{Bracketed, Sectioned};
 
-use crate::ExternalQueries;
 use crate::core::{
-    Depth, ForallBinder, ForallBinderId, Name, RowField, RowType, RowTypeId, Type, TypeId,
+    CheckedSynonym, Depth, ForallBinder, ForallBinderId, Name, RowField, RowType, RowTypeId, Type,
+    TypeId,
 };
+use crate::{CheckedModule, ExternalQueries};
 
 /// The read-only environment threaded through the type checking algorithm.
 ///
@@ -55,6 +58,9 @@ where
 
     pub prim_indexed: Arc<IndexedModule>,
     pub prim_resolved: Arc<ResolvedModule>,
+
+    checked_dependencies: RefCell<FxHashMap<FileId, Arc<CheckedModule>>>,
+    checked_synonyms: RefCell<FxHashMap<(FileId, TypeItemId), Option<CheckedSynonym>>>,
 }
 
 impl<'q, Q> CheckContext<'q, Q>
@@ -113,7 +119,41 @@ where
             resolved,
             prim_indexed,
             prim_resolved,
+            checked_dependencies: RefCell::default(),
+            checked_synonyms: RefCell::default(),
         })
+    }
+
+    pub(crate) fn checked_dependency(&self, file_id: FileId) -> QueryResult<Arc<CheckedModule>> {
+        debug_assert_ne!(file_id, self.id);
+
+        let checked = self.checked_dependencies.borrow().get(&file_id).cloned();
+        if let Some(checked) = checked {
+            return Ok(checked);
+        }
+
+        let checked = self.queries.checked(file_id)?;
+        self.checked_dependencies.borrow_mut().insert(file_id, Arc::clone(&checked));
+        Ok(checked)
+    }
+
+    pub(crate) fn checked_synonym_dependency(
+        &self,
+        file_id: FileId,
+        type_id: TypeItemId,
+    ) -> QueryResult<Option<CheckedSynonym>> {
+        debug_assert_ne!(file_id, self.id);
+
+        let key = (file_id, type_id);
+        let checked_synonym = self.checked_synonyms.borrow().get(&key).cloned();
+        if let Some(checked_synonym) = checked_synonym {
+            return Ok(checked_synonym);
+        }
+
+        let checked = self.checked_dependency(file_id)?;
+        let checked_synonym = checked.lookup_synonym(type_id);
+        self.checked_synonyms.borrow_mut().insert(key, checked_synonym.clone());
+        Ok(checked_synonym)
     }
 }
 

--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -210,7 +210,7 @@ where
                 constraint.type_id,
             );
         } else {
-            let checked = context.queries.checked(file_id)?;
+            let checked = context.checked_dependency(file_id)?;
             let indexed = context.queries.indexed(file_id)?;
             collect_instances_from_checked(
                 &mut instances,

--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -737,6 +737,8 @@ where
     let mut known_non_apart = FxHashSet::default();
     let mut possibly_non_apart = all_positions.clone();
 
+    // Closure monotonicity lets these bounds decide whether the final non-apart positions contain
+    // a covering set before every argument has been compared.
     if positions_cover_all(functional_dependencies, &known_non_apart, &all_positions) {
         return Ok(true);
     }

--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -9,7 +9,7 @@ use crate::context::CheckContext;
 use crate::core::constraint::instances::InstanceCandidate;
 use crate::core::constraint::{CanonicalConstraintId, canonical};
 use crate::core::fd::{
-    Fd, compute_closure, compute_covering_sets, get_all_determined, get_functional_dependencies,
+    Fd, compute_closure, get_all_determined, get_functional_dependencies, positions_cover_all,
 };
 use crate::core::substitute::SubstituteName;
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
@@ -713,9 +713,7 @@ where
     }
 
     let functional_dependencies = get_functional_dependencies(state, context, file_id, type_id)?;
-    let covering_sets = compute_covering_sets(&functional_dependencies, left_arguments.len());
-
-    Ok(!instances_are_apart(state, context, &covering_sets, &left_arguments, &right_arguments)?)
+    instances_overlap(state, context, &functional_dependencies, &left_arguments, &right_arguments)
 }
 
 fn type_arguments(arguments: &[KindOrType]) -> Vec<TypeId> {
@@ -725,40 +723,48 @@ fn type_arguments(arguments: &[KindOrType]) -> Vec<TypeId> {
         .collect_vec()
 }
 
-fn instances_are_apart<Q>(
+fn instances_overlap<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    covering_sets: &[FxHashSet<usize>],
+    functional_dependencies: &[Fd],
     left_arguments: &[TypeId],
     right_arguments: &[TypeId],
 ) -> QueryResult<bool>
 where
     Q: ExternalQueries,
 {
-    for covering_set in covering_sets {
-        let mut covering_set_is_apart = false;
+    let all_positions = FxHashSet::from_iter(0..left_arguments.len());
+    let mut known_non_apart = FxHashSet::default();
+    let mut possibly_non_apart = all_positions.clone();
 
-        for &position in covering_set {
-            if types_apart(
-                state,
-                context,
-                left_arguments[position],
-                right_arguments[position],
-                false,
-            )?
-            .is_apart()
-            {
-                covering_set_is_apart = true;
-                break;
+    if positions_cover_all(functional_dependencies, &known_non_apart, &all_positions) {
+        return Ok(true);
+    }
+
+    for position in 0..left_arguments.len() {
+        let apart = types_apart(
+            state,
+            context,
+            left_arguments[position],
+            right_arguments[position],
+            false,
+        )?
+        .is_apart();
+
+        if apart {
+            possibly_non_apart.remove(&position);
+            if !positions_cover_all(functional_dependencies, &possibly_non_apart, &all_positions) {
+                return Ok(false);
             }
-        }
-
-        if !covering_set_is_apart {
-            return Ok(false);
+        } else {
+            known_non_apart.insert(position);
+            if positions_cover_all(functional_dependencies, &known_non_apart, &all_positions) {
+                return Ok(true);
+            }
         }
     }
 
-    Ok(true)
+    Ok(positions_cover_all(functional_dependencies, &known_non_apart, &all_positions))
 }
 
 fn types_apart<Q>(

--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -967,7 +967,7 @@ where
     let constructor_type = if file_id == context.id {
         state.checked.lookup_term(term_id)
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         checked.lookup_term(term_id)
     };
 

--- a/compiler-core/checking/src/core/fd.rs
+++ b/compiler-core/checking/src/core/fd.rs
@@ -82,6 +82,8 @@ pub fn compute_closure(
     }
 }
 
+/// Closure monotonicity makes this equivalent to `positions` containing a covering set.
+/// Exact equality preserves behavior when a malformed dependency introduces out-of-range positions.
 pub fn positions_cover_all(
     functional_dependencies: &[Fd],
     positions: &FxHashSet<usize>,
@@ -303,6 +305,7 @@ mod tests {
         let all_positions = FxHashSet::from_iter(0..argument_count);
         let cases = [
             vec![Fd::new([0, 1], [2, 3]), Fd::new([2], [0])],
+            // The out-of-range position preserves exact closure-equality behavior for malformed dependencies.
             vec![Fd::new([0, 1], [2, 4]), Fd::new([], [3])],
         ];
 

--- a/compiler-core/checking/src/core/fd.rs
+++ b/compiler-core/checking/src/core/fd.rs
@@ -82,6 +82,14 @@ pub fn compute_closure(
     }
 }
 
+pub fn positions_cover_all(
+    functional_dependencies: &[Fd],
+    positions: &FxHashSet<usize>,
+    all_positions: &FxHashSet<usize>,
+) -> bool {
+    compute_closure(functional_dependencies, positions) == *all_positions
+}
+
 pub fn compute_covering_sets(
     functional_dependencies: &[Fd],
     argument_count: usize,
@@ -246,5 +254,75 @@ mod tests {
         let fundeps = vec![Fd::new([], [0])];
         let result = compute_covering_sets(&fundeps, 1);
         assert_eq!(result, vec![FxHashSet::default()]);
+    }
+
+    #[test]
+    fn closure_decision_matches_covering_sets() {
+        for argument_count in 0..=3 {
+            let all_positions = FxHashSet::from_iter(0..argument_count);
+            let mut possible_dependencies = vec![];
+
+            for determined in 0..argument_count {
+                possible_dependencies.push(Fd::new([], [determined]));
+                for determiner in 0..argument_count {
+                    possible_dependencies.push(Fd::new([determiner], [determined]));
+                }
+            }
+
+            for dependency_mask in 0..(1 << possible_dependencies.len()) {
+                let functional_dependencies = possible_dependencies
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| dependency_mask & (1 << index) != 0)
+                    .map(|(_, dependency)| dependency.clone());
+                let functional_dependencies = functional_dependencies.collect_vec();
+                let covering_sets = compute_covering_sets(&functional_dependencies, argument_count);
+
+                for non_apart_mask in 0..(1 << argument_count) {
+                    let non_apart_positions = (0..argument_count)
+                        .filter(|position| non_apart_mask & (1 << position) != 0);
+                    let non_apart_positions = FxHashSet::from_iter(non_apart_positions);
+                    let expected = covering_sets
+                        .iter()
+                        .any(|covering_set| covering_set.is_subset(&non_apart_positions));
+                    let actual = positions_cover_all(
+                        &functional_dependencies,
+                        &non_apart_positions,
+                        &all_positions,
+                    );
+
+                    assert_eq!(actual, expected);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn closure_decision_preserves_complex_dependency_semantics() {
+        let argument_count = 4;
+        let all_positions = FxHashSet::from_iter(0..argument_count);
+        let cases = [
+            vec![Fd::new([0, 1], [2, 3]), Fd::new([2], [0])],
+            vec![Fd::new([0, 1], [2, 4]), Fd::new([], [3])],
+        ];
+
+        for functional_dependencies in cases {
+            let covering_sets = compute_covering_sets(&functional_dependencies, argument_count);
+            for non_apart_mask in 0..(1 << argument_count) {
+                let non_apart_positions =
+                    (0..argument_count).filter(|position| non_apart_mask & (1 << position) != 0);
+                let non_apart_positions = FxHashSet::from_iter(non_apart_positions);
+                let expected = covering_sets
+                    .iter()
+                    .any(|covering_set| covering_set.is_subset(&non_apart_positions));
+                let actual = positions_cover_all(
+                    &functional_dependencies,
+                    &non_apart_positions,
+                    &all_positions,
+                );
+
+                assert_eq!(actual, expected);
+            }
+        }
     }
 }

--- a/compiler-core/checking/src/core/fd.rs
+++ b/compiler-core/checking/src/core/fd.rs
@@ -47,7 +47,7 @@ where
     let functional_dependencies = if file_id == context.id {
         state.checked.classes.get(&type_id).map(|class| Arc::clone(&class.functional_dependencies))
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         checked.classes.get(&type_id).map(|class| Arc::clone(&class.functional_dependencies))
     };
 

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -115,7 +115,7 @@ where
     let kind = if file_id == context.id {
         state.checked.lookup_type(type_id)
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         checked.lookup_type(type_id)
     };
 
@@ -134,7 +134,7 @@ where
     let term = if file_id == context.id {
         state.checked.lookup_term(term_id)
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         checked.lookup_term(term_id)
     };
 
@@ -183,7 +183,7 @@ where
     if file_id == context.id {
         Ok(state.checked.lookup_class(item_id))
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         Ok(checked.lookup_class(item_id))
     }
 }
@@ -200,8 +200,7 @@ where
     if file_id == context.id {
         Ok(state.checked.lookup_synonym(type_id))
     } else {
-        let checked = context.queries.checked(file_id)?;
-        Ok(checked.lookup_synonym(type_id))
+        context.checked_synonym_dependency(file_id, type_id)
     }
 }
 
@@ -217,7 +216,7 @@ where
     let operator_kind = if file_id == context.id {
         state.checked.lookup_type(type_id)
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         checked.lookup_type(type_id)
     };
 
@@ -263,7 +262,7 @@ where
     let operator_type = if file_id == context.id {
         state.checked.lookup_term(term_id)
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         checked.lookup_term(term_id)
     };
 
@@ -698,7 +697,7 @@ where
     if file_id == context.id {
         Ok(state.checked.lookup_roles(item_id))
     } else {
-        let checked = context.queries.checked(file_id)?;
+        let checked = context.checked_dependency(file_id)?;
         Ok(checked.lookup_roles(item_id))
     }
 }


### PR DESCRIPTION
## Summary

- cache successful checked dependency modules and checked synonym lookups for the lifetime of each module check
- decide functional-dependency instance overlap with lower and upper closure bounds instead of enumerating and minimizing every covering set
- retain the covering-set implementation as a differential test oracle for generated and explicit edge cases

## Motivation

Profiling the frozen Core and Acme compatibility corpora showed repeated checked-query and dependency-tracking work, synonym lookups, and functional-dependency covering-set construction among the checking stage's material costs. The accepted changes remove that repeated work without sharing state between module checks or changing the overlap relation.

The closure decision uses the equivalence:

```
exists C subset-of N where closure(C) == U  iff  closure(N) == U
```

where `N` contains the argument positions that are not provably apart and `U` contains every valid argument position. Lower and upper bounds allow the checker to stop once overlap is certain or impossible.

## Performance

Criterion comparison of the final stack against clean `main`, using identical frozen corpora:

| Workload | Change interval |
|---|---:|
| Core, single-core | -8.18% to -4.60% |
| Acme, single-core | -20.84% to -18.70% |
| Core, 4 threads | -26.76% to -20.95% |
| Acme, 4 threads | -36.03% to -32.85% |

Eight alternating full Core+Acme verifier runs improved median wall time from 20.625 s to 17.575 s (-14.79%; bootstrap 95% CI -16.23% to -13.53%). Median peak RSS was effectively unchanged. For the closure change in isolation, heaptrack recorded 24.3% fewer allocation calls and 17.9% fewer temporary allocations.

Corpus digests:

- Core benchmark: `2b52a9818f526ddaef86ed2a8f52e5a30ff869d96b5d6e11fb73bdef2f111e70`
- Acme benchmark: `e1bb1981625e8438d3afd1f53a36c3f99252017101842506bf34926788f3a679`
- Core+Acme verifier source closure: `d4a6d5076a93464e2f361d27febbe4982b8c08526b8adf2cfb149dca9ec50ece`

Hardware PMU counters were unavailable; no cycle, instruction, cache-miss, branch-miss, or IPC claim is made.

## Correctness

The following passed at each accepted commit boundary and on the final stack:

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (22/22 on the final stack)
- `just t checking`
- Core+Acme compatibility verification
- `just format`
- `git diff --check`

Normalized baseline and final verifier diagnostics were byte-identical, with digest `fcc7761e5217bf931a97bfa73ea4ca8f1bbedd2562141cb2b2b03522a92e992b`. Multiple four-thread benchmark runs exercised independent concurrent module checks. An independent read-only review found no correctness blocker.