### PR TITLE
[checking] Introduce checked Core with explicit evidence

### DIFF
--- a/.agents/skills/workflow-integration-tests/SKILL.md
+++ b/.agents/skills/workflow-integration-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-integration-tests
-description: "Workflow for adding and updating Alexandrite integration-test fixtures for checking, lowering, resolving, and LSP behavior. Use when creating compiler integration tests, reviewing fixture snapshots, or using `just t <category>`."
+description: "Workflow for adding and updating Alexandrite integration-test fixtures for checking, semantic Core, lowering, resolving, and LSP behavior. Use when creating compiler integration tests, reviewing fixture snapshots, or using `just t <category>`."
 ---
 
 # Workflow: Alexandrite Integration Tests
@@ -14,6 +14,7 @@ Use the command reference at `reference/compiler-scripts.md` for test runner syn
 | Category | Alias | Use for | Harness pattern |
 |----------|-------|---------|-----------------|
 | `checking` | `c` | Type checking, inference, kinds, roles, constraints, diagnostics after checking | `Main.purs` only |
+| `semantic` | `s` | Checked Core trees, resolved variables and binders, applications, and evidence placement | `Main.purs` only |
 | `lowering` | `l` | Lowered core output, binding/equation structure, source-to-core name links | every `.purs` file |
 | `resolving` | `r` | Name resolution, imports, exports, qualification, duplicate-name diagnostics | every `.purs` file |
 | `lsp` | - | Hover, definition, completion, import edits, source locations in LSP reports | `Main.purs` only |
@@ -52,6 +53,13 @@ test' [x] = x
 ```
 
 Name declarations predictably: `test`, `test'`, `test2`, `test2'`, etc. Include only edge cases relevant to the behavior.
+
+#### Semantic fixtures
+
+Write source that exposes the checked Core structure being tested. Snapshots use a Core-like
+language rather than valid PureScript: visible type applications use `@Type`, evidence applications
+use `@{ev0}`, and evidence abstractions use `\@{dict0} -> expression`. An `<unimplemented>` body
+means a checking rule has not yet produced that part of the checked Core tree.
 
 #### Lowering fixtures
 
@@ -112,7 +120,7 @@ test = Just life
 ```
 
 - Module name must match filename
-- Checking and LSP fixtures snapshot only `Main.purs`
+- Checking, semantic, and LSP fixtures snapshot only `Main.purs`
 - Lowering and resolving fixtures snapshot every `.purs` file
 
 ## Snapshot Review Focus
@@ -134,6 +142,12 @@ ErrorKind { details } at [location]
 
 Check inferred/checked types, kind/role output, constraints, diagnostics, and source locations.
 
+### Semantic
+
+Check the checked Core tree, especially application associativity, visible type arguments, evidence
+placement and order, resolved variables, and explicit `<unimplemented>` recovery. The report is
+Core-like rather than valid PureScript.
+
 ### Lowering
 
 Check the lowered module report, especially declarations, binders, equations, and source links. Unexpected name-link changes are often as important as textual output changes.
@@ -152,6 +166,7 @@ Before accepting, verify:
 
 1. **The category is appropriate**
    - Checking owns type inference/checking behavior
+   - Semantic owns checked Core structure and evidence placement
    - Lowering owns lowered core/source-link behavior
    - Resolving owns name/import/export behavior
    - LSP owns editor-facing reports
@@ -164,7 +179,7 @@ Before accepting, verify:
    - Checking types are correct
    - `test :: Array Int -> Int` - signature preserved
    - `test' :: forall t. Array t -> t` - polymorphism inferred
-   - Lowering/resolving/LSP changes match the feature or bug being tested
+   - Semantic/lowering/resolving/LSP changes match the feature or bug being tested
 
 4. **No unexpected `???`**
    - `test :: ???` - STOP: inference failure

--- a/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
+++ b/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
@@ -21,6 +21,7 @@ just t <category> --delete "name"  # Dry-run fixture deletion (use --confirm)
 | Category | Alias | Description |
 |----------|-------|-------------|
 | checking | c | Type checker tests |
+| semantic | s | Checked Core semantic-tree tests |
 | lowering | l | Lowering tests |
 | resolving | r | Resolver tests |
 | lsp | - | LSP tests |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "indexmap",
  "interner",
  "itertools 0.14.0",
+ "la-arena",
  "lowering",
  "parking_lot",
  "parsing",

--- a/compiler-core/checking/Cargo.toml
+++ b/compiler-core/checking/Cargo.toml
@@ -10,6 +10,7 @@ indexing = { version = "0.1.0", path = "../indexing" }
 interner = { version = "0.1.0", path = "../interner" }
 indexmap = "2.12.1"
 itertools = "0.14.0"
+la-arena = "0.3.1"
 lowering = { version = "0.1.0", path = "../lowering" }
 parking_lot = "0.12.5"
 petgraph = "0.8.3"

