### PR TITLE
[agents] Install cargo-insta in agent setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -17,4 +17,4 @@ if ! command -v cargo-binstall >/dev/null 2>&1; then
     | BINSTALL_VERSION=1.19.1 bash
 fi
 
-cargo binstall --no-confirm just cargo-nextest
+cargo binstall --no-confirm just cargo-nextest cargo-insta


### PR DESCRIPTION
## Summary

Install `cargo-insta` through the existing `cargo binstall` setup step so snapshot-testing commands are available in agent environments.

## Verification

- `bash -n .agents/setup`
- `git diff --check`