### PR TITLE
[checking] Add initial value declaration lowering

### DIFF
--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -250,7 +250,7 @@ pub struct ConstraintErrors {
 
 pub struct ConstrainedByResiduals {
     pub type_id: TypeId,
-    pub has_constraints: bool,
+    pub evidences: Vec<Evidence>,
 }
 
 pub fn constrain_using_residuals<Q>(
@@ -264,7 +264,7 @@ where
     Q: ExternalQueries,
 {
     if residuals.is_empty() {
-        return Ok(ConstrainedByResiduals { type_id: unconstrained, has_constraints: false });
+        return Ok(ConstrainedByResiduals { type_id: unconstrained, evidences: vec![] });
     }
 
     for residual in residuals.iter_mut() {
@@ -278,14 +278,15 @@ where
     let residuals = partial.into_iter().chain(residuals);
     let generalised = residuals.sorted_by_key(|constraint| constraint.key.wanted).collect_vec();
     let generalised = finalise_generalised_constraints(state, context, generalised)?;
-    let has_constraints = !generalised.is_empty();
 
-    let constrained = generalised.into_iter().rfold(unconstrained, |inner, constraint| {
-        let constraint = state.canonicals.type_id(context, constraint);
+    let constrained = generalised.iter().rfold(unconstrained, |inner, generalised| {
+        let constraint = state.canonicals.type_id(context, generalised.constraint);
         context.intern_constrained(constraint, inner)
     });
+    let evidences = generalised.into_iter().map(|generalised| generalised.evidence);
+    let evidences = evidences.collect();
 
-    Ok(ConstrainedByResiduals { type_id: constrained, has_constraints })
+    Ok(ConstrainedByResiduals { type_id: constrained, evidences })
 }
 
 type PrunedPartial = (Vec<ConstraintInScope>, Option<ConstraintInScope>);
@@ -410,11 +411,16 @@ where
     Ok(constraints.into_values().collect())
 }
 
+struct GeneralisedConstraint {
+    constraint: CanonicalConstraintId,
+    evidence: Evidence,
+}
+
 fn finalise_generalised_constraints<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     constraints: Vec<ConstraintInScope>,
-) -> QueryResult<Vec<CanonicalConstraintId>>
+) -> QueryResult<Vec<GeneralisedConstraint>>
 where
     Q: ExternalQueries,
 {
@@ -432,14 +438,22 @@ where
         minimise_by_superclasses(state, context, generalisable)?;
 
     let mut evidences = vec![];
-    for ConstraintInScope { key, evidence } in &retained {
-        let canonical = state.canonicals.type_id(context, key.wanted);
-        let binder = state.checked.evidence.fresh_binder(canonical);
+    let mut declaration_evidences = vec![];
+    for constraint in &retained {
+        let ConstraintInScope { key, evidence } = constraint;
+        let declaration_evidence = if constraint.is_partial(state, context) {
+            Evidence::Trivial
+        } else {
+            let canonical = state.canonicals.type_id(context, key.wanted);
+            let binder = state.checked.evidence.fresh_binder(canonical);
+            Evidence::Given(binder)
+        };
 
-        let given = state.checked.evidence.allocate(Evidence::Given(binder));
-        state.checked.evidence.solve(evidence.wanted, given);
+        let proof = state.checked.evidence.allocate(declaration_evidence.clone());
+        state.checked.evidence.solve(evidence.wanted, proof);
 
-        evidences.push((key.wanted, given));
+        evidences.push((key.wanted, proof));
+        declaration_evidences.push(declaration_evidence);
     }
 
     let projections = elaborate::elaborate_superclasses_with_evidence(state, context, &evidences)?;
@@ -453,7 +467,12 @@ where
         }
     }
 
-    Ok(retained.into_iter().map(|constraint| constraint.key.wanted).collect())
+    let retained = retained.into_iter().zip(declaration_evidences);
+    let retained = retained.map(|(constraint, evidence)| GeneralisedConstraint {
+        constraint: constraint.key.wanted,
+        evidence,
+    });
+    Ok(retained.collect())
 }
 
 struct MinimisedBySuperclasses {

--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -19,7 +19,9 @@ type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
 
 const FIRST_SUFFIX: NonZeroU32 = NonZeroU32::new(1).unwrap();
 
-pub trait PrettyQueries: QueryProxy<Indexed = Arc<indexing::IndexedModule>> {
+pub trait PrettyQueries:
+    QueryProxy<Indexed = Arc<indexing::IndexedModule>, Lowered = Arc<lowering::LoweredModule>>
+{
     fn lookup_type(&self, id: TypeId) -> Type;
 
     fn lookup_forall_binder(&self, id: ForallBinderId) -> ForallBinder;
@@ -121,6 +123,7 @@ pub struct Pretty<'a, Q: ?Sized> {
     checked: &'a CheckedModule,
     names: PrettyNames,
     show_rigid_kinds: bool,
+    show_forall_kinds: bool,
 }
 
 impl<'a, Q> Pretty<'a, Q>
@@ -128,7 +131,14 @@ where
     Q: PrettyQueries + ?Sized,
 {
     pub fn new(queries: &'a Q, checked: &'a CheckedModule) -> Self {
-        Pretty { queries, width: 100, checked, names: PrettyNames::new(), show_rigid_kinds: true }
+        Pretty {
+            queries,
+            width: 100,
+            checked,
+            names: PrettyNames::new(),
+            show_rigid_kinds: true,
+            show_forall_kinds: true,
+        }
     }
 
     pub fn width(mut self, width: usize) -> Self {
@@ -138,6 +148,11 @@ where
 
     pub fn without_rigid_kinds(mut self) -> Pretty<'a, Q> {
         self.show_rigid_kinds = false;
+        self
+    }
+
+    pub fn without_forall_kinds(mut self) -> Pretty<'a, Q> {
+        self.show_forall_kinds = false;
         self
     }
 
@@ -173,6 +188,7 @@ where
             &self.checked.names,
             &mut self.names,
             self.show_rigid_kinds,
+            self.show_forall_kinds,
         );
 
         let document = if let Some(name) = signature {
@@ -207,6 +223,7 @@ where
     names: &'context FxHashMap<Name, SmolStrId>,
     pretty_names: &'names mut PrettyNames,
     show_rigid_kinds: bool,
+    show_forall_kinds: bool,
 }
 
 impl<'arena, 'context, 'names, Q> Printer<'arena, 'context, 'names, Q>
@@ -219,8 +236,9 @@ where
         names: &'context FxHashMap<Name, SmolStrId>,
         pretty_names: &'names mut PrettyNames,
         show_rigid_kinds: bool,
+        show_forall_kinds: bool,
     ) -> Printer<'arena, 'context, 'names, Q> {
-        Printer { arena, queries, names, pretty_names, show_rigid_kinds }
+        Printer { arena, queries, names, pretty_names, show_rigid_kinds, show_forall_kinds }
     }
 
     fn lookup_type(&self, id: TypeId) -> Type {
@@ -455,12 +473,16 @@ where
             .map(|binder| {
                 let name = self.pretty_names.display_name(self.queries, self.names, binder.name);
                 let text = if binder.visible { format!("@{name}") } else { name.to_string() };
-                let kind = self.traverse(Precedence::Top, binder.kind);
-                self.arena
-                    .text(format!("({} :: ", text))
-                    .append(kind)
-                    .append(self.arena.text(")"))
-                    .group()
+                if self.show_forall_kinds {
+                    let kind = self.traverse(Precedence::Top, binder.kind);
+                    self.arena
+                        .text(format!("({} :: ", text))
+                        .append(kind)
+                        .append(self.arena.text(")"))
+                        .group()
+                } else {
+                    self.arena.text(text)
+                }
             })
             .collect_vec();
 

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -6,7 +6,6 @@ use indexing::{TermItemId, TermItemKind, TypeItemId};
 use lowering::TermItemIr;
 use rustc_hash::FxHashMap;
 
-use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::constraint::ConstraintInScope;
 use crate::core::substitute::{NameToType, SubstituteName};
@@ -15,9 +14,11 @@ use crate::core::{
     normalise, signature, toolkit, unification, zonk,
 };
 use crate::error::{ErrorCrumb, ErrorKind};
+use crate::evidence::Evidence;
 use crate::source::terms::equations;
 use crate::source::{derive, types};
 use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
 
 #[derive(Default)]
 struct TermSccState {
@@ -25,7 +26,7 @@ struct TermSccState {
 }
 
 enum PendingValueGroup {
-    Checked { residuals: Vec<ConstraintInScope> },
+    Checked { residuals: Vec<ConstraintInScope>, evidences: Vec<Evidence> },
     Inferred { residuals: Vec<ConstraintInScope> },
 }
 
@@ -335,7 +336,7 @@ where
                 }
             }
 
