### PR TITLE
[checking] Implement evidence graph

### DIFF
--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -115,6 +115,14 @@ pub struct CheckedSynonym {
 /// ```
 ///
 /// [`CheckedModule::terms`]: crate::CheckedModule::terms
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckedSuperclass {
+    /// Stable source identity of this occurrence in the defining file.
+    pub source_id: lowering::TypeId,
+    /// Constraint expressed in terms of the class head's rigids.
+    pub constraint: TypeId,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedClass {
     /// Post-generalisation kind variable binders.
@@ -123,8 +131,8 @@ pub struct CheckedClass {
     pub type_parameters: Vec<ForallBinderId>,
     /// Canonical class head, e.g. `Eq a` or `Foo @k a`.
     pub canonical: TypeId,
-    /// Superclass constraints expressed in terms of the class head's rigids.
-    pub superclasses: Vec<TypeId>,
+    /// Superclass occurrences from the class declaration.
+    pub superclasses: Vec<CheckedSuperclass>,
     /// Functional dependencies.
     pub functional_dependencies: Arc<[fd::Fd]>,
     /// Class member term item IDs.

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -256,27 +256,43 @@ where
 
         let given = constraint.key.given.iter().copied();
         match compiler::match_compiler_instance(state, context, constraint.key.wanted, given)? {
-            Some(matching::MatchInstance::Match { unifications, constraints }) => {
-                if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
-                    state.checked.evidence.mark_error(constraint.evidence.wanted);
-                } else {
-                    let evidence = compiler::evidence_for_solved_constraint(
-                        state,
-                        context,
-                        constraint.key.wanted,
-                    )?;
+            Some(compiler::CompilerMatch::Match { unifications, constraints, resolution }) => {
+                let solve_with_evidence = |state: &mut CheckState, evidence: Evidence| {
                     let evidence = state.checked.evidence.allocate(evidence);
                     state.checked.evidence.solve(constraint.evidence.wanted, evidence);
+                };
+
+                match resolution {
+                    compiler::CompilerResolution::Trivial => {
+                        solve_with_evidence(state, Evidence::Trivial);
+                    }
+                    compiler::CompilerResolution::Synthesized => {
+                        let evidence = compiler::synthesized_evidence_for_constraint(
+                            state,
+                            context,
+                            constraint.key.wanted,
+                        )?;
+                        solve_with_evidence(state, Evidence::Synthesized(evidence));
+                    }
+                    compiler::CompilerResolution::Warning { message_id } => {
+                        state.insert_error(ErrorKind::CustomWarning { message_id });
+                        solve_with_evidence(state, Evidence::Trivial);
+                    }
+                    compiler::CompilerResolution::Failure { message_id } => {
+                        state.insert_error(ErrorKind::CustomFailure { message_id });
+                        state.checked.evidence.mark_error(constraint.evidence.wanted);
+                    }
                 }
+
                 let constraints = fresh_scoped_constraints(state, &constraint, constraints);
                 work.extend_from_parts(unifications, constraints);
                 continue 'work;
             }
-            Some(matching::MatchInstance::Stuck { stuck, skolem }) => {
+            Some(compiler::CompilerMatch::Stuck { stuck, skolem }) => {
                 blocked.extend(stuck);
                 blocked_on_skolem |= skolem;
             }
-            Some(matching::MatchInstance::Apart) | None => (),
+            Some(compiler::CompilerMatch::Apart) | None => (),
         }
 
         let search = instances::collect_instance_chains(state, context, constraint.key.wanted)?;

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -18,17 +18,19 @@ use itertools::Itertools;
 
 use std::collections::VecDeque;
 use std::mem;
+use std::num::NonZeroU32;
 use std::rc::Rc;
 
 use building_types::QueryResult;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
 use crate::core::fd::{compute_closure, get_functional_dependencies};
 use crate::core::{KindOrType, TypeId, unification};
 use crate::error::{CheckingError, ErrorKind};
-use crate::implication::{ImplicationId, Patterns};
+use crate::evidence::{Evidence, EvidenceId, EvidenceVarId};
+use crate::implication::{GivenConstraint, ImplicationId, Patterns, WantedConstraint};
 use crate::state::{CheckState, UnificationState};
 use crate::{ExternalQueries, Type};
 
@@ -83,7 +85,7 @@ impl Work {
         Q: ExternalQueries,
     {
         while let Some(constraint) = self.unclassified.pop_front() {
-            if is_improving_constraint(state, context, constraint.wanted)? {
+            if is_improving_constraint(state, context, constraint.key.wanted)? {
                 return Ok(Some(constraint));
             }
 
@@ -95,8 +97,35 @@ impl Work {
 }
 
 type Stuck = FxHashMap<u32, Vec<ConstraintInScope>>;
-type ConstraintSet = IndexSet<ConstraintInScope, FxBuildHasher>;
+type ConstraintSet = IndexMap<ConstraintKey, ConstraintEvidence, FxBuildHasher>;
 type Skolem = Vec<ConstraintInScope>;
+
+fn fresh_scoped_constraints(
+    state: &mut CheckState,
+    parent: &ConstraintInScope,
+    constraints: Vec<CanonicalConstraintId>,
+) -> Vec<ConstraintInScope> {
+    let constraints = constraints.into_iter().map(|wanted| {
+        let wanted_evidence = state.checked.evidence.fresh_variable();
+        let given = Rc::clone(&parent.key.given);
+        let given_evidence = Rc::clone(&parent.evidence.given);
+        ConstraintInScope::new(parent.key.scope, given, wanted, given_evidence, wanted_evidence)
+    });
+    constraints.collect()
+}
+
+fn insert_unique_constraint(
+    state: &mut CheckState,
+    constraints: &mut ConstraintSet,
+    constraint: ConstraintInScope,
+) {
+    let ConstraintInScope { key, evidence } = constraint;
+    if let Some(existing) = constraints.get(&key) {
+        state.checked.evidence.merge_duplicate(evidence.wanted, existing.wanted);
+    } else {
+        constraints.insert(key, evidence);
+    }
+}
 
 fn is_improving_constraint<Q>(
     state: &mut CheckState,
@@ -140,12 +169,14 @@ where
     Ok(false)
 }
 
-fn wake_constraints(work: &mut Work, stuck: &mut Stuck, state: &CheckState) {
+fn wake_constraints(work: &mut Work, stuck: &mut Stuck, state: &mut CheckState) {
     let mut awake = ConstraintSet::default();
 
     stuck.retain(|&id, constraints| {
         if let UnificationState::Solved(_) = state.unifications.get(id).state {
-            awake.extend(constraints.iter().cloned());
+            for constraint in constraints.iter().cloned() {
+                insert_unique_constraint(state, &mut awake, constraint);
+            }
             false
         } else {
             true
@@ -159,12 +190,20 @@ fn wake_constraints(work: &mut Work, stuck: &mut Stuck, state: &CheckState) {
     // For each constraint in the constraint set;
     for constraints in stuck.values_mut() {
         // keep only the constraints that are not awake;
-        constraints.retain(|constraint| !awake.contains(constraint));
+        constraints.retain(|constraint| {
+            if let Some(existing) = awake.get(&constraint.key) {
+                state.checked.evidence.merge_duplicate(constraint.evidence.wanted, existing.wanted);
+                false
+            } else {
+                true
+            }
+        });
     }
 
     // and keep only the non-empty constraint sets.
     stuck.retain(|_, constraints| !constraints.is_empty());
 
+    let awake = awake.into_iter().map(ConstraintInScope::from_parts);
     work.extend_constraints(awake);
 }
 
@@ -199,13 +238,11 @@ where
         let mut blocked = FxHashSet::default();
         let mut blocked_on_skolem = false;
 
-        for &provided in &*constraint.given {
-            match matching::match_provided(state, context, constraint.wanted, provided)? {
+        for (provided, provided_evidence) in constraint.given() {
+            match matching::match_provided(state, context, constraint.key.wanted, provided)? {
                 matching::MatchInstance::Match { unifications, constraints } => {
-                    let constraints = constraints.into_iter().map(|wanted| {
-                        let given = Rc::clone(&constraint.given);
-                        ConstraintInScope { given, wanted }
-                    });
+                    state.checked.evidence.solve(constraint.evidence.wanted, provided_evidence);
+                    let constraints = fresh_scoped_constraints(state, &constraint, constraints);
                     work.extend_from_parts(unifications, constraints);
                     continue 'work;
                 }
@@ -217,17 +254,21 @@ where
             }
         }
 
-        match compiler::match_compiler_instance(
-            state,
-            context,
-            constraint.wanted,
-            &constraint.given,
-        )? {
+        let given = constraint.key.given.iter().copied();
+        match compiler::match_compiler_instance(state, context, constraint.key.wanted, given)? {
             Some(matching::MatchInstance::Match { unifications, constraints }) => {
-                let constraints = constraints.into_iter().map(|wanted| {
-                    let given = Rc::clone(&constraint.given);
-                    ConstraintInScope { given, wanted }
-                });
+                if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
+                    state.checked.evidence.mark_error(constraint.evidence.wanted);
+                } else {
+                    let evidence = compiler::evidence_for_solved_constraint(
+                        state,
+                        context,
+                        constraint.key.wanted,
+                    )?;
+                    let evidence = state.checked.evidence.allocate(evidence);
+                    state.checked.evidence.solve(constraint.evidence.wanted, evidence);
+                }
+                let constraints = fresh_scoped_constraints(state, &constraint, constraints);
                 work.extend_from_parts(unifications, constraints);
                 continue 'work;
             }
@@ -238,15 +279,21 @@ where
             Some(matching::MatchInstance::Apart) | None => (),
         }
 
-        let search = instances::collect_instance_chains(state, context, constraint.wanted)?;
+        let search = instances::collect_instance_chains(state, context, constraint.key.wanted)?;
         'chain: for chain in search.chains {
             for candidate in chain {
-                match matching::match_declared(state, context, constraint.wanted, candidate)? {
+                match matching::match_declared(state, context, constraint.key.wanted, candidate)? {
                     matching::MatchInstance::Match { unifications, constraints } => {
-                        let constraints = constraints.into_iter().map(|wanted| {
-                            let given = Rc::clone(&constraint.given);
-                            ConstraintInScope { given, wanted }
-                        });
+                        let constraints = fresh_scoped_constraints(state, &constraint, constraints);
+                        let subgoals = constraints
+                            .iter()
+                            .map(|constraint| constraint.evidence.wanted)
+                            .collect();
+                        let evidence = state
+                            .checked
+                            .evidence
+                            .allocate(Evidence::Instance { origin: candidate.origin, subgoals });
+                        state.checked.evidence.solve(constraint.evidence.wanted, evidence);
                         work.extend_from_parts(unifications, constraints);
                         continue 'work;
                     }
@@ -279,14 +326,21 @@ where
     }
 
     let mut unique_residuals = ConstraintSet::default();
-    unique_residuals.extend(residuals);
+    for residual in residuals {
+        insert_unique_constraint(state, &mut unique_residuals, residual);
+    }
 
     for (_, constraints) in stuck {
-        unique_residuals.extend(constraints);
+        for constraint in constraints {
+            insert_unique_constraint(state, &mut unique_residuals, constraint);
+        }
     }
-    unique_residuals.extend(skolem);
+    for constraint in skolem {
+        insert_unique_constraint(state, &mut unique_residuals, constraint);
+    }
 
-    Ok(unique_residuals.into_iter().collect())
+    let unique_residuals = unique_residuals.into_iter().map(ConstraintInScope::from_parts);
+    Ok(unique_residuals.collect())
 }
 
 pub fn is_type_error<Q>(
@@ -307,16 +361,44 @@ where
             || canonical.type_id == context.prim_type_error.fail))
 }
 
-#[derive(Default, Clone)]
-struct GivenInScope {
-    constraints: Vec<CanonicalConstraintId>,
+#[derive(Clone)]
+struct EvidenceInScope {
+    constraints: Vec<(CanonicalConstraintId, EvidenceId)>,
     seen: IndexSet<CanonicalConstraintId, FxBuildHasher>,
+    evidence_scope: Option<NonZeroU32>,
 }
 
-impl GivenInScope {
-    fn insert(&mut self, constraint: CanonicalConstraintId) {
+impl EvidenceInScope {
+    fn new(root: ImplicationId) -> EvidenceInScope {
+        let mut evidence = EvidenceInScope {
+            constraints: vec![],
+            seen: IndexSet::default(),
+            evidence_scope: None,
+        };
+        evidence.assign_scope(root);
+        evidence
+    }
+
+    fn assign_scope(&mut self, scope: ImplicationId) {
+        let scope = scope
+            .checked_add(1)
+            .and_then(NonZeroU32::new)
+            .expect("invariant violated: evidence scope overflow");
+        self.evidence_scope = Some(scope);
+    }
+
+    fn scope(&self) -> ImplicationId {
+        let scope = self.evidence_scope.expect("invariant violated: evidence scope not assigned");
+        scope.get() - 1
+    }
+
+    fn insert(&mut self, constraint: CanonicalConstraintId, evidence: EvidenceId) {
         if self.seen.insert(constraint) {
-            self.constraints.push(constraint);
+            self.constraints.push((constraint, evidence));
+        } else if let Some((_, current)) =
+            self.constraints.iter_mut().find(|(given, _)| *given == constraint)
+        {
+            *current = evidence;
         }
     }
 
@@ -326,12 +408,60 @@ impl GivenInScope {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct ConstraintInScope {
+pub struct ConstraintKey {
+    pub scope: ImplicationId,
     pub given: Rc<[CanonicalConstraintId]>,
     pub wanted: CanonicalConstraintId,
 }
 
+#[derive(Clone)]
+pub struct ConstraintEvidence {
+    pub given: Rc<[EvidenceId]>,
+    pub wanted: EvidenceVarId,
+}
+
+#[derive(Clone)]
+pub struct ConstraintInScope {
+    pub key: ConstraintKey,
+    pub evidence: ConstraintEvidence,
+}
+
 impl ConstraintInScope {
+    fn new(
+        scope: ImplicationId,
+        given: Rc<[CanonicalConstraintId]>,
+        wanted: CanonicalConstraintId,
+        given_evidence: Rc<[EvidenceId]>,
+        wanted_evidence: EvidenceVarId,
+    ) -> ConstraintInScope {
+        assert_eq!(
+            given.len(),
+            given_evidence.len(),
+            "critical violation: given constraints and evidence must correspond",
+        );
+        let key = ConstraintKey { scope, given, wanted };
+        let evidence = ConstraintEvidence { given: given_evidence, wanted: wanted_evidence };
+        ConstraintInScope { key, evidence }
+    }
+
+    fn from_parts((key, evidence): (ConstraintKey, ConstraintEvidence)) -> ConstraintInScope {
+        assert_eq!(
+            key.given.len(),
+            evidence.given.len(),
+            "critical violation: given constraints and evidence must correspond",
+        );
+        ConstraintInScope { key, evidence }
+    }
+
+    pub fn given(&self) -> impl Iterator<Item = (CanonicalConstraintId, EvidenceId)> + '_ {
+        assert_eq!(
+            self.key.given.len(),
+            self.evidence.given.len(),
+            "critical violation: given constraints and evidence must correspond",
+        );
+        std::iter::zip(self.key.given.iter().copied(), self.evidence.given.iter().copied())
+    }
+
     pub fn zonk<Q>(
         &self,
         state: &mut CheckState,
@@ -340,20 +470,27 @@ impl ConstraintInScope {
     where
         Q: ExternalQueries,
     {
-        let given = self
-            .given
-            .iter()
-            .map(|&given| canonical::zonk_canonical(state, context, given))
-            .collect::<QueryResult<Rc<[_]>>>()?;
-        let wanted = canonical::zonk_canonical(state, context, self.wanted)?;
-        Ok(ConstraintInScope { given, wanted })
+        let given =
+            self.key.given.iter().map(|&given| canonical::zonk_canonical(state, context, given));
+
+        let given = given.collect::<QueryResult<Rc<[_]>>>()?;
+        let wanted = canonical::zonk_canonical(state, context, self.key.wanted)?;
+
+        let given_evidence = Rc::clone(&self.evidence.given);
+        Ok(ConstraintInScope::new(
+            self.key.scope,
+            given,
+            wanted,
+            given_evidence,
+            self.evidence.wanted,
+        ))
     }
 
     pub fn canonical<Q>(&self, state: &CheckState, context: &CheckContext<Q>) -> TypeId
     where
         Q: ExternalQueries,
     {
-        state.canonicals.type_id(context, self.wanted)
+        state.canonicals.type_id(context, self.key.wanted)
     }
 
     pub fn is_partial<Q>(&self, state: &CheckState, context: &CheckContext<Q>) -> bool
@@ -363,7 +500,7 @@ impl ConstraintInScope {
         let Type::Constructor(file_id, type_id) = context.lookup_type(context.prim.partial) else {
             unreachable!("critical violation: Partial is not Partial");
         };
-        let constraint = &state.canonicals[self.wanted];
+        let constraint = &state.canonicals[self.key.wanted];
         constraint.file_id == file_id
             && constraint.type_id == type_id
             && constraint.arguments.is_empty()
@@ -381,9 +518,9 @@ where
     let partial = canonical::canonicalise(state, context, context.prim.partial)?;
 
     let mut constraints = VecDeque::default();
-    let mut stack = vec![(root, GivenInScope::default())];
+    let mut stack = vec![(root, EvidenceInScope::new(root))];
 
-    while let Some((implication_id, mut implication_given)) = stack.pop() {
+    while let Some((implication_id, mut evidence_in_scope)) = stack.pop() {
         let (given, wanted, children, patterns) = {
             let implication = &mut state.implications[implication_id];
             (
@@ -394,14 +531,25 @@ where
             )
         };
 
-        for given in given {
-            if let Some(given) = canonical::canonicalise(state, context, given)? {
-                implication_given.insert(given);
+        let mut introduced_binders = vec![];
+        for GivenConstraint { constraint, evidence } in given {
+            if let Some(given) = canonical::canonicalise(state, context, constraint)? {
+                introduced_binders.push((given, evidence));
+
+                let canonical = state.canonicals.type_id(context, given);
+                state.checked.evidence.bind_binder(evidence, canonical);
+
+                let proof = state.checked.evidence.allocate(Evidence::Given(evidence));
+                evidence_in_scope.insert(given, proof);
             }
         }
 
+        if !introduced_binders.is_empty() {
+            evidence_in_scope.assign_scope(implication_id);
+        }
+
         let elide_missing_patterns =
-            partial.is_some_and(|partial| implication_given.contains(partial));
+            partial.is_some_and(|partial| evidence_in_scope.contains(partial));
 
         if !elide_missing_patterns {
             for Patterns { patterns, crumbs } in patterns {
@@ -412,16 +560,45 @@ where
 
         if !wanted.is_empty() {
             let elaborate::ElaboratedGiven { given, substitution } =
-                elaborate::elaborate_given(state, context, &implication_given.constraints)?;
+                elaborate::elaborate_given(state, context, &evidence_in_scope.constraints)?;
 
+            for (constraint, binder) in introduced_binders {
+                let constraint =
+                    canonical::substitute_canonical(state, context, &substitution, constraint)?;
+                let canonical = state.canonicals.type_id(context, constraint);
+                state.checked.evidence.bind_binder(binder, canonical);
+            }
+
+            for &(constraint, evidence) in &given {
+                let binder = match &state.checked.evidence[evidence] {
+                    Evidence::Given(binder) => Some(*binder),
+                    _ => None,
+                };
+                if let Some(binder) = binder {
+                    let canonical = state.canonicals.type_id(context, constraint);
+                    state.checked.evidence.bind_binder(binder, canonical);
+                }
+            }
+
+            let (given, given_evidence): (Vec<_>, Vec<_>) = given.into_iter().unzip();
             let given: Rc<[CanonicalConstraintId]> = Rc::from(given);
+            let given_evidence: Rc<[EvidenceId]> = Rc::from(given_evidence);
 
-            for wanted in wanted {
-                if let Some(wanted) = canonical::canonicalise(state, context, wanted)? {
+            for WantedConstraint { constraint, evidence: wanted_evidence } in wanted {
+                if let Some(wanted) = canonical::canonicalise(state, context, constraint)? {
                     let given = Rc::clone(&given);
+                    let given_evidence = Rc::clone(&given_evidence);
                     let wanted =
                         canonical::substitute_canonical(state, context, &substitution, wanted)?;
-                    constraints.push_back(ConstraintInScope { given, wanted });
+                    constraints.push_back(ConstraintInScope::new(
+                        evidence_in_scope.scope(),
+                        given,
+                        wanted,
+                        given_evidence,
+                        wanted_evidence,
+                    ));
+                } else {
+                    state.checked.evidence.mark_error(wanted_evidence);
                 }
             }
         }
@@ -429,7 +606,7 @@ where
         let children = children
             .into_iter()
             .rev()
-            .map(|child| (child, GivenInScope::clone(&implication_given)));
+            .map(|child| (child, EvidenceInScope::clone(&evidence_in_scope)));
 
         stack.extend(children)
     }

--- a/compiler-core/checking/src/core/constraint/compiler.rs
+++ b/compiler-core/checking/src/core/constraint/compiler.rs
@@ -15,6 +15,7 @@ use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::unification::{CanUnify, can_unify};
 use crate::core::{RowField, RowType, Type, TypeId, normalise};
+use crate::evidence::{Evidence, ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
@@ -183,7 +184,7 @@ pub fn match_compiler_instance<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     wanted: CanonicalConstraintId,
-    given: &[CanonicalConstraintId],
+    given: impl IntoIterator<Item = CanonicalConstraintId>,
 ) -> QueryResult<Option<MatchInstance>>
 where
     Q: ExternalQueries,
@@ -306,4 +307,66 @@ where
     };
 
     Ok(match_instance)
+}
+
+pub fn is_compiler_error_constraint<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    constraint: CanonicalConstraintId,
+) -> bool
+where
+    Q: ExternalQueries,
+{
+    let canonical = &state.canonicals[constraint];
+    canonical.file_id == context.prim_type_error.file_id
+        && canonical.type_id == context.prim_type_error.fail
+}
+
+pub fn evidence_for_solved_constraint<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    constraint: CanonicalConstraintId,
+) -> QueryResult<Evidence>
+where
+    Q: ExternalQueries,
+{
+    let canonical = &state.canonicals[constraint];
+    let class = (canonical.file_id, canonical.type_id);
+
+    if context.known_reflectable.is_symbol == Some(class) {
+        let Some([symbol]) = canonical.expect_type_arguments::<1>() else {
+            unreachable!("invariant violated: solved IsSymbol constraint has invalid arguments");
+        };
+        let symbol = extract_symbol(state, context, symbol)?.unwrap_or_else(|| {
+            unreachable!("invariant violated: solved IsSymbol constraint has no symbol")
+        });
+        return Ok(Evidence::Synthesized(SynthesizedEvidence::IsSymbol(symbol)));
+    }
+
+    if context.known_reflectable.reflectable == Some(class) {
+        let Some([value, _]) = canonical.expect_type_arguments::<2>() else {
+            unreachable!("invariant violated: solved Reflectable constraint has invalid arguments");
+        };
+        let value = recursively_normalise(state, context, value)?;
+        let reflected = if let Some(symbol) = extract_symbol(state, context, value)? {
+            ReflectableEvidence::String(symbol)
+        } else if let Some(integer) = extract_integer(state, context, value)? {
+            ReflectableEvidence::Integer(integer)
+        } else if value == context.prim_boolean.true_ {
+            ReflectableEvidence::Boolean(true)
+        } else if value == context.prim_boolean.false_ {
+            ReflectableEvidence::Boolean(false)
+        } else if value == context.prim_ordering.lt {
+            ReflectableEvidence::Ordering(ReflectableOrdering::Less)
+        } else if value == context.prim_ordering.eq {
+            ReflectableEvidence::Ordering(ReflectableOrdering::Equal)
+        } else if value == context.prim_ordering.gt {
+            ReflectableEvidence::Ordering(ReflectableOrdering::Greater)
+        } else {
+            unreachable!("invariant violated: solved Reflectable constraint has no value");
+        };
+        return Ok(Evidence::Synthesized(SynthesizedEvidence::Reflectable(reflected)));
+    }
+
+    Ok(Evidence::Trivial)
 }

--- a/compiler-core/checking/src/core/constraint/compiler.rs
+++ b/compiler-core/checking/src/core/constraint/compiler.rs
@@ -14,13 +14,49 @@ use smol_str::SmolStr;
 use crate::context::CheckContext;
 use crate::core::fold::{FoldAction, TypeFold, fold_type};
 use crate::core::unification::{CanUnify, can_unify};
-use crate::core::{RowField, RowType, Type, TypeId, normalise};
-use crate::evidence::{Evidence, ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence};
+use crate::core::{RowField, RowType, SmolStrId, Type, TypeId, normalise};
+use crate::evidence::{ReflectableEvidence, ReflectableOrdering, SynthesizedEvidence};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
 use super::CanonicalConstraintId;
 use super::matching::MatchInstance;
+
+pub enum CompilerResolution {
+    Trivial,
+    Synthesized,
+    Warning { message_id: SmolStrId },
+    Failure { message_id: SmolStrId },
+}
+
+pub enum CompilerMatch {
+    Match {
+        unifications: Vec<(TypeId, TypeId)>,
+        constraints: Vec<CanonicalConstraintId>,
+        resolution: CompilerResolution,
+    },
+    Apart,
+    Stuck {
+        stuck: Vec<u32>,
+        skolem: bool,
+    },
+}
+
+impl CompilerMatch {
+    fn from_instance(instance: MatchInstance, resolution: CompilerResolution) -> CompilerMatch {
+        match instance {
+            MatchInstance::Match { unifications, constraints } => {
+                CompilerMatch::Match { unifications, constraints, resolution }
+            }
+            MatchInstance::Apart => CompilerMatch::Apart,
+            MatchInstance::Stuck { stuck, skolem } => CompilerMatch::Stuck { stuck, skolem },
+        }
+    }
+
+    fn resolved(resolution: CompilerResolution) -> CompilerMatch {
+        CompilerMatch::Match { unifications: vec![], constraints: vec![], resolution }
+    }
+}
 
 #[derive(Clone)]
 pub enum RowView {
@@ -185,13 +221,29 @@ pub fn match_compiler_instance<Q>(
     context: &CheckContext<Q>,
     wanted: CanonicalConstraintId,
     given: impl IntoIterator<Item = CanonicalConstraintId>,
-) -> QueryResult<Option<MatchInstance>>
+) -> QueryResult<Option<CompilerMatch>>
 where
     Q: ExternalQueries,
 {
     let canonical = &state.canonicals[wanted];
     let file_id = canonical.file_id;
     let item_id = canonical.type_id;
+
+    if file_id == context.prim_type_error.file_id {
+        if item_id == context.prim_type_error.warn {
+            let Some(arguments) = canonical.expect_type_arguments::<1>() else {
+                return Ok(None);
+            };
+            return prim_type_error::match_warn(state, context, &arguments);
+        } else if item_id == context.prim_type_error.fail {
+            let Some(arguments) = canonical.expect_type_arguments::<1>() else {
+                return Ok(None);
+            };
+            return prim_type_error::match_fail(state, context, &arguments);
+        } else {
+            return Ok(None);
+        }
+    }
 
     let match_instance = if file_id == context.prim_int.file_id {
         if item_id == context.prim_int.add {
@@ -278,20 +330,6 @@ where
         } else {
             None
         }
-    } else if file_id == context.prim_type_error.file_id {
-        if item_id == context.prim_type_error.warn {
-            let Some(arguments) = canonical.expect_type_arguments::<1>() else {
-                return Ok(None);
-            };
-            prim_type_error::match_warn(state, context, &arguments)?
-        } else if item_id == context.prim_type_error.fail {
-            let Some(arguments) = canonical.expect_type_arguments::<1>() else {
-                return Ok(None);
-            };
-            prim_type_error::match_fail(state, context, &arguments)?
-        } else {
-            None
-        }
     } else if context.known_reflectable.is_symbol == Some((file_id, item_id)) {
         let Some(arguments) = canonical.expect_type_arguments::<1>() else {
             return Ok(None);
@@ -306,10 +344,20 @@ where
         None
     };
 
+    let resolution = if context.known_reflectable.is_symbol == Some((file_id, item_id))
+        || context.known_reflectable.reflectable == Some((file_id, item_id))
+    {
+        CompilerResolution::Synthesized
+    } else {
+        CompilerResolution::Trivial
+    };
+
+    let match_instance =
+        match_instance.map(|instance| CompilerMatch::from_instance(instance, resolution));
     Ok(match_instance)
 }
 
-pub fn is_compiler_error_constraint<Q>(
+pub fn is_fail_constraint<Q>(
     state: &CheckState,
     context: &CheckContext<Q>,
     constraint: CanonicalConstraintId,
@@ -322,11 +370,11 @@ where
         && canonical.type_id == context.prim_type_error.fail
 }
 
-pub fn evidence_for_solved_constraint<Q>(
+pub fn synthesized_evidence_for_constraint<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     constraint: CanonicalConstraintId,
-) -> QueryResult<Evidence>
+) -> QueryResult<SynthesizedEvidence>
 where
     Q: ExternalQueries,
 {
@@ -340,7 +388,7 @@ where
         let symbol = extract_symbol(state, context, symbol)?.unwrap_or_else(|| {
             unreachable!("invariant violated: solved IsSymbol constraint has no symbol")
         });
-        return Ok(Evidence::Synthesized(SynthesizedEvidence::IsSymbol(symbol)));
+        return Ok(SynthesizedEvidence::IsSymbol(symbol));
     }
 
     if context.known_reflectable.reflectable == Some(class) {
@@ -365,8 +413,8 @@ where
         } else {
             unreachable!("invariant violated: solved Reflectable constraint has no value");
         };
-        return Ok(Evidence::Synthesized(SynthesizedEvidence::Reflectable(reflected)));
+        return Ok(SynthesizedEvidence::Reflectable(reflected));
     }
 
-    Ok(Evidence::Trivial)
+    unreachable!("invariant violated: compiler constraint does not synthesize evidence")
 }

--- a/compiler-core/checking/src/core/constraint/compiler/prim_int.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_int.rs
@@ -75,7 +75,7 @@ pub fn match_compare<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     arguments: &[TypeId],
-    given: &[CanonicalConstraintId],
+    given: impl IntoIterator<Item = CanonicalConstraintId>,
 ) -> QueryResult<Option<MatchInstance>>
 where
     Q: ExternalQueries,
@@ -114,14 +114,14 @@ fn match_compare_transitive<Q>(
     left: TypeId,
     right: TypeId,
     ordering: TypeId,
-    given: &[CanonicalConstraintId],
+    given: impl IntoIterator<Item = CanonicalConstraintId>,
 ) -> QueryResult<Option<MatchInstance>>
 where
     Q: ExternalQueries,
 {
     let mut graph: DiGraphMap<TypeId, ()> = DiGraphMap::new();
 
-    for &constraint in given {
+    for constraint in given {
         let constraint = &state.canonicals[constraint];
         if constraint.file_id != context.prim_int.file_id
             || constraint.type_id != context.prim_int.compare

--- a/compiler-core/checking/src/core/constraint/compiler/prim_type_error.rs
+++ b/compiler-core/checking/src/core/constraint/compiler/prim_type_error.rs
@@ -4,11 +4,12 @@ use smol_str::{SmolStr, format_smolstr};
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::constraint::matching::{self, MatchInstance};
+use crate::core::constraint::matching;
 use crate::core::pretty::Pretty;
 use crate::core::{Type, TypeId, normalise, toolkit, zonk};
-use crate::error::ErrorKind;
 use crate::state::CheckState;
+
+use super::{CompilerMatch, CompilerResolution};
 
 fn first_blocking_unification<Q>(
     state: &mut CheckState,
@@ -155,7 +156,7 @@ pub fn match_warn<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     arguments: &[TypeId],
-) -> QueryResult<Option<MatchInstance>>
+) -> QueryResult<Option<CompilerMatch>>
 where
     Q: ExternalQueries,
 {
@@ -163,24 +164,23 @@ where
 
     let message = match render_doc(state, context, doc) {
         Ok(Some(message)) => message,
-        Ok(None) => return Ok(Some(MatchInstance::Stuck { stuck: vec![], skolem: false })),
+        Ok(None) => return Ok(Some(CompilerMatch::Stuck { stuck: vec![], skolem: false })),
         Err(RenderStuck::Blocked(u)) => {
-            return Ok(Some(MatchInstance::Stuck { stuck: vec![u], skolem: false }));
+            return Ok(Some(CompilerMatch::Stuck { stuck: vec![u], skolem: false }));
         }
         Err(RenderStuck::Query(cycle)) => return Err(cycle),
     };
 
     let message_id = context.queries.intern_smol_str(message);
-    state.insert_error(ErrorKind::CustomWarning { message_id });
-
-    Ok(Some(MatchInstance::empty()))
+    let resolution = CompilerResolution::Warning { message_id };
+    Ok(Some(CompilerMatch::resolved(resolution)))
 }
 
 pub fn match_fail<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     arguments: &[TypeId],
-) -> QueryResult<Option<MatchInstance>>
+) -> QueryResult<Option<CompilerMatch>>
 where
     Q: ExternalQueries,
 {
@@ -188,15 +188,14 @@ where
 
     let message = match render_doc(state, context, doc) {
         Ok(Some(message)) => message,
-        Ok(None) => return Ok(Some(MatchInstance::Stuck { stuck: vec![], skolem: false })),
+        Ok(None) => return Ok(Some(CompilerMatch::Stuck { stuck: vec![], skolem: false })),
         Err(RenderStuck::Blocked(u)) => {
-            return Ok(Some(MatchInstance::Stuck { stuck: vec![u], skolem: false }));
+            return Ok(Some(CompilerMatch::Stuck { stuck: vec![u], skolem: false }));
         }
         Err(RenderStuck::Query(cycle)) => return Err(cycle),
     };
 
     let message_id = context.queries.intern_smol_str(message);
-    state.insert_error(ErrorKind::CustomFailure { message_id });
-
-    Ok(Some(MatchInstance::empty()))
+    let resolution = CompilerResolution::Failure { message_id };
+    Ok(Some(CompilerMatch::resolved(resolution)))
 }

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 
 use building_types::QueryResult;
 use itertools::Itertools;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
 use crate::core::constraint::canonical::CanonicalConstraint;
@@ -14,11 +14,12 @@ use crate::core::constraint::matching::MatchInstance;
 use crate::core::constraint::{CanonicalConstraintId, canonical, compiler};
 use crate::core::substitute::{NameToType, SubstituteName};
 use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit};
+use crate::evidence::{Evidence, EvidenceId, Evidences, SuperclassId};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
 pub struct ElaboratedGiven {
-    pub given: Vec<CanonicalConstraintId>,
+    pub given: Vec<(CanonicalConstraintId, EvidenceId)>,
     pub substitution: NameToType,
 }
 
@@ -26,15 +27,53 @@ pub struct ElaboratedGiven {
 pub fn elaborate_given<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    given: &[CanonicalConstraintId],
+    given: &[(CanonicalConstraintId, EvidenceId)],
 ) -> QueryResult<ElaboratedGiven>
 where
     Q: ExternalQueries,
 {
-    let given = elaborate_superclasses(state, context, given)?;
+    let given = elaborate_superclasses_with_evidence(state, context, given)?;
     let given = elaborate_coercible(state, context, given);
     let (given, substitution) = extract_compiler_solved(state, context, given)?;
     Ok(ElaboratedGiven { given, substitution })
+}
+
+/// Elaborates superclasses while retaining the dictionary projection path.
+pub fn elaborate_superclasses_with_evidence<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    given: &[(CanonicalConstraintId, EvidenceId)],
+) -> QueryResult<Vec<(CanonicalConstraintId, EvidenceId)>>
+where
+    Q: ExternalQueries,
+{
+    let mut elaborated = Vec::with_capacity(given.len());
+    let mut seen = FxHashSet::default();
+
+    for &(constraint, evidence) in given {
+        if seen.insert(constraint) {
+            elaborated.push((constraint, evidence));
+        }
+    }
+
+    let constraints = elaborated.iter().map(|&(constraint, _)| constraint);
+    let constraints = constraints.collect_vec();
+    let edges = superclass_edges(state, context, &constraints)?;
+
+    let evidence_by_constraint = elaborated.iter().copied();
+    let mut evidence_by_constraint = evidence_by_constraint.collect::<FxHashMap<_, _>>();
+
+    for edge in edges {
+        let parent = evidence_by_constraint[&edge.parent];
+
+        let evidence = Evidence::Superclass { parent, superclass: edge.superclass_id };
+        let projection = state.checked.evidence.allocate(evidence);
+
+        evidence_by_constraint.insert(edge.child, projection);
+        elaborated.push((edge.child, projection));
+    }
+
+    Ok(elaborated)
 }
 
 /// Elaborates superclasses from a given [`CanonicalConstraint`].
@@ -47,66 +86,73 @@ where
     Q: ExternalQueries,
 {
     let mut elaborated = Vec::with_capacity(given.len());
-    let mut pending = VecDeque::with_capacity(given.len());
     let mut seen = FxHashSet::default();
 
     for &given in given {
         if seen.insert(given) {
             elaborated.push(given);
-            pending.push_back(given);
         }
     }
 
-    while let Some(constraint) = pending.pop_front() {
-        elaborate_via_superclass(
-            state,
-            context,
-            constraint,
-            &mut elaborated,
-            &mut pending,
-            &mut seen,
-        )?;
-    }
+    let edges = superclass_edges(state, context, &elaborated)?;
+    let superclasses = edges.into_iter().map(|edge| edge.child);
+    elaborated.extend(superclasses);
 
     Ok(elaborated)
 }
 
-fn elaborate_via_superclass<Q>(
+struct SuperclassEdge {
+    parent: CanonicalConstraintId,
+    child: CanonicalConstraintId,
+    superclass_id: SuperclassId,
+}
+
+fn superclass_edges<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    constraint: CanonicalConstraintId,
-    constraints: &mut Vec<CanonicalConstraintId>,
-    pending: &mut VecDeque<CanonicalConstraintId>,
-    seen: &mut FxHashSet<CanonicalConstraintId>,
-) -> QueryResult<()>
+    roots: &[CanonicalConstraintId],
+) -> QueryResult<Vec<SuperclassEdge>>
 where
     Q: ExternalQueries,
 {
-    let CanonicalConstraint { file_id, type_id, .. } = state.canonicals[constraint];
-    let Some(class) = toolkit::lookup_file_class(state, context, file_id, type_id)? else {
-        return Ok(());
-    };
+    let mut edges = vec![];
+    let mut pending = VecDeque::with_capacity(roots.len());
+    let mut seen = FxHashSet::default();
 
-    if class.superclasses.is_empty() {
-        return Ok(());
-    }
-
-    let CanonicalConstraint { arguments, .. } = &state.canonicals[constraint];
-    let Some(substitutions) = superclass_substitutions(context, &class, arguments)? else {
-        return Ok(());
-    };
-
-    for superclass in class.superclasses {
-        let superclass = SubstituteName::many(state, context, &substitutions, superclass)?;
-        if let Some(superclass) = canonical::canonicalise(state, context, superclass)?
-            && seen.insert(superclass)
-        {
-            constraints.push(superclass);
-            pending.push_back(superclass);
+    for &root in roots {
+        if seen.insert(root) {
+            pending.push_back(root);
         }
     }
 
-    Ok(())
+    while let Some(parent) = pending.pop_front() {
+        let CanonicalConstraint { file_id, type_id, .. } = state.canonicals[parent];
+        let Some(class) = toolkit::lookup_file_class(state, context, file_id, type_id)? else {
+            continue;
+        };
+
+        if class.superclasses.is_empty() {
+            continue;
+        }
+
+        let CanonicalConstraint { arguments, .. } = &state.canonicals[parent];
+        let Some(substitutions) = superclass_substitutions(context, &class, arguments)? else {
+            continue;
+        };
+
+        for crate::core::CheckedSuperclass { source_id, constraint } in class.superclasses {
+            let child = SubstituteName::many(state, context, &substitutions, constraint)?;
+            if let Some(child) = canonical::canonicalise(state, context, child)?
+                && seen.insert(child)
+            {
+                let superclass_id = SuperclassId { file_id, type_id, source_id };
+                edges.push(SuperclassEdge { parent, child, superclass_id });
+                pending.push_back(child);
+            }
+        }
+    }
+
+    Ok(edges)
 }
 
 fn superclass_substitutions<Q>(
@@ -147,13 +193,16 @@ where
 pub fn elaborate_coercible<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    mut given: Vec<CanonicalConstraintId>,
-) -> Vec<CanonicalConstraintId>
+    mut given: Vec<(CanonicalConstraintId, EvidenceId)>,
+) -> Vec<(CanonicalConstraintId, EvidenceId)>
 where
     Q: ExternalQueries,
 {
-    let symmetric = given.iter().filter_map(|given| {
-        let CanonicalConstraint { file_id, type_id, ref arguments } = state.canonicals[*given];
+    let constraints = given.iter().map(|&(constraint, _)| constraint);
+    let mut seen: FxHashSet<_> = constraints.collect();
+
+    let symmetric = given.iter().filter_map(|&(given, _)| {
+        let CanonicalConstraint { file_id, type_id, ref arguments } = state.canonicals[given];
 
         if (file_id, type_id) != (context.prim_coerce.file_id, context.prim_coerce.coercible) {
             return None;
@@ -166,7 +215,15 @@ where
         };
 
         let arguments = [kind, right, left].into();
-        Some(state.canonicals.intern(CanonicalConstraint { file_id, type_id, arguments }))
+        let constraint =
+            state.canonicals.intern(CanonicalConstraint { file_id, type_id, arguments });
+
+        if !seen.insert(constraint) {
+            return None;
+        }
+
+        let evidence = state.checked.evidence.allocate(Evidence::Trivial);
+        Some((constraint, evidence))
     });
 
     let symmetric = symmetric.collect_vec();
@@ -178,20 +235,32 @@ where
 fn extract_compiler_solved<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    given: Vec<CanonicalConstraintId>,
-) -> QueryResult<(Vec<CanonicalConstraintId>, NameToType)>
+    given: Vec<(CanonicalConstraintId, EvidenceId)>,
+) -> QueryResult<(Vec<(CanonicalConstraintId, EvidenceId)>, NameToType)>
 where
     Q: ExternalQueries,
 {
     let mut substitution = NameToType::default();
     let mut conflicts = FxHashSet::default();
 
-    safe_loop! {
-        let given = canonical::substitute_canonicals(state, context, &substitution, &given)?;
+    loop {
+        let given = given.iter().map(|&(constraint, evidence)| {
+            let constraint =
+                canonical::substitute_canonical(state, context, &substitution, constraint)?;
+            Ok((constraint, evidence))
+        });
+
+        let given_evidence = given.collect::<QueryResult<Vec<_>>>()?;
+
+        let given_evidence =
+            retain_innermost_given_evidence(&state.checked.evidence, given_evidence);
+
         let mut changed = false;
 
-        for &constraint in &given {
-            let Some(matched) = compiler::match_compiler_instance(state, context, constraint, &given)?
+        for &(constraint, _) in &given_evidence {
+            let given_constraints = given_evidence.iter().map(|&(constraint, _)| constraint);
+            let Some(matched) =
+                compiler::match_compiler_instance(state, context, constraint, given_constraints)?
             else {
                 continue;
             };
@@ -201,7 +270,8 @@ where
             };
 
             for (left, right) in unifications {
-                let improvements = extract_improvements(state, context, &substitution, left, right)?;
+                let improvements =
+                    extract_improvements(state, context, &substitution, left, right)?;
                 for (name, replacement) in improvements {
                     if register_improvement(
                         state,
@@ -218,9 +288,34 @@ where
         }
 
         if !changed {
-            return Ok((given, substitution));
+            return Ok((given_evidence, substitution));
         }
     }
+}
+
+fn retain_innermost_given_evidence(
+    evidences: &Evidences,
+    given: Vec<(CanonicalConstraintId, EvidenceId)>,
+) -> Vec<(CanonicalConstraintId, EvidenceId)> {
+    let mut retained = Vec::with_capacity(given.len());
+    for (constraint, evidence) in given {
+        if let Some((_, retained_evidence)) =
+            retained.iter_mut().find(|(retained, _)| *retained == constraint)
+        {
+            let retained_status = &evidences[*retained_evidence];
+            let replacement_status = &evidences[evidence];
+
+            let retained_is_trivial = matches!(retained_status, Evidence::Trivial);
+            let replacement_is_trivial = matches!(replacement_status, Evidence::Trivial);
+
+            if retained_is_trivial || !replacement_is_trivial {
+                *retained_evidence = evidence;
+            }
+        } else {
+            retained.push((constraint, evidence));
+        }
+    }
+    retained
 }
 
 fn extract_improvements<Q>(
@@ -313,5 +408,46 @@ where
             return Ok(type_id);
         }
         type_id = substituted;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use interner::Id;
+
+    use super::retain_innermost_given_evidence;
+    use crate::core::constraint::canonical::CanonicalConstraint;
+    use crate::evidence::{Evidence, EvidenceBinderId, Evidences};
+
+    #[test]
+    fn deduplicated_givens_retain_innermost_evidence() {
+        let first = Id::<CanonicalConstraint>::new(NonZeroU32::new(1).unwrap());
+        let second = Id::<CanonicalConstraint>::new(NonZeroU32::new(2).unwrap());
+
+        let mut evidences = Evidences::default();
+        let outer = evidences.allocate(Evidence::Given(EvidenceBinderId(0)));
+        let unrelated = evidences.allocate(Evidence::Given(EvidenceBinderId(1)));
+        let inner = evidences.allocate(Evidence::Given(EvidenceBinderId(2)));
+
+        let given = vec![(first, outer), (second, unrelated), (first, inner)];
+        let retained = retain_innermost_given_evidence(&evidences, given);
+
+        assert_eq!(retained, vec![(first, inner), (second, unrelated)]);
+    }
+
+    #[test]
+    fn symmetric_coercible_evidence_does_not_replace_explicit_given() {
+        let constraint = Id::<CanonicalConstraint>::new(NonZeroU32::new(1).unwrap());
+
+        let mut evidences = Evidences::default();
+        let explicit = evidences.allocate(Evidence::Given(EvidenceBinderId(0)));
+        let generated = evidences.allocate(Evidence::Trivial);
+
+        let given = vec![(constraint, explicit), (constraint, generated)];
+        let retained = retain_innermost_given_evidence(&evidences, given);
+
+        assert_eq!(retained, vec![(constraint, explicit)]);
     }
 }

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -10,7 +10,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
 use crate::core::constraint::canonical::CanonicalConstraint;
-use crate::core::constraint::matching::MatchInstance;
 use crate::core::constraint::{CanonicalConstraintId, canonical, compiler};
 use crate::core::substitute::{NameToType, SubstituteName};
 use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit};
@@ -265,7 +264,7 @@ where
                 continue;
             };
 
-            let MatchInstance::Match { unifications, .. } = matched else {
+            let compiler::CompilerMatch::Match { unifications, .. } = matched else {
                 continue;
             };
 

--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -20,7 +20,7 @@ use crate::{CheckedModule, ExternalQueries};
 
 pub type InstanceChainKey = (FileId, InstanceChainId);
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum InstanceCandidateOrigin {
     Instance(FileId, InstanceId),
     Derive(FileId, DeriveId),

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -415,7 +415,7 @@ where
     let mut generalisable = vec![];
 
     for constraint in constraints {
-        if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
+        if compiler::is_fail_constraint(state, context, constraint.key.wanted) {
             state.checked.evidence.mark_error(constraint.evidence.wanted);
         } else {
             generalisable.push(constraint)

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -248,18 +248,23 @@ pub struct ConstraintErrors {
     pub unsatisfied: Vec<ConstraintInScope>,
 }
 
+pub struct ConstrainedByResiduals {
+    pub type_id: TypeId,
+    pub has_constraints: bool,
+}
+
 pub fn constrain_using_residuals<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     unconstrained: TypeId,
     mut residuals: Vec<ConstraintInScope>,
     errors: &mut ConstraintErrors,
-) -> QueryResult<TypeId>
+) -> QueryResult<ConstrainedByResiduals>
 where
     Q: ExternalQueries,
 {
     if residuals.is_empty() {
-        return Ok(unconstrained);
+        return Ok(ConstrainedByResiduals { type_id: unconstrained, has_constraints: false });
     }
 
     for residual in residuals.iter_mut() {
@@ -273,13 +278,14 @@ where
     let residuals = partial.into_iter().chain(residuals);
     let generalised = residuals.sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
     let generalised = finalise_generalised_constraints(state, context, generalised)?;
+    let has_constraints = !generalised.is_empty();
 
     let constrained = generalised.into_iter().rfold(unconstrained, |inner, constraint| {
         let constraint = state.canonicals.type_id(context, constraint);
         context.intern_constrained(constraint, inner)
     });
 
-    Ok(constrained)
+    Ok(ConstrainedByResiduals { type_id: constrained, has_constraints })
 }
 
 type PrunedPartial = (Vec<ConstraintInScope>, Option<ConstraintInScope>);

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -22,12 +22,13 @@ use building_types::QueryResult;
 use itertools::Itertools;
 use petgraph::algo;
 use petgraph::prelude::DiGraphMap;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
-use crate::core::constraint::{CanonicalConstraintId, ConstraintInScope, elaborate};
+use crate::core::constraint::{CanonicalConstraintId, ConstraintInScope, compiler, elaborate};
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
 use crate::core::{ForallBinder, Name, Type, TypeId, normalise, zonk};
+use crate::evidence::Evidence;
 use crate::state::{CheckState, UnificationEntry, UnificationState};
 use crate::{ExternalQueries, safe_loop};
 
@@ -268,26 +269,28 @@ where
         let residual = residual.zonk(state, context)?;
 
         if residual.is_partial(state, context) {
-            latent.push(residual.wanted);
+            latent.push(residual);
             continue;
         }
 
-        let canonical = state.canonicals.type_id(context, residual.wanted);
+        let canonical = state.canonicals.type_id(context, residual.key.wanted);
         let unification: FxHashSet<_> =
             collect_unification(state, context, canonical)?.nodes().collect();
 
         if unification.is_empty() {
+            state.checked.evidence.mark_error(residual.evidence.wanted);
             errors.unsatisfied.push(residual);
         } else {
-            pending.push((residual.wanted, unification));
+            pending.push((residual, unification));
         }
     }
 
     let unifications = collect_unification(state, context, type_id)?.nodes().collect();
-    let generalised = classify_constraints(pending, latent, unifications, errors);
+    let generalised = classify_constraints(state, pending, latent, unifications, errors);
 
-    let generalised = generalised.into_iter().sorted().collect_vec();
-    let generalised = minimize_by_superclasses(state, context, generalised)?;
+    let generalised =
+        generalised.into_iter().sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
+    let generalised = finalise_generalised_constraints(state, context, generalised)?;
 
     let constrained = generalised.into_iter().rfold(type_id, |inner, constraint| {
         let constraint = state.canonicals.type_id(context, constraint);
@@ -297,38 +300,77 @@ where
     Ok(constrained)
 }
 
-fn minimize_by_superclasses<Q>(
+fn finalise_generalised_constraints<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    constraints: Vec<CanonicalConstraintId>,
+    constraints: Vec<ConstraintInScope>,
 ) -> QueryResult<Vec<CanonicalConstraintId>>
 where
     Q: ExternalQueries,
 {
-    if constraints.len() <= 1 {
-        return Ok(constraints);
-    }
-
     let mut superclasses = FxHashSet::default();
-    for &constraint in &constraints {
-        for superclass in elaborate::elaborate_superclasses(state, context, &[constraint])? {
-            if superclass != constraint {
+    for constraint in &constraints {
+        for superclass in
+            elaborate::elaborate_superclasses(state, context, &[constraint.key.wanted])?
+        {
+            if superclass != constraint.key.wanted {
                 superclasses.insert(superclass);
             }
         }
     }
 
-    Ok(constraints.into_iter().filter(|constraint| !superclasses.contains(constraint)).collect())
+    let (retained, dropped): (Vec<_>, Vec<_>) = constraints
+        .into_iter()
+        .partition(|constraint| !superclasses.contains(&constraint.key.wanted));
+
+    let mut retained_evidence = vec![];
+    for constraint in &retained {
+        if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
+            state.checked.evidence.mark_error(constraint.evidence.wanted);
+            continue;
+        }
+
+        let canonical = state.canonicals.type_id(context, constraint.key.wanted);
+        let binder = state.checked.evidence.fresh_binder(canonical);
+        let evidence = state.checked.evidence.allocate(Evidence::Given(binder));
+        state.checked.evidence.solve(constraint.evidence.wanted, evidence);
+        retained_evidence.push((constraint.key.wanted, evidence));
+    }
+
+    let projections =
+        elaborate::elaborate_superclasses_with_evidence(state, context, &retained_evidence)?;
+    for constraint in dropped {
+        if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
+            state.checked.evidence.mark_error(constraint.evidence.wanted);
+        } else if let Some((_, evidence)) =
+            projections.iter().find(|(canonical, _)| *canonical == constraint.key.wanted)
+        {
+            state.checked.evidence.solve(constraint.evidence.wanted, *evidence);
+        } else {
+            debug_assert!(
+                false,
+                "invariant violated: minimized constraint has no retained superclass path",
+            );
+            state.checked.evidence.mark_error(constraint.evidence.wanted);
+        }
+    }
+
+    let retained = retained.into_iter().map(|constraint| constraint.key.wanted);
+    Ok(retained.collect())
 }
 
 fn classify_constraints(
-    pending: Vec<(CanonicalConstraintId, FxHashSet<u32>)>,
-    latent: Vec<CanonicalConstraintId>,
+    state: &mut CheckState,
+    pending: Vec<(ConstraintInScope, FxHashSet<u32>)>,
+    latent: Vec<ConstraintInScope>,
     unifications: FxHashSet<u32>,
     errors: &mut ConstraintErrors,
-) -> FxHashSet<CanonicalConstraintId> {
+) -> Vec<ConstraintInScope> {
     let mut reachable = unifications;
-    let mut valid: FxHashSet<_> = latent.into_iter().collect();
+    let mut valid = FxHashMap::default();
+    for constraint in latent {
+        insert_generalised_constraint(state, &mut valid, constraint);
+    }
     let mut remaining = pending;
 
     safe_loop! {
@@ -338,18 +380,37 @@ fn classify_constraints(
             });
 
         if connected.is_empty() {
-            break errors.ambiguous.extend(disconnected.into_iter().map(|(id, _)| id));
+            for (constraint, _) in disconnected {
+                state.checked.evidence.mark_error(constraint.evidence.wanted);
+                errors.ambiguous.push(constraint.key.wanted);
+            }
+            break;
         }
 
         for (constraint, unification) in connected {
-            valid.insert(constraint);
+            insert_generalised_constraint(state, &mut valid, constraint);
             reachable.extend(unification);
         }
 
         remaining = disconnected;
     }
 
-    valid
+    valid.into_values().collect()
+}
+
+fn insert_generalised_constraint(
+    state: &mut CheckState,
+    constraints: &mut FxHashMap<CanonicalConstraintId, ConstraintInScope>,
+    constraint: ConstraintInScope,
+) {
+    if let Some(existing) = constraints.get(&constraint.key.wanted) {
+        state
+            .checked
+            .evidence
+            .merge_duplicate(constraint.evidence.wanted, existing.evidence.wanted);
+    } else {
+        constraints.insert(constraint.key.wanted, constraint);
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -248,56 +248,160 @@ pub struct ConstraintErrors {
     pub unsatisfied: Vec<ConstraintInScope>,
 }
 
-pub fn insert_inferred_residuals<Q>(
+pub fn constrain_using_residuals<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    type_id: TypeId,
-    residuals: Vec<ConstraintInScope>,
+    unconstrained: TypeId,
+    mut residuals: Vec<ConstraintInScope>,
     errors: &mut ConstraintErrors,
 ) -> QueryResult<TypeId>
 where
     Q: ExternalQueries,
 {
     if residuals.is_empty() {
-        return Ok(type_id);
+        return Ok(unconstrained);
     }
 
-    let mut pending = vec![];
-    let mut latent = vec![];
-
-    for residual in residuals {
-        let residual = residual.zonk(state, context)?;
-
-        if residual.is_partial(state, context) {
-            latent.push(residual);
-            continue;
-        }
-
-        let canonical = state.canonicals.type_id(context, residual.key.wanted);
-        let unification: FxHashSet<_> =
-            collect_unification(state, context, canonical)?.nodes().collect();
-
-        if unification.is_empty() {
-            state.checked.evidence.mark_error(residual.evidence.wanted);
-            errors.unsatisfied.push(residual);
-        } else {
-            pending.push((residual, unification));
-        }
+    for residual in residuals.iter_mut() {
+        *residual = residual.zonk(state, context)?;
     }
 
-    let unifications = collect_unification(state, context, type_id)?.nodes().collect();
-    let generalised = classify_constraints(state, pending, latent, unifications, errors);
+    let (residuals, partial) = prune_partial(state, context, residuals);
+    let residuals = prune_unsatisfied(state, context, residuals, errors)?;
+    let residuals = prune_ambiguous(state, context, unconstrained, residuals, errors)?;
 
-    let generalised =
-        generalised.into_iter().sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
+    let residuals = partial.into_iter().chain(residuals);
+    let generalised = residuals.sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
     let generalised = finalise_generalised_constraints(state, context, generalised)?;
 
-    let constrained = generalised.into_iter().rfold(type_id, |inner, constraint| {
+    let constrained = generalised.into_iter().rfold(unconstrained, |inner, constraint| {
         let constraint = state.canonicals.type_id(context, constraint);
         context.intern_constrained(constraint, inner)
     });
 
     Ok(constrained)
+}
+
+type PrunedPartial = (Vec<ConstraintInScope>, Option<ConstraintInScope>);
+
+fn prune_partial<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    pending: Vec<ConstraintInScope>,
+) -> PrunedPartial
+where
+    Q: ExternalQueries,
+{
+    let mut residuals = vec![];
+    let mut partial: Option<ConstraintInScope> = None;
+
+    for constraint in pending {
+        if constraint.is_partial(state, context) {
+            if let Some(existing) = &partial {
+                let residual = constraint.evidence.wanted;
+                let existing = existing.evidence.wanted;
+                state.checked.evidence.merge_duplicate(residual, existing);
+            } else {
+                partial = Some(constraint);
+            }
+        } else {
+            residuals.push(constraint);
+        }
+    }
+
+    (residuals, partial)
+}
+
+type PrunedUnsatisfied = Vec<(ConstraintInScope, FxHashSet<u32>)>;
+
+fn prune_unsatisfied<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    constraints: Vec<ConstraintInScope>,
+    errors: &mut ConstraintErrors,
+) -> QueryResult<PrunedUnsatisfied>
+where
+    Q: ExternalQueries,
+{
+    let mut residuals = vec![];
+
+    for constraint in constraints {
+        let canonical = state.canonicals.type_id(context, constraint.key.wanted);
+
+        let unification: FxHashSet<u32> =
+            collect_unification(state, context, canonical)?.nodes().collect();
+
+        // A residual without unification variables is unsatisfied.
+        // Mark its evidence as an error and queue a diagnostic.
+        if unification.is_empty() {
+            state.checked.evidence.mark_error(constraint.evidence.wanted);
+            errors.unsatisfied.push(constraint);
+        } else {
+            residuals.push((constraint, unification));
+        }
+    }
+
+    Ok(residuals)
+}
+
+type PrunedAmbiguous = Vec<ConstraintInScope>;
+
+fn prune_ambiguous<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    unconstrained: TypeId,
+    pending: Vec<(ConstraintInScope, FxHashSet<u32>)>,
+    errors: &mut ConstraintErrors,
+) -> QueryResult<PrunedAmbiguous>
+where
+    Q: ExternalQueries,
+{
+    type ConstraintMap = FxHashMap<CanonicalConstraintId, ConstraintInScope>;
+
+    let mut reachable_variables: FxHashSet<u32> =
+        collect_unification(state, context, unconstrained)?.nodes().collect();
+
+    let mut constraints = ConstraintMap::default();
+    let mut current = pending;
+
+    safe_loop! {
+        // A constraint is reachable if it contains unfiication variables
+        // in the type being constrained, otherwise, it is unreachable.
+        let (reachable, unreachable): (Vec<_>, Vec<_>) =
+            current.into_iter().partition(|(_, unification)| {
+                unification.iter().any(|variable| reachable_variables.contains(variable))
+            });
+
+        // If there are no more reachable constraints, mark the evidence
+        // of unreachable constraints errors and queue the diagnostics.
+        if reachable.is_empty() {
+            for (constraint, _) in unreachable {
+                state.checked.evidence.mark_error(constraint.evidence.wanted);
+                errors.ambiguous.push(constraint.key.wanted);
+            }
+            break;
+        }
+
+        // Reachable constraints are recorded, and duplicate evidences
+        // are merged. Their unification variables extend the current
+        // unification variable graph. This extension enables transitive
+        // solving such as in `F ?a ?b => G ?b ?c => ?a`, where `?b`
+        // becomes reachable via `?a`.
+        for (constraint, unification) in reachable {
+            if let Some(existing) = constraints.get(&constraint.key.wanted) {
+                let constraint = constraint.evidence.wanted;
+                let existing = existing.evidence.wanted;
+                state.checked.evidence.merge_duplicate(constraint, existing);
+            } else {
+                constraints.insert(constraint.key.wanted, constraint);
+            }
+            reachable_variables.extend(unification);
+        }
+
+        current = unreachable;
+    }
+
+    Ok(constraints.into_values().collect())
 }
 
 fn finalise_generalised_constraints<Q>(
@@ -308,7 +412,59 @@ fn finalise_generalised_constraints<Q>(
 where
     Q: ExternalQueries,
 {
+    let mut generalisable = vec![];
+
+    for constraint in constraints {
+        if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
+            state.checked.evidence.mark_error(constraint.evidence.wanted);
+        } else {
+            generalisable.push(constraint)
+        }
+    }
+
+    let MinimisedBySuperclasses { retained, dropped } =
+        minimise_by_superclasses(state, context, generalisable)?;
+
+    let mut evidences = vec![];
+    for ConstraintInScope { key, evidence } in &retained {
+        let canonical = state.canonicals.type_id(context, key.wanted);
+        let binder = state.checked.evidence.fresh_binder(canonical);
+
+        let given = state.checked.evidence.allocate(Evidence::Given(binder));
+        state.checked.evidence.solve(evidence.wanted, given);
+
+        evidences.push((key.wanted, given));
+    }
+
+    let projections = elaborate::elaborate_superclasses_with_evidence(state, context, &evidences)?;
+    let projections = projections.into_iter().collect::<FxHashMap<_, _>>();
+
+    for constraint in dropped {
+        if let Some(evidence) = projections.get(&constraint.key.wanted) {
+            state.checked.evidence.solve(constraint.evidence.wanted, *evidence);
+        } else {
+            state.checked.evidence.mark_error(constraint.evidence.wanted);
+        }
+    }
+
+    Ok(retained.into_iter().map(|constraint| constraint.key.wanted).collect())
+}
+
+struct MinimisedBySuperclasses {
+    retained: Vec<ConstraintInScope>,
+    dropped: Vec<ConstraintInScope>,
+}
+
+fn minimise_by_superclasses<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<'_, Q>,
+    constraints: Vec<ConstraintInScope>,
+) -> QueryResult<MinimisedBySuperclasses>
+where
+    Q: ExternalQueries,
+{
     let mut superclasses = FxHashSet::default();
+
     for constraint in &constraints {
         for superclass in
             elaborate::elaborate_superclasses(state, context, &[constraint.key.wanted])?
@@ -323,94 +479,7 @@ where
         .into_iter()
         .partition(|constraint| !superclasses.contains(&constraint.key.wanted));
 
-    let mut retained_evidence = vec![];
-    for constraint in &retained {
-        if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
-            state.checked.evidence.mark_error(constraint.evidence.wanted);
-            continue;
-        }
-
-        let canonical = state.canonicals.type_id(context, constraint.key.wanted);
-        let binder = state.checked.evidence.fresh_binder(canonical);
-        let evidence = state.checked.evidence.allocate(Evidence::Given(binder));
-        state.checked.evidence.solve(constraint.evidence.wanted, evidence);
-        retained_evidence.push((constraint.key.wanted, evidence));
-    }
-
-    let projections =
-        elaborate::elaborate_superclasses_with_evidence(state, context, &retained_evidence)?;
-    for constraint in dropped {
-        if compiler::is_compiler_error_constraint(state, context, constraint.key.wanted) {
-            state.checked.evidence.mark_error(constraint.evidence.wanted);
-        } else if let Some((_, evidence)) =
-            projections.iter().find(|(canonical, _)| *canonical == constraint.key.wanted)
-        {
-            state.checked.evidence.solve(constraint.evidence.wanted, *evidence);
-        } else {
-            debug_assert!(
-                false,
-                "invariant violated: minimized constraint has no retained superclass path",
-            );
-            state.checked.evidence.mark_error(constraint.evidence.wanted);
-        }
-    }
-
-    let retained = retained.into_iter().map(|constraint| constraint.key.wanted);
-    Ok(retained.collect())
-}
-
-fn classify_constraints(
-    state: &mut CheckState,
-    pending: Vec<(ConstraintInScope, FxHashSet<u32>)>,
-    latent: Vec<ConstraintInScope>,
-    unifications: FxHashSet<u32>,
-    errors: &mut ConstraintErrors,
-) -> Vec<ConstraintInScope> {
-    let mut reachable = unifications;
-    let mut valid = FxHashMap::default();
-    for constraint in latent {
-        insert_generalised_constraint(state, &mut valid, constraint);
-    }
-    let mut remaining = pending;
-
-    safe_loop! {
-        let (connected, disconnected): (Vec<_>, Vec<_>) =
-            remaining.into_iter().partition(|(_, unification)| {
-                unification.iter().any(|variable| reachable.contains(variable))
-            });
-
-        if connected.is_empty() {
-            for (constraint, _) in disconnected {
-                state.checked.evidence.mark_error(constraint.evidence.wanted);
-                errors.ambiguous.push(constraint.key.wanted);
-            }
-            break;
-        }
-
-        for (constraint, unification) in connected {
-            insert_generalised_constraint(state, &mut valid, constraint);
-            reachable.extend(unification);
-        }
-
-        remaining = disconnected;
-    }
-
-    valid.into_values().collect()
-}
-
-fn insert_generalised_constraint(
-    state: &mut CheckState,
-    constraints: &mut FxHashMap<CanonicalConstraintId, ConstraintInScope>,
-    constraint: ConstraintInScope,
-) {
-    if let Some(existing) = constraints.get(&constraint.key.wanted) {
-        state
-            .checked
-            .evidence
-            .merge_duplicate(constraint.evidence.wanted, existing.evidence.wanted);
-    } else {
-        constraints.insert(constraint.key.wanted, constraint);
-    }
+    Ok(MinimisedBySuperclasses { retained, dropped })
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -72,6 +72,20 @@ where
     Ok(())
 }
 
+pub fn zonk_evidence<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let binders = state.checked.evidence.binders().map(|(id, binder)| (id, binder.constraint));
+    let binders = binders.collect::<Vec<_>>();
+    for (id, constraint) in binders {
+        let constraint = zonk(state, context, constraint)?;
+        state.checked.evidence.bind_binder(id, constraint);
+    }
+
+    Ok(())
+}
+
 pub fn zonk_holes<Q>(state: &mut CheckState, context: &CheckContext<Q>) -> QueryResult<()>
 where
     Q: ExternalQueries,

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -141,6 +141,10 @@ where
             let type_id = zonk(state, context, type_id)?;
             ErrorKind::CannotDeriveForType { type_id }
         }
+        ErrorKind::CannotGeneraliseRecursiveFunction { type_id } => {
+            let type_id = zonk(state, context, type_id)?;
+            ErrorKind::CannotGeneraliseRecursiveFunction { type_id }
+        }
         ErrorKind::ContravariantOccurrence { type_id } => {
             let type_id = zonk(state, context, type_id)?;
             ErrorKind::ContravariantOccurrence { type_id }

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -44,6 +44,9 @@ pub enum ErrorKind {
     CannotDeriveForType {
         type_id: TypeId,
     },
+    CannotGeneraliseRecursiveFunction {
+        type_id: TypeId,
+    },
     ContravariantOccurrence {
         type_id: TypeId,
     },

--- a/compiler-core/checking/src/evidence.rs
+++ b/compiler-core/checking/src/evidence.rs
@@ -1,0 +1,280 @@
+//! Type class evidence produced by constraint solving.
+//!
+//! Evidence variables identify wanted occurrences rather than canonical
+//! constraints. Multiple occurrences of the same constraint therefore remain
+//! distinguishable even when the solver deduplicates their work.
+
+use std::ops::{Index, IndexMut};
+
+use files::FileId;
+use indexing::TypeItemId;
+use smol_str::SmolStr;
+
+use crate::TypeId;
+pub use crate::core::constraint::instances::InstanceCandidateOrigin;
+
+/// A solver-written evidence variable for one wanted occurrence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EvidenceVarId(pub u32);
+
+/// An identifier for a proof in a module's evidence graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EvidenceId(pub u32);
+
+/// A dictionary parameter introduced by a given or generalised constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EvidenceBinderId(pub u32);
+
+/// Stable identity of a superclass declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SuperclassId {
+    pub file_id: FileId,
+    pub type_id: TypeItemId,
+    pub source_id: lowering::TypeId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceState {
+    Unsolved,
+    Solved(EvidenceId),
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvidenceEntry {
+    pub state: EvidenceState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvidenceBinder {
+    /// The canonical constraint represented by this dictionary parameter.
+    pub constraint: TypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SynthesizedEvidence {
+    IsSymbol(SmolStr),
+    Reflectable(ReflectableEvidence),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReflectableEvidence {
+    Integer(i32),
+    String(SmolStr),
+    Boolean(bool),
+    Ordering(ReflectableOrdering),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflectableOrdering {
+    Less,
+    Equal,
+    Greater,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Evidence {
+    /// Indirection from a deduplicated wanted occurrence to its representative.
+    Variable(EvidenceVarId),
+    /// A dictionary parameter in scope.
+    Given(EvidenceBinderId),
+    /// A declared or derived instance applied to its prerequisite dictionaries.
+    Instance { origin: InstanceCandidateOrigin, subgoals: Vec<EvidenceVarId> },
+    /// A superclass dictionary projected from another dictionary.
+    Superclass { parent: EvidenceId, superclass: SuperclassId },
+    /// Compiler-solved evidence with no materialised dictionary contents.
+    ///
+    /// This proof does not remove its evidence application or abstraction.
+    Trivial,
+    /// Compiler-known evidence which must be materialised at runtime.
+    Synthesized(SynthesizedEvidence),
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Evidences {
+    variables: Vec<EvidenceEntry>,
+    binders: Vec<EvidenceBinder>,
+    proofs: Vec<Evidence>,
+}
+
+impl Evidences {
+    pub fn fresh_variable(&mut self) -> EvidenceVarId {
+        let id = EvidenceVarId(self.variables.len() as u32);
+        let entry = EvidenceEntry { state: EvidenceState::Unsolved };
+        self.variables.push(entry);
+        id
+    }
+
+    pub fn fresh_binder(&mut self, constraint: TypeId) -> EvidenceBinderId {
+        let id = EvidenceBinderId(self.binders.len() as u32);
+        self.binders.push(EvidenceBinder { constraint });
+        id
+    }
+
+    pub fn bind_binder(&mut self, id: EvidenceBinderId, constraint: TypeId) {
+        self[id].constraint = constraint;
+    }
+
+    pub fn allocate(&mut self, evidence: Evidence) -> EvidenceId {
+        let id = EvidenceId(self.proofs.len() as u32);
+        self.proofs.push(evidence);
+        id
+    }
+
+    pub fn solve(&mut self, id: EvidenceVarId, evidence: EvidenceId) {
+        let entry = &mut self[id];
+        debug_assert!(
+            matches!(entry.state, EvidenceState::Unsolved),
+            "invariant violated: evidence variable solved more than once",
+        );
+        if matches!(entry.state, EvidenceState::Unsolved) {
+            entry.state = EvidenceState::Solved(evidence);
+        }
+    }
+
+    pub fn merge_duplicate(&mut self, duplicate: EvidenceVarId, representative: EvidenceVarId) {
+        if duplicate == representative {
+            return;
+        }
+
+        match self[duplicate].state {
+            EvidenceState::Unsolved => {}
+            EvidenceState::Solved(proof) if self[proof] == Evidence::Variable(representative) => {
+                return;
+            }
+            EvidenceState::Solved(_) | EvidenceState::Error => {
+                unreachable!("invariant violated: resolved evidence occurrence deduplicated");
+            }
+        }
+
+        let evidence = self.allocate(Evidence::Variable(representative));
+        self.solve(duplicate, evidence);
+    }
+
+    pub fn mark_error(&mut self, id: EvidenceVarId) {
+        let entry = &mut self[id];
+        match entry.state {
+            EvidenceState::Unsolved => {
+                entry.state = EvidenceState::Error;
+            }
+            EvidenceState::Error => {
+                // EvidenceState::Error is idempotent
+            }
+            EvidenceState::Solved(_) => {
+                unreachable!("invariant violated: solved evidence variable marked as error");
+            }
+        }
+    }
+
+    pub fn variables(&self) -> impl Iterator<Item = (EvidenceVarId, &EvidenceEntry)> {
+        let variables = self.variables.iter().enumerate();
+        variables.map(|(index, entry)| (EvidenceVarId(index as u32), entry))
+    }
+
+    pub fn binders(&self) -> impl Iterator<Item = (EvidenceBinderId, &EvidenceBinder)> {
+        let binders = self.binders.iter().enumerate();
+        binders.map(|(index, binder)| (EvidenceBinderId(index as u32), binder))
+    }
+
+    pub fn assert_finished(&self) {
+        assert!(
+            self.variables().all(|(_, entry)| {
+                matches!(entry.state, EvidenceState::Solved(_) | EvidenceState::Error)
+            }),
+            "invariant violated: unsolved evidence variables remain",
+        );
+    }
+}
+
+impl Index<EvidenceVarId> for Evidences {
+    type Output = EvidenceEntry;
+
+    fn index(&self, EvidenceVarId(index): EvidenceVarId) -> &EvidenceEntry {
+        &self.variables[index as usize]
+    }
+}
+
+impl IndexMut<EvidenceVarId> for Evidences {
+    fn index_mut(&mut self, EvidenceVarId(index): EvidenceVarId) -> &mut EvidenceEntry {
+        &mut self.variables[index as usize]
+    }
+}
+
+impl Index<EvidenceBinderId> for Evidences {
+    type Output = EvidenceBinder;
+
+    fn index(&self, EvidenceBinderId(index): EvidenceBinderId) -> &EvidenceBinder {
+        &self.binders[index as usize]
+    }
+}
+
+impl IndexMut<EvidenceBinderId> for Evidences {
+    fn index_mut(&mut self, EvidenceBinderId(index): EvidenceBinderId) -> &mut EvidenceBinder {
+        &mut self.binders[index as usize]
+    }
+}
+
+impl Index<EvidenceId> for Evidences {
+    type Output = Evidence;
+
+    fn index(&self, EvidenceId(index): EvidenceId) -> &Evidence {
+        &self.proofs[index as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::{Evidence, EvidenceState, Evidences};
+    use crate::TypeId;
+
+    #[test]
+    fn trivial_proofs_solve_wanted_occurrences() {
+        let mut evidences = Evidences::default();
+        let wanted = evidences.fresh_variable();
+        let trivial = evidences.allocate(Evidence::Trivial);
+
+        evidences.solve(wanted, trivial);
+
+        assert_eq!(evidences[wanted].state, EvidenceState::Solved(trivial));
+        assert_eq!(evidences[trivial], Evidence::Trivial);
+    }
+
+    #[test]
+    fn marking_an_error_is_idempotent() {
+        let mut evidences = Evidences::default();
+        let wanted = evidences.fresh_variable();
+
+        evidences.mark_error(wanted);
+        evidences.mark_error(wanted);
+
+        assert_eq!(evidences[wanted].state, EvidenceState::Error);
+    }
+
+    #[test]
+    fn duplicate_occurrences_retain_alias_indirection() {
+        let mut evidences = Evidences::default();
+        let representative = evidences.fresh_variable();
+        let duplicate = evidences.fresh_variable();
+
+        evidences.merge_duplicate(duplicate, representative);
+
+        let EvidenceState::Solved(proof) = evidences[duplicate].state else {
+            panic!("duplicate evidence was not solved");
+        };
+        assert_eq!(evidences[proof], Evidence::Variable(representative));
+        assert!(matches!(evidences[representative].state, EvidenceState::Unsolved));
+
+        evidences.merge_duplicate(duplicate, representative);
+    }
+
+    #[test]
+    fn every_occurrence_has_distinct_identity() {
+        let constraint = TypeId::new(NonZeroU32::new(1).unwrap());
+        let mut evidences = Evidences::default();
+
+        assert_ne!(evidences.fresh_variable(), evidences.fresh_variable());
+        assert_ne!(evidences.fresh_binder(constraint), evidences.fresh_binder(constraint));
+    }
+}

--- a/compiler-core/checking/src/implication.rs
+++ b/compiler-core/checking/src/implication.rs
@@ -8,6 +8,7 @@ use smol_str::SmolStr;
 
 use crate::core::TypeId;
 use crate::error::ErrorCrumb;
+use crate::evidence::{EvidenceBinderId, EvidenceVarId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Patterns {
@@ -18,11 +19,23 @@ pub struct Patterns {
 /// A unique identifier for an implication scope.
 pub type ImplicationId = u32;
 
+#[derive(Clone, Copy)]
+pub struct GivenConstraint {
+    pub constraint: TypeId,
+    pub evidence: EvidenceBinderId,
+}
+
+#[derive(Clone, Copy)]
+pub struct WantedConstraint {
+    pub constraint: TypeId,
+    pub evidence: EvidenceVarId,
+}
+
 /// A node in the implication tree.
 #[derive(Default)]
 pub struct Implication {
-    pub given: Vec<TypeId>,
-    pub wanted: VecDeque<TypeId>,
+    pub given: Vec<GivenConstraint>,
+    pub wanted: VecDeque<WantedConstraint>,
     pub patterns: Vec<Patterns>,
     pub children: Vec<ImplicationId>,
     pub parent: Option<ImplicationId>,

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod error;
+pub mod evidence;
 pub mod holes;
 pub mod implication;
 pub mod safety;
@@ -53,6 +54,7 @@ pub trait ExternalQueries:
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct CheckedModule {
+    pub evidence: evidence::Evidences,
     pub types: FxHashMap<TypeItemId, TypeId>,
     pub terms: FxHashMap<TermItemId, TypeId>,
     pub data_declarations: FxHashMap<TypeItemId, CheckedDataDeclaration>,
@@ -204,8 +206,10 @@ fn check_source(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<
     source::check_type_items(&mut state, &context)?;
     source::check_term_items(&mut state, &context)?;
     core::zonk::zonk_nodes(&mut state, &context)?;
+    core::zonk::zonk_evidence(&mut state, &context)?;
     core::zonk::zonk_holes(&mut state, &context)?;
     core::zonk::zonk_errors(&mut state, &context)?;
+    state.checked.evidence.assert_finished();
 
     Ok(state.checked)
 }

--- a/compiler-core/checking/src/source/derive/tools.rs
+++ b/compiler-core/checking/src/source/derive/tools.rs
@@ -51,7 +51,7 @@ where
     }
 
     for superclass in superclasses {
-        let specialised = SubstituteName::many(state, context, &bindings, superclass)?;
+        let specialised = SubstituteName::many(state, context, &bindings, superclass.constraint)?;
         state.push_wanted(specialised);
     }
 
@@ -82,16 +82,18 @@ where
     Q: ExternalQueries,
 {
     for residual in state.solve_constraints(context)? {
-        let attached = state.canonical_errors.remove(&residual.wanted);
+        state.checked.evidence.mark_error(residual.evidence.wanted);
+        let attached = state.canonical_errors.remove(&residual.key.wanted);
         attached.into_iter().flatten().for_each(|error| state.insert_error(error));
 
         let given = residual
+            .key
             .given
             .iter()
             .map(|given| state.canonicals.type_id(context, *given))
             .collect::<Arc<[_]>>();
 
-        let constraint = state.canonicals.type_id(context, residual.wanted);
+        let constraint = state.canonicals.type_id(context, residual.key.wanted);
         state.insert_error(ErrorKind::NoInstanceFound { given, constraint });
     }
     Ok(())

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -773,7 +773,7 @@ where
                 marker
             }
             Some(PendingValueGroup::Inferred { residuals }) => {
-                generalise::insert_inferred_residuals(
+                generalise::constrain_using_residuals(
                     state,
                     context,
                     marker,

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -185,7 +185,8 @@ where
             check_term_signature(state, context, item)?;
         }
 
-        if scc.is_recursive() {
+        let recursive = scc.is_recursive();
+        if recursive {
             prepare_binding_group(state, context, items);
         }
 
@@ -195,7 +196,7 @@ where
             check_term_equation(state, context, &mut term_scc, item)?;
         }
 
-        finalise_term_binding_group(state, context, &mut term_scc, items)?;
+        finalise_term_binding_group(state, context, &mut term_scc, items, recursive)?;
     }
 
     Ok(())
@@ -745,6 +746,7 @@ fn finalise_term_binding_group<Q>(
     context: &CheckContext<Q>,
     scc: &mut TermSccState,
     items: &[TermItemId],
+    recursive: bool,
 ) -> QueryResult<()>
 where
     Q: ExternalQueries,
@@ -753,6 +755,7 @@ where
         marker: TypeId,
         unsolved: Vec<u32>,
         errors: generalise::ConstraintErrors,
+        has_constraints: bool,
     }
 
     let mut pending = vec![];
@@ -767,32 +770,43 @@ where
 
         let mut errors = generalise::ConstraintErrors::default();
 
-        let marker = match group {
+        let (marker, has_constraints) = match group {
             Some(PendingValueGroup::Checked { residuals }) => {
                 errors.unsatisfied.extend(residuals);
-                marker
+                (marker, false)
             }
             Some(PendingValueGroup::Inferred { residuals }) => {
-                generalise::constrain_using_residuals(
+                let constrained = generalise::constrain_using_residuals(
                     state,
                     context,
                     marker,
                     residuals,
                     &mut errors,
-                )?
+                )?;
+                (constrained.type_id, constrained.has_constraints)
             }
-            None => marker,
+            None => (marker, false),
         };
 
         let marker = zonk::zonk(state, context, marker)?;
         let unsolved = generalise::unsolved_unifications(state, context, marker)?;
 
-        pending.push((item_id, Pending { marker, unsolved, errors }));
+        let pending_group = Pending { marker, unsolved, errors, has_constraints };
+        pending.push((item_id, pending_group));
     }
 
-    for (item_id, Pending { marker, unsolved, errors }) in pending {
+    for (item_id, Pending { marker, unsolved, errors, has_constraints }) in pending {
         let marker = generalise::generalise_unsolved(state, context, marker, &unsolved)?;
         state.checked.terms.insert(item_id, marker);
+
+        if recursive && has_constraints {
+            // Keep constraint evidence consistent with the candidate type used for error recovery.
+            // The diagnostic prevents the invalid recursive dictionary abstraction from proceeding.
+            state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
+                let error = ErrorKind::CannotGeneraliseRecursiveFunction { type_id: marker };
+                state.insert_error(error);
+            });
+        }
 
         for error in errors.ambiguous {
             let constraint = state.canonicals.type_id(context, error);

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -372,16 +372,18 @@ where
         };
 
         for residual in residuals {
-            let attached = state.canonical_errors.remove(&residual.wanted);
+            state.checked.evidence.mark_error(residual.evidence.wanted);
+            let attached = state.canonical_errors.remove(&residual.key.wanted);
             attached.into_iter().flatten().for_each(|error| state.insert_error(error));
 
             let given = residual
+                .key
                 .given
                 .iter()
                 .map(|given| state.canonicals.type_id(context, *given))
                 .collect::<Arc<[_]>>();
 
-            let constraint = state.canonicals.type_id(context, residual.wanted);
+            let constraint = state.canonicals.type_id(context, residual.key.wanted);
             state.insert_error(ErrorKind::NoInstanceFound { given, constraint });
         }
 
@@ -799,18 +801,20 @@ where
             });
         }
         for error in errors.unsatisfied {
+            state.checked.evidence.mark_error(error.evidence.wanted);
             state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
-                let attached = state.canonical_errors.remove(&error.wanted);
+                let attached = state.canonical_errors.remove(&error.key.wanted);
                 attached.into_iter().flatten().for_each(|error| state.insert_error(error));
             });
 
             let given = error
+                .key
                 .given
                 .iter()
                 .map(|given| state.canonicals.type_id(context, *given))
                 .collect::<Arc<[_]>>();
 
-            let constraint = state.canonicals.type_id(context, error.wanted);
+            let constraint = state.canonicals.type_id(context, error.key.wanted);
             state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
                 state.insert_error(ErrorKind::NoInstanceFound { given, constraint });
             });

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -259,7 +259,7 @@ where
         if let CaseOfMode::Infer = mode {
             return Ok(context.intern_constrained(context.prim.partial, expected));
         } else {
-            state.push_wanted(context.prim.partial)
+            state.push_wanted(context.prim.partial);
         }
     }
 

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -13,8 +13,8 @@ use smol_str::SmolStr;
 
 use crate::context::CheckContext;
 use crate::core::{
-    CheckedClass, CheckedDataDeclaration, CheckedSynonym, ForallBinder, Role, Type, TypeId, fd,
-    fold, generalise, signature, toolkit, unification, zonk,
+    CheckedClass, CheckedDataDeclaration, CheckedSuperclass, CheckedSynonym, ForallBinder, Role,
+    Type, TypeId, fd, fold, generalise, signature, toolkit, unification, zonk,
 };
 use crate::error::ErrorCrumb;
 use crate::source::types;
@@ -34,7 +34,7 @@ struct PendingSynonymType {
 
 struct PendingClassType {
     parameters: Vec<ForallBinder>,
-    superclasses: Vec<TypeId>,
+    superclasses: Vec<CheckedSuperclass>,
     functional_dependencies: Arc<[fd::Fd]>,
     members: Vec<(TermItemId, TypeId)>,
 }
@@ -740,10 +740,10 @@ where
     };
 
     let mut superclasses = vec![];
-    for &constraint in constraints.iter() {
-        let (superclass, _) =
-            types::check_kind(state, context, constraint, context.prim.constraint)?;
-        superclasses.push(superclass);
+    for &source_id in constraints.iter() {
+        let (constraint, _) =
+            types::check_kind(state, context, source_id, context.prim.constraint)?;
+        superclasses.push(CheckedSuperclass { source_id, constraint });
     }
 
     let functional_dependencies =
@@ -895,7 +895,10 @@ where
 
         let superclasses = superclasses
             .into_iter()
-            .map(|superclass| zonk::zonk(state, context, superclass))
+            .map(|superclass| {
+                let constraint = zonk::zonk(state, context, superclass.constraint)?;
+                Ok(CheckedSuperclass { source_id: superclass.source_id, constraint })
+            })
             .collect::<QueryResult<Vec<_>>>()?;
 
         for (member_id, member_type) in members.iter() {

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -15,7 +15,8 @@ use crate::core::exhaustive::{
 use crate::core::substitute::{NameToType, SubstituteName};
 use crate::core::{Depth, Name, SmolStrId, Type, TypeId, constraint};
 use crate::error::{CheckingError, ErrorCrumb, ErrorKind};
-use crate::implication::{Implications, Patterns};
+use crate::evidence::{EvidenceBinderId, EvidenceVarId};
+use crate::implication::{GivenConstraint, Implications, Patterns, WantedConstraint};
 use crate::{CheckedModule, ExternalQueries};
 
 /// Manages [`Name`] values for [`CheckState`].
@@ -281,12 +282,16 @@ impl CheckState {
         self.checked.errors.push(CheckingError { kind, crumbs });
     }
 
-    pub fn push_wanted(&mut self, constraint: TypeId) {
-        self.implications.current_mut().wanted.push_back(constraint);
+    pub fn push_wanted(&mut self, constraint: TypeId) -> EvidenceVarId {
+        let evidence = self.checked.evidence.fresh_variable();
+        self.implications.current_mut().wanted.push_back(WantedConstraint { constraint, evidence });
+        evidence
     }
 
-    pub fn push_given(&mut self, constraint: TypeId) {
-        self.implications.current_mut().given.push(constraint);
+    pub fn push_given(&mut self, constraint: TypeId) -> EvidenceBinderId {
+        let evidence = self.checked.evidence.fresh_binder(constraint);
+        self.implications.current_mut().given.push(GivenConstraint { constraint, evidence });
+        evidence
     }
 
     pub fn with_implication<T>(&mut self, f: impl FnOnce(&mut CheckState) -> T) -> T {

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -226,6 +226,11 @@ impl ToDiagnostics for CheckingError {
                 let message = render_type(*type_id);
                 (Severity::Error, "CannotDeriveForType", format!("Cannot derive for type: {message}"))
             }
+            ErrorKind::CannotGeneraliseRecursiveFunction { .. } => (
+                Severity::Error,
+                "CannotGeneraliseRecursiveFunction",
+                "Unable to generalise the type of this recursive function.".to_string(),
+            ),
             ErrorKind::ContravariantOccurrence { type_id } => {
                 let message = render_type(*type_id);
                 (
@@ -480,6 +485,12 @@ impl ToDiagnostics for CheckingError {
                 if let Some(hole) = context.checked.lookup_type_hole(*source_type) {
                     diagnostic = attach_hole_binding_trivia(diagnostic, context, &hole.bindings);
                 }
+            }
+            ErrorKind::CannotGeneraliseRecursiveFunction { type_id } => {
+                let inferred = render_type(*type_id);
+                let trivia = format!("The inferred type was: {inferred}");
+                diagnostic = diagnostic.with_trivia(trivia);
+                diagnostic = diagnostic.with_trivia("Try adding a type signature.");
             }
             _ => {}
         }

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -63,8 +63,10 @@ impl<'a> TypeEncoder<'a> {
         self.names.reset();
         let binders = self.encode_forall_binders(class.type_parameters)?;
 
-        let superclasses =
-            class.superclasses.into_iter().map(|superclass| self.encode_type(superclass));
+        let superclasses = class
+            .superclasses
+            .into_iter()
+            .map(|superclass| self.encode_type(superclass.constraint));
         let superclasses = superclasses.collect::<Result<Vec<_>, Error>>()?;
 
         Ok((schema::TypeDeclaration { binders }, superclasses))

--- a/tests-integration/fixtures/checking/1784275320_transitive_superclass_minimisation_evidence/Main.purs
+++ b/tests-integration/fixtures/checking/1784275320_transitive_superclass_minimisation_evidence/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+class Bottom a
+
+class Bottom a <= Middle a
+
+class Middle a <= Top a
+
+foreign import useBottom :: forall a. Bottom a => a -> Int
+
+foreign import useMiddle :: forall a. Middle a => a -> Int
+
+foreign import useTop :: forall a. Top a => a -> Int
+
+test value =
+  let
+    _ = useTop value
+    _ = useMiddle value
+  in
+    useBottom value

--- a/tests-integration/fixtures/checking/1784275320_transitive_superclass_minimisation_evidence/Main.snap
+++ b/tests-integration/fixtures/checking/1784275320_transitive_superclass_minimisation_evidence/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+useBottom :: forall (a :: Type). Bottom @Type (a :: Type) => (a :: Type) -> Int
+useMiddle :: forall (a :: Type). Middle @Type (a :: Type) => (a :: Type) -> Int
+useTop :: forall (a :: Type). Top @Type (a :: Type) => (a :: Type) -> Int
+test :: forall (t :: Type). Top @Type (t :: Type) => (t :: Type) -> Int
+
+Types
+Bottom :: forall (t :: Type). (t :: Type) -> Constraint
+Middle :: forall (t :: Type). (t :: Type) -> Constraint
+Top :: forall (t :: Type). (t :: Type) -> Constraint
+
+Classes
+class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type))
+class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type)) <= Middle @(t :: Type) (a :: (t :: Type))
+class forall (t :: Type) (a :: (t :: Type)). Middle @(t :: Type) (a :: (t :: Type)) <= Top @(t :: Type) (a :: (t :: Type))

--- a/tests-integration/fixtures/checking/1784281200_diamond_superclass_projection_paths/Main.purs
+++ b/tests-integration/fixtures/checking/1784281200_diamond_superclass_projection_paths/Main.purs
@@ -1,0 +1,32 @@
+module Main where
+
+class Bottom a
+
+class Bottom a <= Left a
+
+class Bottom a <= Right a
+
+class (Left a, Right a) <= Top a
+
+foreign import useBottom :: forall a. Bottom a => a -> Int
+
+foreign import useLeft :: forall a. Left a => a -> Int
+
+foreign import useRight :: forall a. Right a => a -> Int
+
+foreign import useTop :: forall a. Top a => a -> Int
+
+testDiamond value =
+  let
+    _ = useTop value
+    _ = useLeft value
+    _ = useRight value
+  in
+    useBottom value
+
+testShared value =
+  let
+    _ = useLeft value
+    _ = useRight value
+  in
+    useBottom value

--- a/tests-integration/fixtures/checking/1784281200_diamond_superclass_projection_paths/Main.snap
+++ b/tests-integration/fixtures/checking/1784281200_diamond_superclass_projection_paths/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+useBottom :: forall (a :: Type). Bottom @Type (a :: Type) => (a :: Type) -> Int
+useLeft :: forall (a :: Type). Left @Type (a :: Type) => (a :: Type) -> Int
+useRight :: forall (a :: Type). Right @Type (a :: Type) => (a :: Type) -> Int
+useTop :: forall (a :: Type). Top @Type (a :: Type) => (a :: Type) -> Int
+testDiamond :: forall (t :: Type). Top @Type (t :: Type) => (t :: Type) -> Int
+testShared ::
+  forall (t :: Type). Left @Type (t :: Type) => Right @Type (t :: Type) => (t :: Type) -> Int
+
+Types
+Bottom :: forall (t :: Type). (t :: Type) -> Constraint
+Left :: forall (t :: Type). (t :: Type) -> Constraint
+Right :: forall (t :: Type). (t :: Type) -> Constraint
+Top :: forall (t :: Type). (t :: Type) -> Constraint
+
+Classes
+class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type))
+class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type)) <= Left @(t :: Type) (a :: (t :: Type))
+class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type)) <= Right @(t :: Type) (a :: (t :: Type))
+class forall (t :: Type) (a :: (t :: Type)). Left @(t :: Type) (a :: (t :: Type)), Right @(t :: Type) (a :: (t :: Type)) <= Top @(t :: Type) (a :: (t :: Type))

--- a/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.purs
+++ b/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+import Prim.TypeError (class Fail, class Warn, Text)
+
+class Value a where
+  value :: a
+
+instance Value Int where
+  value = 42
+
+guardedFailure :: Fail (Text "failure was demanded") => Int
+guardedFailure = (value :: Fail (Text "failure was demanded") => Int)
+
+useFailure :: Int
+useFailure = guardedFailure
+
+guardedWarning :: Warn (Text "warning was demanded") => Int
+guardedWarning = (value :: Warn (Text "warning was demanded") => Int)
+
+useWarning :: Int
+useWarning = guardedWarning

--- a/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.snap
+++ b/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+value :: forall (@a :: Type). Value (a :: Type) => (a :: Type)
+guardedFailure :: Fail (Text "failure was demanded") => Int
+useFailure :: Int
+guardedWarning :: Warn (Text "warning was demanded") => Int
+useWarning :: Int
+
+Types
+Value :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Value (a :: Type)
+  value :: forall (@a :: Type). Value (a :: Type) => (a :: Type)
+
+Instances
+instance Value Int
+
+Diagnostics
+error[CustomFailure]: failure was demanded
+  --> 14:1..14:18
+   |
+14 | useFailure :: Int
+   | ^~~~~~~~~~~~~~~~~
+warning[CustomWarning]: warning was demanded
+  --> 20:1..20:18
+   |
+20 | useWarning :: Int
+   | ^~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.purs
+++ b/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Semigroup a where
+  append :: a -> a -> a
+
+first value = append value (second value)
+
+second value = append value (first value)

--- a/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
@@ -14,3 +14,19 @@ Semigroup :: Type -> Constraint
 Classes
 class forall (a :: Type). Semigroup (a :: Type)
   append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+
+Diagnostics
+error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
+  --> 8:1..8:42
+  |
+8 | second value = append value (first value)
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: The inferred type was: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+  trivia: Try adding a type signature.
+error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
+  --> 6:1..6:42
+  |
+6 | first value = append value (second value)
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: The inferred type was: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+  trivia: Try adding a type signature.

--- a/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+first :: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+second :: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+
+Types
+Semigroup :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Semigroup (a :: Type)
+  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_check_constraint/Main.purs
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_check_constraint/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+class Semigroup a where
+  append :: a -> a -> a
+
+test :: forall a. Semigroup a => a -> a
+test value = append value (test value)

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_check_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_check_constraint/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+test :: forall (a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type)
+
+Types
+Semigroup :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Semigroup (a :: Type)
+  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.purs
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+class Semigroup a where
+  append :: a -> a -> a
+
+test value = append value (test value)

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
@@ -13,3 +13,12 @@ Semigroup :: Type -> Constraint
 Classes
 class forall (a :: Type). Semigroup (a :: Type)
   append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+
+Diagnostics
+error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
+  --> 6:1..6:39
+  |
+6 | test value = append value (test value)
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: The inferred type was: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+  trivia: Try adding a type signature.

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+test :: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+
+Types
+Semigroup :: Type -> Constraint
+
+Classes
+class forall (a :: Type). Semigroup (a :: Type)
+  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.purs
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+partialValue :: Partial => Int
+partialValue = 0
+
+test = if true then test else partialValue

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+partialValue :: Partial => Int
+test :: Partial => Int
+
+Types

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
@@ -8,3 +8,12 @@ partialValue :: Partial => Int
 test :: Partial => Int
 
 Types
+
+Diagnostics
+error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.
+  --> 6:1..6:43
+  |
+6 | test = if true then test else partialValue
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: The inferred type was: Partial => Int
+  trivia: Try adding a type signature.

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.purs
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Prim.TypeError (class Fail, Text)
+
+guardedFailure :: Fail (Text "failure was demanded") => Int
+guardedFailure = 0
+
+test = if true then test else guardedFailure

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+guardedFailure :: Fail (Text "failure was demanded") => Int
+test :: Int
+
+Types
+
+Diagnostics
+error[CustomFailure]: failure was demanded
+  --> 8:1..8:45
+  |
+8 | test = if true then test else guardedFailure
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -289,8 +289,11 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
         if class.superclasses.is_empty() {
             writeln!(out, "class {forall_prefix}{canonical}").unwrap();
         } else {
-            let superclasses =
-                class.superclasses.iter().map(|&superclass| pretty.render(superclass)).join(", ");
+            let superclasses = class
+                .superclasses
+                .iter()
+                .map(|superclass| pretty.render(superclass.constraint))
+                .join(", ");
             writeln!(out, "class {forall_prefix}{superclasses} <= {canonical}").unwrap();
         }
 


### PR DESCRIPTION
XL-level change; this introduces the evidence graph which tracks the synthetic abstractions and applications that will be used in the checked semantic tree.