### PR TITLE
[lsp] Reuse line index for diagnostic positions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "async-lsp",
  "building",
  "checking",
+ "criterion",
  "files",
  "indexing",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ dependencies = [
 name = "tests-compatibility"
 version = "0.1.0"
 dependencies = [
+ "analyzer",
  "anyhow",
  "building",
  "checking",

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -71,9 +71,9 @@ fn collect_diagnostics_core(
         all_diagnostics.extend(error.to_diagnostics(&context));
     }
 
+    let position_converter = position::PositionConverter::new(&content);
     let to_position = |offset: u32| {
-        let position = position::offset_to_utf8_position(&content, TextSize::from(offset))?;
-        position::utf8_position_to_protocol(&content, position, snapshot.position_encoding)
+        position_converter.offset_to_protocol(TextSize::from(offset), snapshot.position_encoding)
     };
 
     let diagnostics = all_diagnostics

--- a/compiler-lsp/analyzer/Cargo.toml
+++ b/compiler-lsp/analyzer/Cargo.toml
@@ -29,4 +29,9 @@ tracing = "0.1.44"
 url = "2.5.7"
 
 [dev-dependencies]
+criterion = "0.6.0"
 insta = "1.45.1"
+
+[[bench]]
+name = "position"
+harness = false

--- a/compiler-lsp/analyzer/benches/position.rs
+++ b/compiler-lsp/analyzer/benches/position.rs
@@ -1,0 +1,87 @@
+use std::hint::black_box;
+
+use analyzer::position::{
+    PositionConverter, PositionEncoding, offset_to_utf8_position, utf8_position_to_protocol,
+};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use syntax::TextSize;
+
+fn content(bytes: usize) -> String {
+    let line = "value😀 = value\n";
+    line.repeat(bytes.div_ceil(line.len()))
+}
+
+fn offsets(content: &str, count: usize) -> Vec<TextSize> {
+    let stride = content.len() / count;
+    let offsets = (0..count).map(|index| {
+        let mut offset = index * stride;
+        while !content.is_char_boundary(offset) {
+            offset += 1;
+        }
+        TextSize::new(offset as u32)
+    });
+
+    offsets.collect()
+}
+
+fn convert_positions(content: &str, offsets: &[TextSize]) -> u64 {
+    let mut checksum = 0;
+    for &offset in offsets {
+        let position = offset_to_utf8_position(content, offset).unwrap();
+        let position =
+            utf8_position_to_protocol(content, position, PositionEncoding::Utf16).unwrap();
+        checksum += u64::from(position.line) + u64::from(position.character);
+    }
+    checksum
+}
+
+fn convert_positions_reusing_index(content: &str, offsets: &[TextSize]) -> u64 {
+    let converter = PositionConverter::new(content);
+    let mut checksum = 0;
+    for &offset in offsets {
+        let position = converter.offset_to_protocol(offset, PositionEncoding::Utf16).unwrap();
+        checksum += u64::from(position.line) + u64::from(position.character);
+    }
+    checksum
+}
+
+fn source_bytes(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("position/source_bytes");
+    group.sample_size(20);
+
+    for bytes in [1_024, 16_384, 262_144] {
+        let content = content(bytes);
+        let offsets = offsets(&content, 32);
+        group.throughput(Throughput::Bytes(content.len() as u64));
+        group.bench_with_input(BenchmarkId::new("rebuild", bytes), &bytes, |bencher, _| {
+            bencher.iter(|| black_box(convert_positions(&content, &offsets)));
+        });
+        group.bench_with_input(BenchmarkId::new("reuse", bytes), &bytes, |bencher, _| {
+            bencher.iter(|| black_box(convert_positions_reusing_index(&content, &offsets)));
+        });
+    }
+
+    group.finish();
+}
+
+fn span_count(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("position/span_count");
+    group.sample_size(20);
+    let content = content(65_536);
+
+    for count in [1, 16, 256] {
+        let offsets = offsets(&content, count * 2);
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("rebuild", count), &count, |bencher, _| {
+            bencher.iter(|| black_box(convert_positions(&content, &offsets)));
+        });
+        group.bench_with_input(BenchmarkId::new("reuse", count), &count, |bencher, _| {
+            bencher.iter(|| black_box(convert_positions_reusing_index(&content, &offsets)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, source_bytes, span_count);
+criterion_main!(benches);

--- a/compiler-lsp/analyzer/src/position.rs
+++ b/compiler-lsp/analyzer/src/position.rs
@@ -50,6 +50,34 @@ pub struct Utf8Range {
     pub end: Utf8Position,
 }
 
+pub struct PositionConverter {
+    line_index: LineIndex,
+}
+
+impl PositionConverter {
+    pub fn new(content: &str) -> PositionConverter {
+        let line_index = LineIndex::new(content);
+        PositionConverter { line_index }
+    }
+
+    pub fn offset_to_protocol(
+        &self,
+        offset: TextSize,
+        encoding: PositionEncoding,
+    ) -> Option<lsp_types::Position> {
+        let line_col = self.line_index.try_line_col(offset)?;
+        let position = match encoding.wide() {
+            None => lsp_types::Position { line: line_col.line, character: line_col.col },
+            Some(encoding) => {
+                let line_col = self.line_index.to_wide(encoding, line_col)?;
+                lsp_types::Position { line: line_col.line, character: line_col.col }
+            }
+        };
+
+        Some(position)
+    }
+}
+
 pub fn protocol_position_to_utf8(
     content: &str,
     position: lsp_types::Position,
@@ -248,9 +276,18 @@ mod tests {
     use syntax::TextSize;
 
     use super::{
-        PositionEncoding, Utf8Position, offset_to_utf8_position, protocol_position_to_utf8,
-        utf8_position_to_offset, utf8_position_to_protocol,
+        PositionConverter, PositionEncoding, Utf8Position, offset_to_utf8_position,
+        protocol_position_to_utf8, utf8_position_to_offset, utf8_position_to_protocol,
     };
+
+    fn offset_to_protocol(
+        content: &str,
+        offset: TextSize,
+        encoding: PositionEncoding,
+    ) -> Option<Position> {
+        let position = offset_to_utf8_position(content, offset)?;
+        utf8_position_to_protocol(content, position, encoding)
+    }
 
     #[test]
     fn utf16_protocol_position_maps_to_utf8_column() {
@@ -320,5 +357,20 @@ mod tests {
         let position =
             protocol_position_to_utf8(content, position, PositionEncoding::Utf16).unwrap();
         assert_eq!(position, Utf8Position { line: 0, column: 3 });
+    }
+
+    #[test]
+    fn reusable_converter_matches_existing_offset_conversion() {
+        let content = "ascii\r\na😀b\n𐐀z";
+        let converter = PositionConverter::new(content);
+
+        for encoding in [PositionEncoding::Utf8, PositionEncoding::Utf16, PositionEncoding::Utf32] {
+            for offset in 0..=content.len() as u32 + 1 {
+                let offset = TextSize::new(offset);
+                let existing = offset_to_protocol(content, offset, encoding);
+                let reused = converter.offset_to_protocol(offset, encoding);
+                assert_eq!(reused, existing, "{encoding:?} at byte offset {offset:?}");
+            }
+        }
     }
 }

--- a/tests-compatibility/Cargo.toml
+++ b/tests-compatibility/Cargo.toml
@@ -34,6 +34,7 @@ url = "2.5.7"
 walkdir = "2.5.0"
 
 [dev-dependencies]
+analyzer = { version = "0.1.0", path = "../compiler-lsp/analyzer" }
 tempfile = "3"
 
 [[bench]]
@@ -50,4 +51,8 @@ harness = false
 
 [[bench]]
 name = "checking_multi_core"
+harness = false
+
+[[bench]]
+name = "diagnostics_positions"
 harness = false

--- a/tests-compatibility/benches/diagnostics_positions.rs
+++ b/tests-compatibility/benches/diagnostics_positions.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::hint::black_box;
+
+use analyzer::position::{
+    PositionConverter, PositionEncoding, offset_to_utf8_position, utf8_position_to_protocol,
+};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use syntax::TextRange;
+use syntax::ast::AstNode;
+use tests_compatibility::{core_source_files, default_cache_dir};
+
+struct ModuleWorkload {
+    content: String,
+    ranges: Vec<TextRange>,
+}
+
+fn workload() -> (usize, usize, usize, Vec<ModuleWorkload>) {
+    let paths = core_source_files();
+    assert!(!paths.is_empty(), "prepare the core compatibility corpus before benchmarking");
+
+    let sources_dir = default_cache_dir().join("sources");
+    let mut packages = BTreeSet::new();
+    let mut bytes = 0;
+    let modules = paths.into_iter().map(|path| {
+        let relative_path = path.strip_prefix(&sources_dir).unwrap();
+        let package = relative_path.components().next().unwrap();
+        packages.insert(package.as_os_str().to_owned());
+
+        let content = fs::read_to_string(&path).unwrap();
+        bytes += content.len();
+
+        let lexed = lexing::lex(&content);
+        let tokens = lexing::layout(&lexed);
+        let (parsed, errors) = parsing::parse(&lexed, &tokens);
+        assert!(errors.is_empty(), "{} has parse errors", path.display());
+
+        let module = parsed.cst();
+        let ranges = module.statements().map(|statements| {
+            let ranges = statements
+                .children()
+                .map(|declaration| declaration.syntax().text_range())
+                .filter(|range| !range.is_empty());
+            ranges.collect::<Vec<_>>()
+        });
+        let ranges = ranges.unwrap_or_default();
+
+        // The corpus compiles without diagnostics, so declaration ranges provide stable,
+        // source-derived proxies at a bounded density for a broken-workspace workload.
+        let range_count = content.len().div_ceil(4_096).clamp(1, 8).min(ranges.len());
+        let ranges = if range_count <= 1 {
+            vec![ranges.get(ranges.len() / 2).copied().unwrap_or(module.syntax().text_range())]
+        } else {
+            let selected = (0..range_count).map(|index| {
+                let range_index = index * (ranges.len() - 1) / (range_count - 1);
+                ranges[range_index]
+            });
+            selected.collect()
+        };
+
+        ModuleWorkload { content, ranges }
+    });
+    let modules = modules.collect::<Vec<_>>();
+
+    (packages.len(), modules.len(), bytes, modules)
+}
+
+fn convert_rebuilding_indexes(modules: &[ModuleWorkload]) -> u64 {
+    let mut checksum = 0;
+    for module in modules {
+        for range in &module.ranges {
+            for offset in [range.start(), range.end()] {
+                let position = offset_to_utf8_position(&module.content, offset).unwrap();
+                let position =
+                    utf8_position_to_protocol(&module.content, position, PositionEncoding::Utf16)
+                        .unwrap();
+                checksum += u64::from(position.line) + u64::from(position.character);
+            }
+        }
+    }
+    checksum
+}
+
+fn convert_reusing_indexes(modules: &[ModuleWorkload]) -> u64 {
+    let mut checksum = 0;
+    for module in modules {
+        let converter = PositionConverter::new(&module.content);
+        for range in &module.ranges {
+            for offset in [range.start(), range.end()] {
+                let position =
+                    converter.offset_to_protocol(offset, PositionEncoding::Utf16).unwrap();
+                checksum += u64::from(position.line) + u64::from(position.character);
+            }
+        }
+    }
+    checksum
+}
+
+fn criterion_benchmark(criterion: &mut Criterion) {
+    let (packages, module_count, bytes, modules) = workload();
+    let ranges = modules.iter().map(|module| module.ranges.len()).sum::<usize>();
+    assert!(bytes > 0);
+    assert!(ranges > 0);
+    eprintln!(
+        "diagnostics corpus: {packages} packages, {module_count} modules, {bytes} bytes, {ranges} diagnostic ranges"
+    );
+
+    let mut group = criterion.benchmark_group("diagnostics_positions/compatibility-core");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(ranges as u64));
+    group.bench_function("rebuild", |bencher| {
+        bencher.iter(|| black_box(convert_rebuilding_indexes(&modules)));
+    });
+    group.bench_function("reuse", |bencher| {
+        bencher.iter(|| black_box(convert_reusing_indexes(&modules)));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Diagnostic publishing converted every span endpoint in two steps. Each step constructed a fresh `line_index::LineIndex`, so a diagnostics request built four indexes per primary or related span and repeatedly scanned the complete source text.

This change adds a request-scoped `PositionConverter` that constructs one line index and converts validated byte offsets directly to LSP positions. `collect_diagnostics_core` now shares that converter across all primary and related diagnostic spans. Other analyzer location call sites remain unchanged.

The existing conversion functions remain available. Equivalence coverage checks the reusable conversion against the previous composition for UTF-8, UTF-16, and UTF-32 at every byte offset in mixed ASCII, CRLF, and non-BMP content, including invalid UTF-8 boundaries and past-EOF offsets.

## Benchmarks

The synthetic analyzer benchmark independently varies source size and span count. A second benchmark exercises all files in the prepared `tests-compatibility` core corpus.

The compatibility corpus is clean, with no naturally occurring compiler diagnostics. The corpus harness therefore selects actual top-level declaration ranges at a deterministic density of one range per 4 KiB, bounded to 1–8 per module. This retains real module sizes, line layouts, Unicode, and declaration boundaries while modeling a broken-workspace diagnostic workload.

Corpus workload:

- 59 packages
- 294 modules
- 1,034,898 source bytes
- 426 diagnostic ranges / 852 endpoints
- UTF-16 protocol conversion

Twenty-sample Criterion run:

| Conversion | Median | Bootstrap median 95% CI | IQR | Criterion typical-time interval |
| --- | ---: | ---: | ---: | ---: |
| Rebuild indexes | 2.7197 ms | 2.7095–2.7478 ms | 2.6993–2.7611 ms | 2.7026–2.7630 ms |
| Reuse indexes | 560.24 µs | 558.39–562.33 µs | 557.99–562.50 µs | 558.98–561.89 µs |

Median speedup: **4.854×** (bootstrap 95% CI: 4.829×–4.908×).

For this workload, index construction falls from 1,704 (two per endpoint) to 294 (one per module/request), an 82.7% reduction.

Benchmark command:

```sh
cargo run -p tests-compatibility -- prepare --preset core
cargo bench -p tests-compatibility --bench diagnostics_positions -- --noplot
```

## Validation

- `cargo run -p tests-compatibility -- verify --preset core --json-output target/compatibility/core-report.json`
  - 59 packages / 294 source files
  - zero compiler errors, compiler warnings, and verifier errors
- `cargo bench -p tests-compatibility --bench diagnostics_positions -- --noplot`
- `cargo check -p tests-compatibility --benches`
- `cargo test -p analyzer position::tests` — 7 passed
- `cargo check -p purescript-alexandrite --tests`
- `just format`
- `cargo fmt --check`
- `git diff --check`