-            let equation_patterns = equations::check_value_equations(
+            let checked_equations = equations::check_value_equations(
                 state,
                 context,
                 equations::EquationTypeOrigin::Explicit(signature_id),
@@ -345,14 +346,14 @@ where
             let exhaustiveness = exhaustive::check_equation_patterns(
                 state,
                 context,
-                &equation_patterns,
+                &checked_equations.patterns,
                 &member.equations,
             )?;
 
             state.report_exhaustiveness(exhaustiveness);
             state.solve_constraints(context)?
         } else if let Some(expected_type) = class_member_type {
-            let equation_patterns = equations::check_value_equations(
+            let checked_equations = equations::check_value_equations(
                 state,
                 context,
                 equations::EquationTypeOrigin::Implicit,
@@ -362,7 +363,7 @@ where
             let exhaustiveness = exhaustive::check_equation_patterns(
                 state,
                 context,
-                &equation_patterns,
+                &checked_equations.patterns,
                 &member.equations,
             )?;
 
@@ -689,9 +690,9 @@ where
     if let Some(signature_id) = signature
         && let Some(signature_type) = state.checked.lookup_term(item_id)
     {
-        let residuals =
+        let (residuals, evidences) =
             check_value_group_core_check(state, context, signature_id, signature_type, equations)?;
-        Ok(Some(PendingValueGroup::Checked { residuals }))
+        Ok(Some(PendingValueGroup::Checked { residuals, evidences }))
     } else {
         let residuals = check_value_group_core_infer(state, context, item_id, equations)?;
         Ok(Some(PendingValueGroup::Inferred { residuals }))
@@ -704,21 +705,26 @@ fn check_value_group_core_check<Q>(
     signature_id: lowering::TypeId,
     signature_type: TypeId,
     equations: &[lowering::Equation],
-) -> QueryResult<Vec<ConstraintInScope>>
+) -> QueryResult<(Vec<ConstraintInScope>, Vec<Evidence>)>
 where
     Q: ExternalQueries,
 {
-    let equation_patterns = equations::check_value_equations(
+    let checked_equations = equations::check_value_equations(
         state,
         context,
         equations::EquationTypeOrigin::Explicit(signature_id),
         signature_type,
         equations,
     )?;
-    let exhaustiveness =
-        exhaustive::check_equation_patterns(state, context, &equation_patterns, equations)?;
+    let exhaustiveness = exhaustive::check_equation_patterns(
+        state,
+        context,
+        &checked_equations.patterns,
+        equations,
+    )?;
     state.report_exhaustiveness(exhaustiveness);
-    state.solve_constraints(context)
+    let residuals = state.solve_constraints(context)?;
+    Ok((residuals, checked_equations.evidences))
 }
 
 fn check_value_group_core_infer<Q>(
@@ -736,7 +742,11 @@ where
         equations::infer_value_equations(state, context, group_type, equations)?;
     let exhaustiveness =
         exhaustive::check_equation_patterns(state, context, &equation_patterns, equations)?;
+    let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);
+    if has_missing {
+        state.push_wanted(context.prim.partial);
+    }
 
     state.solve_constraints(context)
 }
@@ -755,7 +765,8 @@ where
         marker: TypeId,
         unsolved: Vec<u32>,
         errors: generalise::ConstraintErrors,
-        has_constraints: bool,
+        evidences: Vec<Evidence>,
+        inferred_constraints: bool,
     }
 
     let mut pending = vec![];
@@ -770,10 +781,10 @@ where
 
         let mut errors = generalise::ConstraintErrors::default();
 
-        let (marker, has_constraints) = match group {
-            Some(PendingValueGroup::Checked { residuals }) => {
+        let (marker, evidences, inferred_constraints) = match group {
+            Some(PendingValueGroup::Checked { residuals, evidences }) => {
                 errors.unsatisfied.extend(residuals);
-                (marker, false)
+                (marker, evidences, false)
             }
             Some(PendingValueGroup::Inferred { residuals }) => {
                 let constrained = generalise::constrain_using_residuals(
@@ -783,23 +794,25 @@ where
                     residuals,
                     &mut errors,
                 )?;
-                (constrained.type_id, constrained.has_constraints)
+                let inferred_constraints = !constrained.evidences.is_empty();
+                (constrained.type_id, constrained.evidences, inferred_constraints)
             }
-            None => (marker, false),
+            None => (marker, vec![], false),
         };
 
         let marker = zonk::zonk(state, context, marker)?;
         let unsolved = generalise::unsolved_unifications(state, context, marker)?;
 
-        let pending_group = Pending { marker, unsolved, errors, has_constraints };
+        let pending_group = Pending { marker, unsolved, errors, evidences, inferred_constraints };
         pending.push((item_id, pending_group));
     }
 
-    for (item_id, Pending { marker, unsolved, errors, has_constraints }) in pending {
+    for (item_id, Pending { marker, unsolved, errors, evidences, inferred_constraints }) in pending
+    {
         let marker = generalise::generalise_unsolved(state, context, marker, &unsolved)?;
         state.checked.terms.insert(item_id, marker);
 
-        if recursive && has_constraints {
+        if recursive && inferred_constraints {
             // Keep constraint evidence consistent with the candidate type used for error recovery.
             // The diagnostic prevents the invalid recursive dictionary abstraction from proceeding.
             state.with_error_crumb(ErrorCrumb::TermDeclaration(item_id), |state| {
@@ -807,6 +820,8 @@ where
                 state.insert_error(error);
             });
         }
+
+        record_value_declaration(state, context, item_id, marker, evidences)?;
 
         for error in errors.ambiguous {
             let constraint = state.canonicals.type_id(context, error);
@@ -836,6 +851,217 @@ where
     }
 
     Ok(())
+}
+
+fn record_value_declaration<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    item_id: TermItemId,
+    type_id: TypeId,
+    evidences: Vec<Evidence>,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let TermItemKind::Value { equations: sources, .. } = &context.indexed.items[item_id].kind
+    else {
+        return Ok(());
+    };
+    let Some(TermItemIr::ValueGroup { equations, .. }) =
+        context.lowered.info.get_term_item(item_id)
+    else {
+        return Ok(());
+    };
+
+    let complete = !sources.is_empty()
+        && sources.len() == equations.len()
+        && std::iter::zip(sources, equations.iter())
+            .all(|(source, equation)| equation.source == Some(*source));
+    if !complete
+        || !equations.iter().all(|equation| supports_value_equation(state, context, equation))
+    {
+        return Ok(());
+    }
+
+    let mut checked_equations = vec![];
+    for equation in equations.iter() {
+        let source =
+            equation.source.expect("invariant violated: checked value equation has no source");
+
+        let mut binders = vec![];
+        for &binder in equation.binders.iter() {
+            let binder = allocate_value_binder(state, context, binder)?;
+            binders.push(binder);
+        }
+
+        let Some(lowering::GuardedExpression::Unconditional { where_expression }) =
+            &equation.guarded
+        else {
+            unreachable!("invariant violated: unsupported guarded value equation");
+        };
+        let where_expression = where_expression
+            .as_ref()
+            .expect("invariant violated: checked value equation has no expression");
+        let expression = where_expression
+            .expression
+            .expect("invariant violated: checked where expression has no expression");
+        let expression = allocate_value_expression(state, context, expression)?;
+
+        let where_expression = tree::WhereExpression { expression };
+        let guarded_expression = tree::GuardedExpression::Unconditional { where_expression };
+        let equation = tree::Equation { source, binders: Arc::from(binders), guarded_expression };
+        checked_equations.push(equation);
+    }
+
+    let declaration = tree::ValueDeclaration {
+        evidences: Arc::from(evidences),
+        equations: Arc::from(checked_equations),
+    };
+    let declaration =
+        tree::TermDeclaration { type_id, kind: tree::TermDeclarationKind::Value(declaration) };
+    state.checked.tree.insert_term(item_id, declaration);
+
+    Ok(())
+}
+
+fn supports_value_equation<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    equation: &lowering::Equation,
+) -> bool
+where
+    Q: ExternalQueries,
+{
+    if equation.source.is_none()
+        || !equation.binders.iter().all(|&binder| supports_value_binder(state, context, binder))
+    {
+        return false;
+    }
+
+    let Some(lowering::GuardedExpression::Unconditional { where_expression }) = &equation.guarded
+    else {
+        return false;
+    };
+    let Some(where_expression) = where_expression else {
+        return false;
+    };
+    if !where_expression.bindings.is_empty() {
+        return false;
+    }
+    let Some(expression) = where_expression.expression else {
+        return false;
+    };
+
+    if state.checked.nodes.lookup_expression(expression).is_none() {
+        return false;
+    }
+    let Some(lowering::ExpressionKind::Variable { resolution: Some(resolution) }) =
+        context.lowered.info.get_expression_kind(expression)
+    else {
+        return false;
+    };
+    match resolution {
+        lowering::TermVariableResolution::Binder(binder) => matches!(
+            context.lowered.info.get_binder_kind(*binder),
+            Some(lowering::BinderKind::Variable { variable: Some(_) })
+        ),
+        lowering::TermVariableResolution::Let(_)
+        | lowering::TermVariableResolution::Reference(_, _)
+        | lowering::TermVariableResolution::RecordPun(_) => false,
+    }
+}
+
+fn supports_value_binder<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    binder: lowering::BinderId,
+) -> bool
+where
+    Q: ExternalQueries,
+{
+    match context.lowered.info.get_binder_kind(binder) {
+        Some(lowering::BinderKind::Variable { variable: Some(_) }) => {
+            state.checked.nodes.lookup_binder(binder).is_some()
+        }
+        Some(lowering::BinderKind::Constructor { resolution: Some(_), arguments }) => {
+            state.checked.nodes.lookup_binder(binder).is_some()
+                && arguments.iter().all(|&argument| supports_value_binder(state, context, argument))
+        }
+        Some(lowering::BinderKind::Parenthesized { parenthesized: Some(parenthesized) }) => {
+            supports_value_binder(state, context, *parenthesized)
+        }
+        _ => false,
+    }
+}
+
+fn allocate_value_binder<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    source: lowering::BinderId,
+) -> QueryResult<tree::BinderId>
+where
+    Q: ExternalQueries,
+{
+    let kind = context
+        .lowered
+        .info
+        .get_binder_kind(source)
+        .expect("invariant violated: checked value binder is missing");
+
+    if let lowering::BinderKind::Parenthesized { parenthesized: Some(parenthesized) } = kind {
+        return allocate_value_binder(state, context, *parenthesized);
+    }
+
+    let type_id = state
+        .checked
+        .nodes
+        .lookup_binder(source)
+        .expect("invariant violated: checked value binder has no type");
+    let type_id = zonk::zonk(state, context, type_id)?;
+
+    let kind = match kind {
+        lowering::BinderKind::Variable { .. } => tree::BinderKind::Variable,
+        lowering::BinderKind::Constructor { resolution: Some(resolution), arguments } => {
+            let mut checked_arguments = vec![];
+            for &argument in arguments.iter() {
+                let argument = allocate_value_binder(state, context, argument)?;
+                checked_arguments.push(argument);
+            }
+            tree::BinderKind::Constructor {
+                resolution: *resolution,
+                arguments: Arc::from(checked_arguments),
+            }
+        }
+        _ => unreachable!("invariant violated: unsupported checked value binder"),
+    };
+
+    let binder = tree::Binder { source, type_id, kind };
+    Ok(state.checked.tree.allocate_binder(binder))
+}
+
+fn allocate_value_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    source: lowering::ExpressionId,
+) -> QueryResult<tree::ExpressionId>
+where
+    Q: ExternalQueries,
+{
+    let Some(lowering::ExpressionKind::Variable { resolution: Some(resolution) }) =
+        context.lowered.info.get_expression_kind(source)
+    else {
+        unreachable!("invariant violated: unsupported checked value expression");
+    };
+    let type_id = state
+        .checked
+        .nodes
+        .lookup_expression(source)
+        .expect("invariant violated: checked value expression has no type");
+    let type_id = zonk::zonk(state, context, type_id)?;
+
+    let kind = tree::ExpressionKind::Variable { resolution: *resolution };
+    let expression = tree::Expression { type_id, kind };
+    Ok(state.checked.tree.allocate_expression(expression))
 }
 
 fn check_term_operator<Q>(

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -908,7 +908,7 @@ where
         let expression = allocate_value_expression(state, context, expression)?;
 
         let where_expression = tree::WhereExpression { expression };
-        let guarded_expression = tree::GuardedExpression::Unconditional { where_expression };
+        let guarded_expression = tree::GuardedExpression::unconditional(where_expression);
         let equation = tree::Equation { source, binders: Arc::from(binders), guarded_expression };
         checked_equations.push(equation);
     }

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -8,6 +8,7 @@ use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, constraint, signature, toolkit, unification};
 use crate::error::ErrorKind;