--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -95,7 +95,21 @@ pub enum KindOrType {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedDataDeclaration {
+    pub kind: CheckedDataDeclarationKind,
     pub type_parameters: Vec<ForallBinderId>,
+    pub constructors: Vec<CheckedDataConstructor>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckedDataDeclarationKind {
+    Data,
+    Newtype,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedDataConstructor {
+    pub item_id: TermItemId,
+    pub arguments: Vec<TypeId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -31,6 +31,7 @@ pub fn elaborate_given<Q>(
 where
     Q: ExternalQueries,
 {
+    let given = given.iter().copied();
     let given = elaborate_superclasses_with_evidence(state, context, given)?;
     let given = elaborate_coercible(state, context, given);
     let (given, substitution) = extract_compiler_solved(state, context, given)?;
@@ -41,19 +42,14 @@ where
 pub fn elaborate_superclasses_with_evidence<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    given: &[(CanonicalConstraintId, EvidenceId)],
+    given: impl IntoIterator<Item = (CanonicalConstraintId, EvidenceId)>,
 ) -> QueryResult<Vec<(CanonicalConstraintId, EvidenceId)>>
 where
     Q: ExternalQueries,
 {
-    let mut elaborated = Vec::with_capacity(given.len());
     let mut seen = FxHashSet::default();
-
-    for &(constraint, evidence) in given {
-        if seen.insert(constraint) {
-            elaborated.push((constraint, evidence));
-        }
-    }
+    let elaborated = given.into_iter().filter(|(constraint, _)| seen.insert(*constraint));
+    let mut elaborated = elaborated.collect_vec();
 
     let constraints = elaborated.iter().map(|&(constraint, _)| constraint);
     let constraints = constraints.collect_vec();

--- a/compiler-core/checking/src/core/exhaustive/convert.rs
+++ b/compiler-core/checking/src/core/exhaustive/convert.rs
@@ -11,7 +11,7 @@ use sugar::OperatorTree;
 
 use crate::context::CheckContext;
 use crate::core::exhaustive::{PatternConstructor, PatternId};
-use crate::core::{Type, TypeId, normalise};
+use crate::core::{Type, TypeId, normalise, toolkit};
 use crate::state::CheckState;
 use crate::{ExternalQueries, OperatorBranchTypes, safe_loop};
 
@@ -288,10 +288,8 @@ where
         return Ok(state.allocate_wildcard(t));
     };
 
-    // The operator_id points to itself, thus we need to follow the
-    // resolution to find the constructor that it actually points to.
     let Some((constructor_file_id, constructor_item_id)) =
-        resolve_term_operator(context, file_id, item_id)?
+        toolkit::resolve_term_operator_target(context, file_id, item_id)?
     else {
         return Ok(state.allocate_wildcard(t));
     };
@@ -314,32 +312,6 @@ where
     };
 
     Ok(state.allocate_constructor(constructor, result))
-}
-
-fn resolve_term_operator<Q>(
-    context: &CheckContext<Q>,
-    file_id: FileId,
-    item_id: TermItemId,
-) -> QueryResult<Option<(FileId, TermItemId)>>
-where
-    Q: ExternalQueries,
-{
-    let on_lowered = |lowered: &lowering::LoweredModule| {
-        if let Some(lowering::TermItemIr::Operator { resolution, .. }) =
-            lowered.info.get_term_item(item_id)
-        {
-            *resolution
-        } else {
-            None
-        }
-    };
-
-    if file_id == context.id {
-        Ok(on_lowered(&context.lowered))
-    } else {
-        let lowered = context.queries.lowered(file_id)?;
-        Ok(on_lowered(&lowered))
-    }
 }
 
 fn extract_type_application<Q>(

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -434,21 +434,22 @@ where
     let MinimisedBySuperclasses { retained, dropped } =
         minimise_by_superclasses(state, context, generalisable)?;
 
-    let mut given_evidence = Vec::with_capacity(retained.len());
-    let mut generalised = Vec::with_capacity(retained.len());
-    for ConstraintInScope { key, evidence: wanted_evidence } in &retained {
+    let generalised = retained.iter().map(|ConstraintInScope { key, evidence }| {
         let canonical = state.canonicals.type_id(context, key.wanted);
         let binder = state.checked.evidence.fresh_binder(canonical);
 
         let given = state.checked.evidence.allocate(Evidence::Given(binder));
-        state.checked.evidence.solve(wanted_evidence.wanted, given);
+        state.checked.evidence.solve(evidence.wanted, given);
 
-        generalised.push((key.wanted, binder));
-        given_evidence.push((key.wanted, given));
-    }
+        (key.wanted, binder, given)
+    });
 
+    let generalised = generalised.collect_vec();
+
+    let given_evidence =
+        generalised.iter().map(|&(constraint, _, evidence)| (constraint, evidence));
     let projections =
-        elaborate::elaborate_superclasses_with_evidence(state, context, &given_evidence)?;
+        elaborate::elaborate_superclasses_with_evidence(state, context, given_evidence)?;
     let projections = projections.into_iter().collect::<FxHashMap<_, _>>();
 
     for constraint in dropped {
@@ -459,7 +460,8 @@ where
         }
     }
 
-    Ok(generalised)
+    let generalised = generalised.into_iter().map(|(constraint, binder, _)| (constraint, binder));
+    Ok(generalised.collect_vec())
 }
 
 struct MinimisedBySuperclasses {

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -28,7 +28,7 @@ use crate::context::CheckContext;
 use crate::core::constraint::{CanonicalConstraintId, ConstraintInScope, compiler, elaborate};
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
 use crate::core::{ForallBinder, Name, Type, TypeId, normalise, zonk};
-use crate::evidence::Evidence;
+use crate::evidence::{Evidence, EvidenceBinderId};
 use crate::state::{CheckState, UnificationEntry, UnificationState};
 use crate::{ExternalQueries, safe_loop};
 
@@ -250,7 +250,7 @@ pub struct ConstraintErrors {
 
 pub struct ConstrainedByResiduals {
     pub type_id: TypeId,
-    pub has_constraints: bool,
+    pub evidence_binders: Vec<EvidenceBinderId>,
 }
 
 pub fn constrain_using_residuals<Q>(
@@ -264,7 +264,7 @@ where
     Q: ExternalQueries,
 {
     if residuals.is_empty() {
-        return Ok(ConstrainedByResiduals { type_id: unconstrained, has_constraints: false });
+        return Ok(ConstrainedByResiduals { type_id: unconstrained, evidence_binders: vec![] });
     }
 
     for residual in residuals.iter_mut() {
@@ -278,14 +278,17 @@ where
     let residuals = partial.into_iter().chain(residuals);
     let generalised = residuals.sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
     let generalised = finalise_generalised_constraints(state, context, generalised)?;
-    let has_constraints = !generalised.is_empty();
 
-    let constrained = generalised.into_iter().rfold(unconstrained, |inner, constraint| {
+    let evidence_binders = generalised.iter().map(|(_, binder)| *binder);
+    let evidence_binders = evidence_binders.collect();
+
+    let constraints = generalised.into_iter().map(|(constraint, _)| constraint);
+    let constrained = constraints.rfold(unconstrained, |inner, constraint| {
         let constraint = state.canonicals.type_id(context, constraint);
         context.intern_constrained(constraint, inner)
     });
 
-    Ok(ConstrainedByResiduals { type_id: constrained, has_constraints })
+    Ok(ConstrainedByResiduals { type_id: constrained, evidence_binders })
 }
 
 type PrunedPartial = (Vec<ConstraintInScope>, Option<ConstraintInScope>);
@@ -414,7 +417,7 @@ fn finalise_generalised_constraints<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     constraints: Vec<ConstraintInScope>,
-) -> QueryResult<Vec<CanonicalConstraintId>>
+) -> QueryResult<Vec<(CanonicalConstraintId, EvidenceBinderId)>>
 where
     Q: ExternalQueries,
 {
@@ -431,18 +434,21 @@ where
     let MinimisedBySuperclasses { retained, dropped } =
         minimise_by_superclasses(state, context, generalisable)?;
 
-    let mut evidences = vec![];
-    for ConstraintInScope { key, evidence } in &retained {
+    let mut given_evidence = Vec::with_capacity(retained.len());
+    let mut generalised = Vec::with_capacity(retained.len());
+    for ConstraintInScope { key, evidence: wanted_evidence } in &retained {
         let canonical = state.canonicals.type_id(context, key.wanted);
         let binder = state.checked.evidence.fresh_binder(canonical);
 
         let given = state.checked.evidence.allocate(Evidence::Given(binder));
-        state.checked.evidence.solve(evidence.wanted, given);
+        state.checked.evidence.solve(wanted_evidence.wanted, given);
 
-        evidences.push((key.wanted, given));
+        generalised.push((key.wanted, binder));
+        given_evidence.push((key.wanted, given));
     }
 
-    let projections = elaborate::elaborate_superclasses_with_evidence(state, context, &evidences)?;
+    let projections =
+        elaborate::elaborate_superclasses_with_evidence(state, context, &given_evidence)?;
     let projections = projections.into_iter().collect::<FxHashMap<_, _>>();
 
     for constraint in dropped {
@@ -453,7 +459,7 @@ where
         }
     }
 
-    Ok(retained.into_iter().map(|constraint| constraint.key.wanted).collect())
+    Ok(generalised)
 }
 
 struct MinimisedBySuperclasses {

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{TermItemId, TypeItemId};
-use lowering::TypeItemIr;
+use lowering::{TermItemIr, TypeItemIr};
 
 use rustc_hash::FxHashMap;
 
@@ -16,6 +16,7 @@ use crate::core::{
     CheckedClass, CheckedSynonym, ForallBinder, KindOrType, Name, Role, Type, TypeId, constraint,
     normalise, unification,
 };
+use crate::evidence::EvidenceVarId;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
@@ -238,6 +239,29 @@ where
     let resolve = |lowered: &lowering::LoweredModule| {
         lowered.info.get_type_item(type_id).and_then(|item| match item {
             TypeItemIr::Operator { resolution, .. } => *resolution,
+            _ => None,
+        })
+    };
+
+    if file_id == context.id {
+        Ok(resolve(&context.lowered))
+    } else {
+        let lowered = context.queries.lowered(file_id)?;
+        Ok(resolve(&lowered))
+    }
+}
+
+pub fn resolve_term_operator_target<Q>(
+    context: &CheckContext<Q>,
+    file_id: FileId,
+    term_id: TermItemId,
+) -> QueryResult<Option<(FileId, TermItemId)>>
+where
+    Q: ExternalQueries,
+{
+    let resolve = |lowered: &lowering::LoweredModule| {
+        lowered.info.get_term_item(term_id).and_then(|item| match item {
+            TermItemIr::Operator { resolution, .. } => *resolution,
             _ => None,
         })
     };
@@ -486,11 +510,11 @@ where
     Ok(id)
 }
 
-/// Peels constraint layers, pushing each as a wanted.
-pub fn collect_wanteds<Q>(
+fn collect_wanted_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     mut id: TypeId,
+    mut record_evidence: impl FnMut(EvidenceVarId),
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
@@ -499,12 +523,39 @@ where
         id = normalise::expand(state, context, id)?;
         match context.lookup_type(id) {
             Type::Constrained(constraint, constrained) => {
-                state.push_wanted(constraint);
+                let evidence = state.push_wanted(constraint);
+                record_evidence(evidence);
                 id = constrained;
             }
             _ => return Ok(id),
         }
     }
+}
+
+/// Peels constraint layers, pushing each as a wanted.
+pub fn collect_wanted<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    id: TypeId,
+) -> QueryResult<TypeId>
+where
+    Q: ExternalQueries,
+{
+    collect_wanted_core(state, context, id, |_| {})
+}
+
+/// Peels constraint layers, pushing each as a wanted and returning its evidence variable.
+pub fn collect_wanted_with_evidence<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    id: TypeId,
+) -> QueryResult<(TypeId, Vec<EvidenceVarId>)>
+where
+    Q: ExternalQueries,
+{
+    let mut evidence = vec![];
+    let id = collect_wanted_core(state, context, id, |variable| evidence.push(variable))?;
+    Ok((id, evidence))
 }
 
 /// Peels constraint layers, pushing each as a given.
@@ -558,7 +609,7 @@ where
     Q: ExternalQueries,
 {
     let id = instantiate_unifications(state, context, id)?;
-    collect_wanteds(state, context, id)
+    collect_wanted(state, context, id)
 }
 
 pub fn contains_unification<Q>(

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -9,7 +9,11 @@ use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::{Type, TypeId};
 use crate::error::{CheckingError, ErrorKind};
 use crate::holes::{HoleBinding, TermHole, TypeHole};
-use crate::semantic::{CheckedBinderId, CheckedExpressionId, CheckedExpressionKind};
+use crate::semantic::{
+    CheckedAdoExpression, CheckedAdoStep, CheckedApplication, CheckedBinaryApplication,
+    CheckedBinderId, CheckedBlockStatement, CheckedDoExpression, CheckedDoStep,
+    CheckedExpressionId, CheckedExpressionKind, CheckedLetBinding,
+};
 use crate::state::CheckState;
 use crate::{ExternalQueries, OperatorBranchTypes, holes};
 
@@ -103,11 +107,149 @@ where
     let mut expression = state.checked.core.expressions[expression_id].clone();
     expression.type_id = zonk(state, context, expression.type_id)?;
 
-    if let CheckedExpressionKind::TypeApplication { argument, .. } = &mut expression.kind {
-        *argument = zonk(state, context, *argument)?;
+    match &mut expression.kind {
+        CheckedExpressionKind::Do { expression } => {
+            zonk_do_expression(state, context, expression)?;
+        }
+        CheckedExpressionKind::Ado { expression } => {
+            zonk_ado_expression(state, context, expression)?;
+        }
+        CheckedExpressionKind::TypeApplication { argument, .. } => {
+            *argument = zonk(state, context, *argument)?;
+        }
+        _ => (),
     }
 
     state.checked.core.expressions[expression_id] = expression;
+    Ok(())
+}
+
+fn zonk_application<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    application: &mut CheckedApplication,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    application.argument = zonk(state, context, application.argument)?;
+    application.result = zonk(state, context, application.result)?;
+    Ok(())
+}
+
+fn zonk_binary_application<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    application: &mut CheckedBinaryApplication,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    match application {
+        CheckedBinaryApplication::Complete { first, second, .. } => {
+            zonk_application(state, context, first)?;
+            zonk_application(state, context, second)?;
+        }
+        CheckedBinaryApplication::Partial { first, .. } => {
+            zonk_application(state, context, first)?;
+        }
+        CheckedBinaryApplication::Error { .. } => (),
+    }
+    Ok(())
+}
+
+fn zonk_do_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    expression: &mut CheckedDoExpression,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    for step in Arc::make_mut(&mut expression.steps) {
+        match step {
+            CheckedDoStep::Bind { continuation_type, application, .. }
+            | CheckedDoStep::Discard { continuation_type, application, .. } => {
+                *continuation_type = zonk(state, context, *continuation_type)?;
+                zonk_binary_application(state, context, application)?;
+            }
+            CheckedDoStep::Statement(statement) => {
+                zonk_block_statement(state, context, statement)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn zonk_ado_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    expression: &mut CheckedAdoExpression,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    match expression {
+        CheckedAdoExpression::Pure { statements, application, .. } => {
+            if let crate::semantic::CheckedUnaryApplication::Complete { application, .. } =
+                application
+            {
+                zonk_application(state, context, application)?;
+            }
+            for statement in Arc::make_mut(statements) {
+                zonk_block_statement(state, context, statement)?;
+            }
+        }
+        CheckedAdoExpression::Error { statements, .. } => {
+            for statement in Arc::make_mut(statements) {
+                zonk_block_statement(state, context, statement)?;
+            }
+        }
+        CheckedAdoExpression::Actions { steps, lambda_type, .. } => {
+            *lambda_type = zonk(state, context, *lambda_type)?;
+            for step in Arc::make_mut(steps) {
+                zonk_ado_step(state, context, step)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn zonk_ado_step<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    step: &mut CheckedAdoStep,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    match step {
+        CheckedAdoStep::Map { application, .. } | CheckedAdoStep::Apply { application, .. } => {
+            zonk_binary_application(state, context, application)?;
+        }
+        CheckedAdoStep::Statement(statement) => {
+            zonk_block_statement(state, context, statement)?;
+        }
+    }
+    Ok(())
+}
+
+fn zonk_block_statement<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    statement: &mut CheckedBlockStatement,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let CheckedBlockStatement::Let(statement) = statement else {
+        return Ok(());
+    };
+    for binding in Arc::make_mut(&mut statement.bindings) {
+        if let CheckedLetBinding::Name { type_id, .. } = binding {
+            *type_id = zonk(state, context, *type_id)?;
+        }
+    }
     Ok(())
 }
 

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -9,6 +9,7 @@ use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::{Type, TypeId};
 use crate::error::{CheckingError, ErrorKind};
 use crate::holes::{HoleBinding, TermHole, TypeHole};
+use crate::semantic::{CheckedBinderId, CheckedExpressionId, CheckedExpressionKind};
 use crate::state::CheckState;
 use crate::{ExternalQueries, OperatorBranchTypes, holes};
 
@@ -69,6 +70,57 @@ where
     zonk_operator_map!(term_operator);
     zonk_operator_map!(type_operator);
 
+    Ok(())
+}
+
+pub fn zonk_core<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let expressions = state.checked.core.expressions.iter().map(|(id, _)| id);
+    let expressions = expressions.collect::<Vec<_>>();
+    for expression_id in expressions {
+        zonk_checked_expression(state, context, expression_id)?;
+    }
+
+    let binders = state.checked.core.binders.iter().map(|(id, _)| id);
+    let binders = binders.collect::<Vec<_>>();
+    for binder_id in binders {
+        zonk_checked_binder(state, context, binder_id)?;
+    }
+
+    Ok(())
+}
+
+fn zonk_checked_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    expression_id: CheckedExpressionId,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let mut expression = state.checked.core.expressions[expression_id].clone();
+    expression.type_id = zonk(state, context, expression.type_id)?;
+
+    if let CheckedExpressionKind::TypeApplication { argument, .. } = &mut expression.kind {
+        *argument = zonk(state, context, *argument)?;
+    }
+
+    state.checked.core.expressions[expression_id] = expression;
+    Ok(())
+}
+
+fn zonk_checked_binder<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    binder_id: CheckedBinderId,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let type_id = state.checked.core.binders[binder_id].type_id;
+    state.checked.core.binders[binder_id].type_id = zonk(state, context, type_id)?;
     Ok(())
 }
 

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -4,6 +4,7 @@ pub mod evidence;
 pub mod holes;
 pub mod implication;
 pub mod safety;
+pub mod semantic;
 pub mod source;
 pub mod state;
 
@@ -55,6 +56,7 @@ pub trait ExternalQueries:
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct CheckedModule {
     pub evidence: evidence::Evidences,
+    pub core: semantic::CheckedCore,
     pub types: FxHashMap<TypeItemId, TypeId>,
     pub terms: FxHashMap<TermItemId, TypeId>,
     pub data_declarations: FxHashMap<TypeItemId, CheckedDataDeclaration>,
@@ -206,6 +208,7 @@ fn check_source(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<
     source::check_type_items(&mut state, &context)?;
     source::check_term_items(&mut state, &context)?;
     core::zonk::zonk_nodes(&mut state, &context)?;
+    core::zonk::zonk_core(&mut state, &context)?;
     core::zonk::zonk_evidence(&mut state, &context)?;
     core::zonk::zonk_holes(&mut state, &context)?;
     core::zonk::zonk_errors(&mut state, &context)?;

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -1,5 +1,7 @@
 //! Checked Core semantic trees produced by source checking rules.
 
+pub mod pretty;
+
 use std::sync::Arc;
 
 use files::FileId;

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -99,12 +99,125 @@ pub enum CheckedExpressionKind {
     Variable { resolution: lowering::TermVariableResolution },
     Constructor { file_id: FileId, item_id: TermItemId },
     Literal { literal: CheckedLiteral },
+    Error,
+    Do { expression: CheckedDoExpression },
+    Ado { expression: CheckedAdoExpression },
     Case { scrutinees: Arc<[CheckedExpressionId]>, alternatives: Arc<[CheckedCaseAlternative]> },
     Lambda { binders: Arc<[CheckedBinderId]>, expression: CheckedExpressionId },
     TermApplication { function: CheckedExpressionId, argument: CheckedExpressionId },
     TypeApplication { function: CheckedExpressionId, argument: TypeId },
     EvidenceApplication { expression: CheckedExpressionId, evidence: Arc<[EvidenceVarId]> },
     EvidenceAbstraction { binders: Arc<[EvidenceBinderId]>, expression: CheckedExpressionId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedApplication {
+    pub evidence: Arc<[EvidenceVarId]>,
+    pub argument: TypeId,
+    pub result: TypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedUnaryApplication {
+    Complete { function: CheckedExpressionId, application: CheckedApplication },
+    Error { function: CheckedExpressionId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedBinaryApplication {
+    Complete {
+        function: CheckedExpressionId,
+        first: CheckedApplication,
+        second: CheckedApplication,
+    },
+    Partial {
+        function: CheckedExpressionId,
+        first: CheckedApplication,
+    },
+    Error {
+        function: CheckedExpressionId,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedDoExpression {
+    pub steps: Arc<[CheckedDoStep]>,
+    pub final_expression: CheckedExpressionId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedDoStep {
+    Bind {
+        binder: CheckedBinderId,
+        expression: CheckedExpressionId,
+        continuation_type: TypeId,
+        application: CheckedBinaryApplication,
+    },
+    Discard {
+        binder: CheckedBinderId,
+        expression: CheckedExpressionId,
+        continuation_type: TypeId,
+        application: CheckedBinaryApplication,
+    },
+    Statement(CheckedBlockStatement),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedAdoExpression {
+    Pure {
+        statements: Arc<[CheckedBlockStatement]>,
+        expression: CheckedExpressionId,
+        application: CheckedUnaryApplication,
+    },
+    Error {
+        statements: Arc<[CheckedBlockStatement]>,
+        expression: CheckedExpressionId,
+    },
+    Actions {
+        steps: Arc<[CheckedAdoStep]>,
+        expression: CheckedExpressionId,
+        lambda_type: TypeId,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedAdoStep {
+    Map {
+        binder: CheckedBinderId,
+        expression: CheckedExpressionId,
+        application: CheckedBinaryApplication,
+    },
+    Apply {
+        binder: CheckedBinderId,
+        expression: CheckedExpressionId,
+        application: CheckedBinaryApplication,
+    },
+    Statement(CheckedBlockStatement),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedBlockStatement {
+    Let(CheckedLetStatement),
+    Error(CheckedErrorStatement),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedLetStatement {
+    pub source: lowering::DoStatementId,
+    pub bindings: Arc<[CheckedLetBinding]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedLetBinding {
+    Pattern { binder: Option<CheckedBinderId> },
+    Name { binding: lowering::LetBindingNameGroupId, type_id: TypeId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedErrorStatement {
+    pub source: lowering::DoStatementId,
+    pub binder: Option<CheckedBinderId>,
+    pub expression: Option<CheckedExpressionId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -148,4 +261,5 @@ pub enum CheckedBinderKind {
     Named { binder: CheckedBinderId },
     Wildcard,
     Constructor { file_id: FileId, item_id: TermItemId, arguments: Arc<[CheckedBinderId]> },
+    Error,
 }

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use la_arena::{Arena, Idx};
 use rustc_hash::FxHashMap;
+use smol_str::SmolStr;
 
 use crate::TypeId;
 use crate::evidence::{EvidenceBinderId, EvidenceVarId};
@@ -66,10 +67,20 @@ pub struct CheckedExpression {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckedExpressionKind {
     Variable { resolution: lowering::TermVariableResolution },
+    Literal { literal: CheckedLiteral },
     TermApplication { function: CheckedExpressionId, argument: CheckedExpressionId },
     TypeApplication { function: CheckedExpressionId, argument: TypeId },
     EvidenceApplication { expression: CheckedExpressionId, evidence: Arc<[EvidenceVarId]> },
     EvidenceAbstraction { binders: Arc<[EvidenceBinderId]>, expression: CheckedExpressionId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedLiteral {
+    String { kind: lowering::StringKind, value: Option<SmolStr> },
+    Char(Option<char>),
+    Boolean(bool),
+    Integer(Option<i32>),
+    Number(Option<SmolStr>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use files::FileId;
 use indexing::TermItemId;
 use la_arena::{Arena, Idx};
 use rustc_hash::FxHashMap;
@@ -78,6 +79,7 @@ pub struct CheckedExpression {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckedExpressionKind {
     Variable { resolution: lowering::TermVariableResolution },
+    Constructor { file_id: FileId, item_id: TermItemId },
     Literal { literal: CheckedLiteral },
     Lambda { binders: Arc<[CheckedBinderId]>, expression: CheckedExpressionId },
     TermApplication { function: CheckedExpressionId, argument: CheckedExpressionId },

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -33,8 +33,24 @@ impl CheckedCore {
         self.expressions.alloc(expression)
     }
 
-    pub fn allocate_binder(&mut self, type_id: TypeId, kind: CheckedBinderKind) -> CheckedBinderId {
-        let binder = CheckedBinder { type_id, kind };
+    pub fn allocate_source_binder(
+        &mut self,
+        source: lowering::BinderId,
+        type_id: TypeId,
+        kind: CheckedBinderKind,
+    ) -> CheckedBinderId {
+        let binder = CheckedBinder { source: Some(source), type_id, kind };
+        let checked = self.binders.alloc(binder);
+        self.record_binder(source, checked);
+        checked
+    }
+
+    pub fn allocate_synthesized_binder(
+        &mut self,
+        type_id: TypeId,
+        kind: CheckedBinderKind,
+    ) -> CheckedBinderId {
+        let binder = CheckedBinder { source: None, type_id, kind };
         self.binders.alloc(binder)
     }
 
@@ -118,6 +134,8 @@ pub enum CheckedLiteral {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedBinder {
+    /// The canonical allocation origin; additional lowering aliases live in `binders_by_source`.
+    pub source: Option<lowering::BinderId>,
     pub type_id: TypeId,
     pub kind: CheckedBinderKind,
 }

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -101,6 +101,8 @@ pub enum CheckedExpressionKind {
     Literal { literal: CheckedLiteral },
     Array { elements: Arc<[CheckedExpressionId]> },
     Record { fields: Arc<[CheckedRecordField]> },
+    RecordAccess { record: CheckedExpressionId, labels: Arc<[SmolStr]> },
+    RecordUpdate { record: CheckedExpressionId, updates: Arc<[CheckedRecordUpdate]> },
     Error,
     Do { expression: CheckedDoExpression },
     Ado { expression: CheckedAdoExpression },
@@ -116,6 +118,12 @@ pub enum CheckedExpressionKind {
 pub struct CheckedRecordField {
     pub label: SmolStr,
     pub expression: CheckedExpressionId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedRecordUpdate {
+    Leaf { label: SmolStr, expression: CheckedExpressionId },
+    Branch { label: SmolStr, updates: Arc<[CheckedRecordUpdate]> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -260,6 +260,7 @@ pub enum CheckedBinderKind {
     Variable,
     Named { binder: CheckedBinderId },
     Wildcard,
+    Literal(CheckedLiteral),
     Constructor { file_id: FileId, item_id: TermItemId, arguments: Arc<[CheckedBinderId]> },
     Error,
 }

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -81,11 +81,30 @@ pub enum CheckedExpressionKind {
     Variable { resolution: lowering::TermVariableResolution },
     Constructor { file_id: FileId, item_id: TermItemId },
     Literal { literal: CheckedLiteral },
+    Case { scrutinees: Arc<[CheckedExpressionId]>, alternatives: Arc<[CheckedCaseAlternative]> },
     Lambda { binders: Arc<[CheckedBinderId]>, expression: CheckedExpressionId },
     TermApplication { function: CheckedExpressionId, argument: CheckedExpressionId },
     TypeApplication { function: CheckedExpressionId, argument: TypeId },
     EvidenceApplication { expression: CheckedExpressionId, evidence: Arc<[EvidenceVarId]> },
     EvidenceAbstraction { binders: Arc<[EvidenceBinderId]>, expression: CheckedExpressionId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedCaseAlternative {
+    pub binders: Arc<[CheckedBinderId]>,
+    pub results: Arc<[CheckedGuardedExpression]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedGuardedExpression {
+    pub guards: Arc<[CheckedPatternGuard]>,
+    pub expression: CheckedExpressionId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedPatternGuard {
+    Boolean { expression: CheckedExpressionId },
+    Pattern { binder: CheckedBinderId, expression: CheckedExpressionId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,4 +126,6 @@ pub struct CheckedBinder {
 pub enum CheckedBinderKind {
     Variable,
     Named { binder: CheckedBinderId },
+    Wildcard,
+    Constructor { file_id: FileId, item_id: TermItemId, arguments: Arc<[CheckedBinderId]> },
 }

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use indexing::TermItemId;
 use la_arena::{Arena, Idx};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
@@ -16,6 +17,7 @@ pub type CheckedBinderId = Idx<CheckedBinder>;
 pub struct CheckedCore {
     pub expressions: Arena<CheckedExpression>,
     pub binders: Arena<CheckedBinder>,
+    pub term_roots: FxHashMap<TermItemId, CheckedExpressionId>,
     pub expressions_by_source: FxHashMap<lowering::ExpressionId, CheckedExpressionId>,
     pub binders_by_source: FxHashMap<lowering::BinderId, CheckedBinderId>,
 }
@@ -49,12 +51,21 @@ impl CheckedCore {
         assert!(previous.is_none(), "invariant violated: source binder checked twice");
     }
 
+    pub fn record_term_root(&mut self, source: TermItemId, checked: CheckedExpressionId) {
+        let previous = self.term_roots.insert(source, checked);
+        assert!(previous.is_none(), "invariant violated: term root checked twice");
+    }
+
     pub fn lookup_expression(&self, source: lowering::ExpressionId) -> Option<CheckedExpressionId> {
         self.expressions_by_source.get(&source).copied()
     }
 
     pub fn lookup_binder(&self, source: lowering::BinderId) -> Option<CheckedBinderId> {
         self.binders_by_source.get(&source).copied()
+    }
+
+    pub fn lookup_term_root(&self, source: TermItemId) -> Option<CheckedExpressionId> {
+        self.term_roots.get(&source).copied()
     }
 }
 
@@ -68,6 +79,7 @@ pub struct CheckedExpression {
 pub enum CheckedExpressionKind {
     Variable { resolution: lowering::TermVariableResolution },
     Literal { literal: CheckedLiteral },
+    Lambda { binders: Arc<[CheckedBinderId]>, expression: CheckedExpressionId },
     TermApplication { function: CheckedExpressionId, argument: CheckedExpressionId },
     TypeApplication { function: CheckedExpressionId, argument: TypeId },
     EvidenceApplication { expression: CheckedExpressionId, evidence: Arc<[EvidenceVarId]> },

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -99,6 +99,8 @@ pub enum CheckedExpressionKind {
     Variable { resolution: lowering::TermVariableResolution },
     Constructor { file_id: FileId, item_id: TermItemId },
     Literal { literal: CheckedLiteral },
+    Array { elements: Arc<[CheckedExpressionId]> },
+    Record { fields: Arc<[CheckedRecordField]> },
     Error,
     Do { expression: CheckedDoExpression },
     Ado { expression: CheckedAdoExpression },
@@ -108,6 +110,12 @@ pub enum CheckedExpressionKind {
     TypeApplication { function: CheckedExpressionId, argument: TypeId },
     EvidenceApplication { expression: CheckedExpressionId, evidence: Arc<[EvidenceVarId]> },
     EvidenceAbstraction { binders: Arc<[EvidenceBinderId]>, expression: CheckedExpressionId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedRecordField {
+    pub label: SmolStr,
+    pub expression: CheckedExpressionId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/checking/src/semantic.rs
+++ b/compiler-core/checking/src/semantic.rs
@@ -1,0 +1,85 @@
+//! Checked Core semantic trees produced by source checking rules.
+
+use std::sync::Arc;
+
+use la_arena::{Arena, Idx};
+use rustc_hash::FxHashMap;
+
+use crate::TypeId;
+use crate::evidence::{EvidenceBinderId, EvidenceVarId};
+
+pub type CheckedExpressionId = Idx<CheckedExpression>;
+pub type CheckedBinderId = Idx<CheckedBinder>;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct CheckedCore {
+    pub expressions: Arena<CheckedExpression>,
+    pub binders: Arena<CheckedBinder>,
+    pub expressions_by_source: FxHashMap<lowering::ExpressionId, CheckedExpressionId>,
+    pub binders_by_source: FxHashMap<lowering::BinderId, CheckedBinderId>,
+}
+
+impl CheckedCore {
+    pub fn allocate_expression(
+        &mut self,
+        type_id: TypeId,
+        kind: CheckedExpressionKind,
+    ) -> CheckedExpressionId {
+        let expression = CheckedExpression { type_id, kind };
+        self.expressions.alloc(expression)
+    }
+
+    pub fn allocate_binder(&mut self, type_id: TypeId, kind: CheckedBinderKind) -> CheckedBinderId {
+        let binder = CheckedBinder { type_id, kind };
+        self.binders.alloc(binder)
+    }
+
+    pub fn record_expression(
+        &mut self,
+        source: lowering::ExpressionId,
+        checked: CheckedExpressionId,
+    ) {
+        let previous = self.expressions_by_source.insert(source, checked);
+        assert!(previous.is_none(), "invariant violated: source expression checked twice");
+    }
+
+    pub fn record_binder(&mut self, source: lowering::BinderId, checked: CheckedBinderId) {
+        let previous = self.binders_by_source.insert(source, checked);
+        assert!(previous.is_none(), "invariant violated: source binder checked twice");
+    }
+
+    pub fn lookup_expression(&self, source: lowering::ExpressionId) -> Option<CheckedExpressionId> {
+        self.expressions_by_source.get(&source).copied()
+    }
+
+    pub fn lookup_binder(&self, source: lowering::BinderId) -> Option<CheckedBinderId> {
+        self.binders_by_source.get(&source).copied()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedExpression {
+    pub type_id: TypeId,
+    pub kind: CheckedExpressionKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedExpressionKind {
+    Variable { resolution: lowering::TermVariableResolution },
+    TermApplication { function: CheckedExpressionId, argument: CheckedExpressionId },
+    TypeApplication { function: CheckedExpressionId, argument: TypeId },
+    EvidenceApplication { expression: CheckedExpressionId, evidence: Arc<[EvidenceVarId]> },
+    EvidenceAbstraction { binders: Arc<[EvidenceBinderId]>, expression: CheckedExpressionId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedBinder {
+    pub type_id: TypeId,
+    pub kind: CheckedBinderKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckedBinderKind {
+    Variable,
+    Named { binder: CheckedBinderId },
+}

--- a/compiler-core/checking/src/semantic/pretty.rs
+++ b/compiler-core/checking/src/semantic/pretty.rs
@@ -3,7 +3,7 @@
 use files::FileId;
 use indexing::{TermItemId, TermItemKind};
 use itertools::Itertools;
-use lowering::{BinderKind, TermVariableResolution};
+use lowering::{BinderKind, GraphNode, LetBindingNameGroupId, TermVariableResolution};
 use pretty::{Arena, DocAllocator, DocBuilder};
 use smol_str::{SmolStr, SmolStrBuilder};
 
@@ -13,8 +13,11 @@ use crate::evidence::{
     ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
 };
 use crate::semantic::{
-    CheckedBinderId, CheckedBinderKind, CheckedCaseAlternative, CheckedExpressionId,
-    CheckedExpressionKind, CheckedGuardedExpression, CheckedLiteral, CheckedPatternGuard,
+    CheckedAdoExpression, CheckedAdoStep, CheckedBinaryApplication, CheckedBinderId,
+    CheckedBinderKind, CheckedBlockStatement, CheckedCaseAlternative, CheckedDoExpression,
+    CheckedDoStep, CheckedExpressionId, CheckedExpressionKind, CheckedGuardedExpression,
+    CheckedLetBinding, CheckedLetStatement, CheckedLiteral, CheckedPatternGuard,
+    CheckedUnaryApplication,
 };
 use crate::{CheckedModule, PrettyQueries, TypeId};
 
@@ -165,28 +168,28 @@ where
             CheckedExpressionKind::Literal { literal } => {
                 (self.arena.text(self.literal(literal)), Precedence::Atom)
             }
+            CheckedExpressionKind::Error => (self.arena.text("<error>"), Precedence::Atom),
+            CheckedExpressionKind::Do { expression } => {
+                (self.do_expression(&expression), Precedence::Abstraction)
+            }
+            CheckedExpressionKind::Ado { expression } => {
+                (self.ado_expression(&expression), Precedence::Abstraction)
+            }
             CheckedExpressionKind::Case { scrutinees, alternatives } => {
                 let document = self.case_expression(&scrutinees, &alternatives);
                 (document, Precedence::Abstraction)
             }
             CheckedExpressionKind::Lambda { binders, expression } => {
                 let binders = binders.iter().map(|binder_id| self.binder(*binder_id));
-                let binders = binders.collect::<Vec<_>>();
-                let binders = self.separated_by_space(binders).group();
+                let binders = binders.collect_vec();
                 let expression = self.expression(expression, Precedence::Abstraction);
-                let document = self
-                    .arena
-                    .text("\\")
-                    .append(binders)
-                    .append(self.arena.text(" -> "))
-                    .append(expression);
+                let document = self.lambda_document(binders, expression);
                 (document, Precedence::Abstraction)
             }
             CheckedExpressionKind::TermApplication { function, argument } => {
                 let function = self.expression(function, Precedence::Application);
                 let argument = self.expression(argument, Precedence::Atom);
-                let argument = self.arena.line().append(argument).nest(2);
-                let application = function.append(argument).group();
+                let application = self.term_application(function, argument);
                 (application, Precedence::Application)
             }
             CheckedExpressionKind::TypeApplication { function, argument } => {
@@ -199,18 +202,7 @@ where
             }
             CheckedExpressionKind::EvidenceApplication { expression, evidence } => {
                 let expression = self.expression(expression, Precedence::Application);
-                let evidence =
-                    evidence.iter().map(|evidence_id| self.evidence_variable(*evidence_id));
-                let evidence = evidence.collect::<Vec<_>>();
-                let evidence = self.separated_by_comma(evidence).group();
-                let argument = self
-                    .arena
-                    .line()
-                    .append(self.arena.text("@{"))
-                    .append(evidence)
-                    .append(self.arena.text("}"))
-                    .nest(2);
-                let application = expression.append(argument).group();
+                let application = self.evidence_application(expression, &evidence);
                 (application, Precedence::Application)
             }
             CheckedExpressionKind::EvidenceAbstraction { binders, expression } => {
@@ -229,6 +221,212 @@ where
         };
 
         self.parenthesize_if(precedence < outer, document)
+    }
+
+    fn do_expression(&mut self, expression: &CheckedDoExpression) -> Doc<'arena> {
+        let mut continuation =
+            self.expression(expression.final_expression, Precedence::Abstraction);
+
+        for step in expression.steps.iter().rev() {
+            match step {
+                CheckedDoStep::Bind { binder, expression, application, .. }
+                | CheckedDoStep::Discard { binder, expression, application, .. } => {
+                    let binder = self.binder(*binder);
+                    let lambda = self.lambda_document(vec![binder], continuation);
+                    let lambda = self.parenthesize_if(true, lambda);
+                    let action = self.expression(*expression, Precedence::Atom);
+                    continuation = self.binary_application(application, action, lambda);
+                }
+                CheckedDoStep::Statement(statement) => {
+                    continuation = self.block_statement(statement, continuation);
+                }
+            }
+        }
+
+        continuation
+    }
+
+    fn ado_expression(&mut self, expression: &CheckedAdoExpression) -> Doc<'arena> {
+        match expression {
+            CheckedAdoExpression::Pure { statements, expression, application } => {
+                let argument = self.expression(*expression, Precedence::Atom);
+                let mut application = self.unary_application(application, argument);
+                for statement in statements.iter().rev() {
+                    application = self.block_statement(statement, application);
+                }
+                application
+            }
+            CheckedAdoExpression::Error { statements, .. } => {
+                let mut recovery = self.arena.text("<error-ado>");
+                for statement in statements.iter().rev() {
+                    recovery = self.block_statement(statement, recovery);
+                }
+                recovery
+            }
+            CheckedAdoExpression::Actions { steps, expression, .. } => {
+                let binders = steps.iter().filter_map(|step| match step {
+                    CheckedAdoStep::Map { binder, .. } | CheckedAdoStep::Apply { binder, .. } => {
+                        Some(self.binder(*binder))
+                    }
+                    CheckedAdoStep::Statement(_) => None,
+                });
+                let binders = binders.collect_vec();
+                let mut body = self.expression(*expression, Precedence::Abstraction);
+                for step in steps.iter().rev() {
+                    if let CheckedAdoStep::Statement(statement) = step {
+                        body = self.block_statement(statement, body);
+                    }
+                }
+                let lambda = self.lambda_document(binders, body);
+                let mut continuation = self.parenthesize_if(true, lambda);
+
+                for step in steps.iter() {
+                    let (action, application, parenthesize_continuation) = match step {
+                        CheckedAdoStep::Map { expression, application, .. } => {
+                            (*expression, application, false)
+                        }
+                        CheckedAdoStep::Apply { expression, application, .. } => {
+                            (*expression, application, true)
+                        }
+                        CheckedAdoStep::Statement(_) => continue,
+                    };
+                    if parenthesize_continuation {
+                        continuation = self.parenthesize_if(true, continuation);
+                    }
+                    let action = self.expression(action, Precedence::Atom);
+                    continuation = self.binary_application(application, continuation, action);
+                }
+                continuation
+            }
+        }
+    }
+
+    fn block_statement(
+        &mut self,
+        statement: &CheckedBlockStatement,
+        continuation: Doc<'arena>,
+    ) -> Doc<'arena> {
+        match statement {
+            CheckedBlockStatement::Let(statement) => {
+                self.let_statement(statement).append(self.arena.text(" in ")).append(continuation)
+            }
+            CheckedBlockStatement::Error(_) => {
+                self.arena.text("<error-statement>; ").append(continuation)
+            }
+        }
+    }
+
+    fn let_statement(&mut self, statement: &CheckedLetStatement) -> Doc<'arena> {
+        let bindings = statement.bindings.iter().map(|binding| match binding {
+            CheckedLetBinding::Pattern { binder: Some(binder) } => self.binder(*binder),
+            CheckedLetBinding::Pattern { binder: None } => self.arena.text("<missing-pattern>"),
+            CheckedLetBinding::Name { binding, type_id } => {
+                let name = self.let_binding_name(*binding);
+                let type_document = self.type_document(*type_id);
+                self.arena.text(name).append(self.arena.text(" :: ")).append(type_document)
+            }
+        });
+        let bindings = bindings.collect_vec();
+        let bindings = self.separated_by_comma(bindings);
+        self.arena.text("let { ").append(bindings).append(self.arena.text(" }")).group()
+    }
+
+    fn binary_application(
+        &mut self,
+        application: &CheckedBinaryApplication,
+        first: Doc<'arena>,
+        second: Doc<'arena>,
+    ) -> Doc<'arena> {
+        match application {
+            CheckedBinaryApplication::Complete {
+                function,
+                first: first_step,
+                second: second_step,
+            } => {
+                let function = self.expression(*function, Precedence::Application);
+                let function = self.evidence_application(function, &first_step.evidence);
+                let partial = self.term_application(function, first);
+                let partial = self.evidence_application(partial, &second_step.evidence);
+                self.term_application(partial, second)
+            }
+            CheckedBinaryApplication::Partial { function, first: first_step } => {
+                let function = self.expression(*function, Precedence::Application);
+                let function = self.evidence_application(function, &first_step.evidence);
+                let partial = self.term_application(function, first);
+                self.arena
+                    .text("<partial-application ")
+                    .append(partial)
+                    .append(self.arena.text(" "))
+                    .append(second)
+                    .append(self.arena.text(">"))
+            }
+            CheckedBinaryApplication::Error { function } => {
+                let function = self.expression(*function, Precedence::Application);
+                self.arena
+                    .text("<error-application ")
+                    .append(function)
+                    .append(self.arena.text(" "))
+                    .append(first)
+                    .append(self.arena.text(" "))
+                    .append(second)
+                    .append(self.arena.text(">"))
+            }
+        }
+    }
+
+    fn unary_application(
+        &mut self,
+        application: &CheckedUnaryApplication,
+        argument: Doc<'arena>,
+    ) -> Doc<'arena> {
+        match application {
+            CheckedUnaryApplication::Complete { function, application } => {
+                let function = self.expression(*function, Precedence::Application);
+                let function = self.evidence_application(function, &application.evidence);
+                self.term_application(function, argument)
+            }
+            CheckedUnaryApplication::Error { function } => {
+                let function = self.expression(*function, Precedence::Application);
+                self.arena
+                    .text("<error-application ")
+                    .append(function)
+                    .append(self.arena.text(" "))
+                    .append(argument)
+                    .append(self.arena.text(">"))
+            }
+        }
+    }
+
+    fn evidence_application(
+        &mut self,
+        expression: Doc<'arena>,
+        evidence: &[EvidenceVarId],
+    ) -> Doc<'arena> {
+        if evidence.is_empty() {
+            return expression;
+        }
+
+        let evidence = evidence.iter().map(|evidence_id| self.evidence_variable(*evidence_id));
+        let evidence = evidence.collect_vec();
+        let evidence = self.separated_by_comma(evidence).group();
+        let argument = self
+            .arena
+            .line()
+            .append(self.arena.text("@{"))
+            .append(evidence)
+            .append(self.arena.text("}"))
+            .nest(2);
+        expression.append(argument).group()
+    }
+
+    fn term_application(&self, function: Doc<'arena>, argument: Doc<'arena>) -> Doc<'arena> {
+        let argument = self.arena.line().append(argument).nest(2);
+        function.append(argument).group()
+    }
+
+    fn lambda_document(&self, binders: Vec<Doc<'arena>>, expression: Doc<'arena>) -> Doc<'arena> {
+        let binders = self.separated_by_space(binders).group();
+        self.arena.text("\\").append(binders).append(self.arena.text(" -> ")).append(expression)
     }
 
     fn case_expression(
@@ -315,14 +513,26 @@ where
     fn variable(&self, variable: TermVariableResolution) -> String {
         match variable {
             TermVariableResolution::Binder(binder) => self.binder_name(binder),
-            TermVariableResolution::Let(binding) => {
-                format!("let{}", binding.into_raw().into_u32())
-            }
+            TermVariableResolution::Let(binding) => self.let_binding_name(binding),
             TermVariableResolution::RecordPun(pun) => {
                 format!("pun{}", pun.into_raw().get())
             }
             TermVariableResolution::Reference(file_id, item_id) => self.item_name(file_id, item_id),
         }
+    }
+
+    fn let_binding_name(&self, binding: LetBindingNameGroupId) -> String {
+        let graph_node = self.lowered.nodes.let_node(binding);
+        graph_node
+            .and_then(|graph_node| match &self.lowered.graph[graph_node] {
+                GraphNode::Let { bindings, .. } => {
+                    bindings.iter().find_map(|(name, &candidate)| {
+                        (candidate == binding).then(|| name.to_string())
+                    })
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| "<missing-let-name>".to_string())
     }
 
     fn item_name(&self, file_id: FileId, item_id: TermItemId) -> String {
@@ -370,6 +580,7 @@ where
                     .append(arguments)
                     .append(self.arena.text(")"))
             }
+            CheckedBinderKind::Error => self.arena.text("<error>"),
         }
     }
 

--- a/compiler-core/checking/src/semantic/pretty.rs
+++ b/compiler-core/checking/src/semantic/pretty.rs
@@ -1,0 +1,510 @@
+//! Implements the pretty printer for checked Core semantic trees.
+
+use files::FileId;
+use indexing::{TermItemId, TermItemKind};
+use itertools::Itertools;
+use lowering::{BinderKind, TermVariableResolution};
+use pretty::{Arena, DocAllocator, DocBuilder};
+use smol_str::{SmolStr, SmolStrBuilder};
+
+use crate::core::Name;
+use crate::evidence::{
+    Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
+    ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
+};
+use crate::semantic::{
+    CheckedBinderId, CheckedBinderKind, CheckedCaseAlternative, CheckedExpressionId,
+    CheckedExpressionKind, CheckedGuardedExpression, CheckedLiteral, CheckedPatternGuard,
+};
+use crate::{CheckedModule, PrettyQueries, TypeId};
+
+type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
+
+pub struct Pretty<'a, Q: ?Sized> {
+    queries: &'a Q,
+    checked: &'a CheckedModule,
+    lowered: &'a lowering::LoweredModule,
+    types: crate::core::pretty::Pretty<'a, Q>,
+    width: usize,
+}
+
+impl<'a, Q> Pretty<'a, Q>
+where
+    Q: PrettyQueries + ?Sized,
+{
+    pub fn new(
+        queries: &'a Q,
+        checked: &'a CheckedModule,
+        lowered: &'a lowering::LoweredModule,
+    ) -> Pretty<'a, Q> {
+        let types = crate::core::pretty::Pretty::new(queries, checked);
+        Pretty { queries, checked, lowered, types, width: 100 }
+    }
+
+    pub fn width(mut self, width: usize) -> Pretty<'a, Q> {
+        self.width = width;
+        self.types = self.types.width(width);
+        self
+    }
+
+    pub fn reset(&mut self) {
+        self.types.reset();
+    }
+
+    pub fn display_name(&mut self, name: Name) -> SmolStr {
+        self.types.display_name(name)
+    }
+
+    pub fn render_type(&mut self, type_id: TypeId) -> SmolStr {
+        self.types.render(type_id)
+    }
+
+    pub fn render_signature(&mut self, name: &str, type_id: TypeId) -> SmolStr {
+        self.types.render_signature(name, type_id)
+    }
+
+    pub fn render_expression(&mut self, expression_id: CheckedExpressionId) -> SmolStr {
+        let width = self.width;
+        let arena = Arena::new();
+        let mut printer =
+            Printer::new(&arena, self.queries, self.checked, self.lowered, &mut self.types);
+        let document = printer.expression(expression_id, Precedence::Abstraction);
+
+        let mut output = SmolStrBuilder::new();
+        document
+            .render_fmt(width, &mut output)
+            .expect("critical failure: failed to render checked expression");
+        output.finish()
+    }
+
+    pub fn render_binder(&mut self, binder_id: CheckedBinderId) -> SmolStr {
+        let width = self.width;
+        let arena = Arena::new();
+        let printer =
+            Printer::new(&arena, self.queries, self.checked, self.lowered, &mut self.types);
+        let document = printer.binder(binder_id);
+
+        let mut output = SmolStrBuilder::new();
+        document
+            .render_fmt(width, &mut output)
+            .expect("critical failure: failed to render checked binder");
+        output.finish()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Precedence {
+    Abstraction,
+    Application,
+    Atom,
+}
+
+struct Printer<'arena, 'context, 'state, Q>
+where
+    Q: PrettyQueries + ?Sized,
+{
+    arena: &'arena Arena<'arena>,
+    queries: &'context Q,
+    checked: &'context CheckedModule,
+    lowered: &'context lowering::LoweredModule,
+    types: &'state mut crate::core::pretty::Pretty<'context, Q>,
+}
+
+impl<'arena, 'context, 'state, Q> Printer<'arena, 'context, 'state, Q>
+where
+    Q: PrettyQueries + ?Sized,
+{
+    fn new(
+        arena: &'arena Arena<'arena>,
+        queries: &'context Q,
+        checked: &'context CheckedModule,
+        lowered: &'context lowering::LoweredModule,
+        types: &'state mut crate::core::pretty::Pretty<'context, Q>,
+    ) -> Printer<'arena, 'context, 'state, Q> {
+        Printer { arena, queries, checked, lowered, types }
+    }
+
+    fn parenthesize_if(&self, condition: bool, document: Doc<'arena>) -> Doc<'arena> {
+        if condition {
+            self.arena.text("(").append(document).append(self.arena.text(")"))
+        } else {
+            document
+        }
+    }
+
+    fn separated_by_space(&self, documents: Vec<Doc<'arena>>) -> Doc<'arena> {
+        let mut documents = documents.into_iter();
+        let Some(first) = documents.next() else {
+            return self.arena.nil();
+        };
+
+        documents.fold(first, |document, next| document.append(self.arena.line()).append(next))
+    }
+
+    fn separated_by_comma(&self, documents: Vec<Doc<'arena>>) -> Doc<'arena> {
+        let mut documents = documents.into_iter();
+        let Some(first) = documents.next() else {
+            return self.arena.nil();
+        };
+
+        documents.fold(first, |document, next| {
+            document.append(self.arena.text(",")).append(self.arena.line()).append(next)
+        })
+    }
+
+    fn expression(&mut self, expression_id: CheckedExpressionId, outer: Precedence) -> Doc<'arena> {
+        let expression = self.checked.core.expressions[expression_id].clone();
+        let (document, precedence) = match expression.kind {
+            CheckedExpressionKind::Variable { resolution } => {
+                (self.arena.text(self.variable(resolution)), Precedence::Atom)
+            }
+            CheckedExpressionKind::Constructor { file_id, item_id } => {
+                let constructor = self.item_name(file_id, item_id);
+                (self.arena.text(constructor), Precedence::Atom)
+            }
+            CheckedExpressionKind::Literal { literal } => {
+                (self.arena.text(self.literal(literal)), Precedence::Atom)
+            }
+            CheckedExpressionKind::Case { scrutinees, alternatives } => {
+                let document = self.case_expression(&scrutinees, &alternatives);
+                (document, Precedence::Abstraction)
+            }
+            CheckedExpressionKind::Lambda { binders, expression } => {
+                let binders = binders.iter().map(|binder_id| self.binder(*binder_id));
+                let binders = binders.collect::<Vec<_>>();
+                let binders = self.separated_by_space(binders).group();
+                let expression = self.expression(expression, Precedence::Abstraction);
+                let document = self
+                    .arena
+                    .text("\\")
+                    .append(binders)
+                    .append(self.arena.text(" -> "))
+                    .append(expression);
+                (document, Precedence::Abstraction)
+            }
+            CheckedExpressionKind::TermApplication { function, argument } => {
+                let function = self.expression(function, Precedence::Application);
+                let argument = self.expression(argument, Precedence::Atom);
+                let argument = self.arena.line().append(argument).nest(2);
+                let application = function.append(argument).group();
+                (application, Precedence::Application)
+            }
+            CheckedExpressionKind::TypeApplication { function, argument } => {
+                let function = self.expression(function, Precedence::Application);
+                let argument = self.type_document(argument);
+                let argument =
+                    self.arena.line().append(self.arena.text("@")).append(argument).nest(2);
+                let application = function.append(argument).group();
+                (application, Precedence::Application)
+            }
+            CheckedExpressionKind::EvidenceApplication { expression, evidence } => {
+                let expression = self.expression(expression, Precedence::Application);
+                let evidence =
+                    evidence.iter().map(|evidence_id| self.evidence_variable(*evidence_id));
+                let evidence = evidence.collect::<Vec<_>>();
+                let evidence = self.separated_by_comma(evidence).group();
+                let argument = self
+                    .arena
+                    .line()
+                    .append(self.arena.text("@{"))
+                    .append(evidence)
+                    .append(self.arena.text("}"))
+                    .nest(2);
+                let application = expression.append(argument).group();
+                (application, Precedence::Application)
+            }
+            CheckedExpressionKind::EvidenceAbstraction { binders, expression } => {
+                let binders = binders.iter().map(|binder_id| self.evidence_binder(*binder_id));
+                let binders = binders.collect::<Vec<_>>();
+                let binders = self.separated_by_comma(binders).group();
+                let expression = self.expression(expression, Precedence::Abstraction);
+                let document = self
+                    .arena
+                    .text("\\@{")
+                    .append(binders)
+                    .append(self.arena.text("} -> "))
+                    .append(expression);
+                (document, Precedence::Abstraction)
+            }
+        };
+
+        self.parenthesize_if(precedence < outer, document)
+    }
+
+    fn case_expression(
+        &mut self,
+        scrutinees: &[CheckedExpressionId],
+        alternatives: &[CheckedCaseAlternative],
+    ) -> Doc<'arena> {
+        let scrutinees =
+            scrutinees.iter().map(|scrutinee| self.expression(*scrutinee, Precedence::Abstraction));
+        let scrutinees = scrutinees.collect::<Vec<_>>();
+        let scrutinees = self.separated_by_comma(scrutinees).group();
+        let header = self.arena.text("case ").append(scrutinees).append(self.arena.text(" of"));
+
+        let alternatives =
+            alternatives.iter().map(|alternative| self.case_alternative(alternative));
+        let alternatives = alternatives.collect_vec();
+        let alternatives = alternatives.into_iter();
+        let alternatives = alternatives.fold(self.arena.nil(), |document, alternative| {
+            document.append(self.arena.hardline()).append(alternative)
+        });
+
+        header.append(alternatives.nest(2))
+    }
+
+    fn case_alternative(&mut self, alternative: &CheckedCaseAlternative) -> Doc<'arena> {
+        let binders = alternative.binders.iter().map(|binder_id| self.binder(*binder_id));
+        let binders = binders.collect::<Vec<_>>();
+        let binders = self.separated_by_comma(binders).group();
+
+        if let [result] = alternative.results.as_ref()
+            && result.guards.is_empty()
+        {
+            let expression = self.expression(result.expression, Precedence::Abstraction);
+            return binders.append(self.arena.text(" -> ")).append(expression);
+        }
+
+        let results = alternative.results.iter().map(|result| self.guarded_expression(result));
+        let results = results.collect::<Vec<_>>();
+        let results = results.into_iter();
+        let results = results.fold(self.arena.nil(), |document, result| {
+            document.append(self.arena.hardline()).append(result)
+        });
+
+        binders.append(results.nest(2))
+    }
+
+    fn guarded_expression(&mut self, guarded: &CheckedGuardedExpression) -> Doc<'arena> {
+        let guards = guarded.guards.iter().map(|guard| self.pattern_guard(guard));
+        let guards = guards.collect::<Vec<_>>();
+        let expression = self.expression(guarded.expression, Precedence::Abstraction);
+
+        if guards.is_empty() {
+            return self.arena.text("-> ").append(expression);
+        }
+
+        let guards = self.separated_by_comma(guards).group();
+        self.arena.text("| ").append(guards).append(self.arena.text(" -> ")).append(expression)
+    }
+
+    fn pattern_guard(&mut self, guard: &CheckedPatternGuard) -> Doc<'arena> {
+        match *guard {
+            CheckedPatternGuard::Boolean { expression } => {
+                self.expression(expression, Precedence::Abstraction)
+            }
+            CheckedPatternGuard::Pattern { binder, expression } => {
+                let binder = self.binder(binder);
+                let expression = self.expression(expression, Precedence::Abstraction);
+                binder.append(self.arena.text(" <- ")).append(expression)
+            }
+        }
+    }
+
+    fn type_document(&mut self, type_id: TypeId) -> Doc<'arena> {
+        let rendered = self.types.render(type_id);
+        let mut lines = rendered.split('\n');
+        let first = lines.next().unwrap_or_default();
+        let first = self.arena.text(first.to_string());
+
+        lines.fold(first, |document, line| {
+            document.append(self.arena.hardline()).append(self.arena.text(line.to_string()))
+        })
+    }
+
+    fn variable(&self, variable: TermVariableResolution) -> String {
+        match variable {
+            TermVariableResolution::Binder(binder) => self.binder_name(binder),
+            TermVariableResolution::Let(binding) => {
+                format!("let{}", binding.into_raw().into_u32())
+            }
+            TermVariableResolution::RecordPun(pun) => {
+                format!("pun{}", pun.into_raw().get())
+            }
+            TermVariableResolution::Reference(file_id, item_id) => self.item_name(file_id, item_id),
+        }
+    }
+
+    fn item_name(&self, file_id: FileId, item_id: TermItemId) -> String {
+        let indexed = self.queries.indexed(file_id).ok();
+        indexed
+            .and_then(|indexed| indexed.items[item_id].name.clone())
+            .map(String::from)
+            .unwrap_or_else(|| format!("item{}", item_id.into_raw().into_u32()))
+    }
+
+    fn binder(&self, binder_id: CheckedBinderId) -> Doc<'arena> {
+        let checked_binder = &self.checked.core.binders[binder_id];
+        match checked_binder.kind.clone() {
+            CheckedBinderKind::Variable => {
+                let name = checked_binder
+                    .source
+                    .map(|source| self.binder_name(source))
+                    .unwrap_or_else(|| "<unimplemented>".to_string());
+                self.arena.text(name)
+            }
+            CheckedBinderKind::Named { binder } => {
+                let source = checked_binder.source;
+                match source.and_then(|source| self.lowered.info.get_binder_kind(source)) {
+                    Some(BinderKind::Named { named, .. }) => {
+                        let named = named.as_deref().unwrap_or("<missing>");
+                        let binder = self.binder(binder);
+                        self.arena.text(format!("{named}@")).append(binder)
+                    }
+                    _ => self.arena.text("<invalid>"),
+                }
+            }
+            CheckedBinderKind::Wildcard => self.arena.text("_"),
+            CheckedBinderKind::Constructor { file_id, item_id, arguments } => {
+                let constructor = self.item_name(file_id, item_id);
+                if arguments.is_empty() {
+                    return self.arena.text(constructor);
+                }
+
+                let arguments = arguments.iter().map(|argument| self.binder(*argument));
+                let arguments = arguments.collect::<Vec<_>>();
+                let arguments = self.separated_by_comma(arguments).group();
+                self.arena
+                    .text(constructor)
+                    .append(self.arena.text("("))
+                    .append(arguments)
+                    .append(self.arena.text(")"))
+            }
+        }
+    }
+
+    fn binder_name(&self, source: lowering::BinderId) -> String {
+        match self.lowered.info.get_binder_kind(source) {
+            Some(BinderKind::Variable { variable }) => {
+                variable.clone().map(String::from).unwrap_or_else(|| "_".to_string())
+            }
+            Some(BinderKind::Named { named, .. }) => {
+                named.clone().map(String::from).unwrap_or_else(|| "_".to_string())
+            }
+            Some(BinderKind::Parenthesized { parenthesized: Some(binder) }) => {
+                self.binder_name(*binder)
+            }
+            _ => format!("binder{}", source.into_raw().get()),
+        }
+    }
+
+    fn literal(&self, literal: CheckedLiteral) -> String {
+        match literal {
+            CheckedLiteral::String { kind: lowering::StringKind::String, value } => {
+                value.map(|value| format!("{value:?}")).unwrap_or_else(|| "?string".to_string())
+            }
+            CheckedLiteral::String { kind: lowering::StringKind::RawString, value } => value
+                .map(|value| format!("raw{value:?}"))
+                .unwrap_or_else(|| "?raw-string".to_string()),
+            CheckedLiteral::Char(value) => {
+                value.map(|value| format!("{value:?}")).unwrap_or_else(|| "?char".to_string())
+            }
+            CheckedLiteral::Boolean(value) => value.to_string(),
+            CheckedLiteral::Integer(value) => {
+                value.map(|value| value.to_string()).unwrap_or_else(|| "?int".to_string())
+            }
+            CheckedLiteral::Number(value) => {
+                value.map(String::from).unwrap_or_else(|| "?number".to_string())
+            }
+        }
+    }
+
+    fn evidence_variable(&mut self, variable @ EvidenceVarId(index): EvidenceVarId) -> Doc<'arena> {
+        match self.checked.evidence[variable].state {
+            EvidenceState::Unsolved => self.arena.text(format!("ev{index}<unsolved>")),
+            EvidenceState::Solved(evidence) => self.evidence(evidence),
+            EvidenceState::Error => self.arena.text(format!("ev{index}<error>")),
+        }
+    }
+
+    fn evidence(&mut self, evidence_id: EvidenceId) -> Doc<'arena> {
+        match self.checked.evidence[evidence_id].clone() {
+            Evidence::Variable(variable) => self.evidence_variable(variable),
+            Evidence::Given(binder) => self.evidence_binder(binder),
+            Evidence::Instance { origin, subgoals } => {
+                let instance = self.instance_name(origin);
+                if subgoals.is_empty() {
+                    return self.arena.text(instance);
+                }
+
+                let subgoals = subgoals.into_iter().map(|subgoal| self.evidence_variable(subgoal));
+                let subgoals = subgoals.collect::<Vec<_>>();
+                let subgoals = self.separated_by_comma(subgoals).group();
+                self.arena
+                    .text(instance)
+                    .append(self.arena.text(" @{"))
+                    .append(subgoals)
+                    .append(self.arena.text("}"))
+            }
+            Evidence::Superclass { parent, superclass } => {
+                let superclass = self.superclass_name(superclass);
+                let parent = self.evidence(parent);
+                self.arena.text(format!("superclass[{superclass}] ")).append(parent)
+            }
+            Evidence::Trivial => self.arena.text("<trivial>"),
+            Evidence::Synthesized(evidence) => self.synthesized_evidence(evidence),
+        }
+    }
+
+    fn instance_name(&self, origin: InstanceCandidateOrigin) -> String {
+        let file_id = match origin {
+            InstanceCandidateOrigin::Instance(file_id, _)
+            | InstanceCandidateOrigin::Derive(file_id, _) => file_id,
+        };
+        let indexed = self.queries.indexed(file_id).ok();
+        let name = indexed.and_then(|indexed| {
+            indexed.items.iter_terms().find_map(|(_, item)| {
+                let matches = match (origin, &item.kind) {
+                    (
+                        InstanceCandidateOrigin::Instance(_, origin_id),
+                        TermItemKind::Instance { id },
+                    ) => origin_id == *id,
+                    (
+                        InstanceCandidateOrigin::Derive(_, origin_id),
+                        TermItemKind::Derive { id },
+                    ) => origin_id == *id,
+                    _ => false,
+                };
+                matches.then(|| item.name.clone()).flatten()
+            })
+        });
+
+        name.map(String::from).unwrap_or_else(|| match origin {
+            InstanceCandidateOrigin::Instance(_, _) | InstanceCandidateOrigin::Derive(_, _) => {
+                "<anonymous>".to_string()
+            }
+        })
+    }
+
+    fn superclass_name(&self, superclass: SuperclassId) -> String {
+        let indexed = self.queries.indexed(superclass.file_id).ok();
+        indexed
+            .and_then(|indexed| indexed.items[superclass.type_id].name.clone())
+            .map(String::from)
+            .unwrap_or_else(|| "<anonymous>".to_string())
+    }
+
+    fn synthesized_evidence(&self, evidence: SynthesizedEvidence) -> Doc<'arena> {
+        let rendered = match evidence {
+            SynthesizedEvidence::IsSymbol(symbol) => format!("isSymbol({symbol:?})"),
+            SynthesizedEvidence::Reflectable(evidence) => match evidence {
+                ReflectableEvidence::Integer(integer) => format!("reflectable({integer})"),
+                ReflectableEvidence::String(string) => format!("reflectable({string:?})"),
+                ReflectableEvidence::Boolean(boolean) => format!("reflectable({boolean})"),
+                ReflectableEvidence::Ordering(ordering) => {
+                    let ordering = match ordering {
+                        ReflectableOrdering::Less => "LT",
+                        ReflectableOrdering::Equal => "EQ",
+                        ReflectableOrdering::Greater => "GT",
+                    };
+                    format!("reflectable({ordering})")
+                }
+            },
+        };
+        self.arena.text(rendered)
+    }
+
+    fn evidence_binder(&self, EvidenceBinderId(index): EvidenceBinderId) -> Doc<'arena> {
+        self.arena.text(format!("dict{index}"))
+    }
+}

--- a/compiler-core/checking/src/semantic/pretty.rs
+++ b/compiler-core/checking/src/semantic/pretty.rs
@@ -17,7 +17,7 @@ use crate::semantic::{
     CheckedBinderKind, CheckedBlockStatement, CheckedCaseAlternative, CheckedDoExpression,
     CheckedDoStep, CheckedExpressionId, CheckedExpressionKind, CheckedGuardedExpression,
     CheckedLetBinding, CheckedLetStatement, CheckedLiteral, CheckedPatternGuard,
-    CheckedUnaryApplication,
+    CheckedRecordField, CheckedUnaryApplication,
 };
 use crate::{CheckedModule, PrettyQueries, TypeId};
 
@@ -168,6 +168,12 @@ where
             CheckedExpressionKind::Literal { literal } => {
                 (self.arena.text(self.literal(literal)), Precedence::Atom)
             }
+            CheckedExpressionKind::Array { elements } => {
+                (self.array_expression(&elements), Precedence::Atom)
+            }
+            CheckedExpressionKind::Record { fields } => {
+                (self.record_expression(&fields), Precedence::Atom)
+            }
             CheckedExpressionKind::Error => (self.arena.text("<error>"), Precedence::Atom),
             CheckedExpressionKind::Do { expression } => {
                 (self.do_expression(&expression), Precedence::Abstraction)
@@ -221,6 +227,31 @@ where
         };
 
         self.parenthesize_if(precedence < outer, document)
+    }
+
+    fn array_expression(&mut self, elements: &[CheckedExpressionId]) -> Doc<'arena> {
+        let elements =
+            elements.iter().map(|element| self.expression(*element, Precedence::Abstraction));
+        let elements = elements.collect_vec();
+        let elements = self.separated_by_comma(elements).group();
+        self.arena.text("[").append(elements).append(self.arena.text("]"))
+    }
+
+    fn record_expression(&mut self, fields: &[CheckedRecordField]) -> Doc<'arena> {
+        if fields.is_empty() {
+            return self.arena.text("{}");
+        }
+
+        let fields = fields.iter().map(|field| {
+            let expression = self.expression(field.expression, Precedence::Abstraction);
+            self.arena
+                .text(field.label.to_string())
+                .append(self.arena.text(": "))
+                .append(expression)
+        });
+        let fields = fields.collect_vec();
+        let fields = self.separated_by_comma(fields).group();
+        self.arena.text("{ ").append(fields).append(self.arena.text(" }")).group()
     }
 
     fn do_expression(&mut self, expression: &CheckedDoExpression) -> Doc<'arena> {

--- a/compiler-core/checking/src/semantic/pretty.rs
+++ b/compiler-core/checking/src/semantic/pretty.rs
@@ -565,6 +565,7 @@ where
                 }
             }
             CheckedBinderKind::Wildcard => self.arena.text("_"),
+            CheckedBinderKind::Literal(literal) => self.arena.text(self.literal(literal)),
             CheckedBinderKind::Constructor { file_id, item_id, arguments } => {
                 let constructor = self.item_name(file_id, item_id);
                 if arguments.is_empty() {

--- a/compiler-core/checking/src/semantic/pretty.rs
+++ b/compiler-core/checking/src/semantic/pretty.rs
@@ -17,7 +17,7 @@ use crate::semantic::{
     CheckedBinderKind, CheckedBlockStatement, CheckedCaseAlternative, CheckedDoExpression,
     CheckedDoStep, CheckedExpressionId, CheckedExpressionKind, CheckedGuardedExpression,
     CheckedLetBinding, CheckedLetStatement, CheckedLiteral, CheckedPatternGuard,
-    CheckedRecordField, CheckedUnaryApplication,
+    CheckedRecordField, CheckedRecordUpdate, CheckedUnaryApplication,
 };
 use crate::{CheckedModule, PrettyQueries, TypeId};
 
@@ -99,6 +99,7 @@ where
 enum Precedence {
     Abstraction,
     Application,
+    RecordUpdate,
     Atom,
 }
 
@@ -174,6 +175,20 @@ where
             CheckedExpressionKind::Record { fields } => {
                 (self.record_expression(&fields), Precedence::Atom)
             }
+            CheckedExpressionKind::RecordAccess { record, labels } => {
+                let record = self.expression(record, Precedence::Atom);
+                let labels = labels.iter();
+                let labels = labels.fold(record, |record, label| {
+                    record.append(self.arena.text(".")).append(self.arena.text(label.to_string()))
+                });
+                (labels, Precedence::Atom)
+            }
+            CheckedExpressionKind::RecordUpdate { record, updates } => {
+                let record = self.expression(record, Precedence::Atom);
+                let updates = self.record_updates(&updates);
+                let document = record.append(self.arena.text(" ")).append(updates);
+                (document, Precedence::RecordUpdate)
+            }
             CheckedExpressionKind::Error => (self.arena.text("<error>"), Precedence::Atom),
             CheckedExpressionKind::Do { expression } => {
                 (self.do_expression(&expression), Precedence::Abstraction)
@@ -194,7 +209,7 @@ where
             }
             CheckedExpressionKind::TermApplication { function, argument } => {
                 let function = self.expression(function, Precedence::Application);
-                let argument = self.expression(argument, Precedence::Atom);
+                let argument = self.expression(argument, Precedence::RecordUpdate);
                 let application = self.term_application(function, argument);
                 (application, Precedence::Application)
             }
@@ -252,6 +267,23 @@ where
         let fields = fields.collect_vec();
         let fields = self.separated_by_comma(fields).group();
         self.arena.text("{ ").append(fields).append(self.arena.text(" }")).group()
+    }
+
+    fn record_updates(&mut self, updates: &[CheckedRecordUpdate]) -> Doc<'arena> {
+        let updates = updates.iter().map(|update| match update {
+            CheckedRecordUpdate::Leaf { label, expression } => {
+                let expression = self.expression(*expression, Precedence::Abstraction);
+                self.arena.text(label.to_string()).append(self.arena.text(" = ")).append(expression)
+            }
+            CheckedRecordUpdate::Branch { label, updates } => self
+                .arena
+                .text(label.to_string())
+                .append(self.arena.text(" "))
+                .append(self.record_updates(updates)),
+        });
+        let updates = updates.collect_vec();
+        let updates = self.separated_by_comma(updates).group();
+        self.arena.text("{ ").append(updates).append(self.arena.text(" }")).group()
     }
 
     fn do_expression(&mut self, expression: &CheckedDoExpression) -> Doc<'arena> {

--- a/compiler-core/checking/src/source/binder.rs
+++ b/compiler-core/checking/src/source/binder.rs
@@ -10,6 +10,7 @@ use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{RowField, RowType, Type, TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
+use crate::semantic::CheckedBinderKind;
 use crate::source::terms::application;
 use crate::source::{operator, types};
 use crate::state::CheckState;
@@ -254,10 +255,16 @@ where
             }
         }
 
-        lowering::BinderKind::Variable { .. } => match mode {
-            BinderMode::Infer => state.fresh_unification(context.queries, context.prim.t),
-            BinderMode::Check { expected_type, .. } => expected_type,
-        },
+        lowering::BinderKind::Variable { .. } => {
+            let type_id = match mode {
+                BinderMode::Infer => state.fresh_unification(context.queries, context.prim.t),
+                BinderMode::Check { expected_type, .. } => expected_type,
+            };
+            let checked_binder =
+                state.checked.core.allocate_binder(type_id, CheckedBinderKind::Variable);
+            state.checked.core.record_binder(binder_id, checked_binder);
+            type_id
+        }
 
         lowering::BinderKind::Named { binder, .. } => {
             let Some(binder) = binder else { return Ok(unknown) };
@@ -273,6 +280,13 @@ where
                 }
             };
 
+            if let Some(checked_binder) = state.checked.core.lookup_binder(*binder) {
+                let checked_binder = state
+                    .checked
+                    .core
+                    .allocate_binder(type_id, CheckedBinderKind::Named { binder: checked_binder });
+                state.checked.core.record_binder(binder_id, checked_binder);
+            }
             state.checked.nodes.binders.insert(binder_id, type_id);
 
             type_id
@@ -345,7 +359,11 @@ where
 
         lowering::BinderKind::Parenthesized { parenthesized } => {
             let Some(parenthesized) = parenthesized else { return Ok(unknown) };
-            binder_core(state, context, *parenthesized, mode)?
+            let type_id = binder_core(state, context, *parenthesized, mode)?;
+            if let Some(checked_binder) = state.checked.core.lookup_binder(*parenthesized) {
+                state.checked.core.record_binder(binder_id, checked_binder);
+            }
+            type_id
         }
     };
 

--- a/compiler-core/checking/src/source/binder.rs
+++ b/compiler-core/checking/src/source/binder.rs
@@ -276,8 +276,7 @@ where
                     item_id: *term_id,
                     arguments: Arc::from(checked_arguments),
                 };
-                let checked_binder = state.checked.core.allocate_binder(binder_type, kind);
-                state.checked.core.record_binder(binder_id, checked_binder);
+                state.checked.core.allocate_source_binder(binder_id, binder_type, kind);
             }
 
             binder_type
@@ -288,9 +287,11 @@ where
                 BinderMode::Infer => state.fresh_unification(context.queries, context.prim.t),
                 BinderMode::Check { expected_type, .. } => expected_type,
             };
-            let checked_binder =
-                state.checked.core.allocate_binder(type_id, CheckedBinderKind::Variable);
-            state.checked.core.record_binder(binder_id, checked_binder);
+            state.checked.core.allocate_source_binder(
+                binder_id,
+                type_id,
+                CheckedBinderKind::Variable,
+            );
             type_id
         }
 
@@ -309,13 +310,12 @@ where
             };
 
             if let Some(checked_binder) = state.checked.core.lookup_binder(*binder) {
-                let checked_binder = state
-                    .checked
-                    .core
-                    .allocate_binder(type_id, CheckedBinderKind::Named { binder: checked_binder });
-                state.checked.core.record_binder(binder_id, checked_binder);
+                state.checked.core.allocate_source_binder(
+                    binder_id,
+                    type_id,
+                    CheckedBinderKind::Named { binder: checked_binder },
+                );
             }
-            state.checked.nodes.binders.insert(binder_id, type_id);
 
             type_id
         }
@@ -325,9 +325,11 @@ where
                 BinderMode::Infer => state.fresh_unification(context.queries, context.prim.t),
                 BinderMode::Check { expected_type, .. } => expected_type,
             };
-            let checked_binder =
-                state.checked.core.allocate_binder(type_id, CheckedBinderKind::Wildcard);
-            state.checked.core.record_binder(binder_id, checked_binder);
+            state.checked.core.allocate_source_binder(
+                binder_id,
+                type_id,
+                CheckedBinderKind::Wildcard,
+            );
             type_id
         }
 

--- a/compiler-core/checking/src/source/binder.rs
+++ b/compiler-core/checking/src/source/binder.rs
@@ -11,7 +11,7 @@ use crate::context::CheckContext;
 use crate::core::{RowField, RowType, Type, TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::semantic::CheckedBinderKind;
-use crate::source::terms::application;
+use crate::source::terms::{self, application};
 use crate::source::{operator, types};
 use crate::state::CheckState;
 
@@ -177,16 +177,16 @@ where
 
     let binder_type = match kind {
         lowering::BinderKind::Typed { binder, type_ } => {
-            let Some(binder_id) = binder else { return Ok(unknown) };
+            let Some(source_binder) = binder else { return Ok(unknown) };
             let Some(type_id) = type_ else { return Ok(unknown) };
 
             let (type_id, _) = types::infer_kind(state, context, *type_id)?;
             match mode {
                 BinderMode::Check { elaborating: false, .. } => {
-                    check_argument_binder(state, context, *binder_id, type_id)?;
+                    check_argument_binder(state, context, *source_binder, type_id)?;
                 }
                 _ => {
-                    check_binder(state, context, *binder_id, type_id)?;
+                    check_binder(state, context, *source_binder, type_id)?;
                 }
             }
 
@@ -194,14 +194,23 @@ where
                 subtype_for_mode(state, context, type_id, expected_type, elaborating)?;
             }
 
+            if let Some(checked_binder) = state.checked.core.lookup_binder(*source_binder) {
+                state.checked.core.record_binder(binder_id, checked_binder);
+            }
+
             type_id
         }
 
         lowering::BinderKind::OperatorChain { .. } => {
-            let (_, inferred_type) = operator::infer_operator_chain(state, context, binder_id)?;
+            let (checked_binder, inferred_type) =
+                operator::infer_operator_chain(state, context, binder_id)?;
 
             if let BinderMode::Check { expected_type, elaborating } = mode {
                 subtype_for_mode(state, context, inferred_type, expected_type, elaborating)?;
+            }
+
+            if let Some(checked_binder) = checked_binder {
+                state.checked.core.record_binder(binder_id, checked_binder);
             }
 
             inferred_type
@@ -249,10 +258,29 @@ where
 
             if let BinderMode::Check { expected_type, elaborating } = mode {
                 subtype_for_mode(state, context, inferred_type, expected_type, elaborating)?;
-                expected_type
-            } else {
-                inferred_type
             }
+
+            let binder_type = match mode {
+                BinderMode::Infer => inferred_type,
+                BinderMode::Check { expected_type, .. } => expected_type,
+            };
+
+            let checked_arguments =
+                arguments.iter().map(|argument| state.checked.core.lookup_binder(*argument));
+            let checked_arguments = checked_arguments.collect::<Option<Vec<_>>>();
+            if let Some(checked_arguments) = checked_arguments
+                && terms::is_term_constructor(context, *file_id, *term_id)?
+            {
+                let kind = CheckedBinderKind::Constructor {
+                    file_id: *file_id,
+                    item_id: *term_id,
+                    arguments: Arc::from(checked_arguments),
+                };
+                let checked_binder = state.checked.core.allocate_binder(binder_type, kind);
+                state.checked.core.record_binder(binder_id, checked_binder);
+            }
+
+            binder_type
         }
 
         lowering::BinderKind::Variable { .. } => {
@@ -292,10 +320,16 @@ where
             type_id
         }
 
-        lowering::BinderKind::Wildcard => match mode {
-            BinderMode::Infer => state.fresh_unification(context.queries, context.prim.t),
-            BinderMode::Check { expected_type, .. } => expected_type,
-        },
+        lowering::BinderKind::Wildcard => {
+            let type_id = match mode {
+                BinderMode::Infer => state.fresh_unification(context.queries, context.prim.t),
+                BinderMode::Check { expected_type, .. } => expected_type,
+            };
+            let checked_binder =
+                state.checked.core.allocate_binder(type_id, CheckedBinderKind::Wildcard);
+            state.checked.core.record_binder(binder_id, checked_binder);
+            type_id
+        }
 
         lowering::BinderKind::String { .. } => {
             let inferred_type = context.prim.string;

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -345,10 +345,13 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
 
         let operator_type =
             toolkit::lookup_file_term(state, context, target_file_id, target_item_id)?;
-        let resolution =
-            lowering::TermVariableResolution::Reference(target_file_id, target_item_id);
-        let kind = CheckedExpressionKind::Variable { resolution };
-        let operator = state.checked.core.allocate_expression(operator_type, kind);
+        let operator = terms::allocate_term_reference(
+            state,
+            context,
+            target_file_id,
+            target_item_id,
+            operator_type,
+        )?;
 
         let partial_type = context.intern_function(right_type, result_type);
         let operator = terms::application::apply_evidence(

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -12,7 +12,9 @@ use sugar::bracketing::BracketingResult;
 use crate::context::CheckContext;
 use crate::core::{Type, TypeId, normalise, toolkit, unification};
 use crate::evidence::EvidenceVarId;
-use crate::semantic::{CheckedExpressionId, CheckedExpressionKind};
+use crate::semantic::{
+    CheckedBinderId, CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind,
+};
 use crate::source::types::application;
 use crate::source::{binder, synonym, terms, types};
 use crate::state::CheckState;
@@ -516,9 +518,11 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
 
 impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
     type ItemId = TermItemId;
-    type Elaborated = ();
+    type Elaborated = Option<CheckedBinderId>;
 
-    fn unknown_elaborated(_context: &CheckContext<Q>) -> Self::Elaborated {}
+    fn unknown_elaborated(_context: &CheckContext<Q>) -> Self::Elaborated {
+        None
+    }
 
     fn lookup_tree<'q>(
         context: &'q CheckContext<Q>,
@@ -549,7 +553,8 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
         id: Self,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let inferred_type = binder::infer_binder(state, context, id)?;
-        Ok(((), inferred_type))
+        let binder = state.checked.core.lookup_binder(id);
+        Ok((binder, inferred_type))
     }
 
     fn check_surface(
@@ -559,19 +564,40 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
         expected: TypeId,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let checked_type = binder::check_binder(state, context, id, expected)?;
-        Ok(((), checked_type))
+        let binder = state.checked.core.lookup_binder(id);
+        Ok((binder, checked_type))
     }
 
     fn build(
-        _state: &mut CheckState,
-        _context: &CheckContext<Q>,
-        (_, _): (FileId, Self::ItemId),
-        (_, _): (Self::Elaborated, Self::Elaborated),
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        (file_id, item_id): (FileId, Self::ItemId),
+        (left, right): (Self::Elaborated, Self::Elaborated),
         (_, _): (TypeId, TypeId),
         result_type: TypeId,
         _evidence: Arc<[EvidenceVarId]>,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
-        Ok(((), result_type))
+        let Some((left, right)) = left.zip(right) else {
+            return Ok((None, result_type));
+        };
+
+        let Some((target_file_id, target_item_id)) =
+            toolkit::resolve_term_operator_target(context, file_id, item_id)?
+        else {
+            return Ok((None, result_type));
+        };
+
+        if !terms::is_term_constructor(context, target_file_id, target_item_id)? {
+            return Ok((None, result_type));
+        }
+
+        let kind = CheckedBinderKind::Constructor {
+            file_id: target_file_id,
+            item_id: target_item_id,
+            arguments: Arc::from([left, right]),
+        };
+        let binder = state.checked.core.allocate_binder(result_type, kind);
+        Ok((Some(binder), result_type))
     }
 
     fn record_branch_types(

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -596,7 +596,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
             item_id: target_item_id,
             arguments: Arc::from([left, right]),
         };
-        let binder = state.checked.core.allocate_binder(result_type, kind);
+        let binder = state.checked.core.allocate_synthesized_binder(result_type, kind);
         Ok((Some(binder), result_type))
     }
 

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -1,5 +1,7 @@
 //! Implements surface-generic operator chain inference.
 
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use files::FileId;
 use indexing::TermItemId;
@@ -9,6 +11,8 @@ use sugar::bracketing::BracketingResult;
 
 use crate::context::CheckContext;
 use crate::core::{Type, TypeId, normalise, toolkit, unification};
+use crate::evidence::EvidenceVarId;
+use crate::semantic::{CheckedExpressionId, CheckedExpressionKind};
 use crate::source::types::application;
 use crate::source::{binder, synonym, terms, types};
 use crate::state::CheckState;
@@ -143,7 +147,8 @@ where
     };
 
     let operator_type = toolkit::instantiate_unifications(state, context, operator_type)?;
-    let operator_type = toolkit::collect_wanteds(state, context, operator_type)?;
+    let (operator_type, evidence) =
+        toolkit::collect_wanted_with_evidence(state, context, operator_type)?;
 
     let Some((left_type, operator_type)) =
         toolkit::decompose_function(state, context, operator_type)?
@@ -193,7 +198,15 @@ where
         let _ = unification::subtype(state, context, result_type, expected_type)?;
     }
 
-    E::build(state, context, operator, (left, right), (left_type, right_type), result_type)
+    E::build(
+        state,
+        context,
+        operator,
+        (left, right),
+        (left_type, right_type),
+        result_type,
+        Arc::from(evidence),
+    )
 }
 
 pub trait IsOperator<Q: ExternalQueries>: IsElement {
@@ -247,6 +260,7 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
         result_tree: (Self::Elaborated, Self::Elaborated),
         argument_types: (TypeId, TypeId),
         result_type: TypeId,
+        evidence: Arc<[EvidenceVarId]>,
     ) -> QueryResult<(Self::Elaborated, TypeId)>;
 
     fn record_branch_types(
@@ -260,9 +274,11 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
 
 impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
     type ItemId = TermItemId;
-    type Elaborated = ();
+    type Elaborated = Option<CheckedExpressionId>;
 
-    fn unknown_elaborated(_context: &CheckContext<Q>) -> Self::Elaborated {}
+    fn unknown_elaborated(_context: &CheckContext<Q>) -> Self::Elaborated {
+        None
+    }
 
     fn lookup_tree<'q>(
         context: &'q CheckContext<Q>,
@@ -293,7 +309,8 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         id: Self,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let inferred_type = terms::infer_expression(state, context, id)?;
-        Ok(((), inferred_type))
+        let expression = state.checked.core.lookup_expression(id);
+        Ok((expression, inferred_type))
     }
 
     fn check_surface(
@@ -303,18 +320,53 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         expected: TypeId,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let checked_type = terms::check_expression(state, context, id, expected)?;
-        Ok(((), checked_type))
+        let expression = state.checked.core.lookup_expression(id);
+        Ok((expression, checked_type))
     }
 
     fn build(
-        _state: &mut CheckState,
-        _context: &CheckContext<Q>,
-        (_, _): (FileId, Self::ItemId),
-        (_, _): (Self::Elaborated, Self::Elaborated),
-        (_, _): (TypeId, TypeId),
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        (file_id, item_id): (FileId, Self::ItemId),
+        (left, right): (Self::Elaborated, Self::Elaborated),
+        (left_type, right_type): (TypeId, TypeId),
         result_type: TypeId,
+        evidence: Arc<[EvidenceVarId]>,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
-        Ok(((), result_type))
+        let Some((left, right)) = left.zip(right) else {
+            return Ok((None, result_type));
+        };
+
+        let Some((target_file_id, target_item_id)) =
+            toolkit::resolve_term_operator_target(context, file_id, item_id)?
+        else {
+            return Ok((None, result_type));
+        };
+
+        let operator_type =
+            toolkit::lookup_file_term(state, context, target_file_id, target_item_id)?;
+        let resolution =
+            lowering::TermVariableResolution::Reference(target_file_id, target_item_id);
+        let kind = CheckedExpressionKind::Variable { resolution };
+        let operator = state.checked.core.allocate_expression(operator_type, kind);
+
+        let partial_type = context.intern_function(right_type, result_type);
+        let operator = terms::application::apply_evidence(
+            state,
+            context,
+            operator,
+            left_type,
+            partial_type,
+            evidence,
+        );
+
+        let kind = CheckedExpressionKind::TermApplication { function: operator, argument: left };
+        let partial = state.checked.core.allocate_expression(partial_type, kind);
+
+        let kind = CheckedExpressionKind::TermApplication { function: partial, argument: right };
+        let expression = state.checked.core.allocate_expression(result_type, kind);
+
+        Ok((Some(expression), result_type))
     }
 
     fn record_branch_types(
@@ -400,6 +452,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
         (left, right): (Self::Elaborated, Self::Elaborated),
         (left_kind, right_kind): (TypeId, TypeId),
         result_kind: TypeId,
+        _evidence: Arc<[EvidenceVarId]>,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let Some((target_file_id, target_item_id)) =
             toolkit::resolve_type_operator_target(context, file_id, item_id)?
@@ -513,6 +566,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
         (_, _): (Self::Elaborated, Self::Elaborated),
         (_, _): (TypeId, TypeId),
         result_type: TypeId,
+        _evidence: Arc<[EvidenceVarId]>,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         Ok(((), result_type))
     }

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -15,6 +15,8 @@ use crate::core::{
     normalise, signature, toolkit, unification, zonk,
 };
 use crate::error::{ErrorCrumb, ErrorKind};
+use crate::evidence::EvidenceBinderId;
+use crate::semantic::{CheckedExpressionId, CheckedExpressionKind};
 use crate::source::terms::equations;
 use crate::source::{derive, types};
 use crate::state::CheckState;
@@ -25,8 +27,8 @@ struct TermSccState {
 }
 
 enum PendingValueGroup {
-    Checked { residuals: Vec<ConstraintInScope> },
-    Inferred { residuals: Vec<ConstraintInScope> },
+    Checked { residuals: Vec<ConstraintInScope>, root: Option<CheckedExpressionId> },
+    Inferred { residuals: Vec<ConstraintInScope>, root: Option<CheckedExpressionId> },
 }
 
 pub fn check_term_items<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
@@ -335,7 +337,7 @@ where
                 }
             }
 
-            let equation_patterns = equations::check_value_equations(
+            let checked_equations = equations::check_value_equations(
                 state,
                 context,
                 equations::EquationTypeOrigin::Explicit(signature_id),
@@ -345,14 +347,14 @@ where
             let exhaustiveness = exhaustive::check_equation_patterns(
                 state,
                 context,
-                &equation_patterns,
+                &checked_equations.patterns,
                 &member.equations,
             )?;
 
             state.report_exhaustiveness(exhaustiveness);
             state.solve_constraints(context)?
         } else if let Some(expected_type) = class_member_type {
-            let equation_patterns = equations::check_value_equations(
+            let checked_equations = equations::check_value_equations(
                 state,
                 context,
                 equations::EquationTypeOrigin::Implicit,
@@ -362,7 +364,7 @@ where
             let exhaustiveness = exhaustive::check_equation_patterns(
                 state,
                 context,
-                &equation_patterns,
+                &checked_equations.patterns,
                 &member.equations,
             )?;
 
@@ -689,12 +691,12 @@ where
     if let Some(signature_id) = signature
         && let Some(signature_type) = state.checked.lookup_term(item_id)
     {
-        let residuals =
+        let pending =
             check_value_group_core_check(state, context, signature_id, signature_type, equations)?;
-        Ok(Some(PendingValueGroup::Checked { residuals }))
+        Ok(Some(pending))
     } else {
-        let residuals = check_value_group_core_infer(state, context, item_id, equations)?;
-        Ok(Some(PendingValueGroup::Inferred { residuals }))
+        let pending = check_value_group_core_infer(state, context, item_id, equations)?;
+        Ok(Some(pending))
     }
 }
 
@@ -704,21 +706,32 @@ fn check_value_group_core_check<Q>(
     signature_id: lowering::TypeId,
     signature_type: TypeId,
     equations: &[lowering::Equation],
-) -> QueryResult<Vec<ConstraintInScope>>
+) -> QueryResult<PendingValueGroup>
 where
     Q: ExternalQueries,
 {
-    let equation_patterns = equations::check_value_equations(
+    let checked_equations = equations::check_value_equations(
         state,
         context,
         equations::EquationTypeOrigin::Explicit(signature_id),
         signature_type,
         equations,
     )?;
-    let exhaustiveness =
-        exhaustive::check_equation_patterns(state, context, &equation_patterns, equations)?;
+    let exhaustiveness = exhaustive::check_equation_patterns(
+        state,
+        context,
+        &checked_equations.patterns,
+        equations,
+    )?;
     state.report_exhaustiveness(exhaustiveness);
-    state.solve_constraints(context)
+
+    let root = single_equation_root(state, equations, checked_equations.function_type);
+    let root = root.map(|root| {
+        abstract_evidence(state, signature_type, &checked_equations.evidence_binders, root)
+    });
+
+    let residuals = state.solve_constraints(context)?;
+    Ok(PendingValueGroup::Checked { residuals, root })
 }
 
 fn check_value_group_core_infer<Q>(
@@ -726,7 +739,7 @@ fn check_value_group_core_infer<Q>(
     context: &CheckContext<Q>,
     item_id: TermItemId,
     equations: &[lowering::Equation],
-) -> QueryResult<Vec<ConstraintInScope>>
+) -> QueryResult<PendingValueGroup>
 where
     Q: ExternalQueries,
 {
@@ -738,7 +751,61 @@ where
         exhaustive::check_equation_patterns(state, context, &equation_patterns, equations)?;
     state.report_exhaustiveness(exhaustiveness);
 
-    state.solve_constraints(context)
+    let root = single_equation_root(state, equations, group_type);
+    let residuals = state.solve_constraints(context)?;
+    Ok(PendingValueGroup::Inferred { residuals, root })
+}
+
+fn single_equation_root(
+    state: &mut CheckState,
+    equations: &[lowering::Equation],
+    function_type: TypeId,
+) -> Option<CheckedExpressionId> {
+    let [equation] = equations else {
+        return None;
+    };
+
+    let Some(lowering::GuardedExpression::Unconditional { where_expression }) = &equation.guarded
+    else {
+        return None;
+    };
+
+    let Some(where_expression) = where_expression else {
+        return None;
+    };
+
+    if !where_expression.bindings.is_empty() {
+        return None;
+    }
+
+    let source_expression = where_expression.expression?;
+    let expression = state.checked.core.lookup_expression(source_expression)?;
+
+    let checked_binders =
+        equation.binders.iter().map(|binder| state.checked.core.lookup_binder(*binder));
+
+    let checked_binders = checked_binders.collect::<Option<Vec<_>>>()?;
+    if checked_binders.is_empty() {
+        return Some(expression);
+    }
+
+    let kind = CheckedExpressionKind::Lambda { binders: Arc::from(checked_binders), expression };
+    Some(state.checked.core.allocate_expression(function_type, kind))
+}
+
+fn abstract_evidence(
+    state: &mut CheckState,
+    type_id: TypeId,
+    binders: &[EvidenceBinderId],
+    expression: CheckedExpressionId,
+) -> CheckedExpressionId {
+    if binders.is_empty() {
+        return expression;
+    }
+
+    let kind =
+        CheckedExpressionKind::EvidenceAbstraction { binders: Arc::from(binders), expression };
+    state.checked.core.allocate_expression(type_id, kind)
 }
 
 fn finalise_term_binding_group<Q>(
@@ -755,7 +822,8 @@ where
         marker: TypeId,
         unsolved: Vec<u32>,
         errors: generalise::ConstraintErrors,
-        has_constraints: bool,
+        evidence_binders: Vec<EvidenceBinderId>,
+        root: Option<CheckedExpressionId>,
     }
 
     let mut pending = vec![];
@@ -770,12 +838,12 @@ where
 
         let mut errors = generalise::ConstraintErrors::default();
 
-        let (marker, has_constraints) = match group {
-            Some(PendingValueGroup::Checked { residuals }) => {
+        let (marker, evidence_binders, root) = match group {
+            Some(PendingValueGroup::Checked { residuals, root }) => {
                 errors.unsatisfied.extend(residuals);
-                (marker, false)
+                (marker, vec![], root)
             }
-            Some(PendingValueGroup::Inferred { residuals }) => {
+            Some(PendingValueGroup::Inferred { residuals, root }) => {
                 let constrained = generalise::constrain_using_residuals(
                     state,
                     context,
@@ -783,25 +851,32 @@ where
                     residuals,
                     &mut errors,
                 )?;
-                (constrained.type_id, constrained.has_constraints)
+                (constrained.type_id, constrained.evidence_binders, root)
             }
-            None => (marker, false),
+            None => (marker, vec![], None),
         };
 
         let marker = zonk::zonk(state, context, marker)?;
         let unsolved = generalise::unsolved_unifications(state, context, marker)?;
 
-        let pending_group = Pending { marker, unsolved, errors, has_constraints };
+        let pending_group = Pending { marker, unsolved, errors, evidence_binders, root };
         pending.push((item_id, pending_group));
     }
 
-    for (item_id, Pending { marker, unsolved, errors, has_constraints }) in pending {
+    for (item_id, Pending { marker, unsolved, errors, evidence_binders, root }) in pending {
         let marker = generalise::generalise_unsolved(state, context, marker, &unsolved)?;
         state.checked.terms.insert(item_id, marker);
 
+        let root = root.map(|root| abstract_evidence(state, marker, &evidence_binders, root));
+        if let Some(root) = root {
+            state.checked.core.record_term_root(item_id, root);
+        }
+
+        let has_constraints = !evidence_binders.is_empty();
         if recursive && has_constraints {
-            // Keep constraint evidence consistent with the candidate type used for error recovery.
-            // The diagnostic prevents the invalid recursive dictionary abstraction from proceeding.
+            // Keep constraint evidence consistent with the candidate type used
+            // for error recovery. The diagnostic prevents the invalid recursive
+            // dictionary abstraction from reaching elaboration.
             state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
                 let error = ErrorKind::CannotGeneraliseRecursiveFunction { type_id: marker };
                 state.insert_error(error);

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -22,6 +22,7 @@ use crate::context::CheckContext;
 use crate::core::{TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::holes::{HoleBinding, TermHole};
+use crate::semantic::CheckedExpressionKind;
 use crate::source::{operator, types};
 use crate::state::CheckState;
 
@@ -301,7 +302,13 @@ where
 
         lowering::ExpressionKind::Variable { resolution } => {
             let Some(resolution) = *resolution else { return Ok(unknown) };
-            toolkit::lookup_term_variable(state, context, resolution)
+            let type_id = toolkit::lookup_term_variable(state, context, resolution)?;
+            let checked_expression = state
+                .checked
+                .core
+                .allocate_expression(type_id, CheckedExpressionKind::Variable { resolution });
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
         }
 
         lowering::ExpressionKind::OperatorName { resolution } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -150,10 +150,10 @@ where
             Ok(type_id)
         }
         lowering::ExpressionKind::Array { array } => {
-            collections::check_array(state, context, array, expected)
+            collections::check_array(state, context, expression, array, expected)
         }
         lowering::ExpressionKind::Record { record } => {
-            collections::check_record(state, context, record, expected)
+            collections::check_record(state, context, expression, record, expected)
         }
         _ => {
             let inferred = infer_expression_quiet(state, context, expression)?;
@@ -419,11 +419,11 @@ where
         }
 
         lowering::ExpressionKind::Array { array } => {
-            collections::infer_array(state, context, array)
+            collections::infer_array(state, context, expression, array)
         }
 
         lowering::ExpressionKind::Record { record } => {
-            collections::infer_record(state, context, record)
+            collections::infer_record(state, context, expression, record)
         }
 
         lowering::ExpressionKind::Parenthesized { parenthesized } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -22,7 +22,7 @@ use crate::context::CheckContext;
 use crate::core::{TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::holes::{HoleBinding, TermHole};
-use crate::semantic::{CheckedExpressionKind, CheckedLiteral};
+use crate::semantic::{CheckedExpressionId, CheckedExpressionKind, CheckedLiteral};
 use crate::source::{operator, types};
 use crate::state::CheckState;
 
@@ -326,9 +326,8 @@ where
         lowering::ExpressionKind::Constructor { resolution } => {
             let Some((file_id, term_id)) = resolution else { return Ok(unknown) };
             let type_id = toolkit::lookup_file_term(state, context, *file_id, *term_id)?;
-            let resolution = lowering::TermVariableResolution::Reference(*file_id, *term_id);
-            let kind = CheckedExpressionKind::Variable { resolution };
-            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            let checked_expression =
+                allocate_term_reference(state, context, *file_id, *term_id, type_id)?;
             state.checked.core.record_expression(expression, checked_expression);
             Ok(type_id)
         }
@@ -351,10 +350,8 @@ where
             };
             let type_id =
                 toolkit::lookup_file_term(state, context, target_file_id, target_item_id)?;
-            let resolution =
-                lowering::TermVariableResolution::Reference(target_file_id, target_item_id);
-            let kind = CheckedExpressionKind::Variable { resolution };
-            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            let checked_expression =
+                allocate_term_reference(state, context, target_file_id, target_item_id, type_id)?;
             state.checked.core.record_expression(expression, checked_expression);
             Ok(type_id)
         }
@@ -451,6 +448,51 @@ where
             collections::infer_record_update(state, context, record, updates)
         }
     }
+}
+
+pub(crate) fn allocate_term_reference<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    file_id: FileId,
+    item_id: TermItemId,
+    type_id: TypeId,
+) -> QueryResult<CheckedExpressionId>
+where
+    Q: ExternalQueries,
+{
+    let is_constructor = is_term_constructor(context, file_id, item_id)?;
+
+    let kind = if is_constructor {
+        CheckedExpressionKind::Constructor { file_id, item_id }
+    } else {
+        let resolution = lowering::TermVariableResolution::Reference(file_id, item_id);
+        CheckedExpressionKind::Variable { resolution }
+    };
+
+    Ok(state.checked.core.allocate_expression(type_id, kind))
+}
+
+pub(crate) fn is_term_constructor<Q>(
+    context: &CheckContext<Q>,
+    file_id: FileId,
+    item_id: TermItemId,
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    let is_constructor = if file_id == context.id {
+        matches!(
+            context.lowered.info.get_term_item(item_id),
+            Some(lowering::TermItemIr::Constructor { .. })
+        )
+    } else {
+        let lowered = context.queries.lowered(file_id)?;
+        matches!(
+            lowered.info.get_term_item(item_id),
+            Some(lowering::TermItemIr::Constructor { .. })
+        )
+    };
+    Ok(is_constructor)
 }
 
 fn term_hole_bindings<Q>(

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -22,7 +22,7 @@ use crate::context::CheckContext;
 use crate::core::{TypeId, normalise, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::holes::{HoleBinding, TermHole};
-use crate::semantic::CheckedExpressionKind;
+use crate::semantic::{CheckedExpressionKind, CheckedLiteral};
 use crate::source::{operator, types};
 use crate::state::CheckState;
 
@@ -140,7 +140,11 @@ where
         }
         lowering::ExpressionKind::Parenthesized { parenthesized } => {
             let Some(parenthesized) = parenthesized else { return Ok(unknown) };
-            check_expression(state, context, *parenthesized, expected)
+            let type_id = check_expression(state, context, *parenthesized, expected)?;
+            if let Some(checked_expression) = state.checked.core.lookup_expression(*parenthesized) {
+                state.checked.core.record_expression(expression, checked_expression);
+            }
+            Ok(type_id)
         }
         lowering::ExpressionKind::Array { array } => {
             collections::check_array(state, context, array, expected)
@@ -226,12 +230,15 @@ where
     };
 
     match kind {
-        lowering::ExpressionKind::Typed { expression, type_ } => {
-            let Some(e) = expression else { return Ok(unknown) };
+        lowering::ExpressionKind::Typed { expression: annotated, type_ } => {
+            let Some(annotated) = annotated else { return Ok(unknown) };
             let Some(t) = type_ else { return Ok(unknown) };
 
             let (t, _) = types::infer_kind(state, context, *t)?;
-            check_expression(state, context, *e, t)?;
+            check_expression(state, context, *annotated, t)?;
+            if let Some(checked_expression) = state.checked.core.lookup_expression(*annotated) {
+                state.checked.core.record_expression(expression, checked_expression);
+            }
 
             Ok(t)
         }
@@ -257,14 +264,28 @@ where
         lowering::ExpressionKind::Application { function, arguments } => {
             let Some(function) = function else { return Ok(unknown) };
 
-            let mut function_t = infer_expression(state, context, *function)?;
+            let function_type = infer_expression(state, context, *function)?;
+            let function_expression = state.checked.core.lookup_expression(*function);
+            let mut application = application::CheckedApplication {
+                type_id: function_type,
+                expression: function_expression,
+            };
 
             for argument in arguments.iter() {
-                function_t =
-                    application::check_function_application(state, context, function_t, argument)?;
+                application = application::check_core_function_application(
+                    state,
+                    context,
+                    application.type_id,
+                    application.expression,
+                    argument,
+                )?;
             }
 
-            Ok(function_t)
+            if let Some(checked_expression) = application.expression {
+                state.checked.core.record_expression(expression, checked_expression);
+            }
+
+            Ok(application.type_id)
         }
 
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
@@ -297,23 +318,31 @@ where
 
         lowering::ExpressionKind::Constructor { resolution } => {
             let Some((file_id, term_id)) = resolution else { return Ok(unknown) };
-            toolkit::lookup_file_term(state, context, *file_id, *term_id)
+            let type_id = toolkit::lookup_file_term(state, context, *file_id, *term_id)?;
+            let resolution = lowering::TermVariableResolution::Reference(*file_id, *term_id);
+            let kind = CheckedExpressionKind::Variable { resolution };
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
         }
 
         lowering::ExpressionKind::Variable { resolution } => {
             let Some(resolution) = *resolution else { return Ok(unknown) };
             let type_id = toolkit::lookup_term_variable(state, context, resolution)?;
-            let checked_expression = state
-                .checked
-                .core
-                .allocate_expression(type_id, CheckedExpressionKind::Variable { resolution });
+            let kind = CheckedExpressionKind::Variable { resolution };
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
             state.checked.core.record_expression(expression, checked_expression);
             Ok(type_id)
         }
 
         lowering::ExpressionKind::OperatorName { resolution } => {
             let Some((file_id, term_id)) = resolution else { return Ok(unknown) };
-            toolkit::lookup_file_term(state, context, *file_id, *term_id)
+            let type_id = toolkit::lookup_file_term(state, context, *file_id, *term_id)?;
+            let resolution = lowering::TermVariableResolution::Reference(*file_id, *term_id);
+            let kind = CheckedExpressionKind::Variable { resolution };
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
         }
 
         lowering::ExpressionKind::Section => {
@@ -335,15 +364,50 @@ where
             Ok(type_id)
         }
 
-        lowering::ExpressionKind::String { .. } => Ok(context.prim.string),
+        lowering::ExpressionKind::String { kind, value } => {
+            let literal = CheckedLiteral::String { kind: *kind, value: value.clone() };
+            let kind = CheckedExpressionKind::Literal { literal };
+            let type_id = context.prim.string;
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
+        }
 
-        lowering::ExpressionKind::Char { .. } => Ok(context.prim.char),
+        lowering::ExpressionKind::Char { value } => {
+            let literal = CheckedLiteral::Char(*value);
+            let kind = CheckedExpressionKind::Literal { literal };
+            let type_id = context.prim.char;
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
+        }
 
-        lowering::ExpressionKind::Boolean { .. } => Ok(context.prim.boolean),
+        lowering::ExpressionKind::Boolean { boolean } => {
+            let literal = CheckedLiteral::Boolean(*boolean);
+            let kind = CheckedExpressionKind::Literal { literal };
+            let type_id = context.prim.boolean;
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
+        }
 
-        lowering::ExpressionKind::Integer { .. } => Ok(context.prim.int),
+        lowering::ExpressionKind::Integer { value } => {
+            let literal = CheckedLiteral::Integer(*value);
+            let kind = CheckedExpressionKind::Literal { literal };
+            let type_id = context.prim.int;
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
+        }
 
-        lowering::ExpressionKind::Number { .. } => Ok(context.prim.number),
+        lowering::ExpressionKind::Number { value } => {
+            let literal = CheckedLiteral::Number(value.clone());
+            let kind = CheckedExpressionKind::Literal { literal };
+            let type_id = context.prim.number;
+            let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+            state.checked.core.record_expression(expression, checked_expression);
+            Ok(type_id)
+        }
 
         lowering::ExpressionKind::Array { array } => {
             collections::infer_array(state, context, array)
@@ -355,7 +419,11 @@ where
 
         lowering::ExpressionKind::Parenthesized { parenthesized } => {
             let Some(parenthesized) = parenthesized else { return Ok(unknown) };
-            infer_expression(state, context, *parenthesized)
+            let type_id = infer_expression(state, context, *parenthesized)?;
+            if let Some(checked_expression) = state.checked.core.lookup_expression(*parenthesized) {
+                state.checked.core.record_expression(expression, checked_expression);
+            }
+            Ok(type_id)
         }
 
         lowering::ExpressionKind::RecordAccess { record, labels } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -128,7 +128,7 @@ where
             forms::check_if_then_else(state, context, *if_, *then, *else_, expected)
         }
         lowering::ExpressionKind::CaseOf { trunk, branches } => {
-            forms::check_case_of(state, context, trunk, branches, expected)
+            forms::check_case_of(state, context, expression, trunk, branches, expected)
         }
         lowering::ExpressionKind::OperatorChain { .. } => {
             let (checked_expression, checked_type) =
@@ -312,7 +312,7 @@ where
         }
 
         lowering::ExpressionKind::CaseOf { trunk, branches } => {
-            forms::infer_case_of(state, context, trunk, branches)
+            forms::infer_case_of(state, context, expression, trunk, branches)
         }
 
         lowering::ExpressionKind::Do { bind, discard, statements } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -271,28 +271,25 @@ where
         lowering::ExpressionKind::Application { function, arguments } => {
             let Some(function) = function else { return Ok(unknown) };
 
-            let function_type = infer_expression(state, context, *function)?;
-            let function_expression = state.checked.core.lookup_expression(*function);
-            let mut application = application::CheckedApplication {
-                type_id: function_type,
-                expression: function_expression,
-            };
+            let mut function_type = infer_expression(state, context, *function)?;
+            let mut function_expression = state.checked.core.lookup_expression(*function);
 
             for argument in arguments.iter() {
-                application = application::check_core_function_application(
-                    state,
-                    context,
-                    application.type_id,
-                    application.expression,
-                    argument,
-                )?;
+                (function_type, function_expression) =
+                    application::check_core_function_application(
+                        state,
+                        context,
+                        function_type,
+                        function_expression,
+                        argument,
+                    )?;
             }
 
-            if let Some(checked_expression) = application.expression {
+            if let Some(checked_expression) = function_expression {
                 state.checked.core.record_expression(expression, checked_expression);
             }
 
-            Ok(application.type_id)
+            Ok(function_type)
         }
 
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
@@ -316,11 +313,12 @@ where
         }
 
         lowering::ExpressionKind::Do { bind, discard, statements } => {
-            form_do::infer_do(state, context, *bind, *discard, statements)
+            form_do::infer_do(state, context, expression, *bind, *discard, statements)
         }
 
-        lowering::ExpressionKind::Ado { map, apply, pure, statements, expression } => {
-            form_ado::infer_ado(state, context, *map, *apply, *pure, statements, *expression)
+        lowering::ExpressionKind::Ado { map, apply, pure, statements, expression: body } => {
+            let functions = form_ado::AdoFunctions { map: *map, apply: *apply, pure: *pure };
+            form_ado::infer_ado(state, context, expression, functions, statements, *body)
         }
 
         lowering::ExpressionKind::Constructor { resolution } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -438,12 +438,12 @@ where
         lowering::ExpressionKind::RecordAccess { record, labels } => {
             let Some(record) = *record else { return Ok(unknown) };
             let Some(labels) = labels else { return Ok(unknown) };
-            collections::infer_record_access(state, context, record, labels)
+            collections::infer_record_access(state, context, expression, record, labels)
         }
 
         lowering::ExpressionKind::RecordUpdate { record, updates } => {
             let Some(record) = *record else { return Ok(unknown) };
-            collections::infer_record_update(state, context, record, updates)
+            collections::infer_record_update(state, context, expression, record, updates)
         }
     }
 }

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -131,8 +131,11 @@ where
             forms::check_case_of(state, context, trunk, branches, expected)
         }
         lowering::ExpressionKind::OperatorChain { .. } => {
-            let (_, checked_type) =
+            let (checked_expression, checked_type) =
                 operator::check_operator_chain(state, context, expression, expected)?;
+            if let Some(checked_expression) = checked_expression {
+                state.checked.core.record_expression(expression, checked_expression);
+            }
             Ok(checked_type)
         }
         lowering::ExpressionKind::LetIn { bindings, expression } => {
@@ -244,7 +247,11 @@ where
         }
 
         lowering::ExpressionKind::OperatorChain { .. } => {
-            let (_, inferred_type) = operator::infer_operator_chain(state, context, expression)?;
+            let (checked_expression, inferred_type) =
+                operator::infer_operator_chain(state, context, expression)?;
+            if let Some(checked_expression) = checked_expression {
+                state.checked.core.record_expression(expression, checked_expression);
+            }
             Ok(inferred_type)
         }
 
@@ -337,8 +344,15 @@ where
 
         lowering::ExpressionKind::OperatorName { resolution } => {
             let Some((file_id, term_id)) = resolution else { return Ok(unknown) };
-            let type_id = toolkit::lookup_file_term(state, context, *file_id, *term_id)?;
-            let resolution = lowering::TermVariableResolution::Reference(*file_id, *term_id);
+            let Some((target_file_id, target_item_id)) =
+                toolkit::resolve_term_operator_target(context, *file_id, *term_id)?
+            else {
+                return Ok(unknown);
+            };
+            let type_id =
+                toolkit::lookup_file_term(state, context, target_file_id, target_item_id)?;
+            let resolution =
+                lowering::TermVariableResolution::Reference(target_file_id, target_item_id);
             let kind = CheckedExpressionKind::Variable { resolution };
             let checked_expression = state.checked.core.allocate_expression(type_id, kind);
             state.checked.core.record_expression(expression, checked_expression);

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -125,7 +125,7 @@ where
             forms::check_lambda(state, context, expression, binders, *body, expected)
         }
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
-            forms::check_if_then_else(state, context, *if_, *then, *else_, expected)
+            forms::check_if_then_else(state, context, expression, *if_, *then, *else_, expected)
         }
         lowering::ExpressionKind::CaseOf { trunk, branches } => {
             forms::check_case_of(state, context, expression, trunk, branches, expected)
@@ -293,7 +293,7 @@ where
         }
 
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
-            forms::infer_if_then_else(state, context, *if_, *then, *else_)
+            forms::infer_if_then_else(state, context, expression, *if_, *then, *else_)
         }
 
         lowering::ExpressionKind::LetIn { bindings, expression } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -121,8 +121,8 @@ where
     };
 
     match kind {
-        lowering::ExpressionKind::Lambda { binders, expression } => {
-            forms::check_lambda(state, context, binders, *expression, expected)
+        lowering::ExpressionKind::Lambda { binders, expression: body } => {
+            forms::check_lambda(state, context, expression, binders, *body, expected)
         }
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
             forms::check_if_then_else(state, context, *if_, *then, *else_, expected)
@@ -300,8 +300,8 @@ where
             infer_expression(state, context, *expression)
         }
 
-        lowering::ExpressionKind::Lambda { binders, expression } => {
-            forms::infer_lambda(state, context, binders, *expression)
+        lowering::ExpressionKind::Lambda { binders, expression: body } => {
+            forms::infer_lambda(state, context, expression, binders, *body)
         }
 
         lowering::ExpressionKind::CaseOf { trunk, branches } => {

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -1,12 +1,15 @@
 use std::mem;
 use std::ops::ControlFlow;
+use std::sync::Arc;
 
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{ForallBinder, Type, TypeId, normalise, signature, unification};
+use crate::core::substitute::SubstituteName;
+use crate::core::{ForallBinder, Type, TypeId, normalise, unification};
 use crate::error::ErrorKind;
+use crate::evidence::EvidenceVarId;
+use crate::semantic::{CheckedExpressionId, CheckedExpressionKind};
 use crate::source::types;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -18,8 +21,19 @@ pub struct ApplicationAnalysis {
 }
 
 pub struct GenericApplication {
+    pub evidence: Arc<[EvidenceVarId]>,
     pub argument: TypeId,
     pub result: TypeId,
+}
+
+pub struct CheckedApplication {
+    pub type_id: TypeId,
+    pub expression: Option<CheckedExpressionId>,
+}
+
+struct CheckedTypeApplication {
+    argument: Option<TypeId>,
+    result: TypeId,
 }
 
 fn analyse_function_application_step<Q>(
@@ -134,11 +148,10 @@ where
         return Ok(None);
     };
 
-    for constraint in constraints {
-        state.push_wanted(constraint);
-    }
+    let evidence = constraints.into_iter().map(|constraint| state.push_wanted(constraint));
+    let evidence = evidence.collect();
 
-    Ok(Some(GenericApplication { argument, result }))
+    Ok(Some(GenericApplication { evidence, argument, result }))
 }
 
 pub fn check_function_application<Q>(
@@ -155,14 +168,117 @@ where
             let Some(type_argument) = type_argument else {
                 return Ok(context.unknown("missing type argument"));
             };
-            check_function_type_application(state, context, function_type, *type_argument)
+            let result =
+                check_function_type_application(state, context, function_type, *type_argument)?;
+            Ok(result)
         }
         lowering::ExpressionArgument::Term(term_argument) => {
             let Some(term_argument) = term_argument else {
                 return Ok(context.unknown("missing term argument"));
             };
-            check_function_term_application(state, context, function_type, *term_argument)
+            let result =
+                check_function_term_application(state, context, function_type, *term_argument)?;
+            Ok(result)
         }
+    }
+}
+
+pub fn check_core_function_application<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    function_type: TypeId,
+    function_expression: Option<CheckedExpressionId>,
+    argument: &lowering::ExpressionArgument,
+) -> QueryResult<CheckedApplication>
+where
+    Q: ExternalQueries,
+{
+    match argument {
+        lowering::ExpressionArgument::Type(type_argument) => {
+            let Some(type_argument) = type_argument else {
+                let type_id = context.unknown("missing type argument");
+                return Ok(CheckedApplication { type_id, expression: None });
+            };
+            let application = check_core_function_type_application(
+                state,
+                context,
+                function_type,
+                *type_argument,
+            )?;
+            let expression = function_expression.zip(application.argument);
+            let expression = expression.map(|(function, argument)| {
+                let kind = CheckedExpressionKind::TypeApplication { function, argument };
+                state.checked.core.allocate_expression(application.result, kind)
+            });
+            Ok(CheckedApplication { type_id: application.result, expression })
+        }
+        lowering::ExpressionArgument::Term(term_argument) => {
+            let Some(term_argument) = term_argument else {
+                let type_id = context.unknown("missing term argument");
+                return Ok(CheckedApplication { type_id, expression: None });
+            };
+            let application = check_core_function_term_application(
+                state,
+                context,
+                function_type,
+                function_expression,
+                *term_argument,
+            )?;
+            Ok(application)
+        }
+    }
+}
+
+fn check_core_function_term_application<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    function_type: TypeId,
+    function_expression: Option<CheckedExpressionId>,
+    argument_expression: lowering::ExpressionId,
+) -> QueryResult<CheckedApplication>
+where
+    Q: ExternalQueries,
+{
+    let Some(GenericApplication { evidence, argument: argument_type, result }) =
+        check_generic_application(state, context, function_type)?
+    else {
+        let type_id = context.unknown("invalid function application");
+        return Ok(CheckedApplication { type_id, expression: None });
+    };
+
+    let function_expression = function_expression
+        .map(|function| apply_evidence(state, context, function, argument_type, result, evidence));
+
+    super::check_expression(state, context, argument_expression, argument_type)?;
+    let argument_expression = state.checked.core.lookup_expression(argument_expression);
+    let expression = function_expression.zip(argument_expression);
+    let expression = expression.map(|(function, argument)| {
+        let kind = CheckedExpressionKind::TermApplication { function, argument };
+        state.checked.core.allocate_expression(result, kind)
+    });
+
+    Ok(CheckedApplication { type_id: result, expression })
+}
+
+fn apply_evidence<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    function: CheckedExpressionId,
+    argument_type: TypeId,
+    result_type: TypeId,
+    evidence: Arc<[EvidenceVarId]>,
+) -> CheckedExpressionId
+where
+    Q: ExternalQueries,
+{
+    if evidence.is_empty() {
+        function
+    } else {
+        let function_type = context.intern_function(argument_type, result_type);
+        state.checked.core.allocate_expression(
+            function_type,
+            CheckedExpressionKind::EvidenceApplication { expression: function, evidence },
+        )
     }
 }
 
@@ -175,7 +291,7 @@ pub fn check_function_term_application<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(GenericApplication { argument, result }) =
+    let Some(GenericApplication { argument, result, .. }) =
         check_generic_application(state, context, function)?
     else {
         return Ok(context.unknown("invalid function application"));
@@ -193,44 +309,41 @@ pub fn check_function_type_application<Q>(
 where
     Q: ExternalQueries,
 {
-    let signature::DecomposedSignature { binders, constraints, arguments, result } =
-        signature::decompose_signature(
-            state,
-            context,
-            function,
-            signature::DecomposeSignatureMode::Full,
-        )?;
+    let application = check_core_function_type_application(state, context, function, argument)?;
+    Ok(application.result)
+}
 
-    let Some(index) = binders.iter().position(|binder| binder.visible) else {
-        let function_type = function;
-        state.insert_error(ErrorKind::NoVisibleTypeVariable { function_type });
-        return Ok(context.unknown("invalid visible type application"));
-    };
+fn check_core_function_type_application<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    mut function: TypeId,
+    argument: lowering::TypeId,
+) -> QueryResult<CheckedTypeApplication>
+where
+    Q: ExternalQueries,
+{
+    let function_type = function;
 
-    let mut substitution = NameToType::default();
+    safe_loop! {
+        function = normalise::expand(state, context, function)?;
+        let Type::Forall(binder_id, inner) = context.lookup_type(function) else {
+            state.insert_error(ErrorKind::NoVisibleTypeVariable { function_type });
+            let result = context.unknown("invalid visible type application");
+            return Ok(CheckedTypeApplication { argument: None, result });
+        };
 
-    for binder in binders.iter().take(index) {
-        let binder_kind = SubstituteName::many(state, context, &substitution, binder.kind)?;
-        let binder_kind = normalise::expand(state, context, binder_kind)?;
-        let replacement = state.fresh_unification(context.queries, binder_kind);
-        substitution.insert(binder.name, replacement);
+        let ForallBinder { visible, name, kind } = context.lookup_forall_binder(binder_id);
+        let kind = normalise::expand(state, context, kind)?;
+
+        if visible {
+            let (argument_type, _) = types::check_kind(state, context, argument, kind)?;
+            let result = SubstituteName::one(state, context, name, argument_type, inner)?;
+            return Ok(CheckedTypeApplication { argument: Some(argument_type), result });
+        }
+
+        let replacement = state.fresh_unification(context.queries, kind);
+        function = SubstituteName::one(state, context, name, replacement, inner)?;
     }
-
-    let ForallBinder { name: visible_name, kind: visible_kind, .. } = binders[index];
-
-    let visible_kind = SubstituteName::many(state, context, &substitution, visible_kind)?;
-    let visible_kind = normalise::expand(state, context, visible_kind)?;
-
-    let (argument_type, _) = types::check_kind(state, context, argument, visible_kind)?;
-    substitution.insert(visible_name, argument_type);
-
-    let binders = binders.iter().skip(index + 1).copied();
-
-    let function = context.intern_function_list(&arguments, result);
-    let constrained = context.intern_constrained_list(&constraints, function);
-    let quantified = context.intern_forall_iter(binders, constrained);
-
-    SubstituteName::many(state, context, &substitution, quantified)
 }
 
 pub fn infer_infix_chain<Q>(
@@ -249,7 +362,7 @@ where
         let Some(element) = element else { return Ok(context.unknown("missing infix element")) };
 
         let tick_type = super::infer_expression(state, context, *tick)?;
-        let Some(GenericApplication { argument, result }) =
+        let Some(GenericApplication { argument, result, .. }) =
             check_generic_application(state, context, tick_type)?
         else {
             return Ok(context.unknown("invalid function application"));

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -260,7 +260,7 @@ where
     Ok(CheckedApplication { type_id: result, expression })
 }
 
-fn apply_evidence<Q>(
+pub(crate) fn apply_evidence<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     function: CheckedExpressionId,

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -9,7 +9,9 @@ use crate::core::substitute::SubstituteName;
 use crate::core::{ForallBinder, Type, TypeId, normalise, unification};
 use crate::error::ErrorKind;
 use crate::evidence::EvidenceVarId;
-use crate::semantic::{CheckedExpressionId, CheckedExpressionKind};
+use crate::semantic::{
+    CheckedApplication, CheckedBinaryApplication, CheckedExpressionId, CheckedExpressionKind,
+};
 use crate::source::types;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -20,15 +22,15 @@ pub struct ApplicationAnalysis {
     pub result: TypeId,
 }
 
-pub struct GenericApplication {
-    pub evidence: Arc<[EvidenceVarId]>,
-    pub argument: TypeId,
-    pub result: TypeId,
+pub(super) enum BinaryApplicationOutcome {
+    Complete { first: CheckedApplication, second: CheckedApplication },
+    Partial { first: CheckedApplication },
+    Error,
 }
 
-pub struct CheckedApplication {
+pub(super) struct InferredBinaryApplication {
     pub type_id: TypeId,
-    pub expression: Option<CheckedExpressionId>,
+    pub outcome: BinaryApplicationOutcome,
 }
 
 struct CheckedTypeApplication {
@@ -138,7 +140,7 @@ pub fn check_generic_application<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     function: TypeId,
-) -> QueryResult<Option<GenericApplication>>
+) -> QueryResult<Option<CheckedApplication>>
 where
     Q: ExternalQueries,
 {
@@ -151,7 +153,60 @@ where
     let evidence = constraints.into_iter().map(|constraint| state.push_wanted(constraint));
     let evidence = evidence.collect();
 
-    Ok(Some(GenericApplication { evidence, argument, result }))
+    Ok(Some(CheckedApplication { evidence, argument, result }))
+}
+
+pub(super) fn check_binary_application<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    function_type: TypeId,
+    first_argument_type: TypeId,
+    second_argument_type: TypeId,
+) -> QueryResult<InferredBinaryApplication>
+where
+    Q: ExternalQueries,
+{
+    let Some(first @ CheckedApplication { argument, result, .. }) =
+        check_generic_application(state, context, function_type)?
+    else {
+        let type_id = context.unknown("invalid function application");
+        let outcome = BinaryApplicationOutcome::Error;
+        return Ok(InferredBinaryApplication { type_id, outcome });
+    };
+    unification::subtype(state, context, first_argument_type, argument)?;
+
+    let Some(second @ CheckedApplication { argument, result, .. }) =
+        check_generic_application(state, context, result)?
+    else {
+        let type_id = context.unknown("invalid function application");
+        let outcome = BinaryApplicationOutcome::Partial { first };
+        return Ok(InferredBinaryApplication { type_id, outcome });
+    };
+    unification::subtype(state, context, second_argument_type, argument)?;
+
+    let outcome = BinaryApplicationOutcome::Complete { first, second };
+    Ok(InferredBinaryApplication { type_id: result, outcome })
+}
+
+pub(super) fn record_binary_application(
+    state: &mut CheckState,
+    function: Option<lowering::TermVariableResolution>,
+    function_type: TypeId,
+    outcome: BinaryApplicationOutcome,
+) -> CheckedBinaryApplication {
+    let kind = function.map_or(CheckedExpressionKind::Error, |resolution| {
+        CheckedExpressionKind::Variable { resolution }
+    });
+    let function = state.checked.core.allocate_expression(function_type, kind);
+    match outcome {
+        BinaryApplicationOutcome::Complete { first, second } => {
+            CheckedBinaryApplication::Complete { function, first, second }
+        }
+        BinaryApplicationOutcome::Partial { first } => {
+            CheckedBinaryApplication::Partial { function, first }
+        }
+        BinaryApplicationOutcome::Error => CheckedBinaryApplication::Error { function },
+    }
 }
 
 pub fn check_function_application<Q>(
@@ -189,7 +244,7 @@ pub fn check_core_function_application<Q>(
     function_type: TypeId,
     function_expression: Option<CheckedExpressionId>,
     argument: &lowering::ExpressionArgument,
-) -> QueryResult<CheckedApplication>
+) -> QueryResult<(TypeId, Option<CheckedExpressionId>)>
 where
     Q: ExternalQueries,
 {
@@ -197,7 +252,7 @@ where
         lowering::ExpressionArgument::Type(type_argument) => {
             let Some(type_argument) = type_argument else {
                 let type_id = context.unknown("missing type argument");
-                return Ok(CheckedApplication { type_id, expression: None });
+                return Ok((type_id, None));
             };
             let application = check_core_function_type_application(
                 state,
@@ -210,12 +265,12 @@ where
                 let kind = CheckedExpressionKind::TypeApplication { function, argument };
                 state.checked.core.allocate_expression(application.result, kind)
             });
-            Ok(CheckedApplication { type_id: application.result, expression })
+            Ok((application.result, expression))
         }
         lowering::ExpressionArgument::Term(term_argument) => {
             let Some(term_argument) = term_argument else {
                 let type_id = context.unknown("missing term argument");
-                return Ok(CheckedApplication { type_id, expression: None });
+                return Ok((type_id, None));
             };
             let application = check_core_function_term_application(
                 state,
@@ -235,21 +290,21 @@ fn check_core_function_term_application<Q>(
     function_type: TypeId,
     function_expression: Option<CheckedExpressionId>,
     argument_expression: lowering::ExpressionId,
-) -> QueryResult<CheckedApplication>
+) -> QueryResult<(TypeId, Option<CheckedExpressionId>)>
 where
     Q: ExternalQueries,
 {
-    let Some(GenericApplication { evidence, argument: argument_type, result }) =
+    let Some(CheckedApplication { evidence, argument, result }) =
         check_generic_application(state, context, function_type)?
     else {
         let type_id = context.unknown("invalid function application");
-        return Ok(CheckedApplication { type_id, expression: None });
+        return Ok((type_id, None));
     };
 
     let function_expression = function_expression
-        .map(|function| apply_evidence(state, context, function, argument_type, result, evidence));
+        .map(|function| apply_evidence(state, context, function, argument, result, evidence));
 
-    super::check_expression(state, context, argument_expression, argument_type)?;
+    super::check_expression(state, context, argument_expression, argument)?;
     let argument_expression = state.checked.core.lookup_expression(argument_expression);
     let expression = function_expression.zip(argument_expression);
     let expression = expression.map(|(function, argument)| {
@@ -257,7 +312,7 @@ where
         state.checked.core.allocate_expression(result, kind)
     });
 
-    Ok(CheckedApplication { type_id: result, expression })
+    Ok((result, expression))
 }
 
 pub(crate) fn apply_evidence<Q>(
@@ -291,7 +346,7 @@ pub fn check_function_term_application<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(GenericApplication { argument, result, .. }) =
+    let Some(CheckedApplication { argument, result, .. }) =
         check_generic_application(state, context, function)?
     else {
         return Ok(context.unknown("invalid function application"));
@@ -362,7 +417,7 @@ where
         let Some(element) = element else { return Ok(context.unknown("missing infix element")) };
 
         let tick_type = super::infer_expression(state, context, *tick)?;
-        let Some(GenericApplication { argument, result, .. }) =
+        let Some(CheckedApplication { argument, result, .. }) =
             check_generic_application(state, context, tick_type)?
         else {
             return Ok(context.unknown("invalid function application"));

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use smol_str::SmolStr;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{RowField, Type, TypeId, normalise, toolkit, unification};
+use crate::semantic::{CheckedExpressionKind, CheckedRecordField};
 use crate::state::CheckState;
 
 fn infer_record_field_expression<Q>(
@@ -87,17 +90,19 @@ enum RecordMode<'a> {
 pub fn infer_array<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     array: &[lowering::ExpressionId],
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
-    array_core(state, context, array, ArrayMode::Infer)
+    array_core(state, context, expression, array, ArrayMode::Infer)
 }
 
 pub fn check_array<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     array: &[lowering::ExpressionId],
     expected: TypeId,
 ) -> QueryResult<TypeId>
@@ -105,11 +110,11 @@ where
     Q: ExternalQueries,
 {
     if let Some(element) = expected_array_element(state, context, expected)? {
-        array_core(state, context, array, ArrayMode::Check { element })?;
+        array_core(state, context, expression, array, ArrayMode::Check { element })?;
         return Ok(expected);
     }
 
-    let inferred = array_core(state, context, array, ArrayMode::Infer)?;
+    let inferred = array_core(state, context, expression, array, ArrayMode::Infer)?;
     unification::subtype(state, context, inferred, expected)?;
     Ok(inferred)
 }
@@ -134,6 +139,7 @@ where
 fn array_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source: lowering::ExpressionId,
     array: &[lowering::ExpressionId],
     mode: ArrayMode,
 ) -> QueryResult<TypeId>
@@ -157,23 +163,38 @@ where
         }
     }
 
-    Ok(context.intern_application(context.prim.array, element))
+    let type_id = context.intern_application(context.prim.array, element);
+    let elements = array.iter().map(|expression| {
+        if let Some(expression) = state.checked.core.lookup_expression(*expression) {
+            expression
+        } else {
+            state.checked.core.allocate_expression(element, CheckedExpressionKind::Error)
+        }
+    });
+    let elements = elements.collect::<Vec<_>>();
+    let kind = CheckedExpressionKind::Array { elements: Arc::from(elements) };
+    let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+    state.checked.core.record_expression(source, checked_expression);
+
+    Ok(type_id)
 }
 
 pub fn infer_record<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     record: &[lowering::ExpressionRecordItem],
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
-    record_core(state, context, record, RecordMode::Infer)
+    record_core(state, context, expression, record, RecordMode::Infer)
 }
 
 pub fn check_record<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     record: &[lowering::ExpressionRecordItem],
     expected: TypeId,
 ) -> QueryResult<TypeId>
@@ -190,6 +211,7 @@ where
                 let record_type = record_core(
                     state,
                     context,
+                    expression,
                     record,
                     RecordMode::Check { expected_fields: &expected_fields.fields },
                 )?;
@@ -199,7 +221,7 @@ where
         }
     }
 
-    let inferred = infer_record(state, context, record)?;
+    let inferred = infer_record(state, context, expression, record)?;
     unification::subtype(state, context, inferred, expected)?;
     Ok(inferred)
 }
@@ -271,6 +293,7 @@ where
 fn record_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source: lowering::ExpressionId,
     record: &[lowering::ExpressionRecordItem],
     mode: RecordMode<'_>,
 ) -> QueryResult<TypeId>
@@ -278,26 +301,44 @@ where
     Q: ExternalQueries,
 {
     let mut fields = vec![];
+    let mut checked_fields = vec![];
 
     for field in record.iter() {
-        let field = match field {
+        let (field, expression) = match field {
             lowering::ExpressionRecordItem::RecordField { name, value } => {
                 let Some(name) = name else { continue };
                 let Some(value) = value else { continue };
-                record_field_type(state, context, name, *value, mode)?
+                let field = record_field_type(state, context, name, *value, mode)?;
+                let expression = if let Some(expression) =
+                    state.checked.core.lookup_expression(*value)
+                {
+                    expression
+                } else {
+                    state.checked.core.allocate_expression(field.id, CheckedExpressionKind::Error)
+                };
+                (field, expression)
             }
             lowering::ExpressionRecordItem::RecordPun { id, name, resolution } => {
                 let Some(name) = name else { continue };
                 let Some(resolution) = resolution else { continue };
-                record_pun_type(state, context, *id, name, *resolution, mode)?
+                let field = record_pun_type(state, context, *id, name, *resolution, mode)?;
+                let kind = CheckedExpressionKind::Variable { resolution: *resolution };
+                let expression = state.checked.core.allocate_expression(field.id, kind);
+                (field, expression)
             }
         };
 
+        checked_fields.push(CheckedRecordField { label: field.label.clone(), expression });
         fields.push(field);
     }
 
     let row_type = context.intern_row(fields, None);
-    Ok(context.intern_application(context.prim.record, row_type))
+    let type_id = context.intern_application(context.prim.record, row_type);
+    let kind = CheckedExpressionKind::Record { fields: Arc::from(checked_fields) };
+    let checked_expression = state.checked.core.allocate_expression(type_id, kind);
+    state.checked.core.record_expression(source, checked_expression);
+
+    Ok(type_id)
 }
 
 pub fn infer_record_access<Q>(

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -6,7 +6,7 @@ use smol_str::SmolStr;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{RowField, Type, TypeId, normalise, toolkit, unification};
-use crate::semantic::{CheckedExpressionKind, CheckedRecordField};
+use crate::semantic::{CheckedExpressionKind, CheckedRecordField, CheckedRecordUpdate};
 use crate::state::CheckState;
 
 fn infer_record_field_expression<Q>(
@@ -344,13 +344,15 @@ where
 pub fn infer_record_access<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source: lowering::ExpressionId,
     record: lowering::ExpressionId,
     labels: &[SmolStr],
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
-    let mut current_type = super::infer_expression(state, context, record)?;
+    let record_type = super::infer_expression(state, context, record)?;
+    let mut accessed_type = record_type;
 
     for label in labels.iter() {
         let label = SmolStr::clone(label);
@@ -358,26 +360,36 @@ where
         let field_type = state.fresh_unification(context.queries, context.prim.t);
         let tail_type = state.fresh_unification(context.queries, context.prim.row_type);
 
-        let row_type = context.intern_row([RowField { label, id: field_type }], Some(tail_type));
-        let record_type = context.intern_application(context.prim.record, row_type);
+        let field_row = context.intern_row([RowField { label, id: field_type }], Some(tail_type));
+        let field_record = context.intern_application(context.prim.record, field_row);
+        unification::subtype(state, context, accessed_type, field_record)?;
 
-        unification::subtype(state, context, current_type, record_type)?;
-        current_type = field_type;
+        accessed_type = field_type;
     }
 
-    Ok(current_type)
+    let record = state.checked.core.lookup_expression(record).unwrap_or_else(|| {
+        state.checked.core.allocate_expression(record_type, CheckedExpressionKind::Error)
+    });
+
+    let kind = CheckedExpressionKind::RecordAccess { record, labels: Arc::from(labels) };
+    let checked_expression = state.checked.core.allocate_expression(accessed_type, kind);
+    state.checked.core.record_expression(source, checked_expression);
+
+    Ok(accessed_type)
 }
 
 pub fn infer_record_update<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source: lowering::ExpressionId,
     record: lowering::ExpressionId,
     updates: &[lowering::RecordUpdate],
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
-    let (input_fields, output_fields, tail) = infer_record_updates(state, context, updates)?;
+    let (input_fields, output_fields, tail, checked_updates) =
+        infer_record_updates(state, context, updates)?;
 
     let input_row = context.intern_row(input_fields, Some(tail));
     let input_record = context.intern_application(context.prim.record, input_row);
@@ -385,7 +397,15 @@ where
     let output_row = context.intern_row(output_fields, Some(tail));
     let output_record = context.intern_application(context.prim.record, output_row);
 
-    super::check_expression(state, context, record, input_record)?;
+    let record_type = super::check_expression(state, context, record, input_record)?;
+
+    let record = state.checked.core.lookup_expression(record).unwrap_or_else(|| {
+        state.checked.core.allocate_expression(record_type, CheckedExpressionKind::Error)
+    });
+
+    let kind = CheckedExpressionKind::RecordUpdate { record, updates: Arc::from(checked_updates) };
+    let checked_expression = state.checked.core.allocate_expression(output_record, kind);
+    state.checked.core.record_expression(source, checked_expression);
 
     Ok(output_record)
 }
@@ -394,18 +414,18 @@ pub fn infer_record_updates<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     updates: &[lowering::RecordUpdate],
-) -> QueryResult<(Vec<RowField>, Vec<RowField>, TypeId)>
+) -> QueryResult<(Vec<RowField>, Vec<RowField>, TypeId, Vec<CheckedRecordUpdate>)>
 where
     Q: ExternalQueries,
 {
     let mut input_fields = vec![];
     let mut output_fields = vec![];
+    let mut checked_updates = vec![];
 
     for update in updates {
         match update {
             lowering::RecordUpdate::Leaf { name, expression } => {
                 let Some(name) = name else { continue };
-                let label = SmolStr::clone(name);
 
                 let input_id = state.fresh_unification(context.queries, context.prim.t);
                 let output_id = if let Some(expression) = expression {
@@ -414,14 +434,26 @@ where
                     context.unknown("missing record update expression")
                 };
 
-                input_fields.push(RowField { label: label.clone(), id: input_id });
-                output_fields.push(RowField { label, id: output_id });
+                let expression = expression
+                    .and_then(|expression| state.checked.core.lookup_expression(expression))
+                    .unwrap_or_else(|| {
+                        state
+                            .checked
+                            .core
+                            .allocate_expression(output_id, CheckedExpressionKind::Error)
+                    });
+
+                checked_updates
+                    .push(CheckedRecordUpdate::Leaf { label: SmolStr::clone(name), expression });
+
+                input_fields.push(RowField { label: SmolStr::clone(name), id: input_id });
+                output_fields.push(RowField { label: SmolStr::clone(name), id: output_id });
             }
             lowering::RecordUpdate::Branch { name, updates } => {
                 let Some(name) = name else { continue };
-                let label = SmolStr::clone(name);
 
-                let (in_f, out_f, tail) = infer_record_updates(state, context, updates)?;
+                let (in_f, out_f, tail, nested_updates) =
+                    infer_record_updates(state, context, updates)?;
 
                 let in_row = context.intern_row(in_f, Some(tail));
                 let in_id = context.intern_application(context.prim.record, in_row);
@@ -429,13 +461,18 @@ where
                 let out_row = context.intern_row(out_f, Some(tail));
                 let out_id = context.intern_application(context.prim.record, out_row);
 
-                input_fields.push(RowField { label: label.clone(), id: in_id });
-                output_fields.push(RowField { label, id: out_id });
+                checked_updates.push(CheckedRecordUpdate::Branch {
+                    label: SmolStr::clone(name),
+                    updates: Arc::from(nested_updates),
+                });
+
+                input_fields.push(RowField { label: SmolStr::clone(name), id: in_id });
+                output_fields.push(RowField { label: SmolStr::clone(name), id: out_id });
             }
         }
     }
 
     let tail = state.fresh_unification(context.queries, context.prim.row_type);
 
-    Ok((input_fields, output_fields, tail))
+    Ok((input_fields, output_fields, tail, checked_updates))
 }

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -18,7 +18,7 @@ where
 
     if should_instantiate_record_field(context, expression) {
         let id = toolkit::instantiate_unifications(state, context, id)?;
-        toolkit::collect_wanteds(state, context, id)
+        toolkit::collect_wanted(state, context, id)
     } else {
         Ok(id)
     }
@@ -69,7 +69,7 @@ where
 {
     let id = toolkit::lookup_term_variable(state, context, resolution)?;
     let id = toolkit::instantiate_unifications(state, context, id)?;
-    toolkit::collect_wanteds(state, context, id)
+    toolkit::collect_wanted(state, context, id)
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -2,12 +2,15 @@
 //!
 //! See [`check_value_equations`] and [`infer_value_equations`].
 
+use std::sync::Arc;
+
 use building_types::QueryResult;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, constraint, signature, toolkit, unification};
 use crate::error::ErrorKind;
+use crate::evidence::EvidenceBinderId;
 use crate::source::binder;
 use crate::source::terms::guarded;
 use crate::state::CheckState;
@@ -29,17 +32,26 @@ struct ValueEquationSignature {
 /// See documentation for [`check_value_equations`].
 pub type ValueEquationPatterns = Vec<TypeId>;
 
+/// Results shared by equation exhaustiveness checking and checked Core construction.
+pub struct CheckedValueEquations {
+    pub patterns: ValueEquationPatterns,
+    /// Dictionary parameters introduced by the checked signature, in constraint order.
+    pub evidence_binders: Arc<[EvidenceBinderId]>,
+    /// The skolemised function type after removing `forall` and constraint binders.
+    pub function_type: TypeId,
+}
+
 /// Checks a group of [`lowering::Equation`].
 ///
-/// This function returns the instantiated types of the equation's
-/// arguments for use in exhaustiveness checking by the callers.
+/// The result retains the instantiated pattern types for exhaustiveness checking and the
+/// signature binders needed to construct a checked Core binding.
 pub fn check_value_equations<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     origin: EquationTypeOrigin,
     expected_type: TypeId,
     equations: &[lowering::Equation],
-) -> QueryResult<ValueEquationPatterns>
+) -> QueryResult<CheckedValueEquations>
 where
     Q: ExternalQueries,
 {
@@ -48,9 +60,10 @@ where
     let signature::SkolemisedSignature { substitution, constraints, arguments, result } =
         signature::expect_term_signature(state, context, expected_type, required)?;
 
+    let mut evidence_binders = Vec::with_capacity(constraints.len());
     for &constraint in &constraints {
         if !constraint::is_type_error(state, context, constraint)? {
-            state.push_given(constraint);
+            evidence_binders.push(state.push_given(constraint));
         }
     }
 
@@ -64,7 +77,11 @@ where
         check_equations(state, context, origin, &signature, &arguments, equations)
     })?;
 
-    Ok(arguments)
+    Ok(CheckedValueEquations {
+        patterns: arguments,
+        evidence_binders: Arc::from(evidence_binders),
+        function_type: signature.signature,
+    })
 }
 
 /// Infers a group of [`lowering::Equation`].

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -216,14 +216,14 @@ where
 {
     let expression_type = super::infer_expression(state, context, expression)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, map_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, lambda_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));
@@ -245,14 +245,14 @@ where
 {
     let expression_type = super::infer_expression(state, context, expression)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, apply_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, continuation_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -1,18 +1,36 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
+use itertools::Itertools;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
+use crate::semantic::{
+    CheckedAdoExpression, CheckedAdoStep, CheckedApplication, CheckedBinderId, CheckedBinderKind,
+    CheckedBlockStatement, CheckedErrorStatement, CheckedExpressionId, CheckedExpressionKind,
+    CheckedUnaryApplication,
+};
 use crate::source::binder;
 use crate::source::terms::{application, form_do, form_let};
 use crate::state::CheckState;
 
+#[derive(Clone, Copy)]
+enum AdoBinder {
+    Bind(Option<lowering::BinderId>),
+    Discard,
+}
+
 enum AdoStep<'a> {
+    Error {
+        statement: lowering::DoStatementId,
+    },
     Action {
         statement: lowering::DoStatementId,
+        binder: AdoBinder,
         binder_type: TypeId,
-        expression: lowering::ExpressionId,
+        expression: Option<lowering::ExpressionId>,
     },
     Let {
         statement: lowering::DoStatementId,
@@ -20,18 +38,35 @@ enum AdoStep<'a> {
     },
 }
 
+enum AdoApplicationKind {
+    Map,
+    Apply,
+}
+
+pub struct AdoFunctions {
+    pub map: Option<lowering::TermVariableResolution>,
+    pub apply: Option<lowering::TermVariableResolution>,
+    pub pure: Option<lowering::TermVariableResolution>,
+}
+
+struct InferredUnaryApplication {
+    type_id: TypeId,
+    application: Option<CheckedApplication>,
+}
+
 pub fn infer_ado<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    map: Option<lowering::TermVariableResolution>,
-    apply: Option<lowering::TermVariableResolution>,
-    pure: Option<lowering::TermVariableResolution>,
+    source_expression: lowering::ExpressionId,
+    functions: AdoFunctions,
     statement_ids: &[lowering::DoStatementId],
     expression: Option<lowering::ExpressionId>,
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
+    let AdoFunctions { map, apply, pure } = functions;
+
     // First, perform a forward pass where variable bindings are bound
     // to unification variables. Let bindings are not checked here to
     // avoid premature solving of unification variables. Instead, they
@@ -39,6 +74,7 @@ where
     let mut steps = vec![];
     for &statement_id in statement_ids.iter() {
         let Some(statement) = context.lowered.info.get_do_statement(statement_id) else {
+            steps.push(AdoStep::Error { statement: statement_id });
             continue;
         };
         match statement {
@@ -48,27 +84,37 @@ where
                 } else {
                     state.fresh_unification(context.queries, context.prim.t)
                 };
-                let Some(expression) = *expression else { continue };
-                steps.push(AdoStep::Action { statement: statement_id, binder_type, expression });
+                let binder = AdoBinder::Bind(*binder);
+                steps.push(AdoStep::Action {
+                    statement: statement_id,
+                    binder,
+                    binder_type,
+                    expression: *expression,
+                });
             }
             lowering::DoStatement::Let { statements } => {
                 steps.push(AdoStep::Let { statement: statement_id, statements });
             }
             lowering::DoStatement::Discard { expression } => {
                 let binder_type = state.fresh_unification(context.queries, context.prim.t);
-                let Some(expression) = *expression else { continue };
-                steps.push(AdoStep::Action { statement: statement_id, binder_type, expression });
+                steps.push(AdoStep::Action {
+                    statement: statement_id,
+                    binder: AdoBinder::Discard,
+                    binder_type,
+                    expression: *expression,
+                });
             }
         }
     }
 
-    let binder_types: Vec<_> = steps
-        .iter()
-        .filter_map(|step| match step {
-            AdoStep::Action { binder_type, .. } => Some(*binder_type),
-            AdoStep::Let { .. } => None,
-        })
-        .collect();
+    let binder_types = steps.iter().filter_map(|step| match step {
+        AdoStep::Action { binder_type, expression: Some(_), .. } => Some(*binder_type),
+        AdoStep::Error { .. } | AdoStep::Action { expression: None, .. } | AdoStep::Let { .. } => {
+            None
+        }
+    });
+    let binder_types = binder_types.collect_vec();
+    let has_source_actions = steps.iter().any(|step| matches!(step, AdoStep::Action { .. }));
 
     // For ado blocks with no bindings, we check let statements and then
     // apply pure to the expression.
@@ -83,12 +129,62 @@ where
                 })?;
             }
         }
