### PR TITLE
Wake stuck constraints from solved variables

### DIFF
--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -29,7 +29,7 @@ use crate::core::fd::{compute_closure, get_functional_dependencies};
 use crate::core::{KindOrType, TypeId, unification};
 use crate::error::{CheckingError, ErrorKind};
 use crate::implication::{ImplicationId, Patterns};
-use crate::state::{CheckState, UnificationState};
+use crate::state::CheckState;
 use crate::{ExternalQueries, Type};
 
 pub fn solve_implication<Q>(
@@ -94,9 +94,127 @@ impl Work {
     }
 }
 
-type Stuck = FxHashMap<u32, Vec<ConstraintInScope>>;
+#[derive(Default)]
+struct Stuck {
+    by_unification: FxHashMap<u32, Vec<ConstraintInScope>>,
+    by_constraint: FxHashMap<ConstraintInScope, StuckConstraint>,
+    next_order: usize,
+    entries: usize,
+}
+
+struct StuckConstraint {
+    blockers: FxHashSet<u32>,
+    order: usize,
+}
+
+impl Stuck {
+    fn register(
+        &mut self,
+        constraint: ConstraintInScope,
+        blockers: FxHashSet<u32>,
+        statistics: &mut WakeStatistics,
+    ) {
+        let order = self.next_order;
+        self.next_order += 1;
+
+        let entry = self
+            .by_constraint
+            .entry(constraint.clone())
+            .or_insert_with(|| StuckConstraint { blockers: FxHashSet::default(), order });
+
+        for blocker in blockers {
+            if !entry.blockers.insert(blocker) {
+                statistics.duplicate_registrations += 1;
+                continue;
+            }
+
+            self.by_unification.entry(blocker).or_default().push(constraint.clone());
+            self.entries += 1;
+        }
+
+        statistics.peak_stuck_entries = statistics.peak_stuck_entries.max(self.entries);
+    }
+
+    fn wake(
+        &mut self,
+        solved: Vec<u32>,
+        statistics: &mut WakeStatistics,
+    ) -> Vec<ConstraintInScope> {
+        let mut awake = FxHashSet::default();
+
+        for id in solved {
+            statistics.solved_ids_examined += 1;
+            statistics.stuck_keys_scanned += 1;
+
+            let Some(constraints) = self.by_unification.remove(&id) else { continue };
+            statistics.stuck_entries_scanned += constraints.len();
+            awake.extend(constraints);
+        }
+
+        let mut awake = awake
+            .into_iter()
+            .filter_map(|constraint| {
+                let entry = self.by_constraint.remove(&constraint)?;
+                self.entries -= entry.blockers.len();
+
+                for blocker in &entry.blockers {
+                    let Some(constraints) = self.by_unification.get_mut(blocker) else { continue };
+                    statistics.stuck_entries_scanned += constraints.len();
+                    constraints.retain(|registered| registered != &constraint);
+                    if constraints.is_empty() {
+                        self.by_unification.remove(blocker);
+                    }
+                }
+
+                Some((entry.order, constraint))
+            })
+            .collect_vec();
+        awake.sort_unstable_by_key(|(order, _)| *order);
+        statistics.awakened_constraints += awake.len();
+
+        let awake = awake.into_iter().map(|(_, constraint)| constraint);
+        awake.collect()
+    }
+
+    fn into_constraints(self) -> Vec<ConstraintInScope> {
+        let mut constraints = ConstraintSet::default();
+        for registered in self.by_unification.into_values() {
+            constraints.extend(registered);
+        }
+        constraints.into_iter().collect()
+    }
+}
+
 type ConstraintSet = IndexSet<ConstraintInScope, FxBuildHasher>;
 type Skolem = Vec<ConstraintInScope>;