+use crate::evidence::Evidence;
 use crate::source::binder;
 use crate::source::terms::guarded;
 use crate::state::CheckState;
@@ -29,6 +30,11 @@ struct ValueEquationSignature {
 /// See documentation for [`check_value_equations`].
 pub type ValueEquationPatterns = Vec<TypeId>;
 
+pub struct CheckedValueEquations {
+    pub patterns: ValueEquationPatterns,
+    pub evidences: Vec<Evidence>,
+}
+
 /// Checks a group of [`lowering::Equation`].
 ///
 /// This function returns the instantiated types of the equation's
@@ -39,7 +45,7 @@ pub fn check_value_equations<Q>(
     origin: EquationTypeOrigin,
     expected_type: TypeId,
     equations: &[lowering::Equation],
-) -> QueryResult<ValueEquationPatterns>
+) -> QueryResult<CheckedValueEquations>
 where
     Q: ExternalQueries,
 {
@@ -48,9 +54,11 @@ where
     let signature::SkolemisedSignature { substitution, constraints, arguments, result } =
         signature::expect_term_signature(state, context, expected_type, required)?;
 
+    let mut evidences = vec![];
     for &constraint in &constraints {
         if !constraint::is_type_error(state, context, constraint)? {
-            state.push_given(constraint);
+            let evidence = state.push_given(constraint);
+            evidences.push(Evidence::Given(evidence));
         }
     }
 
@@ -64,7 +72,7 @@ where
         check_equations(state, context, origin, &signature, &arguments, equations)
     })?;
 