+        let missing_expression_type = context.unknown("missing ado action");
+        let statements =
+            checked_ado_recovery_statements(state, context, &steps, missing_expression_type);
+        if has_source_actions {
+            let result_type = context.unknown("malformed ado actions");
+            let expression = if let Some(expression) = expression {
+                super::infer_expression(state, context, expression)?;
+                match state.checked.core.lookup_expression(expression) {
+                    Some(expression) => expression,
+                    None => form_do::record_malformed_expression(state, expression, result_type),
+                }
+            } else {
+                form_do::allocate_missing_expression(state, result_type)
+            };
+            record_ado_error_expression(
+                state,
+                source_expression,
+                statements,
+                expression,
+                result_type,
+            );
+            return Ok(result_type);
+        }
         return if let Some(expression) = expression {
             let pure_type = form_do::lookup_or_synthesise_pure(state, context, pure)?;
-            application::check_function_term_application(state, context, pure_type, expression)
+            let inferred = infer_ado_pure_core(state, context, pure_type, expression)?;
+            let result_type = inferred.type_id;
+            let expression = match state.checked.core.lookup_expression(expression) {
+                Some(expression) => expression,
+                None => form_do::record_malformed_expression(state, expression, result_type),
+            };
+            record_ado_pure_expression(
+                state,
+                source_expression,
+                statements,
+                pure,
+                pure_type,
+                expression,
+                inferred,
+            );
+            Ok(result_type)
         } else {
             state.insert_error(ErrorKind::EmptyAdoBlock);
-            Ok(context.unknown("empty ado block"))
+            let result_type = context.unknown("empty ado block");
+            let inferred = InferredUnaryApplication { type_id: result_type, application: None };
+            let expression = form_do::allocate_missing_expression(state, result_type);
+            record_ado_pure_expression(
+                state,
+                source_expression,
+                statements,
+                None,
+                context.unknown("missing pure application"),
+                expression,
+                inferred,
+            );
+            Ok(result_type)
         };
     }
 
