### PR TITLE
[checking] Add checked semantic tree foundation

### DIFF
--- a/.agents/skills/workflow-integration-tests/SKILL.md
+++ b/.agents/skills/workflow-integration-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-integration-tests
-description: "Workflow for adding and updating Alexandrite integration-test fixtures for checking, lowering, resolving, and LSP behavior. Use when creating compiler integration tests, reviewing fixture snapshots, or using `just t <category>`."
+description: "Workflow for adding and updating Alexandrite integration-test fixtures for checking, semantic trees, lowering, resolving, and LSP behavior. Use when creating compiler integration tests, reviewing fixture snapshots, or using `just t <category>`."
 ---
 
 # Workflow: Alexandrite Integration Tests
@@ -14,6 +14,7 @@ Use the command reference at `reference/compiler-scripts.md` for test runner syn
 | Category | Alias | Use for | Harness pattern |
 |----------|-------|---------|-----------------|
 | `checking` | `c` | Type checking, inference, kinds, roles, constraints, diagnostics after checking | `Main.purs` only |
+| `semantic` | `s` | Checked semantic tree declarations, typed expressions and binders, and explicit evidence | `Main.purs` only |
 | `lowering` | `l` | Lowered core output, binding/equation structure, source-to-core name links | every `.purs` file |
 | `resolving` | `r` | Name resolution, imports, exports, qualification, duplicate-name diagnostics | every `.purs` file |
 | `lsp` | - | Hover, definition, completion, import edits, source locations in LSP reports | `Main.purs` only |
@@ -52,6 +53,10 @@ test' [x] = x
 ```
 
 Name declarations predictably: `test`, `test'`, `test2`, `test2'`, etc. Include only edge cases relevant to the behavior.
+
+#### Semantic fixtures
+
+Write source that exposes the checked semantic structure being tested. Keep fixtures focused on the smallest declaration, expression, binder, or evidence shape that distinguishes the behavior.
 
 #### Lowering fixtures
 
@@ -112,7 +117,7 @@ test = Just life
 ```
 
 - Module name must match filename
-- Checking and LSP fixtures snapshot only `Main.purs`
+- Checking, semantic, and LSP fixtures snapshot only `Main.purs`
 - Lowering and resolving fixtures snapshot every `.purs` file
 
 ## Snapshot Review Focus
@@ -134,6 +139,10 @@ ErrorKind { details } at [location]
 
 Check inferred/checked types, kind/role output, constraints, diagnostics, and source locations.
 
+### Semantic
+
+Check semantic declaration kinds, finalized types and kinds, constructor arguments, binders, expressions, and explicit evidence. Confirm that syntax sugar expected to disappear is absent and syntax intentionally preserved by checking remains present.
+
 ### Lowering
 
 Check the lowered module report, especially declarations, binders, equations, and source links. Unexpected name-link changes are often as important as textual output changes.
@@ -152,6 +161,7 @@ Before accepting, verify:
 
 1. **The category is appropriate**
    - Checking owns type inference/checking behavior
+   - Semantic owns the typed semantic tree produced by checking
    - Lowering owns lowered core/source-link behavior
    - Resolving owns name/import/export behavior
    - LSP owns editor-facing reports
@@ -164,7 +174,7 @@ Before accepting, verify:
    - Checking types are correct
    - `test :: Array Int -> Int` - signature preserved
    - `test' :: forall t. Array t -> t` - polymorphism inferred
-   - Lowering/resolving/LSP changes match the feature or bug being tested
+   - Semantic/lowering/resolving/LSP changes match the feature or bug being tested
 
 4. **No unexpected `???`**
    - `test :: ???` - STOP: inference failure
@@ -186,5 +196,5 @@ Before accepting, verify:
 | Unexpected monomorphism | Missing polymorphic context |
 | Wrong error location | Check binder/expression placement |
 | Missing types in snapshot | Module header or imports incorrect |
-| Missing expected module snapshot | Category snapshots only `Main.purs` (`checking`, `lsp`) or module filename does not match module header |
+| Missing expected module snapshot | Category snapshots only `Main.purs` (`checking`, `semantic`, `lsp`) or module filename does not match module header |
 | Extra resolving/lowering snapshot | Every `.purs` file is snapshotted in `resolving` and `lowering` |

--- a/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
+++ b/.agents/skills/workflow-integration-tests/reference/compiler-scripts.md
@@ -21,6 +21,7 @@ just t <category> --delete "name"  # Dry-run fixture deletion (use --confirm)
 | Category | Alias | Description |
 |----------|-------|-------------|
 | checking | c | Type checker tests |
+| semantic | s | Checked semantic tree tests |
 | lowering | l | Lowering tests |
 | resolving | r | Resolver tests |
 | lsp | - | LSP tests |

--- a/.agents/skills/workflow-regression-tests/SKILL.md
+++ b/.agents/skills/workflow-regression-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-regression-tests
-description: "Workflow for splitting a known compiler bug fix into auditable jj history. Use when the current or parent commit already contains a compiler fix and needs a preceding failing integration-test fixture plus a fix commit that updates the same checking, lowering, resolving, or LSP snapshot."
+description: "Workflow for splitting a known compiler bug fix into auditable jj history. Use when the current or parent commit already contains a compiler fix and needs a preceding failing integration-test fixture plus a fix commit that updates the same checking, semantic, lowering, resolving, or LSP snapshot."
 ---
 
 # Workflow: Regression Tests
