### PR TITLE
Fix test runner color detection

### DIFF
--- a/compiler-scripts/src/test_runner/nextest.rs
+++ b/compiler-scripts/src/test_runner/nextest.rs
@@ -1,3 +1,4 @@
+use std::io::{self, IsTerminal};
 use std::process::{Command, Stdio};
 
 use anyhow::Context;
@@ -21,7 +22,9 @@ pub fn build_nextest_command(category: TestCategory, args: &RunArgs) -> Command 
 
     if args.verbose {
         cmd.arg("--status-level=fail");
-        cmd.arg("--color=always");
+        if !io::stderr().is_terminal() {
+            cmd.arg("--color=never");
+        }
     } else {
         cmd.arg("--status-level=none");
     }


### PR DESCRIPTION
## Summary

Detect whether the compiler test runner stderr is connected to a terminal before configuring nextest colors. Disable colors for redirected output while preserving nextest’s normal behavior in interactive terminals.

This check belongs in the compiler script because `just t` runs it through an outer `cargo run`, whose propagated Cargo color state can cause nextest’s automatic mode to emit ANSI escapes into captured output.

## Verification

- `cargo check -p compiler-scripts --tests`
- Redirected `just t semantic __color_detection_probe__ --verbose` contains no ANSI or OSC escapes
- The same command under a pseudo-terminal retains ANSI color output