@@ -143,44 +239,120 @@ where
     };
 
     let mut continuation_type = None;
+    let mut checked_steps = vec![];
+    let missing_expression_type = context.unknown("missing ado action");
 
     for step in &steps {
         match step {
+            AdoStep::Error { statement } => {
+                let error =
+                    CheckedErrorStatement { source: *statement, binder: None, expression: None };
+                let statement = CheckedBlockStatement::Error(error);
+                checked_steps.push(CheckedAdoStep::Statement(statement));
+            }
             AdoStep::Let { statement, statements } => {
                 state.with_error_crumb(ErrorCrumb::CheckingAdoLet(*statement), |state| {
                     form_let::check_let_chunks(state, context, statements)
                 })?;
+                let statement =
+                    form_let::checked_let_statement(state, context, *statement, statements);
+                let statement = CheckedBlockStatement::Let(statement);
+                checked_steps.push(CheckedAdoStep::Statement(statement));
             }
-            AdoStep::Action { statement, expression, .. } => {
-                let statement_type = if let Some(continuation_type) = continuation_type {
-                    // Then, the infer_ado_apply rule applies `apply` to the inferred
-                    // expression type and the continuation type that is a function
-                    // contained within some container, like Effect.
-                    //
-                    //   apply_type        := f (x -> y) -> f x -> f y
-                    //   continuation_type := Effect (?b -> ?in_expression)
-                    //
-                    //   expression_type                 := Effect Int
-                    //   apply(continuation, expression) := Effect ?in_expression
-                    //                                   >>
-                    //                                   >> ?b := Int
-                    //
-                    //   continuation_type := Effect ?in_expression
-                    state.with_error_crumb(ErrorCrumb::InferringAdoApply(*statement), |state| {
-                        infer_ado_apply_core(
-                            state,
-                            context,
-                            apply_type,
-                            continuation_type,
-                            *expression,
-                        )
-                    })?
-                } else {
-                    state.with_error_crumb(ErrorCrumb::InferringAdoMap(*statement), |state| {
-                        infer_ado_map_core(state, context, map_type, lambda_type, *expression)
-                    })?
+            AdoStep::Action { statement, binder, binder_type, expression } => {
+                let Some(source_expression) = *expression else {
+                    let binder = checked_ado_error_binder(state, binder, *binder_type);
+                    let expression =
+                        form_do::allocate_missing_expression(state, missing_expression_type);
+                    let error = CheckedErrorStatement {
+                        source: *statement,
+                        binder,
+                        expression: Some(expression),
+                    };
+                    let statement = CheckedBlockStatement::Error(error);
+                    checked_steps.push(CheckedAdoStep::Statement(statement));
+                    continue;
                 };
-                continuation_type = Some(statement_type);
+                let (inferred, kind, function, function_type) =
+                    if let Some(continuation_type) = continuation_type {
+                        // Then, the infer_ado_apply rule applies `apply` to the inferred
+                        // expression type and the continuation type that is a function
+                        // contained within some container, like Effect.
+                        //
+                        //   apply_type        := f (x -> y) -> f x -> f y
+                        //   continuation_type := Effect (?b -> ?in_expression)
+                        //
+                        //   expression_type                 := Effect Int
+                        //   apply(continuation, expression) := Effect ?in_expression
+                        //                                   >>
+                        //                                   >> ?b := Int
+                        //
+                        //   continuation_type := Effect ?in_expression
+                        let inferred = state.with_error_crumb(
+                            ErrorCrumb::InferringAdoApply(*statement),
+                            |state| {
+                                infer_ado_apply_core(
+                                    state,
+                                    context,
+                                    apply_type,
+                                    continuation_type,
+                                    source_expression,
+                                )
+                            },
+                        )?;
+                        (inferred, AdoApplicationKind::Apply, apply, apply_type)
+                    } else {
+                        let inferred = state.with_error_crumb(
+                            ErrorCrumb::InferringAdoMap(*statement),
+                            |state| {
+                                infer_ado_map_core(
+                                    state,
+                                    context,
+                                    map_type,
+                                    lambda_type,
+                                    source_expression,
+                                )
+                            },
+                        )?;
+                        (inferred, AdoApplicationKind::Map, map, map_type)
+                    };
+                continuation_type = Some(inferred.type_id);
+                let binder = match binder {
+                    AdoBinder::Bind(Some(source)) => {
+                        match state.checked.core.lookup_binder(*source) {
+                            Some(binder) => binder,
+                            None => form_do::record_malformed_binder(state, *source, *binder_type),
+                        }
+                    }
+                    AdoBinder::Bind(None) => form_do::allocate_missing_binder(state, *binder_type),
+                    AdoBinder::Discard => state
+                        .checked
+                        .core
+                        .allocate_synthesized_binder(*binder_type, CheckedBinderKind::Wildcard),
+                };
+                let expression = match state.checked.core.lookup_expression(source_expression) {
+                    Some(expression) => expression,
+                    None => form_do::record_malformed_expression(
+                        state,
+                        source_expression,
+                        missing_expression_type,
+                    ),
+                };
+                let application = application::record_binary_application(
+                    state,
+                    function,
+                    function_type,
+                    inferred.outcome,
+                );
+                let step = match kind {
+                    AdoApplicationKind::Map => {
+                        CheckedAdoStep::Map { binder, expression, application }
+                    }
+                    AdoApplicationKind::Apply => {
+                        CheckedAdoStep::Apply { binder, expression, application }
+                    }
+                };
+                checked_steps.push(step);
             }
         }
     }
@@ -201,63 +373,184 @@ where
         unreachable!("invariant violated: impossible empty steps");
     };
 
+    let expression = match expression {
+        Some(source) => match state.checked.core.lookup_expression(source) {
+            Some(expression) => expression,
+            None => form_do::record_malformed_expression(state, source, in_expression_type),
+        },
+        None => form_do::allocate_missing_expression(state, in_expression_type),
+    };
+
+    record_ado_actions_expression(
+        state,
+        source_expression,
+        checked_steps,
+        expression,
+        lambda_type,
+        continuation_type,
+    );
+
     Ok(continuation_type)
 }
 