@@ -31,6 +31,7 @@ Use the category that owns the observable regression:
 | Category | Alias | Use when the regression is visible in |
 |----------|-------|----------------------------------------|
 | `checking` | `c` | Type checking, inference, kinding, roles, constraints, or checking diagnostics |
+| `semantic` | `s` | Checked semantic declarations, expressions, binders, or explicit evidence |
 | `lowering` | `l` | Lowered core output, equation/binder shape, or source-to-core links |
 | `resolving` | `r` | Name resolution, imports, exports, qualification, re-exports, or resolver diagnostics |
 | `lsp` | - | Hover, definition, completion, import edits, or editor-facing source positions |
@@ -67,7 +68,7 @@ Write a focused PureScript fixture that reproduces one behavior. Use `Main.purs`
 
 Snapshot expectations differ by category:
 
-- `checking` and `lsp` snapshot `Main.purs` only.
+- `checking`, `semantic`, and `lsp` snapshot `Main.purs` only.
 - `lowering` and `resolving` snapshot every `.purs` file in the fixture.
 
 Accept the snapshot in the failing fixture commit:
@@ -76,7 +77,7 @@ Accept the snapshot in the failing fixture commit:
 just t <category> NNN --accept
 ```
 
-The snapshot should intentionally encode the bug: the wrong error, missing type, bad constraint, incorrect lowered output, wrong resolution target, incorrect LSP response, unexpected `???`, or other undesirable current behavior. Do not try to make this commit green by changing compiler behavior; its purpose is to record the failure before the fix.
+The snapshot should intentionally encode the bug: the wrong error, missing type, bad constraint, incorrect semantic tree, incorrect lowered output, wrong resolution target, incorrect LSP response, unexpected `???`, or other undesirable current behavior. Do not try to make this commit green by changing compiler behavior; its purpose is to record the failure before the fix.
 
 ### 3. Return to the fix commit and update the snapshot
 
@@ -107,7 +108,7 @@ Before finishing, verify:
 - The failing fixture commit snapshot captures the bug clearly.
 - The fix commit snapshot changes only what the fix should change.
 - Unexpected `???` does not appear unless it is the regression being documented.
-- Error kinds, locations, inferred types, constraints, lowered bindings, resolved references, and LSP payloads are intentional for the selected category.
+- Error kinds, locations, inferred types, constraints, semantic nodes, lowered bindings, resolved references, and LSP payloads are intentional for the selected category.
 - The fixture is narrow enough for the snapshot diff to be easy to audit.
 - For `lowering` and `resolving`, every changed module snapshot in the fixture is expected.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "indexmap",
  "interner",
  "itertools 0.14.0",
+ "la-arena",
  "lowering",
  "parking_lot",
  "parsing",

--- a/compiler-core/checking/Cargo.toml
+++ b/compiler-core/checking/Cargo.toml
@@ -10,6 +10,7 @@ indexing = { version = "0.1.0", path = "../indexing" }
 interner = { version = "0.1.0", path = "../interner" }
 indexmap = "2.12.1"
 itertools = "0.14.0"
+la-arena = "0.3.1"
 lowering = { version = "0.1.0", path = "../lowering" }
 parking_lot = "0.12.5"
 petgraph = "0.8.3"

--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -95,7 +95,7 @@ pub enum KindOrType {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedDataDeclaration {
-    pub type_parameters: Vec<ForallBinderId>,
+    pub type_parameters: Arc<[ForallBinderId]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -29,10 +29,21 @@ pub trait PrettyQueries: QueryProxy<Indexed = Arc<indexing::IndexedModule>> {
     fn lookup_smol_str(&self, id: SmolStrId) -> SmolStr;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PrettyNames {
     display_by_name: FxHashMap<Name, SmolStr>,
     next_suffix: FxHashMap<SmolStr, NonZeroU32>,
+    default_name: SmolStr,
+}
+
+impl Default for PrettyNames {
+    fn default() -> PrettyNames {
+        PrettyNames {
+            display_by_name: FxHashMap::default(),
+            next_suffix: FxHashMap::default(),
+            default_name: SmolStr::new("t"),
+        }
+    }
 }
 
 impl PrettyNames {
@@ -43,6 +54,10 @@ impl PrettyNames {
     pub fn reset(&mut self) {
         self.display_by_name.clear();
         self.next_suffix.clear();
+    }
+
+    fn set_default_name(&mut self, default_name: &str) {
+        self.default_name = SmolStr::new(default_name);
     }
 
     pub fn display_name<Q>(
@@ -61,7 +76,7 @@ impl PrettyNames {
         let base = names
             .get(&name)
             .map(|&id| queries.lookup_smol_str(id))
-            .unwrap_or_else(|| SmolStr::new("t"));
+            .unwrap_or_else(|| SmolStr::clone(&self.default_name));
 
         let display = self.allocate_display_name(base);
         self.display_by_name.insert(name, SmolStr::clone(&display));
@@ -105,6 +120,7 @@ pub struct Pretty<'a, Q: ?Sized> {
     width: usize,
     checked: &'a CheckedModule,
     names: PrettyNames,
+    show_rigid_kinds: bool,
 }
 
 impl<'a, Q> Pretty<'a, Q>
@@ -112,11 +128,16 @@ where
     Q: PrettyQueries + ?Sized,
 {
     pub fn new(queries: &'a Q, checked: &'a CheckedModule) -> Self {
-        Pretty { queries, width: 100, checked, names: PrettyNames::new() }
+        Pretty { queries, width: 100, checked, names: PrettyNames::new(), show_rigid_kinds: true }
     }
 
     pub fn width(mut self, width: usize) -> Self {
         self.width = width;
+        self
+    }
+
+    pub fn without_rigid_kinds(mut self) -> Pretty<'a, Q> {
+        self.show_rigid_kinds = false;
         self
     }
 
@@ -125,20 +146,34 @@ where
     }
 
     pub fn display_name(&mut self, name: Name) -> SmolStr {
+        self.names.set_default_name("t");
         self.names.display_name(self.queries, &self.checked.names, name)
     }
 
     pub fn render(&mut self, id: TypeId) -> SmolStr {
+        self.names.set_default_name("t");
         self.render_with_signature(None, id)
     }
 
     pub fn render_signature(&mut self, name: &str, id: TypeId) -> SmolStr {
+        self.names.set_default_name("t");
+        self.render_with_signature(Some(name), id)
+    }
+
+    pub fn render_kind_signature(&mut self, name: &str, id: TypeId) -> SmolStr {
+        self.names.set_default_name("k");
         self.render_with_signature(Some(name), id)
     }
 
     fn render_with_signature(&mut self, signature: Option<&str>, id: TypeId) -> SmolStr {
         let arena = Arena::new();
-        let mut printer = Printer::new(&arena, self.queries, &self.checked.names, &mut self.names);
+        let mut printer = Printer::new(
+            &arena,
+            self.queries,
+            &self.checked.names,
+            &mut self.names,
+            self.show_rigid_kinds,
+        );
 
         let document = if let Some(name) = signature {
             printer.signature(name, id)
@@ -171,6 +206,7 @@ where
     queries: &'context Q,
     names: &'context FxHashMap<Name, SmolStrId>,
     pretty_names: &'names mut PrettyNames,
+    show_rigid_kinds: bool,
 }
 
 impl<'arena, 'context, 'names, Q> Printer<'arena, 'context, 'names, Q>
@@ -182,8 +218,9 @@ where
         queries: &'context Q,
         names: &'context FxHashMap<Name, SmolStrId>,
         pretty_names: &'names mut PrettyNames,
+        show_rigid_kinds: bool,
     ) -> Printer<'arena, 'context, 'names, Q> {
-        Printer { arena, queries, names, pretty_names }
+        Printer { arena, queries, names, pretty_names, show_rigid_kinds }
     }
 
     fn lookup_type(&self, id: TypeId) -> Type {
@@ -289,8 +326,15 @@ where
 
             Type::Rigid(name, _, kind) => {
                 let text = self.pretty_names.display_name(self.queries, self.names, name);
-                let kind = self.traverse(Precedence::Top, kind);
-                self.arena.text(format!("({text} :: ")).append(kind).append(self.arena.text(")"))
+                if self.show_rigid_kinds {
+                    let kind = self.traverse(Precedence::Top, kind);
+                    self.arena
+                        .text(format!("({text} :: "))
+                        .append(kind)
+                        .append(self.arena.text(")"))
+                } else {
+                    self.arena.text(text.to_string())
+                }
             }
 
             Type::Unification(unification_id) => self.arena.text(format!("?{unification_id}")),

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -6,6 +6,7 @@ pub mod implication;
 pub mod safety;
 pub mod source;
 pub mod state;
+pub mod tree;
 
 pub mod core;
 pub use core::pretty::PrettyQueries;
@@ -64,6 +65,7 @@ pub struct CheckedModule {
     pub derived: FxHashMap<DeriveId, CheckedInstance>,
     pub roles: FxHashMap<TypeItemId, Arc<[Role]>>,
     pub nodes: CheckedNodes,
+    pub tree: tree::Module,
     pub holes: CheckedHoles,
     pub errors: Vec<CheckingError>,
     pub names: FxHashMap<Name, SmolStrId>,

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TypeItemId};
+use indexing::{TermItemId, TypeItemId, TypeItemKind};
 use itertools::Itertools;
 use lowering::{
     ClassIr, DataIr, LoweringError, NewtypeIr, RecursiveGroup, Scc, SynonymIr, TermItemIr,
@@ -19,7 +19,7 @@ use crate::core::{
 use crate::error::ErrorCrumb;
 use crate::source::types;
 use crate::state::CheckState;
-use crate::{ExternalQueries, safe_loop};
+use crate::{ExternalQueries, safe_loop, tree};
 
 struct PendingDataType {
     parameters: Vec<ForallBinder>,
@@ -546,7 +546,8 @@ where
             context.intern_forall_binder(binder)
         });
 
-        let type_parameters = type_parameters.collect_vec();
+        let type_parameters = type_parameters.collect::<Arc<[_]>>();
+        let mut semantic_constructors = vec![];
 
         for (constructor_id, checked_arguments) in constructors {
             let mut result = type_reference;
@@ -558,10 +559,15 @@ where
                 result = context.intern_application(result, rigid);
             }
 
-            // a -> Tagged @k t a
-            for argument in checked_arguments.into_iter().rev() {
+            let mut arguments = Vec::with_capacity(checked_arguments.len());
+            for argument in checked_arguments {
                 let argument = zonk::zonk(state, context, argument)?;
                 let argument = ApplyKinds::on(state, context, item_id, type_reference, argument)?;
+                arguments.push(argument);
+            }
+
+            // a -> Tagged @k t a
+            for &argument in arguments.iter().rev() {
                 result = context.intern_function(argument, result);
             }
 
@@ -578,9 +584,35 @@ where
             }
 
             state.checked.terms.insert(constructor_id, result);
+
+            let constructor = tree::DataConstructor { arguments: Arc::from(arguments) };
+            let declaration = tree::TermDeclaration {
+                type_id: result,
+                kind: tree::TermDeclarationKind::Constructor(constructor),
+            };
+
+            let declaration = state.checked.tree.insert_term(constructor_id, declaration);
+            semantic_constructors.push(declaration);
         }
 
-        state.checked.data_declarations.insert(item_id, CheckedDataDeclaration { type_parameters });
+        let checked_declaration =
+            CheckedDataDeclaration { type_parameters: Arc::clone(&type_parameters) };
+        state.checked.data_declarations.insert(item_id, checked_declaration);
+
+        let data = tree::DataDeclaration {
+            parameters: type_parameters,
+            constructors: Arc::from(semantic_constructors),
+        };
+
+        let declaration = match &context.indexed.items[item_id].kind {
+            TypeItemKind::Data { .. } => tree::TypeDeclarationKind::Data(data),
+            TypeItemKind::Newtype { .. } => tree::TypeDeclarationKind::Newtype(data),
+            _ => unreachable!("invariant violated: pending data type is not data or newtype"),
+        };
+
+        let roles = state.checked.lookup_roles(item_id).unwrap_or_default();
+        let declaration = tree::TypeDeclaration { kind: constructor_kind, roles, declaration };
+        state.checked.tree.insert_type_declaration(item_id, declaration);
     }
 
     Ok(())

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -1,0 +1,179 @@
+use std::ops::Index;
+use std::sync::Arc;
+
+use files::FileId;
+use indexing::{TermItemId, TypeItemId, ValueEquationId};
+use la_arena::{Arena, ArenaMap, Idx};
+
+use crate::TypeId;
+use crate::core::{ForallBinderId, Role};
+use crate::evidence::Evidence;
+
+pub type ExpressionId = Idx<Expression>;
+pub type BinderId = Idx<Binder>;
+pub type TermDeclarationId = Idx<TermDeclaration>;
+pub type TypeDeclarationId = Idx<TypeDeclaration>;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Module {
+    arena: ModuleArena,
+    terms: ArenaMap<TermItemId, TermDeclarationId>,
+    types: ArenaMap<TypeItemId, TypeDeclarationId>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ModuleArena {
+    expressions: Arena<Expression>,
+    binders: Arena<Binder>,
+    terms: Arena<TermDeclaration>,
+    types: Arena<TypeDeclaration>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TermDeclaration {
+    pub type_id: TypeId,
+    pub kind: TermDeclarationKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TermDeclarationKind {
+    Value(ValueDeclaration),
+    Constructor(DataConstructor),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ValueDeclaration {
+    pub evidences: Arc<[Evidence]>,
+    pub equations: Arc<[Equation]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DataConstructor {
+    pub arguments: Arc<[TypeId]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TypeDeclaration {
+    pub kind: TypeId,
+    pub roles: Arc<[Role]>,
+    pub declaration: TypeDeclarationKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TypeDeclarationKind {
+    Data(DataDeclaration),
+    Newtype(DataDeclaration),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DataDeclaration {
+    pub parameters: Arc<[ForallBinderId]>,
+    pub constructors: Arc<[TermDeclarationId]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Equation {
+    pub source: ValueEquationId,
+    pub binders: Arc<[BinderId]>,
+    pub guarded_expression: GuardedExpression,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum GuardedExpression {
+    Unconditional { where_expression: WhereExpression },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct WhereExpression {
+    pub expression: ExpressionId,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Binder {
+    pub source: lowering::BinderId,
+    pub type_id: TypeId,
+    pub kind: BinderKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BinderKind {
+    Variable,
+    Constructor { resolution: (FileId, TermItemId), arguments: Arc<[BinderId]> },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Expression {
+    pub type_id: TypeId,
+    pub kind: ExpressionKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExpressionKind {
+    Variable { resolution: lowering::TermVariableResolution },
+}
+
+impl Module {
+    pub fn allocate_expression(&mut self, expression: Expression) -> ExpressionId {
+        self.arena.expressions.alloc(expression)
+    }
+
+    pub fn allocate_binder(&mut self, binder: Binder) -> BinderId {
+        self.arena.binders.alloc(binder)
+    }
+
+    pub fn insert_term(&mut self, source: TermItemId, term: TermDeclaration) -> TermDeclarationId {
+        let term = self.arena.terms.alloc(term);
+        self.terms.insert(source, term);
+        term
+    }
+
+    pub fn lookup_term(&self, source: TermItemId) -> Option<TermDeclarationId> {
+        self.terms.get(source).copied()
+    }
+
+    pub fn insert_type_declaration(
+        &mut self,
+        source: TypeItemId,
+        declaration: TypeDeclaration,
+    ) -> TypeDeclarationId {
+        let declaration = self.arena.types.alloc(declaration);
+        self.types.insert(source, declaration);
+        declaration
+    }
+
+    pub fn lookup_type_declaration(&self, source: TypeItemId) -> Option<TypeDeclarationId> {
+        self.types.get(source).copied()
+    }
+}
+
+impl Index<ExpressionId> for Module {
+    type Output = Expression;
+
+    fn index(&self, index: ExpressionId) -> &Expression {
+        &self.arena.expressions[index]
+    }
+}
+
+impl Index<BinderId> for Module {
+    type Output = Binder;
+
+    fn index(&self, index: BinderId) -> &Binder {
+        &self.arena.binders[index]
+    }
+}
+
+impl Index<TermDeclarationId> for Module {
+    type Output = TermDeclaration;
+
+    fn index(&self, index: TermDeclarationId) -> &TermDeclaration {
+        &self.arena.terms[index]
+    }
+}
+
+impl Index<TypeDeclarationId> for Module {
+    type Output = TypeDeclaration;
+
+    fn index(&self, index: TypeDeclarationId) -> &TypeDeclaration {
+        &self.arena.types[index]
+    }
+}

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -1,3 +1,5 @@
+pub mod pretty;
+
 use std::ops::Index;
 use std::sync::Arc;
 

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1,0 +1,188 @@
+//! Implements the pretty printer for the checked semantic tree.
+
+use building_types::QueryResult;
+use files::FileId;
+use indexing::{TermItem, TypeItem};
+use pretty::{Arena, DocAllocator, DocBuilder};
+use smol_str::{SmolStr, SmolStrBuilder};
+
+use crate::CheckedModule;
+use crate::core::Type;
+use crate::core::pretty::{Pretty as TypePretty, PrettyQueries};
+use crate::tree::{TermDeclarationKind, TypeDeclarationKind};
+
+type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
+
+pub struct Pretty<'a, Q: ?Sized> {
+    queries: &'a Q,
+    width: usize,
+    checked: &'a CheckedModule,
+}
+
+impl<'a, Q> Pretty<'a, Q>
+where
+    Q: PrettyQueries + ?Sized,
+{
+    pub fn new(queries: &'a Q, checked: &'a CheckedModule) -> Pretty<'a, Q> {
+        Pretty { queries, width: 100, checked }
+    }
+
+    pub fn width(mut self, width: usize) -> Pretty<'a, Q> {
+        self.width = width;
+        self
+    }
+
+    pub fn render(&self, file_id: FileId) -> QueryResult<SmolStr> {
+        let indexed = self.queries.indexed(file_id)?;
+        let arena = Arena::new();
+        let mut printer = Printer::new(&arena, self.queries, &indexed, self.checked, self.width);
+        let document = printer.module();
+
+        let mut output = SmolStrBuilder::new();
+        document
+            .render_fmt(self.width, &mut output)
+            .expect("critical failure: failed to render checked semantic tree");
+        Ok(output.finish())
+    }
+}
+
+struct Printer<'arena, 'context, 'module, Q>
+where
+    Q: PrettyQueries + ?Sized,
+{
+    arena: &'arena Arena<'arena>,
+    queries: &'context Q,
+    indexed: &'module indexing::IndexedModule,
+    checked: &'context CheckedModule,
+    type_pretty: TypePretty<'context, Q>,
+}
+
+impl<'arena, 'context, 'module, Q> Printer<'arena, 'context, 'module, Q>
+where
+    Q: PrettyQueries + ?Sized,
+{
+    fn new(
+        arena: &'arena Arena<'arena>,
+        queries: &'context Q,
+        indexed: &'module indexing::IndexedModule,
+        checked: &'context CheckedModule,
+        width: usize,
+    ) -> Printer<'arena, 'context, 'module, Q> {
+        let type_pretty = TypePretty::new(queries, checked).without_rigid_kinds().width(width);
+        Printer { arena, queries, indexed, checked, type_pretty }
+    }
+
+    fn module(&mut self) -> Doc<'arena> {
+        let mut declarations = vec![];
+
+        for (type_id, TypeItem { name, .. }) in self.indexed.items.iter_types() {
+            let Some(name) = name else { continue };
+            let Some(declaration_id) = self.checked.tree.lookup_type_declaration(type_id) else {
+                continue;
+            };
+
+            let declaration = &self.checked.tree[declaration_id];
+            let keyword = match &declaration.declaration {
+                TypeDeclarationKind::Data(_) => "data",
+                TypeDeclarationKind::Newtype(_) => "newtype",
+            };
+            let kind = declaration.kind;
+
+            self.type_pretty.reset();
+            let signature = self.type_pretty.render_kind_signature(name, kind);
+            let signature = self.arena.text(format!("{keyword} {signature}"));
+
+            let declaration = self.data_declaration(type_id, keyword, name);
+
+            declarations.push(signature.append(self.arena.hardline()).append(declaration));
+        }
+
+        let mut declarations = declarations.into_iter();
+        if let Some(first) = declarations.next() {
+            declarations.fold(first, |document, declaration| {
+                document
+                    .append(self.arena.hardline())
+                    .append(self.arena.hardline())
+                    .append(declaration)
+            })
+        } else {
+            self.arena.nil()
+        }
+    }
+
+    fn data_declaration(
+        &mut self,
+        type_id: indexing::TypeItemId,
+        keyword: &str,
+        name: &str,
+    ) -> Doc<'arena> {
+        let declaration_id = self
+            .checked
+            .tree
+            .lookup_type_declaration(type_id)
+            .expect("invariant violated: missing checked type declaration");
+        let declaration = &self.checked.tree[declaration_id];
+        let data = match &declaration.declaration {
+            TypeDeclarationKind::Data(data) | TypeDeclarationKind::Newtype(data) => data,
+        };
+
+        let mut parameter_names = vec![];
+        for &parameter in data.parameters.iter() {
+            let parameter = self.queries.lookup_forall_binder(parameter);
+            let name = self.type_pretty.display_name(parameter.name);
+            parameter_names.push((name.to_string(), parameter.visible));
+        }
+
+        let mut head = self.arena.text(format!("{keyword} {name}"));
+        for (parameter, visible) in &parameter_names {
+            let parameter = if *visible { format!("@{parameter}") } else { parameter.to_string() };
+            head = head.append(self.arena.text(format!(" {parameter}")));
+        }
+
+        let mut declaration = head;
+        let constructors = self.indexed.data_constructors(type_id);
+        for (&declaration_id, constructor_id) in data.constructors.iter().zip(constructors) {
+            let TermItem { name: constructor_name, .. } = &self.indexed.items[constructor_id];
+            let Some(constructor_name) = constructor_name else { continue };
+            let constructor = &self.checked.tree[declaration_id];
+            let TermDeclarationKind::Constructor(constructor) = &constructor.kind else {
+                unreachable!("invariant violated: data declaration contains a value declaration");
+            };
+
+            let mut result = self.arena.text(name.to_string());
+            for (parameter, _) in &parameter_names {
+                result = result.append(self.arena.text(format!(" {parameter}")));
+            }
+
+            let mut constructor_type = result;
+            for &argument_id in constructor.arguments.iter().rev() {
+                let argument = self.type_pretty.render(argument_id);
+                let argument = match self.queries.lookup_type(argument_id) {
+                    Type::Forall(..)
+                    | Type::Constrained(..)
+                    | Type::Function(..)
+                    | Type::Kinded(..) => format!("({argument})"),
+                    _ => argument.to_string(),
+                };
+
+                let result = constructor_type;
+                constructor_type = self
+                    .arena
+                    .text(argument)
+                    .append(self.arena.text(" ->"))
+                    .append(self.arena.line().append(result).nest(2))
+                    .group();
+            }
+
+            let constructor_type = self.arena.line().append(constructor_type).nest(4);
+            let constructor = self
+                .arena
+                .text(format!("  | {constructor_name} ::"))
+                .append(constructor_type)
+                .group();
+            declaration = declaration.append(self.arena.hardline()).append(constructor);
+        }
+
+        declaration
+    }
+}

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -306,7 +306,8 @@ impl<'a> ModuleEncoder<'a> {
             indexing::TypeItemKind::Data { constructors, .. } => {
                 let declaration = self.checked.lookup_data_declaration(type_id);
                 let declaration = if let Some(declaration) = declaration {
-                    Some(self.type_encoder.encode_declaration(declaration.type_parameters)?)
+                    let type_parameters = declaration.type_parameters.iter().copied();
+                    Some(self.type_encoder.encode_declaration(type_parameters)?)
                 } else {
                     None
                 };
@@ -319,7 +320,8 @@ impl<'a> ModuleEncoder<'a> {
             indexing::TypeItemKind::Newtype { constructors, .. } => {
                 let declaration = self.checked.lookup_data_declaration(type_id);
                 let declaration = if let Some(declaration) = declaration {
-                    Some(self.type_encoder.encode_declaration(declaration.type_parameters)?)
+                    let type_parameters = declaration.type_parameters.iter().copied();
+                    Some(self.type_encoder.encode_declaration(type_parameters)?)
                 } else {
                     None
                 };

--- a/compiler-scripts/src/main.rs
+++ b/compiler-scripts/src/main.rs
@@ -9,7 +9,7 @@ use compiler_scripts::test_runner::{
 #[derive(Parser)]
 #[command(about = "Compiler development scripts")]
 struct Cli {
-    /// Test category: checking (c), lowering (l), resolving (r), lsp, docs
+    /// Test category: checking (c), semantic (s), lowering (l), resolving (r), lsp, docs
     category: TestCategory,
 
     #[command(flatten)]

--- a/compiler-scripts/src/test_runner/category.rs
+++ b/compiler-scripts/src/test_runner/category.rs
@@ -5,6 +5,7 @@ use anyhow::bail;
 #[derive(Copy, Clone, Debug)]
 pub enum TestCategory {
     Checking,
+    Semantic,
     Lowering,
     Resolving,
     Lsp,
@@ -15,6 +16,7 @@ impl TestCategory {
     pub fn as_str(&self) -> &'static str {
         match self {
             TestCategory::Checking => "checking",
+            TestCategory::Semantic => "semantic",
             TestCategory::Lowering => "lowering",
             TestCategory::Resolving => "resolving",
             TestCategory::Lsp => "lsp",
@@ -40,12 +42,13 @@ impl FromStr for TestCategory {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "checking" | "c" => Ok(TestCategory::Checking),
+            "semantic" | "s" => Ok(TestCategory::Semantic),
             "lowering" | "l" => Ok(TestCategory::Lowering),
             "resolving" | "r" => Ok(TestCategory::Resolving),
             "lsp" => Ok(TestCategory::Lsp),
             "docs" => Ok(TestCategory::Docs),
             _ => bail!(
-                "unknown test category '{}', expected: checking (c), lowering (l), resolving (r), lsp, docs",
+                "unknown test category '{}', expected: checking (c), semantic (s), lowering (l), resolving (r), lsp, docs",
                 s
             ),
         }

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ coverage-html:
 @integration *args="":
   cargo nextest run -p tests-integration "$@" --status-level=fail --final-status-level=fail --failure-output=final
 
-[doc("Run integration tests with snapshot diffing: checking|lowering|resolving|lsp")]
+[doc("Run integration tests with snapshot diffing: checking|semantic|lowering|resolving|lsp")]
 @t *args="":
   cargo run -q -p compiler-scripts --release -- "$@"
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -32,6 +32,10 @@ name = "checking"
 harness = false
 
 [[test]]
+name = "semantic"
+harness = false
+
+[[test]]
 name = "lowering"
 harness = false
 

--- a/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.purs
+++ b/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.purs
@@ -3,3 +3,8 @@ module Main where
 data Proxy a = Proxy
 
 newtype Tagged t a = Tagged a
+
+data Maybe :: Type -> Type
+data Maybe a
+  = Just a
+  | Nothing

--- a/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.purs
+++ b/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+data Proxy a = Proxy
+
+newtype Tagged t a = Tagged a

--- a/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.snap
+++ b/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.snap
@@ -3,15 +3,15 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-Types
-data Proxy :: forall (t :: Type). (t :: Type) -> Type
-  parameters: [a :: (t :: Type)]
-  roles: [Phantom]
-  Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
-newtype Tagged :: forall (t :: Type). (t :: Type) -> Type -> Type
-  parameters: [t1 :: (t :: Type), a :: Type]
-  roles: [Phantom, Representational]
-  Tagged ::
-  forall (t :: Type) (@t1 :: (t :: Type)) (@a :: Type).
-    (a :: Type) -> Tagged @(t :: Type) (t1 :: (t :: Type)) (a :: Type)
-    (a :: Type)
+data Proxy :: forall (k :: Type). k -> Type
+data Proxy @a
+  | Proxy :: Proxy a
+
+newtype Tagged :: forall (k :: Type). k -> Type -> Type
+newtype Tagged @t @a
+  | Tagged :: a -> Tagged t a
+
+data Maybe :: Type -> Type
+data Maybe @a
+  | Just :: a -> Maybe a
+  | Nothing :: Maybe a

--- a/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.snap
+++ b/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+Types
+data Proxy :: forall (t :: Type). (t :: Type) -> Type
+  parameters: [a :: (t :: Type)]
+  roles: [Phantom]
+  Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
+newtype Tagged :: forall (t :: Type). (t :: Type) -> Type -> Type
+  parameters: [t1 :: (t :: Type), a :: Type]
+  roles: [Phantom, Representational]
+  Tagged ::
+  forall (t :: Type) (@t1 :: (t :: Type)) (@a :: Type).
+    (a :: Type) -> Tagged @(t :: Type) (t1 :: (t :: Type)) (a :: Type)
+    (a :: Type)

--- a/tests-integration/src/fixtures.rs
+++ b/tests-integration/src/fixtures.rs
@@ -52,6 +52,24 @@ pub fn checking(path: &Path) -> FixtureResult {
     Ok(())
 }
 
+pub fn semantic(path: &Path) -> FixtureResult {
+    let folder = fixture_folder(path)?;
+    let file = module_name(path)?;
+    let (engine, _) = crate::load_compiler(folder);
+    let Some(id) = engine.module_file(&file) else {
+        return Err(missing_module(path, &file).into());
+    };
+
+    let report = crate::generated::semantic::report(&engine, id);
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path(snapshot_path(folder));
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| insta::assert_snapshot!(file, report));
+
+    Ok(())
+}
+
 pub fn lowering(path: &Path) -> FixtureResult {
     let folder = fixture_folder(path)?;
     let file = module_name(path)?;

--- a/tests-integration/src/generated.rs
+++ b/tests-integration/src/generated.rs
@@ -1,3 +1,4 @@
 pub mod basic;
 pub mod docs;
 pub mod lsp;
+pub mod semantic;

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -1,78 +1,8 @@
-use std::fmt::Write;
-
 use analyzer::QueryEngine;
-use checking::core::pretty;
-use checking::tree::{TermDeclarationKind, TypeDeclarationKind};
-use checking::{PrettyQueries, tree};
+use checking::tree::pretty;
 use files::FileId;
-use indexing::{TermItem, TypeItem};
-use itertools::Itertools;
 
 pub fn report(engine: &QueryEngine, id: FileId) -> String {
-    let indexed = engine.indexed(id).unwrap();
     let checked = engine.checked(id).unwrap();
-    let mut pretty = pretty::Pretty::new(engine, &checked);
-    let mut out = String::default();
-
-    writeln!(out, "Types").unwrap();
-
-    for (type_id, TypeItem { name, .. }) in indexed.items.iter_types() {
-        let Some(name) = name else { continue };
-        let Some(declaration_id) = checked.tree.lookup_type_declaration(type_id) else {
-            continue;
-        };
-
-        let declaration = &checked.tree[declaration_id];
-        let (keyword, data) = match &declaration.declaration {
-            TypeDeclarationKind::Data(data) => ("data", data),
-            TypeDeclarationKind::Newtype(data) => ("newtype", data),
-        };
-
-        pretty.reset();
-        let signature = pretty.render_signature(name, declaration.kind);
-        writeln!(out, "{keyword} {signature}").unwrap();
-
-        write_parameters(&mut out, engine, &mut pretty, data);
-
-        let mut roles = declaration.roles.iter().map(|role| format!("{role:?}"));
-        let roles = roles.join(", ");
-        writeln!(out, "  roles: [{roles}]").unwrap();
-
-        let constructors = indexed.data_constructors(type_id);
-        for (&declaration_id, constructor_id) in data.constructors.iter().zip(constructors) {
-            let TermItem { name, .. } = &indexed.items[constructor_id];
-            let Some(name) = name else { continue };
-            let declaration = &checked.tree[declaration_id];
-            let TermDeclarationKind::Constructor(constructor) = &declaration.kind else {
-                unreachable!("invariant violated: data declaration contains a value declaration");
-            };
-
-            pretty.reset();
-            let signature = pretty.render_signature(name, declaration.type_id);
-            writeln!(out, "  {signature}").unwrap();
-
-            for &argument in constructor.arguments.iter() {
-                let argument = pretty.render(argument);
-                writeln!(out, "    {argument}").unwrap();
-            }
-        }
-    }
-
-    out
-}
-
-fn write_parameters(
-    out: &mut String,
-    engine: &QueryEngine,
-    pretty: &mut pretty::Pretty<'_, QueryEngine>,
-    data: &tree::DataDeclaration,
-) {
-    let mut parameters = data.parameters.iter().map(|&parameter| {
-        let parameter = engine.lookup_forall_binder(parameter);
-        let name = pretty.display_name(parameter.name);
-        let kind = pretty.render(parameter.kind);
-        format!("{name} :: {kind}")
-    });
-    let parameters = parameters.join(", ");
-    writeln!(out, "  parameters: [{parameters}]").unwrap();
+    pretty::Pretty::new(engine, &checked).render(id).unwrap().to_string()
 }

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -1,0 +1,78 @@
+use std::fmt::Write;
+
+use analyzer::QueryEngine;
+use checking::core::pretty;
+use checking::tree::{TermDeclarationKind, TypeDeclarationKind};
+use checking::{PrettyQueries, tree};
+use files::FileId;
+use indexing::{TermItem, TypeItem};
+use itertools::Itertools;
+
+pub fn report(engine: &QueryEngine, id: FileId) -> String {
+    let indexed = engine.indexed(id).unwrap();
+    let checked = engine.checked(id).unwrap();
+    let mut pretty = pretty::Pretty::new(engine, &checked);
+    let mut out = String::default();
+
+    writeln!(out, "Types").unwrap();
+
+    for (type_id, TypeItem { name, .. }) in indexed.items.iter_types() {
+        let Some(name) = name else { continue };
+        let Some(declaration_id) = checked.tree.lookup_type_declaration(type_id) else {
+            continue;
+        };
+
+        let declaration = &checked.tree[declaration_id];
+        let (keyword, data) = match &declaration.declaration {
+            TypeDeclarationKind::Data(data) => ("data", data),
+            TypeDeclarationKind::Newtype(data) => ("newtype", data),
+        };
+
+        pretty.reset();
+        let signature = pretty.render_signature(name, declaration.kind);
+        writeln!(out, "{keyword} {signature}").unwrap();
+
+        write_parameters(&mut out, engine, &mut pretty, data);
+
+        let mut roles = declaration.roles.iter().map(|role| format!("{role:?}"));
+        let roles = roles.join(", ");
+        writeln!(out, "  roles: [{roles}]").unwrap();
+
+        let constructors = indexed.data_constructors(type_id);
+        for (&declaration_id, constructor_id) in data.constructors.iter().zip(constructors) {
+            let TermItem { name, .. } = &indexed.items[constructor_id];
+            let Some(name) = name else { continue };
+            let declaration = &checked.tree[declaration_id];
+            let TermDeclarationKind::Constructor(constructor) = &declaration.kind else {
+                unreachable!("invariant violated: data declaration contains a value declaration");
+            };
+
+            pretty.reset();
+            let signature = pretty.render_signature(name, declaration.type_id);
+            writeln!(out, "  {signature}").unwrap();
+
+            for &argument in constructor.arguments.iter() {
+                let argument = pretty.render(argument);
+                writeln!(out, "    {argument}").unwrap();
+            }
+        }
+    }
+
+    out
+}
+
+fn write_parameters(
+    out: &mut String,
+    engine: &QueryEngine,
+    pretty: &mut pretty::Pretty<'_, QueryEngine>,
+    data: &tree::DataDeclaration,
+) {
+    let mut parameters = data.parameters.iter().map(|&parameter| {
+        let parameter = engine.lookup_forall_binder(parameter);
+        let name = pretty.display_name(parameter.name);
+        let kind = pretty.render(parameter.kind);
+        format!("{name} :: {kind}")
+    });
+    let parameters = parameters.join(", ");
+    writeln!(out, "  parameters: [{parameters}]").unwrap();
+}

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -40,7 +40,7 @@ pub fn load_compiler(folder: &Path) -> (QueryEngine, Files) {
     let mut files = Files::default();
     prim::configure(&mut engine, &mut files);
 
-    if folder.starts_with("fixtures/checking/") {
+    if folder.starts_with("fixtures/checking/") || folder.starts_with("fixtures/semantic/") {
         let prelude = Path::new("fixtures/checking/prelude");
         load_folder(prelude).for_each(|path| {
             load_file(&mut engine, &mut files, &path);

--- a/tests-integration/tests/semantic.rs
+++ b/tests-integration/tests/semantic.rs
@@ -1,0 +1,7 @@
+fn semantic(path: &std::path::Path) -> datatest_stable::Result<()> {
+    tests_integration::fixtures::semantic(path)
+}
+
+datatest_stable::harness! {
+    { test = semantic, root = "fixtures/semantic", pattern = r".*/Main\.purs$" },
+}


### PR DESCRIPTION
Introduce the initial arena-allocated checked semantic tree representation as a foundation for carrying typed PureScript semantics beyond lowering without committing to a backend representation.

This first slice records checked data and newtype declarations, including their type parameters and constructors, while leaving the existing checking interfaces in place during migration. It also adds a semantic integration-test category and a PureScript-like printer for inspecting collected declarations. The printer preserves binder visibility at declaration sites and uses distinct generated names for kind and type variables.

Checks:
- `cargo check --workspace --tests`
- `just t semantic 1784637780`