+
+#[derive(Default)]
+struct WakeStatistics {
+    wake_calls: usize,
+    solved_ids_examined: usize,
+    stuck_keys_scanned: usize,
+    stuck_entries_scanned: usize,
+    duplicate_registrations: usize,
+    awakened_constraints: usize,
+    peak_stuck_entries: usize,
+}
+
+impl Drop for WakeStatistics {
+    fn drop(&mut self) {
+        if std::env::var_os("ALEXANDRITE_PROFILE_CONSTRAINT_WAKE").is_some() {
+            eprintln!(
+                "constraint-wake wake_calls={} solved_ids_examined={} stuck_keys_scanned={} stuck_entries_scanned={} duplicate_registrations={} awakened_constraints={} peak_stuck_entries={}",
+                self.wake_calls,
+                self.solved_ids_examined,
+                self.stuck_keys_scanned,
+                self.stuck_entries_scanned,
+                self.duplicate_registrations,
+                self.awakened_constraints,
+                self.peak_stuck_entries,
+            );
+        }
+    }
+}
 
 fn is_improving_constraint<Q>(
     state: &mut CheckState,
@@ -140,31 +258,14 @@ where
     Ok(false)
 }
 
-fn wake_constraints(work: &mut Work, stuck: &mut Stuck, state: &CheckState) {
-    let mut awake = ConstraintSet::default();
-
-    stuck.retain(|&id, constraints| {
-        if let UnificationState::Solved(_) = state.unifications.get(id).state {
-            awake.extend(constraints.iter().cloned());
-            false
-        } else {
-            true
-        }
-    });
-
-    if awake.is_empty() {
-        return;
-    }
-
-    // For each constraint in the constraint set;
-    for constraints in stuck.values_mut() {
-        // keep only the constraints that are not awake;
-        constraints.retain(|constraint| !awake.contains(constraint));
-    }
-
-    // and keep only the non-empty constraint sets.
-    stuck.retain(|_, constraints| !constraints.is_empty());
-
+fn wake_constraints(
+    work: &mut Work,
+    stuck: &mut Stuck,
+    solved: Vec<u32>,
+    statistics: &mut WakeStatistics,
+) {
+    statistics.wake_calls += 1;
+    let awake = stuck.wake(solved, statistics);
     work.extend_constraints(awake);
 }
 
@@ -180,15 +281,17 @@ where
     let mut stuck = Stuck::default();
     let mut skolem = Skolem::default();
     let mut residuals = vec![];
+    let mut wake_statistics = WakeStatistics::default();
+    state.unifications.take_solved();
 
     'work: loop {
-        let mut has_unification = false;
         for (t1, t2) in mem::take(&mut work.unifications) {
-            has_unification |= unification::unify(state, context, t1, t2)?;
+            unification::unify(state, context, t1, t2)?;
         }
 
-        if has_unification {
-            wake_constraints(&mut work, &mut stuck, state);
+        let solved = state.unifications.take_solved();
+        if !solved.is_empty() {
+            wake_constraints(&mut work, &mut stuck, solved, &mut wake_statistics);
             work.extend_constraints(mem::take(&mut skolem));
         }
 
@@ -271,19 +374,14 @@ where
                 residuals.push(constraint);
             }
         } else {
-            for id in blocked {
-                let constraint = ConstraintInScope::clone(&constraint);
-                stuck.entry(id).or_default().push(constraint);
-            }
+            stuck.register(constraint, blocked, &mut wake_statistics);
         }
     }
 
     let mut unique_residuals = ConstraintSet::default();
     unique_residuals.extend(residuals);
 
-    for (_, constraints) in stuck {
-        unique_residuals.extend(constraints);
-    }
+    unique_residuals.extend(stuck.into_constraints());
     unique_residuals.extend(skolem);
 
     Ok(unique_residuals.into_iter().collect())