-pub fn infer_ado_map_core<Q>(
+fn infer_ado_pure_core<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    pure_type: TypeId,
+    expression: lowering::ExpressionId,
+) -> QueryResult<InferredUnaryApplication>
+where
+    Q: ExternalQueries,
+{
+    let expression_type = super::infer_expression(state, context, expression)?;
+    let Some(application) = application::check_generic_application(state, context, pure_type)?
+    else {
+        let type_id = context.unknown("invalid function application");
+        return Ok(InferredUnaryApplication { type_id, application: None });
+    };
+    unification::subtype(state, context, expression_type, application.argument)?;
+    Ok(InferredUnaryApplication { type_id: application.result, application: Some(application) })
+}
+
+fn record_ado_pure_expression(
+    state: &mut CheckState,
+    source_expression: lowering::ExpressionId,
+    statements: Vec<CheckedBlockStatement>,
+    function: Option<lowering::TermVariableResolution>,
+    function_type: TypeId,
+    expression: CheckedExpressionId,
+    inferred: InferredUnaryApplication,
+) {
+    let kind = function.map_or(CheckedExpressionKind::Error, |resolution| {
+        CheckedExpressionKind::Variable { resolution }
+    });
+    let function = state.checked.core.allocate_expression(function_type, kind);
+    let application = match inferred.application {
+        Some(application) => CheckedUnaryApplication::Complete { function, application },
+        None => CheckedUnaryApplication::Error { function },
+    };
+
+    let statements = Arc::from(statements);
+
+    let expression = CheckedAdoExpression::Pure { statements, expression, application };
+    let kind = CheckedExpressionKind::Ado { expression };
+
+    let expression = state.checked.core.allocate_expression(inferred.type_id, kind);
+    state.checked.core.record_expression(source_expression, expression);
+}
+
+fn record_ado_actions_expression(
+    state: &mut CheckState,
+    source_expression: lowering::ExpressionId,
+    steps: Vec<CheckedAdoStep>,
+    expression: CheckedExpressionId,
+    lambda_type: TypeId,
+    result_type: TypeId,
+) {
+    let expression =
+        CheckedAdoExpression::Actions { steps: Arc::from(steps), expression, lambda_type };
+    let kind = CheckedExpressionKind::Ado { expression };
+    let expression = state.checked.core.allocate_expression(result_type, kind);
+    state.checked.core.record_expression(source_expression, expression);
+}
+
+fn record_ado_error_expression(
+    state: &mut CheckState,
+    source_expression: lowering::ExpressionId,
+    statements: Vec<CheckedBlockStatement>,
+    expression: CheckedExpressionId,
+    result_type: TypeId,
+) {
+    let expression = CheckedAdoExpression::Error { statements: statements.into(), expression };
+    let kind = CheckedExpressionKind::Ado { expression };
+    let expression = state.checked.core.allocate_expression(result_type, kind);
+    state.checked.core.record_expression(source_expression, expression);
+}
+
+fn checked_ado_error_binder(
+    state: &mut CheckState,
+    binder: &AdoBinder,
+    binder_type: TypeId,
+) -> Option<CheckedBinderId> {
+    match binder {
+        AdoBinder::Bind(Some(source)) => Some(match state.checked.core.lookup_binder(*source) {
+            Some(binder) => binder,
+            None => form_do::record_malformed_binder(state, *source, binder_type),
+        }),
+        AdoBinder::Bind(None) => Some(form_do::allocate_missing_binder(state, binder_type)),
+        AdoBinder::Discard => None,
+    }
+}
+
+fn checked_ado_recovery_statements<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    steps: &[AdoStep<'_>],
+    missing_expression_type: TypeId,
+) -> Vec<CheckedBlockStatement>
+where
+    Q: ExternalQueries,
+{
+    let checked_steps = steps.iter().filter_map(|step| {
+        let statement = match step {
+            AdoStep::Error { statement } => {
+                let error =
+                    CheckedErrorStatement { source: *statement, binder: None, expression: None };
+                CheckedBlockStatement::Error(error)
+            }
+            AdoStep::Let { statement, statements } => {
+                let statement =
+                    form_let::checked_let_statement(state, context, *statement, statements);
+                CheckedBlockStatement::Let(statement)
+            }
+            AdoStep::Action { statement, binder, binder_type, expression: None } => {
+                let binder = checked_ado_error_binder(state, binder, *binder_type);
+                let expression =
+                    form_do::allocate_missing_expression(state, missing_expression_type);
+                let error = CheckedErrorStatement {
+                    source: *statement,
+                    binder,
+                    expression: Some(expression),
+                };
+                CheckedBlockStatement::Error(error)
+            }
+            AdoStep::Action { expression: Some(_), .. } => return None,
+        };
+        Some(statement)
+    });
+    checked_steps.collect_vec()
+}
+
+fn infer_ado_map_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     map_type: TypeId,
     lambda_type: TypeId,
     expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
+) -> QueryResult<application::InferredBinaryApplication>
 where
     Q: ExternalQueries,
 {
     let expression_type = super::infer_expression(state, context, expression)?;
-
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, map_type)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, lambda_type, argument)?;
-
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, result)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, expression_type, argument)?;
-
-    Ok(result)
+    application::check_binary_application(state, context, map_type, lambda_type, expression_type)
 }
 
-pub fn infer_ado_apply_core<Q>(
+fn infer_ado_apply_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     apply_type: TypeId,
     continuation_type: TypeId,
     expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
+) -> QueryResult<application::InferredBinaryApplication>
 where
     Q: ExternalQueries,
 {
     let expression_type = super::infer_expression(state, context, expression)?;
-
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, apply_type)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, continuation_type, argument)?;
-
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, result)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, expression_type, argument)?;
-
-    Ok(result)
+    application::check_binary_application(
+        state,
+        context,
+        apply_type,
+        continuation_type,
+        expression_type,
+    )
 }

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -415,14 +415,14 @@ where
     let expression_type = super::infer_expression(state, context, expression)?;
     let lambda_type = context.intern_function(binder_type, continuation_type);
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, bind_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, expression_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -1,4 +1,5 @@
 use std::iter;
+use std::sync::Arc;
 
 use building_types::QueryResult;
 use itertools::{Itertools, Position};
@@ -7,13 +8,21 @@ use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
+use crate::semantic::{
+    CheckedBinderKind, CheckedBlockStatement, CheckedDoExpression, CheckedDoStep,
+    CheckedErrorStatement, CheckedExpressionId, CheckedExpressionKind,
+};
 use crate::source::binder;
 use crate::source::terms::{application, form_let};
 use crate::state::CheckState;
 
 enum DoStep<'a> {
+    Error {
+        statement: lowering::DoStatementId,
+    },
     Bind {
         statement: lowering::DoStatementId,
+        binder: Option<lowering::BinderId>,
         binder_type: TypeId,
         expression: Option<lowering::ExpressionId>,
     },
@@ -35,9 +44,19 @@ impl DoStep<'_> {
 
 enum DoBlockFinalStep {
     Empty,
-    InvalidBind { statement: lowering::DoStatementId, expression: Option<lowering::ExpressionId> },
-    Discard { expression: Option<lowering::ExpressionId> },
-    InvalidLet { statement: lowering::DoStatementId },
+    InvalidBind {
+        statement: lowering::DoStatementId,
+        binder: Option<lowering::BinderId>,
+        binder_type: TypeId,
+        expression: Option<lowering::ExpressionId>,
+    },
+    Discard {
+        statement: lowering::DoStatementId,
+        expression: Option<lowering::ExpressionId>,
+    },
+    InvalidLet {
+        statement: lowering::DoStatementId,
+    },
 }
 
 impl DoBlockFinalStep {
@@ -148,6 +167,7 @@ where
 pub fn infer_do<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source_expression: lowering::ExpressionId,
     bind: Option<lowering::TermVariableResolution>,
     discard: Option<lowering::TermVariableResolution>,
     statement_id: &[lowering::DoStatementId],
@@ -162,6 +182,7 @@ where
     let mut steps = vec![];
     for &statement_id in statement_id.iter() {
         let Some(statement) = context.lowered.info.get_do_statement(statement_id) else {
+            steps.push(DoStep::Error { statement: statement_id });
             continue;
         };
         match statement {
@@ -173,6 +194,7 @@ where
                 };
                 steps.push(DoStep::Bind {
                     statement: statement_id,
+                    binder: *binder,
                     binder_type,
                     expression: *expression,
                 });
@@ -186,28 +208,35 @@ where
         }
     }
 