-    Ok(arguments)
+    Ok(CheckedValueEquations { patterns: arguments, evidences })
 }
 
 /// Infers a group of [`lowering::Equation`].

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -139,7 +139,7 @@ where
     };
 
     if let Some(signature_id) = name.signature {
-        let equation_patterns = equations::check_value_equations(
+        let checked_equations = equations::check_value_equations(
             state,
             context,
             equations::EquationTypeOrigin::Explicit(signature_id),
@@ -149,7 +149,7 @@ where
         let exhaustiveness = exhaustive::check_equation_patterns(
             state,
             context,
-            &equation_patterns,
+            &checked_equations.patterns,
             &name.equations,
         )?;
         state.report_exhaustiveness(exhaustiveness);

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -81,13 +81,32 @@ pub struct Equation {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum GuardedExpression {
-    Unconditional { where_expression: WhereExpression },
+pub struct GuardedExpression {
+    pub alternatives: Arc<[GuardedAlternative]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GuardedAlternative {
+    pub pattern_guards: Arc<[PatternGuard]>,
+    pub where_expression: WhereExpression,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PatternGuard {
+    Boolean { expression: ExpressionId },
+    Pattern { binder: BinderId, expression: ExpressionId },
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct WhereExpression {
     pub expression: ExpressionId,
+}
+
+impl GuardedExpression {
+    pub fn unconditional(where_expression: WhereExpression) -> GuardedExpression {
+        let alternative = GuardedAlternative { pattern_guards: Arc::from([]), where_expression };
+        GuardedExpression { alternatives: Arc::from([alternative]) }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -12,8 +12,8 @@ use crate::core::Type;
 use crate::core::pretty::{Pretty as TypePretty, PrettyQueries};
 use crate::evidence::Evidence;
 use crate::tree::{
-    BinderId, BinderKind, ExpressionId, ExpressionKind, GuardedExpression, TermDeclarationKind,
-    TypeDeclarationKind,
+    BinderId, BinderKind, ExpressionId, ExpressionKind, GuardedAlternative, GuardedExpression,
+    PatternGuard, TermDeclarationKind, TypeDeclarationKind,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -244,9 +244,7 @@ where
 
         let mut equations = vec![];
         for equation in value.equations.iter() {
-            let GuardedExpression::Unconditional { where_expression } =
-                &equation.guarded_expression;
-            let mut expression = self.expression(where_expression.expression)?;
+            let mut expression = self.guarded_expression(&equation.guarded_expression)?;
 
             for &binder in equation.binders.iter().rev() {
                 let binder = self.binder(binder)?;
@@ -285,6 +283,62 @@ where
         });
 
         Ok(Some(signature.append(self.arena.hardline()).append(equations)))
+    }
+
+    fn guarded_expression(&self, guarded: &GuardedExpression) -> QueryResult<Doc<'arena>> {
+        if let [alternative] = guarded.alternatives.as_ref()
+            && alternative.pattern_guards.is_empty()
+        {
+            return self.expression(alternative.where_expression.expression);
+        }
+
+        let mut alternatives = vec![];
+        for alternative in guarded.alternatives.iter() {
+            alternatives.push(self.guarded_alternative(alternative)?);
+        }
+
+        let mut alternatives = alternatives.into_iter();
+        let Some(first) = alternatives.next() else {
+            return Ok(self.arena.text("<error>"));
+        };
+        let alternatives = alternatives.fold(first, |document, alternative| {
+            document.append(self.arena.hardline()).append(alternative)
+        });
+        Ok(alternatives)
+    }
+
+    fn guarded_alternative(&self, alternative: &GuardedAlternative) -> QueryResult<Doc<'arena>> {
+        let mut pattern_guards = vec![];
+        for pattern_guard in alternative.pattern_guards.iter() {
+            pattern_guards.push(self.pattern_guard(pattern_guard)?);
+        }
+
+        let expression = self.expression(alternative.where_expression.expression)?;
+        let mut pattern_guards = pattern_guards.into_iter();
+        let Some(first) = pattern_guards.next() else {
+            return Ok(self.arena.text("| -> ").append(expression));
+        };
+        let pattern_guards = pattern_guards.fold(first, |document, pattern_guard| {
+            document.append(self.arena.text(", ")).append(pattern_guard)
+        });
+        let alternative = self
+            .arena
+            .text("| ")
+            .append(pattern_guards)
+            .append(self.arena.text(" -> "))
+            .append(expression);
+        Ok(alternative)
+    }
+
+    fn pattern_guard(&self, pattern_guard: &PatternGuard) -> QueryResult<Doc<'arena>> {
+        match *pattern_guard {
+            PatternGuard::Boolean { expression } => self.expression(expression),
+            PatternGuard::Pattern { binder, expression } => {
+                let binder = self.binder(binder)?;
+                let expression = self.expression(expression)?;
+                Ok(binder.append(self.arena.text(" <- ")).append(expression))
+            }
+        }
     }
 
     fn binder(&self, binder_id: BinderId) -> QueryResult<Doc<'arena>> {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -3,13 +3,18 @@
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{TermItem, TypeItem};
+use lowering::TermVariableResolution;
 use pretty::{Arena, DocAllocator, DocBuilder};
 use smol_str::{SmolStr, SmolStrBuilder};
 
 use crate::CheckedModule;
 use crate::core::Type;
 use crate::core::pretty::{Pretty as TypePretty, PrettyQueries};
-use crate::tree::{TermDeclarationKind, TypeDeclarationKind};
+use crate::evidence::Evidence;
+use crate::tree::{
+    BinderId, BinderKind, ExpressionId, ExpressionKind, GuardedExpression, TermDeclarationKind,
+    TypeDeclarationKind,
+};
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
 
@@ -34,9 +39,18 @@ where
 
     pub fn render(&self, file_id: FileId) -> QueryResult<SmolStr> {
         let indexed = self.queries.indexed(file_id)?;
+        let lowered = self.queries.lowered(file_id)?;
         let arena = Arena::new();
-        let mut printer = Printer::new(&arena, self.queries, &indexed, self.checked, self.width);
-        let document = printer.module();
+        let mut printer = Printer::new(
+            &arena,
+            self.queries,
+            file_id,
+            &indexed,
+            &lowered,
+            self.checked,
+            self.width,
+        );
+        let document = printer.module()?;
 
         let mut output = SmolStrBuilder::new();
         document
@@ -52,9 +66,12 @@ where
 {
     arena: &'arena Arena<'arena>,
     queries: &'context Q,
+    file_id: FileId,
     indexed: &'module indexing::IndexedModule,
+    lowered: &'module lowering::LoweredModule,
     checked: &'context CheckedModule,
     type_pretty: TypePretty<'context, Q>,
+    width: usize,
 }
 
 impl<'arena, 'context, 'module, Q> Printer<'arena, 'context, 'module, Q>
@@ -64,15 +81,17 @@ where
     fn new(
         arena: &'arena Arena<'arena>,
         queries: &'context Q,
+        file_id: FileId,
         indexed: &'module indexing::IndexedModule,
+        lowered: &'module lowering::LoweredModule,
         checked: &'context CheckedModule,
         width: usize,
     ) -> Printer<'arena, 'context, 'module, Q> {
         let type_pretty = TypePretty::new(queries, checked).without_rigid_kinds().width(width);
-        Printer { arena, queries, indexed, checked, type_pretty }
+        Printer { arena, queries, file_id, indexed, lowered, checked, type_pretty, width }
     }
 
-    fn module(&mut self) -> Doc<'arena> {
+    fn module(&mut self) -> QueryResult<Doc<'arena>> {
         let mut declarations = vec![];
 
         for (type_id, TypeItem { name, .. }) in self.indexed.items.iter_types() {
@@ -97,16 +116,31 @@ where
             declarations.push(signature.append(self.arena.hardline()).append(declaration));
         }
 
+        for (term_id, TermItem { name, .. }) in self.indexed.items.iter_terms() {
+            let Some(name) = name else { continue };
+            let Some(declaration_id) = self.checked.tree.lookup_term(term_id) else {
+                continue;
+            };
+            let declaration = &self.checked.tree[declaration_id];
+            let TermDeclarationKind::Value(_) = &declaration.kind else {
+                continue;
+            };
+            let Some(declaration) = self.value_declaration(term_id, name)? else {
+                continue;
+            };
+            declarations.push(declaration);
+        }
+
         let mut declarations = declarations.into_iter();
         if let Some(first) = declarations.next() {
-            declarations.fold(first, |document, declaration| {
+            Ok(declarations.fold(first, |document, declaration| {
                 document
                     .append(self.arena.hardline())
                     .append(self.arena.hardline())
                     .append(declaration)
-            })
+            }))
         } else {
-            self.arena.nil()
+            Ok(self.arena.nil())
         }
     }
 
@@ -184,5 +218,145 @@ where
         }
 
         declaration
+    }
+
+    fn value_declaration(
+        &mut self,
+        term_id: indexing::TermItemId,
+        name: &str,
+    ) -> QueryResult<Option<Doc<'arena>>> {
+        let declaration_id = self
+            .checked
+            .tree
+            .lookup_term(term_id)
+            .expect("invariant violated: missing checked term declaration");
+        let declaration = &self.checked.tree[declaration_id];
+        let TermDeclarationKind::Value(value) = &declaration.kind else {
+            unreachable!("invariant violated: term declaration is not a value");
+        };
+
+        let mut type_pretty = TypePretty::new(self.queries, self.checked)
+            .without_rigid_kinds()
+            .without_forall_kinds()
+            .width(self.width);
+        let type_id = type_pretty.render(declaration.type_id);
+        let signature = self.arena.text(format!("{name} :: {type_id}"));
+
+        let mut equations = vec![];
+        for equation in value.equations.iter() {
+            let GuardedExpression::Unconditional { where_expression } =
+                &equation.guarded_expression;
+            let mut expression = self.expression(where_expression.expression)?;
+
+            for &binder in equation.binders.iter().rev() {
+                let binder = self.binder(binder)?;
+                expression = self
+                    .arena
+                    .text("\\")
+                    .append(binder)
+                    .append(self.arena.text(" ->"))
+                    .append(self.arena.line().append(expression).nest(2))
+                    .group();
+            }
+            for evidence in value.evidences.iter().rev() {
+                let binder = match evidence {
+                    Evidence::Trivial => "{trivial}",
+                    _ => return Ok(None),
+                };
+                expression = self
+                    .arena
+                    .text(format!("\\{binder} ->"))
+                    .append(self.arena.line().append(expression).nest(2))
+                    .group();
+            }
+
+            let equation = self
+                .arena
+                .text(format!("{name} ="))
+                .append(self.arena.line().append(expression).nest(2))
+                .group();
+            equations.push(equation);
+        }
+
+        let mut equations = equations.into_iter();
+        let Some(first) = equations.next() else { return Ok(None) };
+        let equations = equations.fold(first, |document, equation| {
+            document.append(self.arena.hardline()).append(equation)
+        });
+
+        Ok(Some(signature.append(self.arena.hardline()).append(equations)))
+    }
+
+    fn binder(&self, binder_id: BinderId) -> QueryResult<Doc<'arena>> {
+        let binder = &self.checked.tree[binder_id];
+        match &binder.kind {
+            BinderKind::Variable => {
+                let kind = self
+                    .lowered
+                    .info
+                    .get_binder_kind(binder.source)
+                    .expect("invariant violated: semantic variable binder has no source");
+                let lowering::BinderKind::Variable { variable: Some(variable) } = kind else {
+                    unreachable!("invariant violated: semantic variable binder has invalid source");
+                };
+                Ok(self.arena.text(variable.to_string()))
+            }
+            BinderKind::Constructor { resolution, arguments } => {
+                let name = self.term_name(resolution.0, resolution.1)?;
+                let name = name.unwrap_or_else(|| "?".to_string());
+                let mut constructor = self.arena.text(name);
+                if arguments.is_empty() {
+                    return Ok(constructor);
+                }
+                for &argument in arguments.iter() {
+                    let argument = self.binder(argument)?;
+                    constructor = constructor.append(self.arena.space()).append(argument);
+                }
+                Ok(self.arena.text("(").append(constructor).append(self.arena.text(")")))
+            }
+        }
+    }
+
+    fn expression(&self, expression_id: ExpressionId) -> QueryResult<Doc<'arena>> {
+        let expression = &self.checked.tree[expression_id];
+        match expression.kind {
+            ExpressionKind::Variable { resolution } => {
+                let name = match resolution {
+                    TermVariableResolution::Binder(binder) => {
+                        let kind =
+                            self.lowered.info.get_binder_kind(binder).expect(
+                                "invariant violated: variable expression binder is missing",
+                            );
+                        let lowering::BinderKind::Variable { variable: Some(variable) } = kind
+                        else {
+                            unreachable!(
+                                "invariant violated: variable expression resolves to invalid binder"
+                            );
+                        };
+                        variable.to_string()
+                    }
+                    TermVariableResolution::Reference(file_id, term_id) => {
+                        self.term_name(file_id, term_id)?.unwrap_or_else(|| "?".to_string())
+                    }
+                    TermVariableResolution::Let(_) | TermVariableResolution::RecordPun(_) => {
+                        unreachable!("invariant violated: unsupported semantic variable resolution")
+                    }
+                };
+                Ok(self.arena.text(name))
+            }
+        }
+    }
+
+    fn term_name(
+        &self,
+        file_id: FileId,
+        term_id: indexing::TermItemId,
+    ) -> QueryResult<Option<String>> {
+        if file_id == self.file_id {
+            return Ok(self.indexed.items[term_id].name.as_ref().map(ToString::to_string));
+        }
+
+        let indexed = self.queries.indexed(file_id)?;
+        Ok(indexed.items[term_id].name.as_ref().map(ToString::to_string))
     }
 }

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -567,6 +567,7 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
                     Some(recursive::lower_equation_like(
                         state,
                         context,
+                        Some(*id),
                         cst,
                         cst::ValueEquation::function_binders,
                         cst::ValueEquation::guarded_expression,
@@ -896,6 +897,7 @@ fn lower_instance_statements(
                         Some(recursive::lower_equation_like(
                             state,
                             context,
+                            None,
                             cst,
                             cst::InstanceEquationStatement::function_binders,
                             cst::InstanceEquationStatement::guarded_expression,

--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -802,6 +802,7 @@ fn lower_equation_chunk(
                 Some(lower_equation_like(
                     state,
                     context,
+                    None,
                     cst,
                     cst::LetBindingEquation::function_binders,
                     cst::LetBindingEquation::guarded_expression,
@@ -843,6 +844,7 @@ fn lower_equation_chunk(
 pub(crate) fn lower_equation_like<T: AstNode>(
     state: &mut State,
     context: &Context,
+    source: Option<indexing::ValueEquationId>,
     equation: T,
     binders: impl Fn(&T) -> Option<cst::FunctionBinders>,
     guarded: impl Fn(&T) -> Option<cst::GuardedExpression>,
@@ -856,7 +858,7 @@ pub(crate) fn lower_equation_like<T: AstNode>(
                 .collect()
         };
         let guarded = guarded(&equation).map(|cst| lower_guarded(state, context, &cst));
-        Equation { binders, guarded }
+        Equation { source, binders, guarded }
     })
 }
 

--- a/compiler-core/lowering/src/intermediate.rs
+++ b/compiler-core/lowering/src/intermediate.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use files::FileId;
-use indexing::{TermItemId, TypeItemId};
+use indexing::{TermItemId, TypeItemId, ValueEquationId};
 use la_arena::{Arena, ArenaMap, Idx};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
@@ -210,6 +210,7 @@ pub enum TypeKind {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Equation {
+    pub source: Option<ValueEquationId>,
     pub binders: Arc<[BinderId]>,
     pub guarded: Option<GuardedExpression>,
 }

--- a/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.purs
+++ b/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+fromMaybe default (Just value) = value
+fromMaybe default Nothing = default

--- a/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.snap
+++ b/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Type -> Type
+data Maybe @a
+  | Just :: a -> Maybe a
+  | Nothing :: Maybe a
+
+fromMaybe :: forall t. t -> Maybe t -> t
+fromMaybe = \default -> \(Just value) -> value
+fromMaybe = \default -> \Nothing -> default

--- a/tests-integration/fixtures/semantic/1784643600_variable_value_declaration/Main.purs
+++ b/tests-integration/fixtures/semantic/1784643600_variable_value_declaration/Main.purs
@@ -1,0 +1,3 @@
+module Main where
+
+identity a = a

--- a/tests-integration/fixtures/semantic/1784643600_variable_value_declaration/Main.snap
+++ b/tests-integration/fixtures/semantic/1784643600_variable_value_declaration/Main.snap
@@ -1,0 +1,7 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall t. t -> t
+identity = \a -> a


### PR DESCRIPTION
## Summary

Build on #193 by recording the first checked value declarations in the semantic tree.

- preserve top-level value equation source identities through lowering
- record variable and constructor binders, variable expressions, unconditional equations, and declaration evidence
- infer and retain `Partial` as `Evidence::Trivial` for incomplete inferred declarations
- render declaration evidence and equation binders as normalized lambdas
- cover variable and constructor-pattern declarations in separate semantic fixtures

Unsupported value syntax remains absent from the semantic tree until its checked representation is introduced.

## Stack

This PR is stacked on #193 and should be reviewed after it.

## Verification

- `just t semantic`
- `just t checking`
- `cargo nextest run -p checking`
- `cargo check --workspace --tests`