@@ -435,4 +533,71 @@ where
     }
 
     Ok(constraints)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::{
+        CanonicalConstraintId, ConstraintInScope, Stuck, WakeStatistics, Work, wake_constraints,
+    };
+    use rustc_hash::FxHashSet;
+
+    fn constraint(id: u32) -> ConstraintInScope {
+        let wanted = CanonicalConstraintId::new(NonZeroU32::new(id).unwrap());
+        ConstraintInScope { given: [].into(), wanted }
+    }
+
+    #[test]
+    fn many_blockers_only_examine_solved_wait_lists() {
+        const BLOCKERS: u32 = 1_000;
+
+        let mut stuck = Stuck::default();
+        let mut statistics = WakeStatistics::default();
+
+        for blocker in 0..BLOCKERS {
+            stuck.register(
+                constraint(blocker + 1),
+                FxHashSet::from_iter([blocker]),
+                &mut statistics,
+            );
+        }
+
+        let mut work = Work::new(Default::default());
+        for blocker in (0..BLOCKERS).rev() {
+            wake_constraints(&mut work, &mut stuck, vec![blocker], &mut statistics);
+            assert!(work.unclassified.pop_front() == Some(constraint(blocker + 1)));
+        }
+
+        assert_eq!(statistics.wake_calls, BLOCKERS as usize);
+        assert_eq!(statistics.solved_ids_examined, BLOCKERS as usize);
+        assert_eq!(statistics.stuck_keys_scanned, BLOCKERS as usize);
+        assert_eq!(statistics.stuck_entries_scanned, BLOCKERS as usize);
+        assert_eq!(statistics.awakened_constraints, BLOCKERS as usize);
+        assert_eq!(statistics.peak_stuck_entries, BLOCKERS as usize);
+        assert!(stuck.into_constraints().is_empty());
+    }
+
+    #[test]
+    fn multiple_solved_blockers_requeue_each_constraint_once_in_registration_order() {
+        let first = constraint(1);
+        let second = constraint(2);
+        let mut stuck = Stuck::default();
+        let mut statistics = WakeStatistics::default();
+
+        stuck.register(first.clone(), FxHashSet::from_iter([10, 20]), &mut statistics);
+        stuck.register(second.clone(), FxHashSet::from_iter([20]), &mut statistics);
+        stuck.register(first.clone(), FxHashSet::from_iter([10, 20]), &mut statistics);
+
+        let mut work = Work::new(Default::default());
+        wake_constraints(&mut work, &mut stuck, vec![20, 10], &mut statistics);
+        let awake = work.unclassified.into_iter().collect::<Vec<_>>();
+
+        assert!(awake == [first, second]);
+        assert_eq!(statistics.wake_calls, 1);
+        assert_eq!(statistics.duplicate_registrations, 2);
+        assert_eq!(statistics.awakened_constraints, 2);
+        assert!(stuck.into_constraints().is_empty());
+    }
 }

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -53,6 +53,7 @@ pub struct UnificationEntry {
 #[derive(Debug, Default)]
 pub struct Unifications {
     entries: Vec<UnificationEntry>,
+    solved: Vec<u32>,
     unique: u32,
 }
 
@@ -75,7 +76,17 @@ impl Unifications {
     }
 
     pub fn solve(&mut self, index: u32, solution: TypeId) {
-        self.get_mut(index).state = UnificationState::Solved(solution);
+        let entry = self.get_mut(index);
+        let newly_solved = matches!(entry.state, UnificationState::Unsolved);
+        entry.state = UnificationState::Solved(solution);
+
+        if newly_solved {
+            self.solved.push(index);
+        }
+    }
+
+    pub fn take_solved(&mut self) -> Vec<u32> {
+        mem::take(&mut self.solved)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &UnificationEntry> {
@@ -355,5 +366,27 @@ impl CheckState {
 
     pub fn allocate_wildcard(&mut self, t: TypeId) -> PatternId {
         self.allocate_pattern(PatternKind::Wildcard, t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::{Depth, TypeId, Unifications};
+
+    fn type_id(id: u32) -> TypeId {
+        TypeId::new(NonZeroU32::new(id).unwrap())
+    }
+
+    #[test]
+    fn solved_notifications_only_report_transitions() {
+        let mut unifications = Unifications::default();
+        let id = unifications.fresh(Depth(0), type_id(1));
+
+        unifications.solve(id, type_id(2));
+        unifications.solve(id, type_id(3));
+
+        assert_eq!(unifications.take_solved(), [id]);
     }
 }


### PR DESCRIPTION
## Summary

Replace global constraint wake-up scans with event-directed wait lists keyed by unification variables that actually transition from unsolved to solved.

The previous solver called `wake_constraints` after any successful unification attempt. Each call scanned every stuck key to discover solved variables and, after finding one, re-filtered every remaining stuck entry to remove duplicate registrations. Successful equality checks could therefore trigger wake scans even when no unification variable changed.

The new implementation:

- records only `Unsolved -> Solved` transitions in unification state;
- probes only wait lists for those solved IDs;
- maintains a reverse constraint-to-blockers index for targeted removal;
- removes all registrations before requeueing an awakened constraint;
- retains improving-constraint priority and deterministic first-registration wake order;
- preserves the previous residual traversal order; and
- exposes opt-in counters with `ALEXANDRITE_PROFILE_CONSTRAINT_WAKE=1`.

## Measurements

Benchmarks used the existing single-core compatibility benchmark in quick mode with wake instrumentation enabled:

```console
ALEXANDRITE_PROFILE_CONSTRAINT_WAKE=1 \
  cargo bench -p tests-compatibility --bench checking_single_core -- check-core --quick
```

### Non-empty 59-package core corpus

| | Before | After |
|---|---:|---:|
| Criterion interval | 606.89–629.61 ms | 566.26–580.82 ms |
| Median estimate | 611.43 ms | 577.91 ms |
| Aggregate wake calls across samples | 21,090 | 765 |

The median estimate improved by 5.5%, while wake calls fell by 96.4%. The final run examined 987 actual solved-ID events and performed no stuck-entry scans because this corpus did not subsequently solve the blockers of its stuck constraints.

### Non-empty 633-package acme corpus

The final quick run measured 13.671–13.744 s (13.686 s median). Across its Criterion samples, instrumentation recorded:

- 96,930 wake calls;
- 188,268 solved IDs/key probes;
- 5,145 targeted stuck entries scanned;
- 2,928 awakened constraints;
- zero duplicate registrations; and
- a maximum per-solve peak stuck size of 38 entries.

There is no valid pre-change acme timing because that corpus had not yet been downloaded when the baseline was captured, so this result is reported as an exercised large-corpus profile rather than a claimed speedup.

### Synthetic many-blocker fixture

The focused 1,000-blocker test solves independent blockers one at a time. For that schedule, the old global algorithm examines 500,500 stuck keys and re-filters 499,500 remaining entries. The new measured counters are:

- 1,000 wake calls;
- 1,000 solved IDs/key probes;
- 1,000 stuck entries scanned;
- 1,000 awakened constraints;
- zero duplicate registrations; and
- peak stuck size 1,000.

That reduces combined key/entry examination from 1,000,000 to 2,000 (99.8%). A second fixture verifies that a constraint registered on multiple blockers is requeued exactly once and that registration order is preserved.

## Preserved invariants

- Improving constraints remain prioritized by the unchanged `Work::pop_next` path.
- Each awakened constraint is enqueued once even when several blockers solve together.
- Awakened constraints use deterministic first-registration order.
- Reverse registrations are removed before requeue, preventing stale future wakeups.
- Skolem retries occur only after a real solve transition; path compression does not emit false events.
- Residual and diagnostic ordering remains unchanged.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking` — 25/25 passed
- focused nextest coverage for the 1,000-blocker schedule, multi-blocker single-requeue ordering, and transition-only notifications
- `just t checking` — all checking fixtures passed with no pending snapshots
- focused checking fixtures `1772440440`, `1772440500`, `1778051580`, `1779694800`, and `1781629500`
- `git diff --check`