-    let final_step = match steps.last() {
-        Some(DoStep::Bind { statement, expression, .. }) => {
-            DoBlockFinalStep::InvalidBind { statement: *statement, expression: *expression }
+    let final_step = match steps.iter().rev().find(|step| !matches!(step, DoStep::Error { .. })) {
+        Some(DoStep::Bind { statement, binder, binder_type, expression }) => {
+            DoBlockFinalStep::InvalidBind {
+                statement: *statement,
+                binder: *binder,
+                binder_type: *binder_type,
+                expression: *expression,
+            }
         }
-        Some(DoStep::Discard { expression, .. }) => {
-            DoBlockFinalStep::Discard { expression: *expression }
+        Some(DoStep::Discard { statement, expression }) => {
+            DoBlockFinalStep::Discard { statement: *statement, expression: *expression }
         }
         Some(DoStep::Let { statement, .. }) => {
             DoBlockFinalStep::InvalidLet { statement: *statement }
         }
+        Some(DoStep::Error { .. }) => unreachable!("error steps were filtered out"),
         None => DoBlockFinalStep::Empty,
     };
 
     let (has_bind_step, has_discard_step) = {
         let mut has_bind = false;
         let mut has_discard = false;
-        for (position, statement) in steps.iter().with_position() {
+        let checked_steps = steps.iter().filter(|step| !matches!(step, DoStep::Error { .. }));
+        for (position, statement) in checked_steps.with_position() {
             let is_final = matches!(position, Position::Last | Position::Only);
             match statement {
                 DoStep::Bind { .. } => has_bind = true,
                 DoStep::Discard { .. } if !is_final => has_discard = true,
-                _ => (),
+                DoStep::Error { .. } | DoStep::Discard { .. } | DoStep::Let { .. } => (),
             }
         }
         (has_bind, has_discard)
@@ -228,27 +257,47 @@ where
     let final_expression = match final_step {
         DoBlockFinalStep::Empty => {
             state.insert_error(ErrorKind::EmptyDoBlock);
-            return Ok(context.unknown("empty do block"));
+            let result_type = context.unknown("empty do block");
+            let checked_steps = steps.iter().filter_map(|step| match step {
+                DoStep::Error { statement } => {
+                    let error = CheckedErrorStatement {
+                        source: *statement,
+                        binder: None,
+                        expression: None,
+                    };
+                    let statement = CheckedBlockStatement::Error(error);
+                    Some(CheckedDoStep::Statement(statement))
+                }
+                DoStep::Bind { .. } | DoStep::Discard { .. } | DoStep::Let { .. } => None,
+            });
+            let checked_steps = checked_steps.collect_vec();
+            let final_expression = allocate_missing_expression(state, result_type);
+            record_do_expression(
+                state,
+                source_expression,
+                checked_steps,
+                final_expression,
+                result_type,
+            );
+            return Ok(result_type);
         }
         // Technically valid, syntactically disallowed. This allows
         // partially-written do expressions to infer, with a friendly
         // warning to nudge the user that `bind` is prohibited.
-        DoBlockFinalStep::InvalidBind { statement, expression } => {
+        DoBlockFinalStep::InvalidBind { statement, expression, .. } => {
             state.with_error_crumb(ErrorCrumb::InferringDoBind(statement), |state| {
                 state.insert_error(ErrorKind::InvalidFinalBind);
             });
-            let Some(expression) = expression else {
+            if expression.is_none() {
                 state.insert_error(ErrorKind::EmptyDoBlock);
-                return Ok(context.unknown("empty do block"));
-            };
-            Some(expression)
+            }
+            expression
         }
-        DoBlockFinalStep::Discard { expression } => {
-            let Some(expression) = expression else {
+        DoBlockFinalStep::Discard { expression, .. } => {
+            if expression.is_none() {
                 state.insert_error(ErrorKind::EmptyDoBlock);
-                return Ok(context.unknown("empty do block"));
-            };
-            Some(expression)
+            }
+            expression
         }
         DoBlockFinalStep::InvalidLet { statement } => {
             state.with_error_crumb(ErrorCrumb::CheckingDoLet(statement), |state| {
@@ -339,47 +388,134 @@ where
     // to the previous approach that emulated desugared checking.
 
     let mut continuations = continuation_types.iter().tuple_windows::<(_, _)>();
+    let mut checked_steps = vec![];
+    let missing_expression_type = context.unknown("missing do expression");
 
     for step in &steps {
         match step {
+            DoStep::Error { statement } => {
+                let error =
+                    CheckedErrorStatement { source: *statement, binder: None, expression: None };
+                let statement = CheckedBlockStatement::Error(error);
+                checked_steps.push(CheckedDoStep::Statement(statement));
+            }
             DoStep::Let { statement, statements } => {
                 state.with_error_crumb(ErrorCrumb::CheckingDoLet(*statement), |state| {
                     form_let::check_let_chunks(state, context, statements)
                 })?;
+                let statement =
+                    form_let::checked_let_statement(state, context, *statement, statements);
+                let statement = CheckedBlockStatement::Let(statement);
+                checked_steps.push(CheckedDoStep::Statement(statement));
             }
-            DoStep::Bind { statement, binder_type, expression } => {
+            DoStep::Bind { statement, binder, binder_type, expression } => {
                 let Some((&now_type, &next_type)) = continuations.next() else {
                     continue;
                 };
-                let Some(expression) = *expression else {
+                let Some(source_expression) = *expression else {
+                    let binder = match binder {
+                        Some(source) => match state.checked.core.lookup_binder(*source) {
+                            Some(binder) => binder,
+                            None => record_malformed_binder(state, *source, *binder_type),
+                        },
+                        None => allocate_missing_binder(state, *binder_type),
+                    };
+                    let expression = allocate_missing_expression(state, missing_expression_type);
+                    let error = CheckedErrorStatement {
+                        source: *statement,
+                        binder: Some(binder),
+                        expression: Some(expression),
+                    };
+                    let statement = CheckedBlockStatement::Error(error);
+                    checked_steps.push(CheckedDoStep::Statement(statement));
                     continue;
                 };
-                state.with_error_crumb(ErrorCrumb::InferringDoBind(*statement), |state| {
-                    let statement_type = infer_do_bind_core(
-                        state,
-                        context,
-                        bind_type,
-                        next_type,
-                        expression,
-                        *binder_type,
-                    )?;
-                    unification::subtype(state, context, statement_type, now_type)?;
-                    Ok(())
-                })?;
+                let inferred =
+                    state.with_error_crumb(ErrorCrumb::InferringDoBind(*statement), |state| {
+                        let inferred = infer_do_bind_core(
+                            state,
+                            context,
+                            bind_type,
+                            next_type,
+                            source_expression,
+                            *binder_type,
+                        )?;
+                        unification::subtype(state, context, inferred.type_id, now_type)?;
+                        Ok(inferred)
+                    })?;
+                let binder = match binder {
+                    Some(source) => match state.checked.core.lookup_binder(*source) {
+                        Some(binder) => binder,
+                        None => record_malformed_binder(state, *source, *binder_type),
+                    },
+                    None => allocate_missing_binder(state, *binder_type),
+                };
+                let expression = match state.checked.core.lookup_expression(source_expression) {
+                    Some(expression) => expression,
+                    None => record_malformed_expression(state, source_expression, now_type),
+                };
+                let application = application::record_binary_application(
+                    state,
+                    bind,
+                    bind_type,
+                    inferred.outcome,
+                );
+                checked_steps.push(CheckedDoStep::Bind {
+                    binder,
+                    expression,
+                    continuation_type: next_type,
+                    application,
+                });
             }
             DoStep::Discard { statement, expression } => {
                 let Some((&now_type, &next_type)) = continuations.next() else {
                     continue;
                 };
-                let Some(expression) = *expression else {
+                let Some(source_expression) = *expression else {
+                    let expression = allocate_missing_expression(state, missing_expression_type);
+                    let error = CheckedErrorStatement {
+                        source: *statement,
+                        binder: None,
+                        expression: Some(expression),
+                    };
+                    let statement = CheckedBlockStatement::Error(error);
+                    checked_steps.push(CheckedDoStep::Statement(statement));
                     continue;
                 };
-                state.with_error_crumb(ErrorCrumb::InferringDoDiscard(*statement), |state| {
-                    let statement_type =
-                        infer_do_discard_core(state, context, discard_type, next_type, expression)?;
-                    unification::subtype(state, context, statement_type, now_type)?;
-                    Ok(())
-                })?;
+                let (binder_type, inferred) = state.with_error_crumb(
+                    ErrorCrumb::InferringDoDiscard(*statement),
+                    |state| {
+                        let (binder_type, inferred) = infer_do_discard_core(
+                            state,
+                            context,
+                            discard_type,
+                            next_type,
+                            source_expression,
+                        )?;
+                        unification::subtype(state, context, inferred.type_id, now_type)?;
+                        Ok((binder_type, inferred))
+                    },
+                )?;
+                let binder = state
+                    .checked
+                    .core
+                    .allocate_synthesized_binder(binder_type, CheckedBinderKind::Wildcard);
+                let expression = match state.checked.core.lookup_expression(source_expression) {
+                    Some(expression) => expression,
+                    None => record_malformed_expression(state, source_expression, now_type),
+                };
+                let application = application::record_binary_application(
+                    state,
+                    discard,
+                    discard_type,
+                    inferred.outcome,
+                );
+                checked_steps.push(CheckedDoStep::Discard {
+                    binder,
+                    expression,
+                    continuation_type: next_type,
+                    application,
+                });
             }
         }
     }
@@ -398,50 +534,155 @@ where
         super::check_expression(state, context, final_expression, final_continuation)?;
     }
 
+    let final_expression = match final_step {
+        DoBlockFinalStep::InvalidBind { statement, binder, binder_type, expression } => {
+            let binder = match binder {
+                Some(source) => match state.checked.core.lookup_binder(source) {
+                    Some(binder) => binder,
+                    None => record_malformed_binder(state, source, binder_type),
+                },
+                None => allocate_missing_binder(state, binder_type),
+            };
+            let expression = match expression {
+                Some(source) => match state.checked.core.lookup_expression(source) {
+                    Some(expression) => expression,
+                    None => record_malformed_expression(
+                        state,
+                        source,
+                        context.unknown("malformed final do expression"),
+                    ),
+                },
+                None => allocate_missing_expression(
+                    state,
+                    context.unknown("missing final do expression"),
+                ),
+            };
+            let error = CheckedErrorStatement {
+                source: statement,
+                binder: Some(binder),
+                expression: Some(expression),
+            };
+            let statement = CheckedBlockStatement::Error(error);
+            checked_steps.push(CheckedDoStep::Statement(statement));
+            None
+        }
+        DoBlockFinalStep::Discard { statement: _, expression: Some(expression) } => {
+            Some(expression)
+        }
+        DoBlockFinalStep::Discard { statement, expression: None } => {
+            let expression =
+                allocate_missing_expression(state, context.unknown("missing final do expression"));
+            let error = CheckedErrorStatement {
+                source: statement,
+                binder: None,
+                expression: Some(expression),
+            };
+            let statement = CheckedBlockStatement::Error(error);
+            checked_steps.push(CheckedDoStep::Statement(statement));
+            None
+        }
+        DoBlockFinalStep::InvalidLet { .. } => None,
+        DoBlockFinalStep::Empty => unreachable!("empty do blocks return before checking steps"),
+    };
+    let final_expression = match final_expression {
+        Some(source) => match state.checked.core.lookup_expression(source) {
+            Some(expression) => expression,
+            None => record_malformed_expression(state, source, final_continuation),
+        },
+        None => allocate_missing_expression(state, final_continuation),
+    };
+    record_do_expression(
+        state,
+        source_expression,
+        checked_steps,
+        final_expression,
+        first_continuation,
+    );
+
     Ok(first_continuation)
 }
 
-pub fn infer_do_bind_core<Q>(
+fn record_do_expression(
+    state: &mut CheckState,
+    source_expression: lowering::ExpressionId,
+    steps: Vec<CheckedDoStep>,
+    final_expression: CheckedExpressionId,
+    result_type: TypeId,
+) {
+    let expression = CheckedDoExpression { steps: Arc::from(steps), final_expression };
+    let kind = CheckedExpressionKind::Do { expression };
+    let expression = state.checked.core.allocate_expression(result_type, kind);
+    state.checked.core.record_expression(source_expression, expression);
+}
+
+pub(super) fn allocate_missing_expression(
+    state: &mut CheckState,
+    type_id: TypeId,
+) -> CheckedExpressionId {
+    state.checked.core.allocate_expression(type_id, CheckedExpressionKind::Error)
+}
+
+pub(super) fn record_malformed_expression(
+    state: &mut CheckState,
+    source: lowering::ExpressionId,
+    fallback_type: TypeId,
+) -> CheckedExpressionId {
+    let type_id = state.checked.nodes.lookup_expression(source).unwrap_or(fallback_type);
+    let expression = state.checked.core.allocate_expression(type_id, CheckedExpressionKind::Error);
+    state.checked.core.record_expression(source, expression);
+    expression
+}
+
+pub(super) fn allocate_missing_binder(
+    state: &mut CheckState,
+    type_id: TypeId,
+) -> crate::semantic::CheckedBinderId {
+    state.checked.core.allocate_synthesized_binder(type_id, CheckedBinderKind::Error)
+}
+
+pub(super) fn record_malformed_binder(
+    state: &mut CheckState,
+    source: lowering::BinderId,
+    fallback_type: TypeId,
+) -> crate::semantic::CheckedBinderId {
+    let type_id = state.checked.nodes.lookup_binder(source).unwrap_or(fallback_type);
+    state.checked.core.allocate_source_binder(source, type_id, CheckedBinderKind::Error)
+}
+
+pub(super) fn infer_do_bind_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     bind_type: TypeId,
     continuation_type: TypeId,
     expression: lowering::ExpressionId,
     binder_type: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<application::InferredBinaryApplication>
 where
     Q: ExternalQueries,
 {
     let expression_type = super::infer_expression(state, context, expression)?;
     let lambda_type = context.intern_function(binder_type, continuation_type);
-
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, bind_type)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, expression_type, argument)?;
-
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, result)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, lambda_type, argument)?;
-
-    Ok(result)
+    application::check_binary_application(state, context, bind_type, expression_type, lambda_type)
 }
 
-pub fn infer_do_discard_core<Q>(
+fn infer_do_discard_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     discard_type: TypeId,
     continuation_type: TypeId,
     expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
+) -> QueryResult<(TypeId, application::InferredBinaryApplication)>
 where
     Q: ExternalQueries,
 {
     let binder_type = state.fresh_unification(context.queries, context.prim.t);
-    infer_do_bind_core(state, context, discard_type, continuation_type, expression, binder_type)
+    let application = infer_do_bind_core(
+        state,
+        context,
+        discard_type,
+        continuation_type,
+        expression,
+        binder_type,
+    )?;
+    Ok((binder_type, application))
 }

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -139,7 +139,7 @@ where
     };
 
     if let Some(signature_id) = name.signature {
-        let equation_patterns = equations::check_value_equations(
+        let checked_equations = equations::check_value_equations(
             state,
             context,
             equations::EquationTypeOrigin::Explicit(signature_id),
@@ -149,7 +149,7 @@ where
         let exhaustiveness = exhaustive::check_equation_patterns(
             state,
             context,
-            &equation_patterns,
+            &checked_equations.patterns,
             &name.equations,
         )?;
         state.report_exhaustiveness(exhaustiveness);

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{Type, exhaustive, normalise, toolkit, unification};
 use crate::error::ErrorCrumb;
+use crate::semantic::{CheckedLetBinding, CheckedLetStatement};
 use crate::source::terms::{equations, guarded};
 use crate::source::{binder, types};
 use crate::state::CheckState;
@@ -27,6 +30,39 @@ where
         }
     }
     Ok(())
+}
+
+pub(super) fn checked_let_statement<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    source: lowering::DoStatementId,
+    chunks: &[lowering::LetBindingChunk],
+) -> CheckedLetStatement
+where
+    Q: ExternalQueries,
+{
+    let mut checked_bindings = vec![];
+    for chunk in chunks {
+        match chunk {
+            lowering::LetBindingChunk::Pattern { binder, .. } => {
+                let binder = binder.and_then(|binder| state.checked.core.lookup_binder(binder));
+                checked_bindings.push(CheckedLetBinding::Pattern { binder });
+            }
+            lowering::LetBindingChunk::Names { bindings, .. } => {
+                let name_bindings = bindings.iter().map(|&binding| {
+                    let type_id = state
+                        .checked
+                        .nodes
+                        .lookup_let(binding)
+                        .unwrap_or_else(|| context.unknown("malformed let binding"));
+                    CheckedLetBinding::Name { binding, type_id }
+                });
+                checked_bindings.extend(name_bindings);
+            }
+        }
+    }
+    let bindings = Arc::from(checked_bindings);
+    CheckedLetStatement { source, bindings }
 }
 
 pub fn check_pattern_let_binding<Q>(

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -51,7 +51,7 @@ where
     let expression_type = if binder::requires_instantiation(context, binder) {
         toolkit::instantiate_constrained(state, context, expression_type)?
     } else {
-        toolkit::collect_wanteds(state, context, expression_type)?
+        toolkit::collect_wanted(state, context, expression_type)?
     };
 
     let binder_type = binder::check_binder(state, context, binder, expression_type)?;

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -5,7 +5,9 @@ use building_types::QueryResult;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, exhaustive, toolkit, unification};
-use crate::semantic::CheckedExpressionKind;
+use crate::semantic::{
+    CheckedCaseAlternative, CheckedExpressionKind, CheckedGuardedExpression, CheckedPatternGuard,
+};
 use crate::source::terms::{form_let, guarded};
 use crate::source::{binder, terms};
 use crate::state::CheckState;
@@ -223,18 +225,20 @@ where
 pub fn infer_case_of<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    case: lowering::ExpressionId,
     trunk: &[lowering::ExpressionId],
     branches: &[lowering::CaseBranch],
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
-    case_of_core(state, context, trunk, branches, CaseOfMode::Infer)
+    case_of_core(state, context, case, trunk, branches, CaseOfMode::Infer)
 }
 
 pub fn check_case_of<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    case: lowering::ExpressionId,
     trunk: &[lowering::ExpressionId],
     branches: &[lowering::CaseBranch],
     expected: TypeId,
@@ -242,12 +246,13 @@ pub fn check_case_of<Q>(
 where
     Q: ExternalQueries,
 {
-    case_of_core(state, context, trunk, branches, CaseOfMode::Check { expected })
+    case_of_core(state, context, case, trunk, branches, CaseOfMode::Check { expected })
 }
 
 fn case_of_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    case: lowering::ExpressionId,
     trunk: &[lowering::ExpressionId],
     branches: &[lowering::CaseBranch],
     mode: CaseOfMode,
@@ -291,15 +296,136 @@ where
     let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);
 
-    if has_missing {
-        if let CaseOfMode::Infer = mode {
-            return Ok(context.intern_constrained(context.prim.partial, expected));
-        } else {
-            state.push_wanted(context.prim.partial);
+    let result_type = if has_missing {
+        match mode {
+            CaseOfMode::Infer => context.intern_constrained(context.prim.partial, expected),
+            CaseOfMode::Check { .. } => {
+                state.push_wanted(context.prim.partial);
+                expected
+            }
         }
+    } else {
+        expected
+    };
+
+    record_case(state, case, trunk, branches, result_type);
+
+    Ok(result_type)
+}
+
+fn record_case(
+    state: &mut CheckState,
+    case: lowering::ExpressionId,
+    trunk: &[lowering::ExpressionId],
+    branches: &[lowering::CaseBranch],
+    case_type: TypeId,
+) {
+    if trunk.is_empty() || branches.is_empty() {
+        return;
     }
 
-    Ok(expected)
+    let scrutinees =
+        trunk.iter().map(|expression| state.checked.core.lookup_expression(*expression));
+    let Some(scrutinees) = scrutinees.collect::<Option<Vec<_>>>() else { return };
+
+    let mut alternatives = Vec::with_capacity(branches.len());
+    for branch in branches {
+        if branch.binders.len() != trunk.len() {
+            return;
+        }
+
+        let binders = branch.binders.iter().map(|binder| state.checked.core.lookup_binder(*binder));
+        let Some(binders) = binders.collect::<Option<Vec<_>>>() else { return };
+        let Some(results) = checked_guarded_expressions(state, &branch.guarded_expression) else {
+            return;
+        };
+
+        alternatives.push(CheckedCaseAlternative {
+            binders: Arc::from(binders),
+            results: Arc::from(results),
+        });
+    }
+
+    let kind = CheckedExpressionKind::Case {
+        scrutinees: Arc::from(scrutinees),
+        alternatives: Arc::from(alternatives),
+    };
+    let checked_case = state.checked.core.allocate_expression(case_type, kind);
+    state.checked.core.record_expression(case, checked_case);
+}
+
+fn checked_guarded_expressions(
+    state: &CheckState,
+    guarded: &Option<lowering::GuardedExpression>,
+) -> Option<Vec<CheckedGuardedExpression>> {
+    match guarded.as_ref()? {
+        lowering::GuardedExpression::Unconditional { where_expression } => {
+            let expression = checked_where_expression(state, where_expression.as_ref()?)?;
+            let guarded = CheckedGuardedExpression { guards: Arc::from([]), expression };
+            Some(vec![guarded])
+        }
+        lowering::GuardedExpression::Conditionals { pattern_guarded } => {
+            checked_conditional_guarded_expressions(state, pattern_guarded)
+        }
+    }
+}
+
+fn checked_conditional_guarded_expressions(
+    state: &CheckState,
+    guarded: &[lowering::PatternGuarded],
+) -> Option<Vec<CheckedGuardedExpression>> {
+    if guarded.is_empty() {
+        return None;
+    }
+
+    let mut results = Vec::with_capacity(guarded.len());
+    for guarded in guarded {
+        results.push(checked_conditional_guarded_expression(state, guarded)?);
+    }
+    Some(results)
+}
+
+fn checked_conditional_guarded_expression(
+    state: &CheckState,
+    guarded: &lowering::PatternGuarded,
+) -> Option<CheckedGuardedExpression> {
+    if guarded.pattern_guards.is_empty() {
+        return None;
+    }
+
+    let guards = guarded.pattern_guards.iter().map(|guard| checked_pattern_guard(state, guard));
+    let guards = guards.collect::<Option<Vec<_>>>()?;
+
+    let where_expression = guarded.where_expression.as_ref()?;
+    let expression = checked_where_expression(state, where_expression)?;
+    Some(CheckedGuardedExpression { guards: Arc::from(guards), expression })
+}
+
+fn checked_pattern_guard(
+    state: &CheckState,
+    guard: &lowering::PatternGuard,
+) -> Option<CheckedPatternGuard> {
+    let source_expression = guard.expression?;
+    let expression = state.checked.core.lookup_expression(source_expression)?;
+    match guard.binder {
+        Some(source_binder) => {
+            let binder = state.checked.core.lookup_binder(source_binder)?;
+            Some(CheckedPatternGuard::Pattern { binder, expression })
+        }
+        None => Some(CheckedPatternGuard::Boolean { expression }),
+    }
+}
+
+fn checked_where_expression(
+    state: &CheckState,
+    where_expression: &lowering::WhereExpression,
+) -> Option<crate::semantic::CheckedExpressionId> {
+    if !where_expression.bindings.is_empty() {
+        return None;
+    }
+
+    let expression = where_expression.expression?;
+    state.checked.core.lookup_expression(expression)
 }
 
 pub fn check_let_in<Q>(

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -6,7 +6,8 @@ use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, exhaustive, toolkit, unification};
 use crate::semantic::{
-    CheckedCaseAlternative, CheckedExpressionKind, CheckedGuardedExpression, CheckedPatternGuard,
+    CheckedBinderKind, CheckedCaseAlternative, CheckedExpressionKind, CheckedGuardedExpression,
+    CheckedLiteral, CheckedPatternGuard,
 };
 use crate::source::terms::{form_let, guarded};
 use crate::source::{binder, terms};
@@ -27,6 +28,7 @@ enum CaseOfMode {
 pub fn infer_if_then_else<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     if_: Option<lowering::ExpressionId>,
     then: Option<lowering::ExpressionId>,
     else_: Option<lowering::ExpressionId>,
@@ -34,12 +36,13 @@ pub fn infer_if_then_else<Q>(
 where
     Q: ExternalQueries,
 {
-    if_then_else_core(state, context, if_, then, else_, IfThenElseMode::Infer)
+    if_then_else_core(state, context, expression, if_, then, else_, IfThenElseMode::Infer)
 }
 
 pub fn check_if_then_else<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     if_: Option<lowering::ExpressionId>,
     then: Option<lowering::ExpressionId>,
     else_: Option<lowering::ExpressionId>,
@@ -48,12 +51,21 @@ pub fn check_if_then_else<Q>(
 where
     Q: ExternalQueries,
 {
-    if_then_else_core(state, context, if_, then, else_, IfThenElseMode::Check { expected })
+    if_then_else_core(
+        state,
+        context,
+        expression,
+        if_,
+        then,
+        else_,
+        IfThenElseMode::Check { expected },
+    )
 }
 
 fn if_then_else_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    expression: lowering::ExpressionId,
     if_: Option<lowering::ExpressionId>,
     then: Option<lowering::ExpressionId>,
     else_: Option<lowering::ExpressionId>,
@@ -79,7 +91,56 @@ where
         super::check_expression(state, context, else_, result_type)?;
     }
 
+    record_if_then_else(state, context.prim.boolean, expression, if_, then, else_, result_type);
+
     Ok(result_type)
+}
+
+fn record_if_then_else(
+    state: &mut CheckState,
+    boolean_type: TypeId,
+    expression: lowering::ExpressionId,
+    if_: Option<lowering::ExpressionId>,
+    then: Option<lowering::ExpressionId>,
+    else_: Option<lowering::ExpressionId>,
+    result_type: TypeId,
+) {
+    let Some(if_) = if_.and_then(|if_| state.checked.core.lookup_expression(if_)) else {
+        return;
+    };
+    let Some(then) = then.and_then(|then| state.checked.core.lookup_expression(then)) else {
+        return;
+    };
+    let Some(else_) = else_.and_then(|else_| state.checked.core.lookup_expression(else_)) else {
+        return;
+    };
+
+    let true_binder = state.checked.core.allocate_synthesized_binder(
+        boolean_type,
+        CheckedBinderKind::Literal(CheckedLiteral::Boolean(true)),
+    );
+    let false_binder = state.checked.core.allocate_synthesized_binder(
+        boolean_type,
+        CheckedBinderKind::Literal(CheckedLiteral::Boolean(false)),
+    );
+    let then_result = CheckedGuardedExpression { guards: Arc::from([]), expression: then };
+    let else_result = CheckedGuardedExpression { guards: Arc::from([]), expression: else_ };
+    let alternatives = [
+        CheckedCaseAlternative {
+            binders: Arc::from([true_binder]),
+            results: Arc::from([then_result]),
+        },
+        CheckedCaseAlternative {
+            binders: Arc::from([false_binder]),
+            results: Arc::from([else_result]),
+        },
+    ];
+    let kind = CheckedExpressionKind::Case {
+        scrutinees: Arc::from([if_]),
+        alternatives: Arc::from(alternatives),
+    };
+    let checked_expression = state.checked.core.allocate_expression(result_type, kind);
+    state.checked.core.record_expression(expression, checked_expression);
 }
 
 pub fn infer_lambda<Q>(

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, exhaustive, toolkit, unification};
+use crate::semantic::CheckedExpressionKind;
 use crate::source::terms::{form_let, guarded};
 use crate::source::{binder, terms};
 use crate::state::CheckState;
@@ -80,6 +83,7 @@ where
 pub fn infer_lambda<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    lambda: lowering::ExpressionId,
     binders: &[lowering::BinderId],
     expression: Option<lowering::ExpressionId>,
 ) -> QueryResult<TypeId>
@@ -109,16 +113,20 @@ where
     let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);
 
-    if has_missing {
-        Ok(context.intern_constrained(context.prim.partial, function_type))
+    let lambda_type = if has_missing {
+        context.intern_constrained(context.prim.partial, function_type)
     } else {
-        Ok(function_type)
-    }
+        function_type
+    };
+
+    record_lambda(state, lambda, binders, expression, lambda_type);
+    Ok(lambda_type)
 }
 
 pub fn check_lambda<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    lambda: lowering::ExpressionId,
     binders: &[lowering::BinderId],
     expression: Option<lowering::ExpressionId>,
     expected: TypeId,
@@ -164,7 +172,35 @@ where
         state.push_wanted(context.prim.partial);
     }
 
+    record_lambda(state, lambda, binders, expression, function_type);
     Ok(function_type)
+}
+
+fn record_lambda(
+    state: &mut CheckState,
+    lambda: lowering::ExpressionId,
+    binders: &[lowering::BinderId],
+    expression: Option<lowering::ExpressionId>,
+    type_id: TypeId,
+) {
+    let Some(expression) =
+        expression.and_then(|expression| state.checked.core.lookup_expression(expression))
+    else {
+        return;
+    };
+
+    let checked_binders = binders.iter().map(|binder| state.checked.core.lookup_binder(*binder));
+    let checked_binders = checked_binders.collect::<Option<Vec<_>>>();
+    let Some(checked_binders) = checked_binders else { return };
+
+    if checked_binders.is_empty() {
+        state.checked.core.record_expression(lambda, expression);
+        return;
+    }
+
+    let kind = CheckedExpressionKind::Lambda { binders: Arc::from(checked_binders), expression };
+    let checked_lambda = state.checked.core.allocate_expression(type_id, kind);
+    state.checked.core.record_expression(lambda, checked_lambda);
 }
 
 pub fn instantiate_trunk_types<Q>(

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -13,8 +13,9 @@ use smol_str::SmolStr;
 
 use crate::context::CheckContext;
 use crate::core::{
-    CheckedClass, CheckedDataDeclaration, CheckedSuperclass, CheckedSynonym, ForallBinder, Role,
-    Type, TypeId, fd, fold, generalise, signature, toolkit, unification, zonk,
+    CheckedClass, CheckedDataConstructor, CheckedDataDeclaration, CheckedDataDeclarationKind,
+    CheckedSuperclass, CheckedSynonym, ForallBinder, Role, Type, TypeId, fd, fold, generalise,
+    signature, toolkit, unification, zonk,
 };
 use crate::error::ErrorCrumb;
 use crate::source::types;
@@ -22,6 +23,7 @@ use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
 struct PendingDataType {
+    kind: CheckedDataDeclarationKind,
     parameters: Vec<ForallBinder>,
     constructors: Vec<(TermItemId, Vec<TypeId>)>,
     declared_roles: Arc<[lowering::Role]>,
@@ -302,11 +304,29 @@ where
     match item {
         TypeItemIr::DataGroup { signature, data, roles } => {
             let Some(DataIr { variables }) = data else { return Ok(()) };
-            check_data_equation(state, context, scc, item_id, *signature, variables, roles)?;
+            let pending = check_data_equation(
+                state,
+                context,
+                item_id,
+                CheckedDataDeclarationKind::Data,
+                *signature,
+                variables,
+                roles,
+            )?;
+            scc.data.push((item_id, pending));
         }
         TypeItemIr::NewtypeGroup { signature, newtype, roles } => {
             let Some(NewtypeIr { variables }) = newtype else { return Ok(()) };
-            check_data_equation(state, context, scc, item_id, *signature, variables, roles)?;
+            let pending = check_data_equation(
+                state,
+                context,
+                item_id,
+                CheckedDataDeclarationKind::Newtype,
+                *signature,
+                variables,
+                roles,
+            )?;
+            scc.data.push((item_id, pending));
         }
         TypeItemIr::SynonymGroup { signature, synonym, .. } => {
             let Some(SynonymIr { variables, synonym }) = synonym else { return Ok(()) };
@@ -330,12 +350,12 @@ where
 fn check_data_equation<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    scc: &mut TypeSccState,
     item_id: TypeItemId,
+    kind: CheckedDataDeclarationKind,
     signature: Option<lowering::TypeId>,
     variables: &[TypeVariableBinding],
     declared_roles: &Arc<[lowering::Role]>,
-) -> QueryResult<()>
+) -> QueryResult<PendingDataType>
 where
     Q: ExternalQueries,
 {
@@ -350,9 +370,7 @@ where
     let constructors = check_data_constructors(state, context, item_id)?;
     let declared_roles = Arc::clone(declared_roles);
 
-    scc.data.push((item_id, PendingDataType { parameters, constructors, declared_roles }));
-
-    Ok(())
+    Ok(PendingDataType { kind, parameters, constructors, declared_roles })
 }
 
 fn check_data_equation_check<Q>(
@@ -497,7 +515,9 @@ fn finalise_data_declarations<Q>(
 where
     Q: ExternalQueries,
 {
-    for (item_id, PendingDataType { parameters, constructors, .. }) in mem::take(&mut scc.data) {
+    for (item_id, PendingDataType { kind, parameters, constructors, .. }) in
+        mem::take(&mut scc.data)
+    {
         // constructor_kind should have already been generalised by the
         // finalise_binding_group function. The kind signature is used
         // as the source of truth for constructing kind applications.
@@ -548,6 +568,8 @@ where
 
         let type_parameters = type_parameters.collect_vec();
 
+        let mut checked_constructors = Vec::with_capacity(constructors.len());
+
         for (constructor_id, checked_arguments) in constructors {
             let mut result = type_reference;
 
@@ -559,9 +581,13 @@ where
             }
 
             // a -> Tagged @k t a
-            for argument in checked_arguments.into_iter().rev() {
+            let checked_arguments = checked_arguments.into_iter().map(|argument| {
                 let argument = zonk::zonk(state, context, argument)?;
-                let argument = ApplyKinds::on(state, context, item_id, type_reference, argument)?;
+                ApplyKinds::on(state, context, item_id, type_reference, argument)
+            });
+            let checked_arguments = checked_arguments.collect::<QueryResult<Vec<_>>>()?;
+
+            for &argument in checked_arguments.iter().rev() {
                 result = context.intern_function(argument, result);
             }
 
@@ -578,9 +604,15 @@ where
             }
 
             state.checked.terms.insert(constructor_id, result);
+            checked_constructors.push(CheckedDataConstructor {
+                item_id: constructor_id,
+                arguments: checked_arguments,
+            });
         }
 
-        state.checked.data_declarations.insert(item_id, CheckedDataDeclaration { type_parameters });
+        let declaration =
+            CheckedDataDeclaration { kind, type_parameters, constructors: checked_constructors };
+        state.checked.data_declarations.insert(item_id, declaration);
     }
 
     Ok(())
@@ -595,7 +627,7 @@ where
     Q: ExternalQueries,
 {
     for (item_id, pending) in &scc.data {
-        let PendingDataType { parameters, constructors, declared_roles } = pending;
+        let PendingDataType { parameters, constructors, declared_roles, .. } = pending;
         let inferred_roles =
             super::roles::infer_data_roles(state, context, parameters, constructors)?;
         let resolved_roles = super::roles::check_declared_roles(

--- a/compiler-scripts/src/main.rs
+++ b/compiler-scripts/src/main.rs
@@ -9,7 +9,7 @@ use compiler_scripts::test_runner::{
 #[derive(Parser)]
 #[command(about = "Compiler development scripts")]
 struct Cli {
-    /// Test category: checking (c), lowering (l), resolving (r), lsp, docs
+    /// Test category: checking (c), semantic (s), lowering (l), resolving (r), lsp, docs
     category: TestCategory,
 
     #[command(flatten)]

--- a/compiler-scripts/src/test_runner/category.rs
+++ b/compiler-scripts/src/test_runner/category.rs
@@ -5,6 +5,7 @@ use anyhow::bail;
 #[derive(Copy, Clone, Debug)]
 pub enum TestCategory {
     Checking,
+    Semantic,
     Lowering,
     Resolving,
     Lsp,
@@ -15,6 +16,7 @@ impl TestCategory {
     pub fn as_str(&self) -> &'static str {
         match self {
             TestCategory::Checking => "checking",
+            TestCategory::Semantic => "semantic",
             TestCategory::Lowering => "lowering",
             TestCategory::Resolving => "resolving",
             TestCategory::Lsp => "lsp",
@@ -40,12 +42,13 @@ impl FromStr for TestCategory {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "checking" | "c" => Ok(TestCategory::Checking),
+            "semantic" | "s" => Ok(TestCategory::Semantic),
             "lowering" | "l" => Ok(TestCategory::Lowering),
             "resolving" | "r" => Ok(TestCategory::Resolving),
             "lsp" => Ok(TestCategory::Lsp),
             "docs" => Ok(TestCategory::Docs),
             _ => bail!(
-                "unknown test category '{}', expected: checking (c), lowering (l), resolving (r), lsp, docs",
+                "unknown test category '{}', expected: checking (c), semantic (s), lowering (l), resolving (r), lsp, docs",
                 s
             ),
         }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -32,6 +32,10 @@ name = "checking"
 harness = false
 
 [[test]]
+name = "semantic"
+harness = false
+
+[[test]]
 name = "lowering"
 harness = false
 

--- a/tests-integration/fixtures/semantic/1784472060_application_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1784472060_application_evidence/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+class Constraint a
+
+foreign import make :: Constraint String => Int -> String
+
+instance constraintString :: Constraint String
+
+test = make 0

--- a/tests-integration/fixtures/semantic/1784472060_application_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784472060_application_evidence/Main.snap
@@ -6,4 +6,4 @@ expression: report
 module Main where
 
 test :: String
-test = make @{ev0} 0
+test = make @{constraintString} 0

--- a/tests-integration/fixtures/semantic/1784472060_application_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784472060_application_evidence/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+test :: String
+test = make @{ev0} 0

--- a/tests-integration/fixtures/semantic/1784472600_term_application/Main.purs
+++ b/tests-integration/fixtures/semantic/1784472600_term_application/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+apply function argument = function argument

--- a/tests-integration/fixtures/semantic/1784472600_term_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784472600_term_application/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+apply ::
+  forall (t :: Type) (t1 :: Type). ((t :: Type) -> (t1 :: Type)) -> (t :: Type) -> (t1 :: Type)
+apply function argument = function argument

--- a/tests-integration/fixtures/semantic/1784472600_term_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784472600_term_application/Main.snap
@@ -7,4 +7,4 @@ module Main where
 
 apply ::
   forall (t :: Type) (t1 :: Type). ((t :: Type) -> (t1 :: Type)) -> (t :: Type) -> (t1 :: Type)
-apply function argument = function argument
+apply = \function argument -> function argument

--- a/tests-integration/fixtures/semantic/1784472600_type_application/Main.purs
+++ b/tests-integration/fixtures/semantic/1784472600_type_application/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+foreign import identity :: forall @a. a -> a
+
+test = identity @Int 0

--- a/tests-integration/fixtures/semantic/1784472600_type_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784472600_type_application/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+test :: Int
+test = identity @Int 0

--- a/tests-integration/fixtures/semantic/1784473020_given_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1784473020_given_evidence/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Constraint a
+
+foreign import make :: forall a. Constraint a => a -> String
+
+test :: forall a. Constraint a => a -> String
+test value = make value

--- a/tests-integration/fixtures/semantic/1784473020_given_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784473020_given_evidence/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+test :: forall (a :: Type). Constraint @Type (a :: Type) => (a :: Type) -> String
+test value = make @{ev0} value

--- a/tests-integration/fixtures/semantic/1784473020_given_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784473020_given_evidence/Main.snap
@@ -6,4 +6,4 @@ expression: report
 module Main where
 
 test :: forall (a :: Type). Constraint @Type (a :: Type) => (a :: Type) -> String
-test value = make @{ev0} value
+test value = make @{dict0} value

--- a/tests-integration/fixtures/semantic/1784473020_synthesized_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1784473020_synthesized_evidence/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Symbol (class IsSymbol)
+
+foreign import make :: IsSymbol "hello" => Int -> String
+
+test = make 0

--- a/tests-integration/fixtures/semantic/1784473020_synthesized_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784473020_synthesized_evidence/Main.snap
@@ -6,4 +6,4 @@ expression: report
 module Main where
 
 test :: String
-test = make @{ev0} 0
+test = make @{isSymbol("hello")} 0

--- a/tests-integration/fixtures/semantic/1784473020_synthesized_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784473020_synthesized_evidence/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+test :: String
+test = make @{ev0} 0

--- a/tests-integration/fixtures/semantic/1784473020_trivial_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1784473020_trivial_evidence/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Prim.Row as Row
+
+foreign import make :: Row.Lacks "missing" (value :: Int) => Int -> String
+
+test = make 0

--- a/tests-integration/fixtures/semantic/1784473020_trivial_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784473020_trivial_evidence/Main.snap
@@ -6,4 +6,4 @@ expression: report
 module Main where
 
 test :: String
-test = make @{ev0} 0
+test = make @{<trivial>} 0

--- a/tests-integration/fixtures/semantic/1784473020_trivial_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784473020_trivial_evidence/Main.snap
@@ -1,0 +1,9 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+test :: String
+test = make @{ev0} 0

--- a/tests-integration/fixtures/semantic/1784479080_inferred_evidence_abstraction/Main.purs
+++ b/tests-integration/fixtures/semantic/1784479080_inferred_evidence_abstraction/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+class Constraint a
+
+foreign import make :: forall a. Constraint a => a -> String
+
+test value = make value

--- a/tests-integration/fixtures/semantic/1784479080_inferred_evidence_abstraction/Main.snap
+++ b/tests-integration/fixtures/semantic/1784479080_inferred_evidence_abstraction/Main.snap
@@ -5,5 +5,5 @@ expression: report
 ---
 module Main where
 
-test :: forall (a :: Type). Constraint @Type (a :: Type) => (a :: Type) -> String
+test :: forall (t :: Type). Constraint @Type (t :: Type) => (t :: Type) -> String
 test = \@{dict0} -> \value -> make @{dict0} value

--- a/tests-integration/fixtures/semantic/1784479080_source_lambda/Main.purs
+++ b/tests-integration/fixtures/semantic/1784479080_source_lambda/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+test :: forall a. a -> a
+test = \value -> value
+
+test' = \value -> value

--- a/tests-integration/fixtures/semantic/1784479080_source_lambda/Main.snap
+++ b/tests-integration/fixtures/semantic/1784479080_source_lambda/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+test :: forall (a :: Type). (a :: Type) -> (a :: Type)
+test = \value -> value
+
+test' :: forall (t :: Type). (t :: Type) -> (t :: Type)
+test' = \value -> value

--- a/tests-integration/fixtures/semantic/1784507820_operator_chain_bracketing/Main.purs
+++ b/tests-integration/fixtures/semantic/1784507820_operator_chain_bracketing/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+foreign import add :: Int -> Int -> Int
+foreign import multiply :: Int -> Int -> Int
+foreign import append :: Int -> Int -> Int
+
+infixl 6 add as +
+infixl 7 multiply as *
+infixr 5 append as <+>
+
+precedence = 1 + 2 * 3 + 4
+
+rightAssociative = 1 <+> 2 <+> 3
+
+prefix = (+) 1 2

--- a/tests-integration/fixtures/semantic/1784507820_operator_chain_bracketing/Main.snap
+++ b/tests-integration/fixtures/semantic/1784507820_operator_chain_bracketing/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+precedence :: Int
+precedence = add (add 1 (multiply 2 3)) 4
+
+rightAssociative :: Int
+rightAssociative = append 1 (append 2 3)
+
+prefix :: Int
+prefix = add 1 2

--- a/tests-integration/fixtures/semantic/1784507820_operator_chain_evidence/Main.purs
+++ b/tests-integration/fixtures/semantic/1784507820_operator_chain_evidence/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+class Combine a where
+  combine :: a -> a -> a
+
+instance combineInt :: Combine Int where
+  combine = combineIntImpl
+
+foreign import combineIntImpl :: Int -> Int -> Int
+
+infixl 5 combine as <>
+
+resolved :: Int
+resolved = 1 <> 2
+
+given :: forall a. Combine a => a -> a -> a
+given left right = left <> right

--- a/tests-integration/fixtures/semantic/1784507820_operator_chain_evidence/Main.snap
+++ b/tests-integration/fixtures/semantic/1784507820_operator_chain_evidence/Main.snap
@@ -1,0 +1,12 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+resolved :: Int
+resolved = combine @{combineInt} 1 2
+
+given :: forall (a :: Type). Combine (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+given = \@{dict0} -> \left right -> combine @{dict0} left right

--- a/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.purs
+++ b/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.purs
@@ -21,4 +21,26 @@ operatorApplied = 1 :+: 2
 
 operatorBare = (:+:)
 
+unwrapOne (One value) = value
+
+unwrapPair (left :+: right) = left
+
+unwrapNested (first :+: second :+: third) = first
+
+choose choice = case choice of
+  Empty -> 0
+  One value -> value
+  Pair left _ -> left
+
+guarded condition choice = case choice of
+  One nested
+    | condition, One value <- nested -> value
+  Pair left right
+    | One value <- left -> value
+    | One value <- right -> value
+  _ -> 0
+
+matchPartial choice = case choice of
+  One value -> value
+
 wrapped = Wrapped Empty

--- a/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.purs
+++ b/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+data Choice a = Empty | One a | Pair a a
+
+newtype Wrapped a = Wrapped (Choice a)
+
+data Fix :: forall k. ((k -> Type) -> k -> Type) -> k -> Type
+data Fix f a = Fix (f (Fix f) a)
+
+infixr 5 Pair as :+:
+
+bare = One
+
+nullary = Empty
+
+applied = One 1
+
+partial = Pair 1
+
+operatorApplied = 1 :+: 2
+
+operatorBare = (:+:)
+
+wrapped = Wrapped Empty

--- a/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.purs
+++ b/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.purs
@@ -43,4 +43,11 @@ guarded condition choice = case choice of
 matchPartial choice = case choice of
   One value -> value
 
+chooseNested choice = case choice of
+  One nested -> case nested of
+    One value -> value
+    Pair left _ -> left
+    _ -> 0
+  _ -> 0
+
 wrapped = Wrapped Empty

--- a/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.snap
+++ b/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.snap
@@ -41,13 +41,31 @@ unwrapNested :: forall (t :: Type). Choice (Choice (t :: Type)) -> Choice (t :: 
 unwrapNested = \Pair(first, Pair(second, third)) -> first
 
 choose :: Choice Int -> Int
-choose = \choice -> case choice of Empty -> 0; One(value) -> value; Pair(left, _) -> left; else -> unreachable
+choose = \choice -> case choice of
+  Empty -> 0
+  One(value) -> value
+  Pair(left, _) -> left
 
 guarded :: Boolean -> Choice (Choice Int) -> Int
-guarded = \condition choice -> case choice of One(nested) | condition, One(value) <- nested -> value; Pair(left, right) | One(value) <- left -> value | One(value) <- right -> value; _ -> 0; else -> unreachable
+guarded = \condition choice -> case choice of
+  One(nested)
+    | condition, One(value) <- nested -> value
+  Pair(left, right)
+    | One(value) <- left -> value
+    | One(value) <- right -> value
+  _ -> 0
 
 matchPartial :: forall (t :: Type). Partial => Choice (t :: Type) -> (t :: Type)
-matchPartial = \@{dict0} -> \choice -> case choice of One(value) -> value; else -> unreachable
+matchPartial = \@{dict0} -> \choice -> case choice of
+  One(value) -> value
+
+chooseNested :: Choice (Choice Int) -> Int
+chooseNested = \choice -> case choice of
+  One(nested) -> case nested of
+    One(value) -> value
+    Pair(left, _) -> left
+    _ -> 0
+  _ -> 0
 
 wrapped :: forall (t :: Type). Wrapped (t :: Type)
 wrapped = Wrapped Empty

--- a/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.snap
+++ b/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.snap
@@ -31,5 +31,23 @@ operatorApplied = Pair 1 2
 operatorBare :: forall (t :: Type). (t :: Type) -> (t :: Type) -> Choice (t :: Type)
 operatorBare = Pair
 
+unwrapOne :: forall (t :: Type). Choice (t :: Type) -> (t :: Type)
+unwrapOne = \One(value) -> value
+
+unwrapPair :: forall (t :: Type). Choice (t :: Type) -> (t :: Type)
+unwrapPair = \Pair(left, right) -> left
+
+unwrapNested :: forall (t :: Type). Choice (Choice (t :: Type)) -> Choice (t :: Type)
+unwrapNested = \Pair(first, Pair(second, third)) -> first
+
+choose :: Choice Int -> Int
+choose = \choice -> case choice of Empty -> 0; One(value) -> value; Pair(left, _) -> left; else -> unreachable
+
+guarded :: Boolean -> Choice (Choice Int) -> Int
+guarded = \condition choice -> case choice of One(nested) | condition, One(value) <- nested -> value; Pair(left, right) | One(value) <- left -> value | One(value) <- right -> value; _ -> 0; else -> unreachable
+
+matchPartial :: forall (t :: Type). Partial => Choice (t :: Type) -> (t :: Type)
+matchPartial = \@{dict0} -> \choice -> case choice of One(value) -> value; else -> unreachable
+
 wrapped :: forall (t :: Type). Wrapped (t :: Type)
 wrapped = Wrapped Empty

--- a/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.snap
+++ b/tests-integration/fixtures/semantic/1784511060_algebraic_data_constructors/Main.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+data Choice (a :: Type) = Empty | One ((a :: Type)) | Pair ((a :: Type)) ((a :: Type))
+
+newtype Wrapped (a :: Type) = Wrapped (Choice (a :: Type))
+
+data Fix (f :: ((k :: Type) -> Type) -> (k :: Type) -> Type) (a :: (k :: Type)) = Fix ((f :: ((k :: Type) -> Type) -> (k :: Type) -> Type)
+  (Fix @(k :: Type) (f :: ((k :: Type) -> Type) -> (k :: Type) -> Type))
+  (a :: (k :: Type)))
+
+bare :: forall (t :: Type). (t :: Type) -> Choice (t :: Type)
+bare = One
+
+nullary :: forall (t :: Type). Choice (t :: Type)
+nullary = Empty
+
+applied :: Choice Int
+applied = One 1
+
+partial :: Int -> Choice Int
+partial = Pair 1
+
+operatorApplied :: Choice Int
+operatorApplied = Pair 1 2
+
+operatorBare :: forall (t :: Type). (t :: Type) -> (t :: Type) -> Choice (t :: Type)
+operatorBare = Pair
+
+wrapped :: forall (t :: Type). Wrapped (t :: Type)
+wrapped = Wrapped Empty

--- a/tests-integration/fixtures/semantic/1784520720_do_expressions/IndexedDo.purs
+++ b/tests-integration/fixtures/semantic/1784520720_do_expressions/IndexedDo.purs
@@ -1,0 +1,27 @@
+module IndexedDo where
+
+foreign import data Render :: Type -> Type -> Type -> Type
+
+data Unit = Unit
+
+foreign import data Start :: Type
+
+foreign import data Use1 :: Type -> Type
+foreign import data Use2 :: Type -> Type
+
+foreign import bind ::
+  forall a b x y z.
+  Render x y a ->
+  (a -> Render y z b) ->
+  Render x z b
+
+foreign import discard ::
+  forall a b x y z.
+  Render x y a ->
+  (a -> Render y z b) ->
+  Render x z b
+
+foreign import pure :: forall a x. a -> Render x x a
+
+foreign import use1 :: forall hooks. Render hooks (Use1 hooks) Unit
+foreign import use2 :: forall hooks. Render hooks (Use2 hooks) Unit

--- a/tests-integration/fixtures/semantic/1784520720_do_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784520720_do_expressions/Main.purs
@@ -1,0 +1,35 @@
+module Main where
+
+import IndexedDo as Indexed
+
+foreign import data Box :: Type -> Type
+
+data Pair a b = Pair a b
+
+class Rebindable f where
+  bind :: forall a b. f a -> (a -> f b) -> f b
+  discard :: forall a b. f a -> (a -> f b) -> f b
+  pure :: forall a. a -> f a
+
+foreign import bindBox :: forall a b. Box a -> (a -> Box b) -> Box b
+foreign import discardBox :: forall a b. Box a -> (a -> Box b) -> Box b
+foreign import pureBox :: forall a. a -> Box a
+
+instance rebindableBox :: Rebindable Box where
+  bind = bindBox
+  discard = discardBox
+  pure = pureBox
+
+foreign import boxedInt :: Box Int
+foreign import boxedString :: Box String
+
+test = do
+  value <- boxedInt
+  boxedString
+  pure (Pair value "done")
+
+indexed :: Indexed.Render Indexed.Start (Indexed.Use2 (Indexed.Use1 Indexed.Start)) Indexed.Unit
+indexed = Indexed.do
+  first <- Indexed.use1
+  Indexed.use2
+  Indexed.pure first

--- a/tests-integration/fixtures/semantic/1784520720_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784520720_do_expressions/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+data Pair (a :: Type) (b :: Type) = Pair ((a :: Type)) ((b :: Type))
+
+test :: Box (Pair Int String)
+test = <unimplemented>
+
+indexed :: Render Start (Use2 (Use1 Start)) Unit
+indexed = <unimplemented>

--- a/tests-integration/fixtures/semantic/1784520720_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784520720_do_expressions/Main.snap
@@ -8,7 +8,8 @@ module Main where
 data Pair (a :: Type) (b :: Type) = Pair ((a :: Type)) ((b :: Type))
 
 test :: Box (Pair Int String)
-test = <unimplemented>
+test = bind @{rebindableBox} boxedInt
+  (\value -> discard @{rebindableBox} boxedString (\_ -> pure @{rebindableBox} (Pair value "done")))
 
 indexed :: Render Start (Use2 (Use1 Start)) Unit
-indexed = <unimplemented>
+indexed = bind use1 (\first -> discard use2 (\_ -> pure first))

--- a/tests-integration/fixtures/semantic/1784521320_ado_expressions/IndexedAdo.purs
+++ b/tests-integration/fixtures/semantic/1784521320_ado_expressions/IndexedAdo.purs
@@ -1,0 +1,27 @@
+module IndexedAdo where
+
+foreign import data Render :: Type -> Type -> Type -> Type
+
+data Unit = Unit
+
+foreign import data Start :: Type
+
+foreign import data Use1 :: Type -> Type
+foreign import data Use2 :: Type -> Type
+
+foreign import map ::
+  forall a b x y.
+  (a -> b) ->
+  Render x y a ->
+  Render x y b
+
+foreign import apply ::
+  forall a b x y z.
+  Render x y (a -> b) ->
+  Render y z a ->
+  Render x z b
+
+foreign import pure :: forall a x. a -> Render x x a
+
+foreign import use1 :: forall hooks. Render hooks (Use1 hooks) Unit
+foreign import use2 :: forall hooks. Render hooks (Use2 hooks) Unit

--- a/tests-integration/fixtures/semantic/1784521320_ado_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784521320_ado_expressions/Main.purs
@@ -1,0 +1,45 @@
+module Main where
+
+import IndexedAdo as Indexed
+
+foreign import data Box :: Type -> Type
+
+data Pair a b = Pair a b
+
+class Rebindable f where
+  map :: forall a b. (a -> b) -> f a -> f b
+  apply :: forall a b. f (a -> b) -> f a -> f b
+  pure :: forall a. a -> f a
+
+foreign import mapBox :: forall a b. (a -> b) -> Box a -> Box b
+foreign import applyBox :: forall a b. Box (a -> b) -> Box a -> Box b
+foreign import pureBox :: forall a. a -> Box a
+
+instance rebindableBox :: Rebindable Box where
+  map = mapBox
+  apply = applyBox
+  pure = pureBox
+
+foreign import boxedInt :: Box Int
+foreign import boxedString :: Box String
+
+test = ado
+  left <- boxedInt
+  right <- boxedString
+  in Pair left right
+
+discard = ado
+  boxedInt
+  value <- boxedString
+  in value
+
+pureAdo = ado in 42
+
+indexed :: Indexed.Render Indexed.Start (Indexed.Use2 (Indexed.Use1 Indexed.Start)) (Pair Indexed.Unit Indexed.Unit)
+indexed = Indexed.ado
+  first <- Indexed.use1
+  second <- Indexed.use2
+  in Pair first second
+
+indexedPure :: forall hooks. Indexed.Render hooks hooks Int
+indexedPure = Indexed.ado in 42

--- a/tests-integration/fixtures/semantic/1784521320_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784521320_ado_expressions/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+data Pair (a :: Type) (b :: Type) = Pair ((a :: Type)) ((b :: Type))
+
+test :: Box (Pair Int String)
+test = <unimplemented>
+
+discard :: Box String
+discard = <unimplemented>
+
+pureAdo :: forall (t :: Type -> Type). Rebindable (t :: Type -> Type) => (t :: Type -> Type) Int
+pureAdo = <unimplemented>
+
+indexed :: Render Start (Use2 (Use1 Start)) (Pair Unit Unit)
+indexed = <unimplemented>
+
+indexedPure :: forall (hooks :: Type). Render (hooks :: Type) (hooks :: Type) Int
+indexedPure = <unimplemented>

--- a/tests-integration/fixtures/semantic/1784521320_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784521320_ado_expressions/Main.snap
@@ -8,16 +8,16 @@ module Main where
 data Pair (a :: Type) (b :: Type) = Pair ((a :: Type)) ((b :: Type))
 
 test :: Box (Pair Int String)
-test = <unimplemented>
+test = apply @{rebindableBox} (map @{rebindableBox} (\left right -> Pair left right) boxedInt) boxedString
 
 discard :: Box String
-discard = <unimplemented>
+discard = apply @{rebindableBox} (map @{rebindableBox} (\_ value -> value) boxedInt) boxedString
 
 pureAdo :: forall (t :: Type -> Type). Rebindable (t :: Type -> Type) => (t :: Type -> Type) Int
-pureAdo = <unimplemented>
+pureAdo = \@{dict0} -> pure @{dict0} 42
 
 indexed :: Render Start (Use2 (Use1 Start)) (Pair Unit Unit)
-indexed = <unimplemented>
+indexed = apply (map (\first second -> Pair first second) use1) use2
 
 indexedPure :: forall (hooks :: Type). Render (hooks :: Type) (hooks :: Type) Int
-indexedPure = <unimplemented>
+indexedPure = pure 42

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/ErrorAdo.purs
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/ErrorAdo.purs
@@ -1,0 +1,9 @@
+module ErrorAdo where
+
+foreign import data Box :: Type -> Type
+
+foreign import map :: Int
+foreign import apply :: forall a b. Box (a -> b) -> Box a -> Box b
+foreign import pure :: forall a. a -> Box a
+
+foreign import boxedInt :: Box Int

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/ErrorApplyAdo.purs
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/ErrorApplyAdo.purs
@@ -1,0 +1,9 @@
+module ErrorApplyAdo where
+
+foreign import data Box :: Type -> Type
+
+foreign import map :: forall a b. (a -> b) -> Box a -> Box b
+foreign import apply :: Int
+foreign import pure :: forall a. a -> Box a
+
+foreign import boxedInt :: Box Int

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/Main.purs
@@ -1,0 +1,67 @@
+module Main where
+
+import ErrorAdo as Error
+import ErrorApplyAdo as ErrorApply
+import PartialAdo as Partial
+import PartialApplyAdo as PartialApply
+
+foreign import data Box :: Type -> Type
+
+data Pair a b = Pair a b
+
+foreign import map :: forall a b. (a -> b) -> Box a -> Box b
+foreign import apply :: forall a b. Box (a -> b) -> Box a -> Box b
+foreign import pure :: forall a. a -> Box a
+
+foreign import boxedInt :: Box Int
+foreign import boxedString :: Box String
+
+missingAction :: Box (Pair Int String)
+missingAction = ado
+  left <-
+  right <- boxedString
+  in Pair left right
+
+soleMissingAction :: Box Int
+soleMissingAction = ado
+  value <-
+  in value
+
+localLet :: Box (Pair Int String)
+localLet = ado
+  left <- boxedInt
+  let kept = left
+  right <- boxedString
+  in Pair kept right
+
+missingIn :: Box Int
+missingIn = ado
+  value <- boxedInt
+  in
+
+pureLet :: Box Int
+pureLet = ado
+  let value = 42
+  in value
+
+empty = ado
+
+partialApplication = Partial.ado
+  value <- Partial.boxedInt
+  in value
+
+errorApplication = Error.ado
+  value <- Error.boxedInt
+  in value
+
+partialApplyApplication = PartialApply.ado
+  first <- PartialApply.boxedInt
+  second <- PartialApply.boxedInt
+  in Pair first second
+
+errorApplyApplication = ErrorApply.ado
+  first <- ErrorApply.boxedInt
+  second <- ErrorApply.boxedInt
+  in Pair first second
+
+errorPureApplication = Partial.ado in 42

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+data Pair (a :: Type) (b :: Type) = Pair ((a :: Type)) ((b :: Type))
+
+missingAction :: Box (Pair Int String)
+missingAction = <unimplemented>
+
+soleMissingAction :: Box Int
+soleMissingAction = <unimplemented>
+
+localLet :: Box (Pair Int String)
+localLet = <unimplemented>
+
+missingIn :: Box Int
+missingIn = <unimplemented>
+
+pureLet :: Box Int
+pureLet = <unimplemented>
+
+empty :: ?[empty ado block]
+empty = <unimplemented>
+
+partialApplication :: ?[invalid function application]
+partialApplication = <unimplemented>
+
+errorApplication :: ?[invalid function application]
+errorApplication = <unimplemented>
+
+partialApplyApplication :: ?[invalid function application]
+partialApplyApplication = <unimplemented>
+
+errorApplyApplication :: ?[invalid function application]
+errorApplyApplication = <unimplemented>
+
+errorPureApplication :: ?[invalid function application]
+errorPureApplication = <unimplemented>

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/Main.snap
@@ -8,34 +8,34 @@ module Main where
 data Pair (a :: Type) (b :: Type) = Pair ((a :: Type)) ((b :: Type))
 
 missingAction :: Box (Pair Int String)
-missingAction = <unimplemented>
+missingAction = map (\right -> <error-statement>; Pair left right) boxedString
 
 soleMissingAction :: Box Int
-soleMissingAction = <unimplemented>
+soleMissingAction = <error-statement>; <error-ado>
 
 localLet :: Box (Pair Int String)
-localLet = <unimplemented>
+localLet = apply (map (\left right -> let { kept :: Int } in Pair kept right) boxedInt) boxedString
 
 missingIn :: Box Int
-missingIn = <unimplemented>
+missingIn = map (\value -> <error>) boxedInt
 
 pureLet :: Box Int
-pureLet = <unimplemented>
+pureLet = let { value :: Int } in pure value
 
 empty :: ?[empty ado block]
-empty = <unimplemented>
+empty = <error-application <error> <error>>
 
 partialApplication :: ?[invalid function application]
-partialApplication = <unimplemented>
+partialApplication = <partial-application map (\value -> value) boxedInt>
 
 errorApplication :: ?[invalid function application]
-errorApplication = <unimplemented>
+errorApplication = <error-application map (\value -> value) boxedInt>
 
 partialApplyApplication :: ?[invalid function application]
-partialApplyApplication = <unimplemented>
+partialApplyApplication = <partial-application apply (map (\first second -> Pair first second) boxedInt) boxedInt>
 
 errorApplyApplication :: ?[invalid function application]
-errorApplyApplication = <unimplemented>
+errorApplyApplication = <error-application apply (map (\first second -> Pair first second) boxedInt) boxedInt>
 
 errorPureApplication :: ?[invalid function application]
-errorPureApplication = <unimplemented>
+errorPureApplication = <error-application pure 42>

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/PartialAdo.purs
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/PartialAdo.purs
@@ -1,0 +1,9 @@
+module PartialAdo where
+
+foreign import data Box :: Type -> Type
+
+foreign import map :: forall a. a -> Box a
+foreign import apply :: forall a b. Box (a -> b) -> Box a -> Box b
+foreign import pure :: Int
+
+foreign import boxedInt :: Box Int

--- a/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/PartialApplyAdo.purs
+++ b/tests-integration/fixtures/semantic/1784524020_ado_error_recovery/PartialApplyAdo.purs
@@ -1,0 +1,9 @@
+module PartialApplyAdo where
+
+foreign import data Box :: Type -> Type
+
+foreign import map :: forall a b. (a -> b) -> Box a -> Box b
+foreign import apply :: forall a. a -> Box a
+foreign import pure :: forall a. a -> Box a
+
+foreign import boxedInt :: Box Int

--- a/tests-integration/fixtures/semantic/1784524020_do_error_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784524020_do_error_recovery/Main.purs
@@ -1,0 +1,41 @@
+module Main where
+
+import PartialDo as Partial
+
+foreign import data Box :: Type -> Type
+
+foreign import bind :: forall a b. Box a -> (a -> Box b) -> Box b
+foreign import discard :: forall a b. Box a -> (a -> Box b) -> Box b
+foreign import pure :: forall a. a -> Box a
+
+foreign import boxedInt :: Box Int
+
+missingAction :: Box Int
+missingAction = do
+  value <-
+  pure 42
+
+missingFinalAction :: Box Int
+missingFinalAction = do
+  value <- boxedInt
+  result <-
+
+localLet :: Box Int
+localLet = do
+  value <- boxedInt
+  let kept = value
+  pure kept
+
+finalBind :: Box Int
+finalBind = do
+  value <- pure 42
+
+finalLet :: Box Int
+finalLet = do
+  let value = 42
+
+empty = do
+
+partialApplication = Partial.do
+  value <- Partial.boxedInt
+  Partial.pure value

--- a/tests-integration/fixtures/semantic/1784524020_do_error_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784524020_do_error_recovery/Main.snap
@@ -6,22 +6,22 @@ expression: report
 module Main where
 
 missingAction :: Box Int
-missingAction = <unimplemented>
+missingAction = <error-statement>; pure 42
 
 missingFinalAction :: Box Int
-missingFinalAction = <unimplemented>
+missingFinalAction = bind boxedInt (\value -> <error-statement>; <error>)
 
 localLet :: Box Int
-localLet = <unimplemented>
+localLet = bind boxedInt (\value -> let { kept :: Int } in pure kept)
 
 finalBind :: Box Int
-finalBind = <unimplemented>
+finalBind = <error-statement>; <error>
 
 finalLet :: Box Int
-finalLet = <unimplemented>
+finalLet = let { value :: Int } in <error>
 
 empty :: ?[empty do block]
-empty = <unimplemented>
+empty = <error>
 
 partialApplication :: ?[invalid function application]
-partialApplication = <unimplemented>
+partialApplication = <partial-application bind boxedInt (\value -> pure value)>

--- a/tests-integration/fixtures/semantic/1784524020_do_error_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784524020_do_error_recovery/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+missingAction :: Box Int
+missingAction = <unimplemented>
+
+missingFinalAction :: Box Int
+missingFinalAction = <unimplemented>
+
+localLet :: Box Int
+localLet = <unimplemented>
+
+finalBind :: Box Int
+finalBind = <unimplemented>
+
+finalLet :: Box Int
+finalLet = <unimplemented>
+
+empty :: ?[empty do block]
+empty = <unimplemented>
+
+partialApplication :: ?[invalid function application]
+partialApplication = <unimplemented>

--- a/tests-integration/fixtures/semantic/1784524020_do_error_recovery/PartialDo.purs
+++ b/tests-integration/fixtures/semantic/1784524020_do_error_recovery/PartialDo.purs
@@ -1,0 +1,9 @@
+module PartialDo where
+
+foreign import data Box :: Type -> Type
+
+foreign import bind :: forall a. Box a -> Box a
+foreign import discard :: forall a b. Box a -> (a -> Box b) -> Box b
+foreign import pure :: forall a. a -> Box a
+
+foreign import boxedInt :: Box Int

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/IndexedAdo.purs
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/IndexedAdo.purs
@@ -1,0 +1,43 @@
+module IndexedAdo where
+
+import Prim.Int (class Add)
+
+foreign import data Render :: Int -> Int -> Type -> Type
+
+data Unit = Unit
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+class MapAt (state :: Int) where
+  map ::
+    forall a b next.
+    Add state 1 next =>
+    (a -> b) ->
+    Render state state a ->
+    Render state next b
+
+class ApplyAt (state :: Int) where
+  apply ::
+    forall a b start next.
+    Add state 1 next =>
+    Render start state (a -> b) ->
+    Render state state a ->
+    Render start next b
+
+instance mapAtZero :: MapAt 0 where
+  map = unsafeCoerce
+
+else instance mapAtFallback :: MapAt state where
+  map = unsafeCoerce
+
+instance applyAtTwo :: ApplyAt 2 where
+  apply = unsafeCoerce
+
+else instance applyAtFallback :: ApplyAt state where
+  apply = unsafeCoerce
+
+pure :: forall a state. a -> Render state state a
+pure = unsafeCoerce
+
+action :: forall state. Render state state Unit
+action = unsafeCoerce Unit

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/Main.purs
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import IndexedAdo as Indexed
+
+data Quadruple a b c d = Quadruple a b c d
+
+indexed :: Indexed.Render 0 4 (Quadruple Indexed.Unit Indexed.Unit Indexed.Unit Indexed.Unit)
+indexed = Indexed.ado
+  first <- Indexed.action
+  second <- Indexed.action
+  third <- Indexed.action
+  fourth <- Indexed.action
+  in Quadruple first second third fourth

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/Main.snap
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+data Quadruple (a :: Type) (b :: Type) (c :: Type) (d :: Type) = Quadruple ((a :: Type)) ((b :: Type)) ((c :: Type)) ((d :: Type))
+
+indexed :: Render 0 4 (Quadruple Unit Unit Unit Unit)
+indexed = <unimplemented>

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/Main.snap
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_ado/Main.snap
@@ -8,4 +8,12 @@ module Main where
 data Quadruple (a :: Type) (b :: Type) (c :: Type) (d :: Type) = Quadruple ((a :: Type)) ((b :: Type)) ((c :: Type)) ((d :: Type))
 
 indexed :: Render 0 4 (Quadruple Unit Unit Unit Unit)
-indexed = <unimplemented>
+indexed = apply @{applyAtFallback, <trivial>}
+  (apply @{applyAtTwo, <trivial>}
+    (apply @{applyAtFallback, <trivial>}
+      (map @{mapAtZero, <trivial>}
+        (\first second third fourth -> Quadruple first second third fourth)
+        action)
+      action)
+    action)
+  action

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/IndexedDo.purs
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/IndexedDo.purs
@@ -1,0 +1,41 @@
+module IndexedDo where
+
+import Prim.Int (class Add)
+
+foreign import data Render :: Int -> Int -> Type -> Type
+
+data Unit = Unit
+
+foreign import unsafeCoerce :: forall a b. a -> b
+
+class BindAt (state :: Int) where
+  bind ::
+    forall a b next end.
+    Add state 1 next =>
+    Render state state a ->
+    (a -> Render next end b) ->
+    Render state end b
+  discard ::
+    forall a b next end.
+    Add state 1 next =>
+    Render state state a ->
+    (a -> Render next end b) ->
+    Render state end b
+
+instance bindAtZero :: BindAt 0 where
+  bind = unsafeCoerce
+  discard = unsafeCoerce
+
+else instance bindAtTwo :: BindAt 2 where
+  bind = unsafeCoerce
+  discard = unsafeCoerce
+
+else instance bindAtFallback :: BindAt state where
+  bind = unsafeCoerce
+  discard = unsafeCoerce
+
+pure :: forall a state. a -> Render state state a
+pure = unsafeCoerce
+
+action :: forall state. Render state state Unit
+action = unsafeCoerce Unit

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/Main.purs
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import IndexedDo as Indexed
+
+data Quadruple a b c d = Quadruple a b c d
+
+indexed :: Indexed.Render 0 4 (Quadruple Indexed.Unit Indexed.Unit Indexed.Unit Indexed.Unit)
+indexed = Indexed.do
+  first <- Indexed.action
+  second <- Indexed.action
+  third <- Indexed.action
+  fourth <- Indexed.action
+  Indexed.pure (Quadruple first second third fourth)

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/Main.snap
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+data Quadruple (a :: Type) (b :: Type) (c :: Type) (d :: Type) = Quadruple ((a :: Type)) ((b :: Type)) ((c :: Type)) ((d :: Type))
+
+indexed :: Render 0 4 (Quadruple Unit Unit Unit Unit)
+indexed = <unimplemented>

--- a/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/Main.snap
+++ b/tests-integration/fixtures/semantic/1784548800_state_sensitive_indexed_do/Main.snap
@@ -8,4 +8,8 @@ module Main where
 data Quadruple (a :: Type) (b :: Type) (c :: Type) (d :: Type) = Quadruple ((a :: Type)) ((b :: Type)) ((c :: Type)) ((d :: Type))
 
 indexed :: Render 0 4 (Quadruple Unit Unit Unit Unit)
-indexed = <unimplemented>
+indexed = bind @{bindAtZero, <trivial>} action
+  (\first -> bind @{bindAtFallback, <trivial>} action
+    (\second -> bind @{bindAtTwo, <trivial>} action
+      (\third -> bind @{bindAtFallback, <trivial>} action
+        (\fourth -> pure (Quadruple first second third fourth)))))

--- a/tests-integration/fixtures/semantic/1784561760_if_then_else/Main.purs
+++ b/tests-integration/fixtures/semantic/1784561760_if_then_else/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+checked :: Boolean -> Int
+checked condition = if condition then 1 else 2
+
+inferred condition = if condition then "yes" else "no"

--- a/tests-integration/fixtures/semantic/1784561760_if_then_else/Main.snap
+++ b/tests-integration/fixtures/semantic/1784561760_if_then_else/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+checked :: Boolean -> Int
+checked = \condition -> case condition of
+  true -> 1
+  false -> 2
+
+inferred :: Boolean -> String
+inferred = \condition -> case condition of
+  true -> "yes"
+  false -> "no"

--- a/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.purs
+++ b/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.purs
@@ -19,3 +19,7 @@ punValue = 42
 punnedRecord = { punValue }
 
 emptyRecord = {}
+
+recordAccess = inferredRecord.nested.value
+
+recordUpdate = inferredRecord { array = [3], nested { value = false } }

--- a/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.purs
+++ b/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+foreign import identity :: forall a. a -> a
+
+checkedArray :: Array Int
+checkedArray = [identity 1, 2]
+
+inferredArray = ["one", "two"]
+
+emptyArray = []
+
+checkedRecord :: { number :: Int, text :: String }
+checkedRecord = { number: identity 1, text: "value" }
+
+inferredRecord = { array: [1, 2], nested: { value: true } }
+
+punValue = 42
+
+punnedRecord = { punValue }
+
+emptyRecord = {}

--- a/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.snap
+++ b/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+module Main where
+
+checkedArray :: Array Int
+checkedArray = [identity 1, 2]
+
+inferredArray :: Array String
+inferredArray = ["one", "two"]
+
+emptyArray :: forall (t :: Type). Array (t :: Type)
+emptyArray = []
+
+checkedRecord :: { number :: Int, text :: String }
+checkedRecord = { number: identity 1, text: "value" }
+
+inferredRecord :: { array :: Array Int, nested :: { value :: Boolean } }
+inferredRecord = { array: [1, 2], nested: { value: true } }
+
+punValue :: Int
+punValue = 42
+
+punnedRecord :: { punValue :: Int }
+punnedRecord = { punValue: punValue }
+
+emptyRecord :: {}
+emptyRecord = {}

--- a/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.snap
+++ b/tests-integration/fixtures/semantic/1784564400_array_and_record_literals/Main.snap
@@ -28,3 +28,9 @@ punnedRecord = { punValue: punValue }
 
 emptyRecord :: {}
 emptyRecord = {}
+
+recordAccess :: Boolean
+recordAccess = inferredRecord.nested.value
+
+recordUpdate :: { array :: Array Int, nested :: { value :: Boolean } }
+recordUpdate = inferredRecord { array = [3], nested { value = false } }

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -52,6 +52,24 @@ pub fn checking(path: &Path) -> FixtureResult {
     Ok(())
 }
 
+pub fn semantic(path: &Path) -> FixtureResult {
+    let folder = fixture_folder(path)?;
+    let file = module_name(path)?;
+    let (engine, _) = crate::load_compiler(folder);
+    let Some(id) = engine.module_file(&file) else {
+        return Err(missing_module(path, &file).into());
+    };
+
+    let report = crate::generated::semantic::report(&engine, id, &file);
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path(snapshot_path(folder));
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| insta::assert_snapshot!(file, report));
+
+    Ok(())
+}
+
 pub fn lowering(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let file = module_name(path)?;

--- a/tests-integration/src/generated.rs
+++ b/tests-integration/src/generated.rs
@@ -1,3 +1,4 @@
 pub mod basic;
 pub mod docs;
 pub mod lsp;
+pub mod semantic;

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 use analyzer::QueryEngine;
-use checking::CheckedModule;
-use checking::core::pretty;
+use checking::core::{CheckedDataDeclarationKind, pretty};
 use checking::evidence::{
     Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
     ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
@@ -11,8 +10,9 @@ use checking::evidence::{
 use checking::semantic::{
     CheckedBinderId, CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
 };
+use checking::{CheckedModule, PrettyQueries};
 use files::FileId;
-use indexing::{TermItem, TermItemId, TermItemKind};
+use indexing::{TermItem, TermItemId, TermItemKind, TypeItem, TypeItemId};
 use lowering::{BinderKind, Equation, GuardedExpression, TermItemIr, TermVariableResolution};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -24,6 +24,7 @@ enum Precedence {
 
 struct SemanticPrinter<'a> {
     engine: &'a QueryEngine,
+    file_id: FileId,
     checked: &'a CheckedModule,
     lowered: &'a lowering::LoweredModule,
     pretty: pretty::Pretty<'a, QueryEngine>,
@@ -33,6 +34,7 @@ struct SemanticPrinter<'a> {
 impl<'a> SemanticPrinter<'a> {
     fn new(
         engine: &'a QueryEngine,
+        file_id: FileId,
         checked: &'a CheckedModule,
         lowered: &'a lowering::LoweredModule,
     ) -> SemanticPrinter<'a> {
@@ -40,7 +42,7 @@ impl<'a> SemanticPrinter<'a> {
         let binder_sources =
             checked.core.binders_by_source.iter().map(|(source, checked)| (*checked, *source));
         let binder_sources = binder_sources.collect();
-        SemanticPrinter { engine, checked, lowered, pretty, binder_sources }
+        SemanticPrinter { engine, file_id, checked, lowered, pretty, binder_sources }
     }
 
     fn write_item(&mut self, output: &mut String, item_id: TermItemId, item: &TermItem) {
@@ -65,6 +67,47 @@ impl<'a> SemanticPrinter<'a> {
             }
         }
 
+        writeln!(output).unwrap();
+    }
+
+    fn write_data_declaration(
+        &mut self,
+        output: &mut String,
+        item_id: TypeItemId,
+        item: &TypeItem,
+    ) {
+        let Some(name) = item.name.as_deref() else { return };
+        let Some(declaration) = self.checked.lookup_data_declaration(item_id) else { return };
+
+        self.pretty.reset();
+        let type_parameters = declaration.type_parameters.iter().map(|&binder_id| {
+            let binder = self.engine.lookup_forall_binder(binder_id);
+            let name = self.pretty.display_name(binder.name);
+            let kind = self.pretty.render(binder.kind);
+            format!("({name} :: {kind})")
+        });
+        let type_parameters = type_parameters.collect::<Vec<_>>();
+        let head = if type_parameters.is_empty() {
+            name.to_string()
+        } else {
+            format!("{name} {}", type_parameters.join(" "))
+        };
+
+        let constructors = declaration.constructors.iter().map(|constructor| {
+            let name = self.item_name(self.file_id, constructor.item_id);
+            let arguments = constructor
+                .arguments
+                .iter()
+                .map(|&argument| self.pretty.render(argument))
+                .collect::<Vec<_>>();
+            if arguments.is_empty() { name } else { format!("{name} ({})", arguments.join(") (")) }
+        });
+        let constructors = constructors.collect::<Vec<_>>().join(" | ");
+        let keyword = match declaration.kind {
+            CheckedDataDeclarationKind::Data => "data",
+            CheckedDataDeclarationKind::Newtype => "newtype",
+        };
+        writeln!(output, "{keyword} {head} = {constructors}").unwrap();
         writeln!(output).unwrap();
     }
 
@@ -111,6 +154,10 @@ impl<'a> SemanticPrinter<'a> {
         let (rendered, precedence) = match expression.kind {
             CheckedExpressionKind::Variable { resolution } => {
                 (self.variable(resolution), Precedence::Atom)
+            }
+            CheckedExpressionKind::Constructor { file_id, item_id } => {
+                let constructor = self.item_name(file_id, item_id);
+                (constructor, Precedence::Atom)
             }
             CheckedExpressionKind::Literal { literal } => {
                 (Self::literal(literal), Precedence::Atom)
@@ -327,11 +374,15 @@ pub fn report(engine: &QueryEngine, id: FileId, name: &str) -> String {
     let checked = engine.checked(id).unwrap();
     let lowered = engine.lowered(id).unwrap();
     let indexed = engine.indexed(id).unwrap();
-    let mut printer = SemanticPrinter::new(engine, &checked, &lowered);
+    let mut printer = SemanticPrinter::new(engine, id, &checked, &lowered);
 
     let mut output = String::new();
     writeln!(output, "module {name} where").unwrap();
     writeln!(output).unwrap();
+
+    for (item_id, item) in indexed.items.iter_types() {
+        printer.write_data_declaration(&mut output, item_id, item);
+    }
 
     for (item_id, item) in indexed.items.iter_terms() {
         printer.write_item(&mut output, item_id, item);

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Write;
 
 use analyzer::QueryEngine;
@@ -8,7 +9,7 @@ use checking::evidence::{
     ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
 };
 use checking::semantic::{
-    CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
+    CheckedBinderId, CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
 };
 use files::FileId;
 use indexing::{TermItem, TermItemId, TermItemKind};
@@ -26,6 +27,7 @@ struct SemanticPrinter<'a> {
     checked: &'a CheckedModule,
     lowered: &'a lowering::LoweredModule,
     pretty: pretty::Pretty<'a, QueryEngine>,
+    binder_sources: HashMap<CheckedBinderId, lowering::BinderId>,
 }
 
 impl<'a> SemanticPrinter<'a> {
@@ -35,7 +37,10 @@ impl<'a> SemanticPrinter<'a> {
         lowered: &'a lowering::LoweredModule,
     ) -> SemanticPrinter<'a> {
         let pretty = pretty::Pretty::new(engine, checked);
-        SemanticPrinter { engine, checked, lowered, pretty }
+        let binder_sources =
+            checked.core.binders_by_source.iter().map(|(source, checked)| (*checked, *source));
+        let binder_sources = binder_sources.collect();
+        SemanticPrinter { engine, checked, lowered, pretty, binder_sources }
     }
 
     fn write_item(&mut self, output: &mut String, item_id: TermItemId, item: &TermItem) {
@@ -51,8 +56,13 @@ impl<'a> SemanticPrinter<'a> {
         let signature = self.pretty.render_signature(name, type_id);
         writeln!(output, "{signature}").unwrap();
 
-        for equation in equations.iter() {
-            self.write_equation(output, name, equation);
+        if let Some(expression) = self.checked.core.lookup_term_root(item_id) {
+            let expression = self.expression(expression, Precedence::Abstraction);
+            writeln!(output, "{name} = {expression}").unwrap();
+        } else {
+            for equation in equations.iter() {
+                self.write_equation(output, name, equation);
+            }
         }
 
         writeln!(output).unwrap();
@@ -104,6 +114,12 @@ impl<'a> SemanticPrinter<'a> {
             }
             CheckedExpressionKind::Literal { literal } => {
                 (Self::literal(literal), Precedence::Atom)
+            }
+            CheckedExpressionKind::Lambda { binders, expression } => {
+                let binders = binders.iter().map(|binder| self.checked_binder(*binder));
+                let binders = binders.collect::<Vec<_>>();
+                let expression = self.expression(expression, Precedence::Abstraction);
+                (format!("\\{} -> {expression}", binders.join(" ")), Precedence::Abstraction)
             }
             CheckedExpressionKind::TermApplication { function, argument } => {
                 let function = self.expression(function, Precedence::Application);
@@ -168,6 +184,13 @@ impl<'a> SemanticPrinter<'a> {
                 _ => "<invalid named binder>".to_string(),
             },
         }
+    }
+
+    fn checked_binder(&self, checked: CheckedBinderId) -> String {
+        self.binder_sources
+            .get(&checked)
+            .map(|source| self.binder(*source))
+            .unwrap_or_else(|| "<unimplemented>".to_string())
     }
 
     fn binder_name(&self, source: lowering::BinderId) -> String {

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -9,6 +9,7 @@ use checking::evidence::{
 };
 use checking::semantic::{
     CheckedBinderId, CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
+    CheckedPatternGuard,
 };
 use checking::{CheckedModule, PrettyQueries};
 use files::FileId;
@@ -40,7 +41,15 @@ impl<'a> SemanticPrinter<'a> {
     ) -> SemanticPrinter<'a> {
         let pretty = pretty::Pretty::new(engine, checked);
         let binder_sources =
-            checked.core.binders_by_source.iter().map(|(source, checked)| (*checked, *source));
+            checked.core.binders_by_source.iter().filter_map(|(source, checked)| {
+                let kind = lowered.info.get_binder_kind(*source)?;
+                match kind {
+                    BinderKind::Variable { .. } | BinderKind::Named { .. } => {
+                        Some((*checked, *source))
+                    }
+                    _ => None,
+                }
+            });
         let binder_sources = binder_sources.collect();
         SemanticPrinter { engine, file_id, checked, lowered, pretty, binder_sources }
     }
@@ -162,6 +171,40 @@ impl<'a> SemanticPrinter<'a> {
             CheckedExpressionKind::Literal { literal } => {
                 (Self::literal(literal), Precedence::Atom)
             }
+            CheckedExpressionKind::Case { scrutinees, alternatives, failure } => {
+                let scrutinees = scrutinees
+                    .iter()
+                    .map(|scrutinee| self.expression(*scrutinee, Precedence::Abstraction));
+                let scrutinees = scrutinees.collect::<Vec<_>>();
+
+                let mut rendered_alternatives = vec![];
+                for alternative in alternatives.iter() {
+                    let binders =
+                        alternative.binders.iter().map(|binder| self.checked_binder(*binder));
+                    let binders = binders.collect::<Vec<_>>().join(", ");
+
+                    let mut rendered_results = vec![];
+                    for result in alternative.results.iter() {
+                        let guards = result.guards.iter().map(|guard| self.pattern_guard(guard));
+                        let guards = guards.collect::<Vec<_>>();
+                        let expression =
+                            self.expression(result.expression, Precedence::Abstraction);
+                        if guards.is_empty() {
+                            rendered_results.push(format!("-> {expression}"));
+                        } else {
+                            let guards = guards.join(", ");
+                            rendered_results.push(format!("| {guards} -> {expression}"));
+                        }
+                    }
+                    rendered_alternatives.push(format!("{binders} {}", rendered_results.join(" ")));
+                }
+
+                let failure = self.expression(failure, Precedence::Abstraction);
+                rendered_alternatives.push(format!("else -> {failure}"));
+                let alternatives = rendered_alternatives.join("; ");
+                let rendered = format!("case {} of {alternatives}", scrutinees.join(", "));
+                (rendered, Precedence::Abstraction)
+            }
             CheckedExpressionKind::Lambda { binders, expression } => {
                 let binders = binders.iter().map(|binder| self.checked_binder(*binder));
                 let binders = binders.collect::<Vec<_>>();
@@ -219,25 +262,52 @@ impl<'a> SemanticPrinter<'a> {
             return "<unimplemented>".to_string();
         };
 
-        match self.checked.core.binders[checked].kind {
-            CheckedBinderKind::Variable => self.binder_name(source),
-            CheckedBinderKind::Named { .. } => match self.lowered.info.get_binder_kind(source) {
-                Some(BinderKind::Named { named, binder }) => {
-                    let named = named.as_deref().unwrap_or("<missing>");
-                    let binder = binder.map(|binder| self.binder(binder));
-                    let binder = binder.unwrap_or_else(|| "<unimplemented>".to_string());
-                    format!("{named}@{binder}")
-                }
-                _ => "<invalid named binder>".to_string(),
-            },
-        }
+        self.checked_binder(checked)
     }
 
     fn checked_binder(&self, checked: CheckedBinderId) -> String {
-        self.binder_sources
-            .get(&checked)
-            .map(|source| self.binder(*source))
-            .unwrap_or_else(|| "<unimplemented>".to_string())
+        match self.checked.core.binders[checked].kind.clone() {
+            CheckedBinderKind::Variable => self
+                .binder_sources
+                .get(&checked)
+                .map(|source| self.binder_name(*source))
+                .unwrap_or_else(|| "<unimplemented>".to_string()),
+            CheckedBinderKind::Named { binder: checked_binder } => {
+                let source = self.binder_sources.get(&checked).copied();
+                match source.and_then(|source| self.lowered.info.get_binder_kind(source)) {
+                    Some(BinderKind::Named { named, .. }) => {
+                        let named = named.as_deref().unwrap_or("<missing>");
+                        let binder = self.checked_binder(checked_binder);
+                        format!("{named}@{binder}")
+                    }
+                    _ => "<invalid>".to_string(),
+                }
+            }
+            CheckedBinderKind::Wildcard => "_".to_string(),
+            CheckedBinderKind::Constructor { file_id, item_id, arguments } => {
+                let constructor = self.item_name(file_id, item_id);
+                if arguments.is_empty() {
+                    constructor
+                } else {
+                    let arguments = arguments.iter().map(|argument| self.checked_binder(*argument));
+                    let arguments = arguments.collect::<Vec<_>>().join(", ");
+                    format!("{constructor}({arguments})")
+                }
+            }
+        }
+    }
+
+    fn pattern_guard(&mut self, guard: &CheckedPatternGuard) -> String {
+        match *guard {
+            CheckedPatternGuard::Boolean { expression } => {
+                self.expression(expression, Precedence::Abstraction)
+            }
+            CheckedPatternGuard::Pattern { binder, expression } => {
+                let binder = self.checked_binder(binder);
+                let expression = self.expression(expression, Precedence::Abstraction);
+                format!("{binder} <- {expression}")
+            }
+        }
     }
 
     fn binder_name(&self, source: lowering::BinderId) -> String {

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -1,27 +1,12 @@
-use std::collections::HashMap;
 use std::fmt::Write;
 
 use analyzer::QueryEngine;
-use checking::core::{CheckedDataDeclarationKind, pretty};
-use checking::evidence::{
-    Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
-    ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
-};
-use checking::semantic::{
-    CheckedBinderId, CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
-    CheckedPatternGuard,
-};
+use checking::core::CheckedDataDeclarationKind;
+use checking::semantic::pretty;
 use checking::{CheckedModule, PrettyQueries};
 use files::FileId;
-use indexing::{TermItem, TermItemId, TermItemKind, TypeItem, TypeItemId};
-use lowering::{BinderKind, Equation, GuardedExpression, TermItemIr, TermVariableResolution};
-
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum Precedence {
-    Abstraction,
-    Application,
-    Atom,
-}
+use indexing::{TermItem, TermItemId, TypeItem, TypeItemId};
+use lowering::{Equation, GuardedExpression, TermItemIr};
 
 struct SemanticPrinter<'a> {
     engine: &'a QueryEngine,
@@ -29,7 +14,6 @@ struct SemanticPrinter<'a> {
     checked: &'a CheckedModule,
     lowered: &'a lowering::LoweredModule,
     pretty: pretty::Pretty<'a, QueryEngine>,
-    binder_sources: HashMap<CheckedBinderId, lowering::BinderId>,
 }
 
 impl<'a> SemanticPrinter<'a> {
@@ -39,19 +23,8 @@ impl<'a> SemanticPrinter<'a> {
         checked: &'a CheckedModule,
         lowered: &'a lowering::LoweredModule,
     ) -> SemanticPrinter<'a> {
-        let pretty = pretty::Pretty::new(engine, checked);
-        let binder_sources =
-            checked.core.binders_by_source.iter().filter_map(|(source, checked)| {
-                let kind = lowered.info.get_binder_kind(*source)?;
-                match kind {
-                    BinderKind::Variable { .. } | BinderKind::Named { .. } => {
-                        Some((*checked, *source))
-                    }
-                    _ => None,
-                }
-            });
-        let binder_sources = binder_sources.collect();
-        SemanticPrinter { engine, file_id, checked, lowered, pretty, binder_sources }
+        let pretty = pretty::Pretty::new(engine, checked, lowered);
+        SemanticPrinter { engine, file_id, checked, lowered, pretty }
     }
 
     fn write_item(&mut self, output: &mut String, item_id: TermItemId, item: &TermItem) {
@@ -68,7 +41,7 @@ impl<'a> SemanticPrinter<'a> {
         writeln!(output, "{signature}").unwrap();
 
         if let Some(expression) = self.checked.core.lookup_term_root(item_id) {
-            let expression = self.expression(expression, Precedence::Abstraction);
+            let expression = self.pretty.render_expression(expression);
             writeln!(output, "{name} = {expression}").unwrap();
         } else {
             for equation in equations.iter() {
@@ -92,7 +65,7 @@ impl<'a> SemanticPrinter<'a> {
         let type_parameters = declaration.type_parameters.iter().map(|&binder_id| {
             let binder = self.engine.lookup_forall_binder(binder_id);
             let name = self.pretty.display_name(binder.name);
-            let kind = self.pretty.render(binder.kind);
+            let kind = self.pretty.render_type(binder.kind);
             format!("({name} :: {kind})")
         });
         let type_parameters = type_parameters.collect::<Vec<_>>();
@@ -107,7 +80,7 @@ impl<'a> SemanticPrinter<'a> {
             let arguments = constructor
                 .arguments
                 .iter()
-                .map(|&argument| self.pretty.render(argument))
+                .map(|&argument| self.pretty.render_type(argument))
                 .collect::<Vec<_>>();
             if arguments.is_empty() { name } else { format!("{name} ({})", arguments.join(") (")) }
         });
@@ -121,8 +94,14 @@ impl<'a> SemanticPrinter<'a> {
     }
 
     fn write_equation(&mut self, output: &mut String, name: &str, equation: &Equation) {
-        let binders = equation.binders.iter().map(|binder| self.binder(*binder));
-        let binders = binders.collect::<Vec<_>>();
+        let mut binders = Vec::with_capacity(equation.binders.len());
+        for binder in equation.binders.iter() {
+            let Some(checked) = self.checked.core.lookup_binder(*binder) else {
+                binders.push("<unimplemented>".to_string());
+                continue;
+            };
+            binders.push(self.pretty.render_binder(checked).to_string());
+        }
         let head = if binders.is_empty() {
             name.to_string()
         } else {
@@ -153,100 +132,9 @@ impl<'a> SemanticPrinter<'a> {
     ) {
         let expression = source.and_then(|source| self.checked.core.lookup_expression(source));
         let body = expression
-            .map(|expression| self.expression(expression, Precedence::Abstraction))
+            .map(|expression| self.pretty.render_expression(expression).to_string())
             .unwrap_or_else(|| "<unimplemented>".to_string());
         writeln!(output, "{head} = {body}").unwrap();
-    }
-
-    fn expression(&mut self, expression_id: CheckedExpressionId, outer: Precedence) -> String {
-        let expression = self.checked.core.expressions[expression_id].clone();
-        let (rendered, precedence) = match expression.kind {
-            CheckedExpressionKind::Variable { resolution } => {
-                (self.variable(resolution), Precedence::Atom)
-            }
-            CheckedExpressionKind::Constructor { file_id, item_id } => {
-                let constructor = self.item_name(file_id, item_id);
-                (constructor, Precedence::Atom)
-            }
-            CheckedExpressionKind::Literal { literal } => {
-                (Self::literal(literal), Precedence::Atom)
-            }
-            CheckedExpressionKind::Case { scrutinees, alternatives, failure } => {
-                let scrutinees = scrutinees
-                    .iter()
-                    .map(|scrutinee| self.expression(*scrutinee, Precedence::Abstraction));
-                let scrutinees = scrutinees.collect::<Vec<_>>();
-
-                let mut rendered_alternatives = vec![];
-                for alternative in alternatives.iter() {
-                    let binders =
-                        alternative.binders.iter().map(|binder| self.checked_binder(*binder));
-                    let binders = binders.collect::<Vec<_>>().join(", ");
-
-                    let mut rendered_results = vec![];
-                    for result in alternative.results.iter() {
-                        let guards = result.guards.iter().map(|guard| self.pattern_guard(guard));
-                        let guards = guards.collect::<Vec<_>>();
-                        let expression =
-                            self.expression(result.expression, Precedence::Abstraction);
-                        if guards.is_empty() {
-                            rendered_results.push(format!("-> {expression}"));
-                        } else {
-                            let guards = guards.join(", ");
-                            rendered_results.push(format!("| {guards} -> {expression}"));
-                        }
-                    }
-                    rendered_alternatives.push(format!("{binders} {}", rendered_results.join(" ")));
-                }
-
-                let failure = self.expression(failure, Precedence::Abstraction);
-                rendered_alternatives.push(format!("else -> {failure}"));
-                let alternatives = rendered_alternatives.join("; ");
-                let rendered = format!("case {} of {alternatives}", scrutinees.join(", "));
-                (rendered, Precedence::Abstraction)
-            }
-            CheckedExpressionKind::Lambda { binders, expression } => {
-                let binders = binders.iter().map(|binder| self.checked_binder(*binder));
-                let binders = binders.collect::<Vec<_>>();
-                let expression = self.expression(expression, Precedence::Abstraction);
-                (format!("\\{} -> {expression}", binders.join(" ")), Precedence::Abstraction)
-            }
-            CheckedExpressionKind::TermApplication { function, argument } => {
-                let function = self.expression(function, Precedence::Application);
-                let argument = self.expression(argument, Precedence::Atom);
-                (format!("{function} {argument}"), Precedence::Application)
-            }
-            CheckedExpressionKind::TypeApplication { function, argument } => {
-                let function = self.expression(function, Precedence::Application);
-                let argument = self.pretty.render(argument);
-                (format!("{function} @{argument}"), Precedence::Application)
-            }
-            CheckedExpressionKind::EvidenceApplication { expression, evidence } => {
-                let expression = self.expression(expression, Precedence::Application);
-                let evidence = evidence.iter().map(|evidence| self.evidence_variable(*evidence));
-                let evidence = evidence.collect::<Vec<_>>();
-                (format!("{expression} @{{{}}}", evidence.join(", ")), Precedence::Application)
-            }
-            CheckedExpressionKind::EvidenceAbstraction { binders, expression } => {
-                let binders = binders.iter().map(|binder| Self::evidence_binder(*binder));
-                let binders = binders.collect::<Vec<_>>();
-                let expression = self.expression(expression, Precedence::Abstraction);
-                (format!("\\@{{{}}} -> {expression}", binders.join(", ")), Precedence::Abstraction)
-            }
-        };
-
-        if precedence < outer { format!("({rendered})") } else { rendered }
-    }
-
-    fn variable(&self, variable: TermVariableResolution) -> String {
-        match variable {
-            TermVariableResolution::Binder(binder) => self.binder_name(binder),
-            TermVariableResolution::Let(binding) => format!("let{}", binding.into_raw().into_u32()),
-            TermVariableResolution::RecordPun(pun) => {
-                format!("pun{}", pun.into_raw().get())
-            }
-            TermVariableResolution::Reference(file_id, item_id) => self.item_name(file_id, item_id),
-        }
     }
 
     fn item_name(&self, file_id: FileId, item_id: TermItemId) -> String {
@@ -255,188 +143,6 @@ impl<'a> SemanticPrinter<'a> {
             .and_then(|indexed| indexed.items[item_id].name.clone())
             .map(String::from)
             .unwrap_or_else(|| format!("item{}", item_id.into_raw().into_u32()))
-    }
-
-    fn binder(&self, source: lowering::BinderId) -> String {
-        let Some(checked) = self.checked.core.lookup_binder(source) else {
-            return "<unimplemented>".to_string();
-        };
-
-        self.checked_binder(checked)
-    }
-
-    fn checked_binder(&self, checked: CheckedBinderId) -> String {
-        match self.checked.core.binders[checked].kind.clone() {
-            CheckedBinderKind::Variable => self
-                .binder_sources
-                .get(&checked)
-                .map(|source| self.binder_name(*source))
-                .unwrap_or_else(|| "<unimplemented>".to_string()),
-            CheckedBinderKind::Named { binder: checked_binder } => {
-                let source = self.binder_sources.get(&checked).copied();
-                match source.and_then(|source| self.lowered.info.get_binder_kind(source)) {
-                    Some(BinderKind::Named { named, .. }) => {
-                        let named = named.as_deref().unwrap_or("<missing>");
-                        let binder = self.checked_binder(checked_binder);
-                        format!("{named}@{binder}")
-                    }
-                    _ => "<invalid>".to_string(),
-                }
-            }
-            CheckedBinderKind::Wildcard => "_".to_string(),
-            CheckedBinderKind::Constructor { file_id, item_id, arguments } => {
-                let constructor = self.item_name(file_id, item_id);
-                if arguments.is_empty() {
-                    constructor
-                } else {
-                    let arguments = arguments.iter().map(|argument| self.checked_binder(*argument));
-                    let arguments = arguments.collect::<Vec<_>>().join(", ");
-                    format!("{constructor}({arguments})")
-                }
-            }
-        }
-    }
-
-    fn pattern_guard(&mut self, guard: &CheckedPatternGuard) -> String {
-        match *guard {
-            CheckedPatternGuard::Boolean { expression } => {
-                self.expression(expression, Precedence::Abstraction)
-            }
-            CheckedPatternGuard::Pattern { binder, expression } => {
-                let binder = self.checked_binder(binder);
-                let expression = self.expression(expression, Precedence::Abstraction);
-                format!("{binder} <- {expression}")
-            }
-        }
-    }
-
-    fn binder_name(&self, source: lowering::BinderId) -> String {
-        match self.lowered.info.get_binder_kind(source) {
-            Some(BinderKind::Variable { variable }) => {
-                variable.clone().map(String::from).unwrap_or_else(|| "_".to_string())
-            }
-            Some(BinderKind::Named { named, .. }) => {
-                named.clone().map(String::from).unwrap_or_else(|| "_".to_string())
-            }
-            Some(BinderKind::Parenthesized { parenthesized: Some(binder) }) => {
-                self.binder_name(*binder)
-            }
-            _ => format!("binder{}", source.into_raw().get()),
-        }
-    }
-
-    fn literal(literal: CheckedLiteral) -> String {
-        match literal {
-            CheckedLiteral::String { kind: lowering::StringKind::String, value } => {
-                value.map(|value| format!("{value:?}")).unwrap_or_else(|| "?string".to_string())
-            }
-            CheckedLiteral::String { kind: lowering::StringKind::RawString, value } => value
-                .map(|value| format!("raw{value:?}"))
-                .unwrap_or_else(|| "?raw-string".to_string()),
-            CheckedLiteral::Char(value) => {
-                value.map(|value| format!("{value:?}")).unwrap_or_else(|| "?char".to_string())
-            }
-            CheckedLiteral::Boolean(value) => value.to_string(),
-            CheckedLiteral::Integer(value) => {
-                value.map(|value| value.to_string()).unwrap_or_else(|| "?int".to_string())
-            }
-            CheckedLiteral::Number(value) => {
-                value.map(String::from).unwrap_or_else(|| "?number".to_string())
-            }
-        }
-    }
-
-    fn evidence_variable(&self, variable @ EvidenceVarId(id): EvidenceVarId) -> String {
-        match self.checked.evidence[variable].state {
-            EvidenceState::Unsolved => format!("<unsolved evidence ev{id}>"),
-            EvidenceState::Solved(evidence) => self.evidence(evidence),
-            EvidenceState::Error => format!("<error evidence ev{id}>"),
-        }
-    }
-
-    fn evidence(&self, evidence_id: EvidenceId) -> String {
-        match self.checked.evidence[evidence_id].clone() {
-            Evidence::Variable(variable) => self.evidence_variable(variable),
-            Evidence::Given(binder) => Self::evidence_binder(binder),
-            Evidence::Instance { origin, subgoals } => {
-                let instance = self.instance_name(origin);
-                if subgoals.is_empty() {
-                    instance
-                } else {
-                    let subgoals =
-                        subgoals.into_iter().map(|subgoal| self.evidence_variable(subgoal));
-                    let subgoals = subgoals.collect::<Vec<_>>();
-                    format!("{instance} @{{{}}}", subgoals.join(", "))
-                }
-            }
-            Evidence::Superclass { parent, superclass } => {
-                let superclass = self.superclass_name(superclass);
-                let parent = self.evidence(parent);
-                format!("superclass[{superclass}] {parent}")
-            }
-            Evidence::Trivial => "<trivial>".to_string(),
-            Evidence::Synthesized(evidence) => Self::synthesized_evidence(evidence),
-        }
-    }
-
-    fn instance_name(&self, origin: InstanceCandidateOrigin) -> String {
-        let file_id = match origin {
-            InstanceCandidateOrigin::Instance(file_id, _)
-            | InstanceCandidateOrigin::Derive(file_id, _) => file_id,
-        };
-        let indexed = self.engine.indexed(file_id).ok();
-        let name = indexed.and_then(|indexed| {
-            indexed.items.iter_terms().find_map(|(_, item)| {
-                let matches = match (origin, &item.kind) {
-                    (
-                        InstanceCandidateOrigin::Instance(_, origin_id),
-                        TermItemKind::Instance { id },
-                    ) => origin_id == *id,
-                    (
-                        InstanceCandidateOrigin::Derive(_, origin_id),
-                        TermItemKind::Derive { id },
-                    ) => origin_id == *id,
-                    _ => false,
-                };
-                matches.then(|| item.name.clone()).flatten()
-            })
-        });
-
-        name.map(String::from).unwrap_or_else(|| match origin {
-            InstanceCandidateOrigin::Instance(_, _) => "<anonymous instance>".to_string(),
-            InstanceCandidateOrigin::Derive(_, _) => "<anonymous derived instance>".to_string(),
-        })
-    }
-
-    fn superclass_name(&self, superclass: SuperclassId) -> String {
-        let indexed = self.engine.indexed(superclass.file_id).ok();
-        indexed
-            .and_then(|indexed| indexed.items[superclass.type_id].name.clone())
-            .map(String::from)
-            .unwrap_or_else(|| "<anonymous superclass>".to_string())
-    }
-
-    fn synthesized_evidence(evidence: SynthesizedEvidence) -> String {
-        match evidence {
-            SynthesizedEvidence::IsSymbol(symbol) => format!("isSymbol({symbol:?})"),
-            SynthesizedEvidence::Reflectable(evidence) => match evidence {
-                ReflectableEvidence::Integer(integer) => format!("reflectable({integer})"),
-                ReflectableEvidence::String(string) => format!("reflectable({string:?})"),
-                ReflectableEvidence::Boolean(boolean) => format!("reflectable({boolean})"),
-                ReflectableEvidence::Ordering(ordering) => {
-                    let ordering = match ordering {
-                        ReflectableOrdering::Less => "LT",
-                        ReflectableOrdering::Equal => "EQ",
-                        ReflectableOrdering::Greater => "GT",
-                    };
-                    format!("reflectable({ordering})")
-                }
-            },
-        }
-    }
-
-    fn evidence_binder(EvidenceBinderId(id): EvidenceBinderId) -> String {
-        format!("dict{id}")
     }
 }
 

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -3,12 +3,15 @@ use std::fmt::Write;
 use analyzer::QueryEngine;
 use checking::CheckedModule;
 use checking::core::pretty;
-use checking::evidence::{EvidenceBinderId, EvidenceVarId};
+use checking::evidence::{
+    Evidence, EvidenceBinderId, EvidenceId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
+    ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
+};
 use checking::semantic::{
     CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
 };
 use files::FileId;
-use indexing::{TermItem, TermItemId};
+use indexing::{TermItem, TermItemId, TermItemKind};
 use lowering::{BinderKind, Equation, GuardedExpression, TermItemIr, TermVariableResolution};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -114,7 +117,7 @@ impl<'a> SemanticPrinter<'a> {
             }
             CheckedExpressionKind::EvidenceApplication { expression, evidence } => {
                 let expression = self.expression(expression, Precedence::Application);
-                let evidence = evidence.iter().map(|evidence| Self::evidence_variable(*evidence));
+                let evidence = evidence.iter().map(|evidence| self.evidence_variable(*evidence));
                 let evidence = evidence.collect::<Vec<_>>();
                 (format!("{expression} @{{{}}}", evidence.join(", ")), Precedence::Application)
             }
@@ -203,8 +206,93 @@ impl<'a> SemanticPrinter<'a> {
         }
     }
 
-    fn evidence_variable(EvidenceVarId(id): EvidenceVarId) -> String {
-        format!("ev{id}")
+    fn evidence_variable(&self, variable @ EvidenceVarId(id): EvidenceVarId) -> String {
+        match self.checked.evidence[variable].state {
+            EvidenceState::Unsolved => format!("<unsolved evidence ev{id}>"),
+            EvidenceState::Solved(evidence) => self.evidence(evidence),
+            EvidenceState::Error => format!("<error evidence ev{id}>"),
+        }
+    }
+
+    fn evidence(&self, evidence_id: EvidenceId) -> String {
+        match self.checked.evidence[evidence_id].clone() {
+            Evidence::Variable(variable) => self.evidence_variable(variable),
+            Evidence::Given(binder) => Self::evidence_binder(binder),
+            Evidence::Instance { origin, subgoals } => {
+                let instance = self.instance_name(origin);
+                if subgoals.is_empty() {
+                    instance
+                } else {
+                    let subgoals =
+                        subgoals.into_iter().map(|subgoal| self.evidence_variable(subgoal));
+                    let subgoals = subgoals.collect::<Vec<_>>();
+                    format!("{instance} @{{{}}}", subgoals.join(", "))
+                }
+            }
+            Evidence::Superclass { parent, superclass } => {
+                let superclass = self.superclass_name(superclass);
+                let parent = self.evidence(parent);
+                format!("superclass[{superclass}] {parent}")
+            }
+            Evidence::Trivial => "<trivial>".to_string(),
+            Evidence::Synthesized(evidence) => Self::synthesized_evidence(evidence),
+        }
+    }
+
+    fn instance_name(&self, origin: InstanceCandidateOrigin) -> String {
+        let file_id = match origin {
+            InstanceCandidateOrigin::Instance(file_id, _)
+            | InstanceCandidateOrigin::Derive(file_id, _) => file_id,
+        };
+        let indexed = self.engine.indexed(file_id).ok();
+        let name = indexed.and_then(|indexed| {
+            indexed.items.iter_terms().find_map(|(_, item)| {
+                let matches = match (origin, &item.kind) {
+                    (
+                        InstanceCandidateOrigin::Instance(_, origin_id),
+                        TermItemKind::Instance { id },
+                    ) => origin_id == *id,
+                    (
+                        InstanceCandidateOrigin::Derive(_, origin_id),
+                        TermItemKind::Derive { id },
+                    ) => origin_id == *id,
+                    _ => false,
+                };
+                matches.then(|| item.name.clone()).flatten()
+            })
+        });
+
+        name.map(String::from).unwrap_or_else(|| match origin {
+            InstanceCandidateOrigin::Instance(_, _) => "<anonymous instance>".to_string(),
+            InstanceCandidateOrigin::Derive(_, _) => "<anonymous derived instance>".to_string(),
+        })
+    }
+
+    fn superclass_name(&self, superclass: SuperclassId) -> String {
+        let indexed = self.engine.indexed(superclass.file_id).ok();
+        indexed
+            .and_then(|indexed| indexed.items[superclass.type_id].name.clone())
+            .map(String::from)
+            .unwrap_or_else(|| "<anonymous superclass>".to_string())
+    }
+
+    fn synthesized_evidence(evidence: SynthesizedEvidence) -> String {
+        match evidence {
+            SynthesizedEvidence::IsSymbol(symbol) => format!("isSymbol({symbol:?})"),
+            SynthesizedEvidence::Reflectable(evidence) => match evidence {
+                ReflectableEvidence::Integer(integer) => format!("reflectable({integer})"),
+                ReflectableEvidence::String(string) => format!("reflectable({string:?})"),
+                ReflectableEvidence::Boolean(boolean) => format!("reflectable({boolean})"),
+                ReflectableEvidence::Ordering(ordering) => {
+                    let ordering = match ordering {
+                        ReflectableOrdering::Less => "LT",
+                        ReflectableOrdering::Equal => "EQ",
+                        ReflectableOrdering::Greater => "GT",
+                    };
+                    format!("reflectable({ordering})")
+                }
+            },
+        }
     }
 
     fn evidence_binder(EvidenceBinderId(id): EvidenceBinderId) -> String {

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -1,0 +1,230 @@
+use std::fmt::Write;
+
+use analyzer::QueryEngine;
+use checking::CheckedModule;
+use checking::core::pretty;
+use checking::evidence::{EvidenceBinderId, EvidenceVarId};
+use checking::semantic::{
+    CheckedBinderKind, CheckedExpressionId, CheckedExpressionKind, CheckedLiteral,
+};
+use files::FileId;
+use indexing::{TermItem, TermItemId};
+use lowering::{BinderKind, Equation, GuardedExpression, TermItemIr, TermVariableResolution};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Precedence {
+    Abstraction,
+    Application,
+    Atom,
+}
+
+struct SemanticPrinter<'a> {
+    engine: &'a QueryEngine,
+    checked: &'a CheckedModule,
+    lowered: &'a lowering::LoweredModule,
+    pretty: pretty::Pretty<'a, QueryEngine>,
+}
+
+impl<'a> SemanticPrinter<'a> {
+    fn new(
+        engine: &'a QueryEngine,
+        checked: &'a CheckedModule,
+        lowered: &'a lowering::LoweredModule,
+    ) -> SemanticPrinter<'a> {
+        let pretty = pretty::Pretty::new(engine, checked);
+        SemanticPrinter { engine, checked, lowered, pretty }
+    }
+
+    fn write_item(&mut self, output: &mut String, item_id: TermItemId, item: &TermItem) {
+        let Some(name) = item.name.as_deref() else { return };
+        let Some(type_id) = self.checked.lookup_term(item_id) else { return };
+        let Some(TermItemIr::ValueGroup { equations, .. }) =
+            self.lowered.info.get_term_item(item_id)
+        else {
+            return;
+        };
+
+        self.pretty.reset();
+        let signature = self.pretty.render_signature(name, type_id);
+        writeln!(output, "{signature}").unwrap();
+
+        for equation in equations.iter() {
+            self.write_equation(output, name, equation);
+        }
+
+        writeln!(output).unwrap();
+    }
+
+    fn write_equation(&mut self, output: &mut String, name: &str, equation: &Equation) {
+        let binders = equation.binders.iter().map(|binder| self.binder(*binder));
+        let binders = binders.collect::<Vec<_>>();
+        let head = if binders.is_empty() {
+            name.to_string()
+        } else {
+            format!("{name} {}", binders.join(" "))
+        };
+
+        match &equation.guarded {
+            Some(GuardedExpression::Unconditional { where_expression }) => {
+                let where_expression = where_expression
+                    .as_ref()
+                    .filter(|where_expression| where_expression.bindings.is_empty());
+                let expression =
+                    where_expression.and_then(|where_expression| where_expression.expression);
+                self.write_equation_body(output, &head, expression);
+            }
+            Some(GuardedExpression::Conditionals { .. }) => {
+                self.write_equation_body(output, &head, None)
+            }
+            None => self.write_equation_body(output, &head, None),
+        }
+    }
+
+    fn write_equation_body(
+        &mut self,
+        output: &mut String,
+        head: &str,
+        source: Option<lowering::ExpressionId>,
+    ) {
+        let expression = source.and_then(|source| self.checked.core.lookup_expression(source));
+        let body = expression
+            .map(|expression| self.expression(expression, Precedence::Abstraction))
+            .unwrap_or_else(|| "<unimplemented>".to_string());
+        writeln!(output, "{head} = {body}").unwrap();
+    }
+
+    fn expression(&mut self, expression_id: CheckedExpressionId, outer: Precedence) -> String {
+        let expression = self.checked.core.expressions[expression_id].clone();
+        let (rendered, precedence) = match expression.kind {
+            CheckedExpressionKind::Variable { resolution } => {
+                (self.variable(resolution), Precedence::Atom)
+            }
+            CheckedExpressionKind::Literal { literal } => {
+                (Self::literal(literal), Precedence::Atom)
+            }
+            CheckedExpressionKind::TermApplication { function, argument } => {
+                let function = self.expression(function, Precedence::Application);
+                let argument = self.expression(argument, Precedence::Atom);
+                (format!("{function} {argument}"), Precedence::Application)
+            }
+            CheckedExpressionKind::TypeApplication { function, argument } => {
+                let function = self.expression(function, Precedence::Application);
+                let argument = self.pretty.render(argument);
+                (format!("{function} @{argument}"), Precedence::Application)
+            }
+            CheckedExpressionKind::EvidenceApplication { expression, evidence } => {
+                let expression = self.expression(expression, Precedence::Application);
+                let evidence = evidence.iter().map(|evidence| Self::evidence_variable(*evidence));
+                let evidence = evidence.collect::<Vec<_>>();
+                (format!("{expression} @{{{}}}", evidence.join(", ")), Precedence::Application)
+            }
+            CheckedExpressionKind::EvidenceAbstraction { binders, expression } => {
+                let binders = binders.iter().map(|binder| Self::evidence_binder(*binder));
+                let binders = binders.collect::<Vec<_>>();
+                let expression = self.expression(expression, Precedence::Abstraction);
+                (format!("\\@{{{}}} -> {expression}", binders.join(", ")), Precedence::Abstraction)
+            }
+        };
+
+        if precedence < outer { format!("({rendered})") } else { rendered }
+    }
+
+    fn variable(&self, variable: TermVariableResolution) -> String {
+        match variable {
+            TermVariableResolution::Binder(binder) => self.binder_name(binder),
+            TermVariableResolution::Let(binding) => format!("let{}", binding.into_raw().into_u32()),
+            TermVariableResolution::RecordPun(pun) => {
+                format!("pun{}", pun.into_raw().get())
+            }
+            TermVariableResolution::Reference(file_id, item_id) => self.item_name(file_id, item_id),
+        }
+    }
+
+    fn item_name(&self, file_id: FileId, item_id: TermItemId) -> String {
+        let indexed = self.engine.indexed(file_id).ok();
+        indexed
+            .and_then(|indexed| indexed.items[item_id].name.clone())
+            .map(String::from)
+            .unwrap_or_else(|| format!("item{}", item_id.into_raw().into_u32()))
+    }
+
+    fn binder(&self, source: lowering::BinderId) -> String {
+        let Some(checked) = self.checked.core.lookup_binder(source) else {
+            return "<unimplemented>".to_string();
+        };
+
+        match self.checked.core.binders[checked].kind {
+            CheckedBinderKind::Variable => self.binder_name(source),
+            CheckedBinderKind::Named { .. } => match self.lowered.info.get_binder_kind(source) {
+                Some(BinderKind::Named { named, binder }) => {
+                    let named = named.as_deref().unwrap_or("<missing>");
+                    let binder = binder.map(|binder| self.binder(binder));
+                    let binder = binder.unwrap_or_else(|| "<unimplemented>".to_string());
+                    format!("{named}@{binder}")
+                }
+                _ => "<invalid named binder>".to_string(),
+            },
+        }
+    }
+
+    fn binder_name(&self, source: lowering::BinderId) -> String {
+        match self.lowered.info.get_binder_kind(source) {
+            Some(BinderKind::Variable { variable }) => {
+                variable.clone().map(String::from).unwrap_or_else(|| "_".to_string())
+            }
+            Some(BinderKind::Named { named, .. }) => {
+                named.clone().map(String::from).unwrap_or_else(|| "_".to_string())
+            }
+            Some(BinderKind::Parenthesized { parenthesized: Some(binder) }) => {
+                self.binder_name(*binder)
+            }
+            _ => format!("binder{}", source.into_raw().get()),
+        }
+    }
+
+    fn literal(literal: CheckedLiteral) -> String {
+        match literal {
+            CheckedLiteral::String { kind: lowering::StringKind::String, value } => {
+                value.map(|value| format!("{value:?}")).unwrap_or_else(|| "?string".to_string())
+            }
+            CheckedLiteral::String { kind: lowering::StringKind::RawString, value } => value
+                .map(|value| format!("raw{value:?}"))
+                .unwrap_or_else(|| "?raw-string".to_string()),
+            CheckedLiteral::Char(value) => {
+                value.map(|value| format!("{value:?}")).unwrap_or_else(|| "?char".to_string())
+            }
+            CheckedLiteral::Boolean(value) => value.to_string(),
+            CheckedLiteral::Integer(value) => {
+                value.map(|value| value.to_string()).unwrap_or_else(|| "?int".to_string())
+            }
+            CheckedLiteral::Number(value) => {
+                value.map(String::from).unwrap_or_else(|| "?number".to_string())
+            }
+        }
+    }
+
+    fn evidence_variable(EvidenceVarId(id): EvidenceVarId) -> String {
+        format!("ev{id}")
+    }
+
+    fn evidence_binder(EvidenceBinderId(id): EvidenceBinderId) -> String {
+        format!("dict{id}")
+    }
+}
+
+pub fn report(engine: &QueryEngine, id: FileId, name: &str) -> String {
+    let checked = engine.checked(id).unwrap();
+    let lowered = engine.lowered(id).unwrap();
+    let indexed = engine.indexed(id).unwrap();
+    let mut printer = SemanticPrinter::new(engine, &checked, &lowered);
+
+    let mut output = String::new();
+    writeln!(output, "module {name} where").unwrap();
+    writeln!(output).unwrap();
+
+    for (item_id, item) in indexed.items.iter_terms() {
+        printer.write_item(&mut output, item_id, item);
+    }
+
+    output
+}

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -40,7 +40,7 @@ pub fn load_compiler(folder: &Path) -> (QueryEngine, Files) {
     let mut files = Files::default();
     prim::configure(&mut engine, &mut files);
 
-    if folder.starts_with("fixtures/checking/") {
+    if folder.starts_with("fixtures/checking/") || folder.starts_with("fixtures/semantic/") {
         let prelude = Path::new("fixtures/checking/prelude");
         load_folder(prelude).for_each(|path| {
             load_file(&mut engine, &mut files, &path);

--- a/tests-integration/tests/semantic.rs
+++ b/tests-integration/tests/semantic.rs
@@ -1,0 +1,7 @@
+fn semantic(path: &std::path::Path) -> datatest_stable::Result<()> {
+    tests_integration::fixtures::semantic(path)
+}
+
+datatest_stable::harness! {
+    { test = semantic, root = "fixtures/semantic", pattern = r".*/Main\.purs$" },
+}


### PR DESCRIPTION
## Motivation

Checking currently produces types and source-keyed side tables, but downstream compiler stages also need the semantic choices made while checking: which type-class proof was selected and exactly where implicit dictionaries are introduced or applied.

The previous elaboration prototype reconstructed those choices by re-traversing lowered syntax with placement coordinates. That required the checker and elaborator to maintain matching traversals and left correctness guarded by runtime placement assertions.

This PR starts the replacement architecture. The checker now retains a solved evidence graph and constructs a recursive checked Core tree directly at the checking seam. A future elaborator can consume `CheckedModule` without replaying `LoweredModule`, bracketing, or sugar queries.

## Design

### Evidence is a checked result

Each wanted occurrence receives a stable `EvidenceVarId`. Solving retains the selected proof, including givens, declared and derived instances, superclass projections, synthesized compiler evidence, erased/trivial evidence, and errors. Duplicate constraints alias evidence variables rather than erasing occurrence identity.

Compiler-known side effects are moved out of speculative matching and into selected evidence elaboration, so failed candidates cannot emit diagnostics or mutate checking results.

### Recursive inference follows PureScript semantics

Constrained recursive inference is rejected with `CannotGeneralizeRecursiveFunction`, matching PureScript rather than attempting to infer dictionary passing for recursive SCCs. The implementation is preceded by focused failing fixtures covering direct recursion, mutual recursion, `Partial`, and explicitly checked recursive bindings.

### Checked Core records semantic seams

`CheckedCore` owns typed expression and binder arenas with source-provenance maps. Ordinary applications build recursive nodes for:

- term application;
- visible type application;
- evidence application;
- evidence abstraction;
- literals and resolved variables.

Evidence applications wrap the current expression exactly where checking consumes a `Type::Constrained` layer. This permits a dictionary to occur between two source arguments rather than flattening all evidence onto an application root.

Checked Core is zonked with the rest of the checked module. Forms not yet migrated remain explicitly unrepresented instead of being reconstructed downstream.

### Semantic snapshots render selected proofs

A new `semantic` integration-test category renders the checked tree recursively. Evidence applications follow the solved evidence graph, including nested instance prerequisites, givens, synthesized proofs, and trivial evidence.

## Review order

1. `Add solver evidence graph`
2. `Improve generalisation code`
3. `Move compiler-solved side effects`
4. `Add failing test cases for constrained recursive inference`
5. `Reject constrained recursive inference`
6. `Introduce checked Core representation`
7. `Record checked Core applications`
8. `Add checked Core integration snapshots`
9. `Add initial checked Core semantic fixtures`
10. `Render solved evidence in checked Core snapshots`

## Scope and deferred work

This PR establishes the evidence model and the first checked-tree vertical slice. It intentionally defers:

- checked nodes for lambdas, collections, records, operators, sections, `do`, `ado`, equations, guards, and local lets;
- final evidence-abstraction construction at generalized binding boundaries;
- total checked-tree validation;
- retargeting `compiler-core/elaborating` to consume only `CheckedModule`;
- deleting the old source re-traversal elaborator.

## Validation

- `cargo check -p checking --tests`
- `cargo check -p tests-integration --tests`
- `cargo check -p compiler-scripts`
- `cargo doc -p checking --no-deps`
- `just t checking`
- `just t semantic`
- `just format`
- `git diff --check`

The application/evidence changes also received a focused Oracle re-review after fixes for visible-type-application ordering, evidence placement when an argument lacks Core, and transitional API visibility. Final recommendation: ship.

## Review context

- [Evidence graph and checked semantic tree design](https://ampcode.com/threads/T-019f63f6-3c61-755b-a4d1-50bad2b69fd9)
- [Checked Core implementation](https://ampcode.com/threads/T-019f7a98-1e13-70fe-92ae-d84031a2b8bd)