### PR TITLE
[checking] Retain class and instance dictionary structure

### DIFF
--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -134,9 +134,9 @@ pub struct CheckedClassMember {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedClass {
     /// Post-generalisation kind variable binders.
-    pub kind_binders: Vec<ForallBinderId>,
+    pub kind_binders: Arc<[ForallBinderId]>,
     /// Post-generalisation type parameter binders.
-    pub type_parameters: Vec<ForallBinderId>,
+    pub type_parameters: Arc<[ForallBinderId]>,
     /// Canonical class head, e.g. `Eq a` or `Foo @k a`.
     pub canonical: TypeId,
     /// Superclass occurrences from the class declaration.

--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -123,6 +123,14 @@ pub struct CheckedSuperclass {
     pub constraint: TypeId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckedClassMember {
+    /// Stable identity of the generated class member selector.
+    pub item_id: TermItemId,
+    /// Declared member type before the class dictionary constraint is added.
+    pub field_type: TypeId,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckedClass {
     /// Post-generalisation kind variable binders.
@@ -135,8 +143,8 @@ pub struct CheckedClass {
     pub superclasses: Vec<CheckedSuperclass>,
     /// Functional dependencies.
     pub functional_dependencies: Arc<[fd::Fd]>,
-    /// Class member term item IDs.
-    pub members: Vec<TermItemId>,
+    /// Class members in declaration order.
+    pub members: Vec<CheckedClassMember>,
 }
 
 /// Represents a checked instance declaration head.

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -359,24 +359,6 @@ where
     Ok(unique_residuals.collect())
 }
 
-pub fn is_type_error<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    constraint: TypeId,
-) -> QueryResult<bool>
-where
-    Q: ExternalQueries,
-{
-    let Some(canonical) = canonical::canonicalise(state, context, constraint)? else {
-        return Ok(false);
-    };
-
-    let canonical = &state.canonicals[canonical];
-    Ok(canonical.file_id == context.prim_type_error.file_id
-        && (canonical.type_id == context.prim_type_error.warn
-            || canonical.type_id == context.prim_type_error.fail))
-}
-
 #[derive(Clone)]
 struct EvidenceInScope {
     constraints: Vec<(CanonicalConstraintId, EvidenceId)>,

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -154,7 +154,7 @@ where
     Ok(edges)
 }
 
-fn superclass_substitutions<Q>(
+pub(crate) fn superclass_substitutions<Q>(
     context: &CheckContext<Q>,
     class: &CheckedClass,
     arguments: &[KindOrType],

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -165,7 +165,7 @@ where
     let mut bindings = NameToType::default();
     let mut arguments = arguments.iter().copied();
 
-    for &binder_id in &class.kind_binders {
+    for &binder_id in class.kind_binders.iter() {
         let Some(KindOrType::Kind(argument)) = arguments.next() else {
             return Ok(None);
         };
@@ -173,7 +173,7 @@ where
         bindings.insert(binder.name, argument);
     }
 
-    for &binder_id in &class.type_parameters {
+    for &binder_id in class.type_parameters.iter() {
         let Some(KindOrType::Type(argument)) = arguments.next() else {
             return Ok(None);
         };

--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -111,6 +111,13 @@ impl PrettyNames {
             suffix = try_next_suffix(suffix).expect("critical failure: exhausted suffixes");
         }
     }
+
+    pub(crate) fn assign_display_name(&mut self, name: Name, display: SmolStr) {
+        if !self.next_suffix.contains_key(&display) {
+            self.next_suffix.insert(SmolStr::clone(&display), FIRST_SUFFIX);
+        }
+        self.display_by_name.insert(name, display);
+    }
 }
 
 fn try_next_suffix(suffix: NonZeroU32) -> Option<NonZeroU32> {
@@ -163,6 +170,10 @@ where
     pub fn display_name(&mut self, name: Name) -> SmolStr {
         self.names.set_default_name("t");
         self.names.display_name(self.queries, &self.checked.names, name)
+    }
+
+    pub(crate) fn assign_display_name(&mut self, name: Name, display: SmolStr) {
+        self.names.assign_display_name(name, display);
     }
 
     pub fn render(&mut self, id: TypeId) -> SmolStr {

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -105,6 +105,20 @@ where
                     constructor.arguments.iter().map(|&argument| zonk(state, context, argument));
                 constructor.arguments = arguments.collect::<QueryResult<Arc<[_]>>>()?;
             }
+            TermDeclarationKind::Instance(instance) => {
+                for parameter in Arc::make_mut(&mut instance.rigid_parameters) {
+                    *parameter = zonk(state, context, *parameter)?;
+                }
+                for evidence in Arc::make_mut(&mut instance.evidences) {
+                    evidence.constraint = zonk(state, context, evidence.constraint)?;
+                }
+                for superclass in Arc::make_mut(&mut instance.superclasses) {
+                    superclass.constraint = zonk(state, context, superclass.constraint)?;
+                }
+                for member in Arc::make_mut(&mut instance.members) {
+                    member.implementation_type = zonk(state, context, member.implementation_type)?;
+                }
+            }
         }
     }
     state.checked.tree.arena.terms = term_declarations;

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -10,7 +10,7 @@ use crate::core::{Type, TypeId};
 use crate::error::{CheckingError, ErrorKind};
 use crate::holes::{HoleBinding, TermHole, TypeHole};
 use crate::state::CheckState;
-use crate::tree::{BinderKind, ExpressionKind, TermDeclarationKind};
+use crate::tree::{BinderKind, ExpressionKind, TermDeclarationKind, TypeDeclarationKind};
 use crate::{ExternalQueries, OperatorBranchTypes, holes};
 
 struct Zonk;
@@ -112,6 +112,18 @@ where
     let mut type_declarations = mem::take(&mut state.checked.tree.arena.types);
     for (_, declaration) in type_declarations.iter_mut() {
         declaration.kind = zonk(state, context, declaration.kind)?;
+        match &mut declaration.declaration {
+            TypeDeclarationKind::Data(_) | TypeDeclarationKind::Newtype(_) => {}
+            TypeDeclarationKind::Class(class) => {
+                for superclass in Arc::make_mut(&mut class.superclasses) {
+                    superclass.constraint = zonk(state, context, superclass.constraint)?;
+                }
+
+                for member in Arc::make_mut(&mut class.members) {
+                    member.field_type = zonk(state, context, member.field_type)?;
+                }
+            }
+        }
     }
     state.checked.tree.arena.types = type_declarations;
 

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -142,18 +142,14 @@ where
         OperatorKindMode::Check { expected_type } => (unknown_elaborated, expected_type),
     };
 
-    let operator_type = toolkit::instantiate_unifications(state, context, operator_type)?;
-    let operator_type = toolkit::collect_wanteds(state, context, operator_type)?;
-
-    let Some((left_type, operator_type)) =
-        toolkit::decompose_function(state, context, operator_type)?
+    let Some(terms::application::GenericApplication { argument: left_type, result: operator_type }) =
+        terms::application::check_generic_application(state, context, operator_type)?
     else {
         return Ok(unknown);
     };
 
-    let operator_type = toolkit::instantiate_unifications(state, context, operator_type)?;
-    let Some((right_type, result_type)) =
-        toolkit::decompose_function(state, context, operator_type)?
+    let Some(terms::application::GenericApplication { argument: right_type, result: result_type }) =
+        terms::application::check_generic_application(state, context, operator_type)?
     else {
         return Ok(unknown);
     };

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -456,7 +456,7 @@ where
     let mut bindings = NameToType::default();
     let mut instance_arguments = instance_arguments.iter().copied();
 
-    for &binder_id in &class_info.kind_binders {
+    for &binder_id in class_info.kind_binders.iter() {
         let Some(KindOrType::Kind(argument)) = instance_arguments.next() else {
             return Ok(None);
         };
@@ -464,7 +464,7 @@ where
         bindings.insert(binder.name, argument);
     }
 
-    for &binder_id in &class_info.type_parameters {
+    for &binder_id in class_info.type_parameters.iter() {
         let Some(KindOrType::Type(argument)) = instance_arguments.next() else {
             return Ok(None);
         };

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -14,7 +14,7 @@ use crate::core::{
     signature, toolkit, unification, zonk,
 };
 use crate::error::{ErrorCrumb, ErrorKind};
-use crate::evidence::Evidence;
+use crate::evidence::{Evidence, SuperclassId};
 use crate::source::terms::equations;
 use crate::source::{derive, types};
 use crate::state::CheckState;
@@ -231,12 +231,16 @@ where
                 continue;
             };
 
-            let Some(instance) = state.checked.lookup_instance(instance_id) else {
+            let Some(checked_instance) = state.checked.lookup_instance(instance_id) else {
                 continue;
             };
 
-            let Some(instance) =
-                toolkit::instance_info(state, context, instance.signature, instance.resolution)?
+            let Some(instance) = toolkit::instance_info(
+                state,
+                context,
+                checked_instance.signature,
+                checked_instance.resolution,
+            )?
             else {
                 continue;
             };
@@ -247,6 +251,7 @@ where
                 item_id,
                 members,
                 (class_file, class_id),
+                checked_instance.signature,
                 &instance,
             )?;
         }
@@ -261,6 +266,7 @@ fn check_instance_member_groups<Q>(
     instance_item_id: TermItemId,
     members: &[lowering::InstanceMemberGroup],
     (class_file, class_id): (FileId, TypeItemId),
+    instance_signature: TypeId,
     instance: &toolkit::InstanceInfo,
 ) -> QueryResult<()>
 where
@@ -272,16 +278,24 @@ where
                 constraints: instance_constraints,
                 arguments: instance_arguments,
                 substitution,
+                rigids,
             } = freshen_instance_rigids(state, context, instance)?;
 
             state.with_implicit(context, &substitution, |state| {
-                for &constraint in &instance_constraints {
-                    if !constraint::is_type_error(state, context, constraint)? {
-                        state.push_given(constraint);
-                    }
+                debug_assert_eq!(instance_constraints.len(), instance.constraints.len());
+                let mut instance_evidences = vec![];
+                for (&constraint, &signature_constraint) in
+                    std::iter::zip(&instance_constraints, &instance.constraints)
+                {
+                    let evidence = state.push_given(constraint);
+                    let evidence = Evidence::Given(evidence);
+                    instance_evidences.push(tree::InstanceEvidence {
+                        constraint: signature_constraint,
+                        evidence,
+                    });
                 }
 
-                emit_instance_superclass_constraints(
+                let superclasses = emit_instance_superclass_constraints(
                     state,
                     context,
                     class_file,
@@ -289,8 +303,9 @@ where
                     &instance_arguments,
                 )?;
 
+                let mut checked_members = vec![];
                 for member in members {
-                    state.with_implication(|state| {
+                    let checked_member = state.with_implication(|state| {
                         check_instance_member_group(
                             state,
                             context,
@@ -299,9 +314,44 @@ where
                             &instance_arguments,
                         )
                     })?;
+                    if let Some(checked_member) = checked_member {
+                        checked_members.push(checked_member);
+                    }
                 }
 
-                derive::tools::solve_and_report_constraints(state, context)
+                if let Some(class) =
+                    toolkit::lookup_file_class(state, context, class_file, class_id)?
+                {
+                    let positions = class
+                        .members
+                        .iter()
+                        .enumerate()
+                        .map(|(position, member)| (member.item_id, position));
+                    let positions = positions.collect::<FxHashMap<_, _>>();
+                    checked_members.sort_by_key(|member| {
+                        if member.resolution.0 == class_file {
+                            positions.get(&member.resolution.1).copied().unwrap_or(usize::MAX)
+                        } else {
+                            usize::MAX
+                        }
+                    });
+                }
+
+                derive::tools::solve_and_report_constraints(state, context)?;
+
+                let instance = tree::InstanceDeclaration {
+                    class: (class_file, class_id),
+                    rigid_parameters: Arc::from(rigids),
+                    evidences: Arc::from(instance_evidences),
+                    superclasses: Arc::from(superclasses),
+                    members: Arc::from(checked_members),
+                };
+                let declaration = tree::TermDeclaration {
+                    type_id: instance_signature,
+                    kind: tree::TermDeclarationKind::Instance(instance),
+                };
+                state.checked.tree.insert_term(instance_item_id, declaration);
+                Ok(())
             })
         })
     })
@@ -313,7 +363,7 @@ fn check_instance_member_group<Q>(
     member: &lowering::InstanceMemberGroup,
     (class_file, class_id): (FileId, TypeItemId),
     instance_arguments: &[KindOrType],
-) -> QueryResult<()>
+) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,
 {
@@ -363,6 +413,7 @@ where
         )?;
 
         state.report_exhaustiveness(exhaustiveness);
+        Ok(record_instance_member(member, signature_member_type, checked_equations))
     } else if let Some(expected_type) = class_member_type {
         let checked_equations = equations::check_value_equations(
             state,
@@ -379,15 +430,42 @@ where
         )?;
 
         state.report_exhaustiveness(exhaustiveness);
+        Ok(record_instance_member(member, expected_type, checked_equations))
+    } else {
+        Ok(None)
+    }
+}
+
+fn record_instance_member(
+    member: &lowering::InstanceMemberGroup,
+    implementation_type: TypeId,
+    checked: equations::CheckedValueEquations,
+) -> Option<tree::InstanceMember> {
+    let resolution = member.resolution?;
+    let equations = checked.equations.into_iter().map(equations::ElaboratedEquation::into_tree);
+    let equations = equations.collect::<Option<Vec<_>>>()?;
+
+    let complete = !member.equations.is_empty()
+        && member.equations.len() == equations.len()
+        && std::iter::zip(member.equations.iter(), &equations)
+            .all(|(source, equation)| source.source == Some(equation.source));
+    if !complete {
+        return None;
     }
 
-    Ok(())
+    Some(tree::InstanceMember {
+        resolution,
+        implementation_type,
+        evidences: Arc::from(checked.evidences),
+        equations: Arc::from(equations),
+    })
 }
 
 struct FreshenedInstanceRigids {
     constraints: Vec<TypeId>,
     arguments: Vec<KindOrType>,
     substitution: NameToType,
+    rigids: Vec<TypeId>,
 }
 
 fn freshen_instance_rigids<Q>(
@@ -399,12 +477,14 @@ where
     Q: ExternalQueries,
 {
     let mut substitution = NameToType::default();
+    let mut rigids = Vec::with_capacity(instance.binders.len());
 
     for binder in &instance.binders {
         let kind = SubstituteName::many(state, context, &substitution, binder.kind)?;
         let text = state.checked.lookup_name(binder.name);
         let rigid = state.fresh_rigid_named(context.queries, kind, text);
         substitution.insert(binder.name, rigid);
+        rigids.push(rigid);
     }
 
     let constraints = instance
@@ -419,7 +499,7 @@ where
         .map(|&argument| substitute_kind_or_type(state, context, &substitution, argument))
         .collect::<QueryResult<Vec<_>>>()?;
 
-    Ok(FreshenedInstanceRigids { constraints, arguments, substitution })
+    Ok(FreshenedInstanceRigids { constraints, arguments, substitution, rigids })
 }
 
 fn emit_instance_superclass_constraints<Q>(
@@ -428,26 +508,33 @@ fn emit_instance_superclass_constraints<Q>(
     class_file: FileId,
     class_id: TypeItemId,
     instance_arguments: &[KindOrType],
-) -> QueryResult<()>
+) -> QueryResult<Vec<tree::InstanceSuperclass>>
 where
     Q: ExternalQueries,
 {
     let Some(class) = toolkit::lookup_file_class(state, context, class_file, class_id)? else {
-        return Ok(());
+        return Ok(vec![]);
     };
     let Some(substitution) =
         constraint::elaborate::superclass_substitutions(context, &class, instance_arguments)?
     else {
-        return Ok(());
+        return Ok(vec![]);
     };
 
+    let mut checked_superclasses = Vec::with_capacity(class.superclasses.len());
     for superclass in &class.superclasses {
         let constraint =
             SubstituteName::many(state, context, &substitution, superclass.constraint)?;
-        state.push_wanted(constraint);
+        let evidence = state.push_wanted(constraint);
+        let id = SuperclassId {
+            file_id: class_file,
+            type_id: class_id,
+            source_id: superclass.source_id,
+        };
+        checked_superclasses.push(tree::InstanceSuperclass { id, constraint, evidence });
     }
 
-    Ok(())
+    Ok(checked_superclasses)
 }
 
 fn instantiate_class_member_type<Q>(

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -825,7 +825,9 @@ fn record_value_declaration<Q>(
 
     let complete = !sources.is_empty()
         && sources.len() == equations.len()
-        && std::iter::zip(sources, &equations).all(|(source, equation)| equation.source == *source);
+        && std::iter::zip(sources, &equations).all(|(source, equation)| {
+            equation.source == indexing::EquationSourceId::Value(*source)
+        });
     if !complete {
         return;
     }

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -10,8 +10,8 @@ use crate::context::CheckContext;
 use crate::core::constraint::ConstraintInScope;
 use crate::core::substitute::{NameToType, SubstituteName};
 use crate::core::{
-    CheckedInstance, ForallBinder, KindOrType, Type, TypeId, constraint, exhaustive, generalise,
-    normalise, signature, toolkit, unification, zonk,
+    CheckedInstance, KindOrType, Type, TypeId, constraint, exhaustive, generalise, normalise,
+    signature, toolkit, unification, zonk,
 };
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::evidence::Evidence;
@@ -304,17 +304,11 @@ where
             }
         }
 
-        let class_member_type = if let Some((member_file, member_id)) = member.resolution {
-            Some(toolkit::lookup_file_term(state, context, member_file, member_id)?)
-        } else {
-            None
-        };
-
-        let class_member_type = if let Some(class_member_type) = class_member_type {
+        let class_member_type = if let Some(member_resolution) = member.resolution {
             instantiate_class_member_type(
                 state,
                 context,
-                class_member_type,
+                member_resolution,
                 (class_file, class_id),
                 &instance_arguments,
             )?
@@ -441,7 +435,7 @@ where
 fn instantiate_class_member_type<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    class_member_type: TypeId,
+    (member_file, member_id): (FileId, TermItemId),
     (class_file, class_id): (FileId, TypeItemId),
     instance_arguments: &[KindOrType],
 ) -> QueryResult<Option<TypeId>>
@@ -452,33 +446,29 @@ where
         return Ok(None);
     };
 
-    let signature::DecomposedSignature { binders, constraints, arguments, result } =
-        signature::decompose_signature(
-            state,
-            context,
-            class_member_type,
-            signature::DecomposeSignatureMode::Full,
-        )?;
-
-    let class_binder_count = class_info.kind_binders.len() + class_info.type_parameters.len();
-    if binders.len() < class_binder_count {
+    if member_file != class_file {
         return Ok(None);
     }
-
-    let (class_binders, member_binders) = binders.split_at(class_binder_count);
+    let Some(member) = class_info.members.iter().find(|member| member.item_id == member_id) else {
+        return Ok(None);
+    };
 
     let mut bindings = NameToType::default();
     let mut instance_arguments = instance_arguments.iter().copied();
 
-    for binder in class_binders {
-        let Some(argument) = instance_arguments.next() else {
+    for &binder_id in &class_info.kind_binders {
+        let Some(KindOrType::Kind(argument)) = instance_arguments.next() else {
             return Ok(None);
         };
+        let binder = context.lookup_forall_binder(binder_id);
+        bindings.insert(binder.name, argument);
+    }
 
-        let argument = match argument {
-            KindOrType::Kind(argument) | KindOrType::Type(argument) => argument,
+    for &binder_id in &class_info.type_parameters {
+        let Some(KindOrType::Type(argument)) = instance_arguments.next() else {
+            return Ok(None);
         };
-
+        let binder = context.lookup_forall_binder(binder_id);
         bindings.insert(binder.name, argument);
     }
 
@@ -486,66 +476,9 @@ where
         return Ok(None);
     }
 
-    let constraints = substitute_normalise_types(state, context, &bindings, &constraints)?;
-    let arguments = substitute_normalise_types(state, context, &bindings, &arguments)?;
-    let mut constrained = substitute_normalise_type(state, context, &bindings, result)?;
-
-    let mut constraints = constraints.into_iter();
-    let Some(constraint) = constraints.next() else {
-        return Ok(None);
-    };
-
-    let Some(constraint) = constraint::canonical::canonicalise(state, context, constraint)? else {
-        return Ok(None);
-    };
-
-    let constraint = state.canonicals[constraint].clone();
-
-    if (constraint.file_id, constraint.type_id) != (class_file, class_id) {
-        return Ok(None);
-    }
-
-    constrained = context.intern_function_list(&arguments, constrained);
-    for constraint in constraints.rev() {
-        constrained = context.intern_constrained(constraint, constrained);
-    }
-
-    for binder in member_binders.iter().rev() {
-        // member_binders refers to type variables from class_binders
-        let kind = substitute_normalise_type(state, context, &bindings, binder.kind)?;
-        let binder_id = context.intern_forall_binder(ForallBinder { kind, ..*binder });
-        constrained = context.intern_forall(binder_id, constrained);
-    }
-
-    Ok(Some(constrained))
-}
-
-fn substitute_normalise_type<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    bindings: &NameToType,
-    type_id: TypeId,
-) -> QueryResult<TypeId>
-where
-    Q: ExternalQueries,
-{
-    let type_id = SubstituteName::many(state, context, bindings, type_id)?;
-    normalise::normalise(state, context, type_id)
-}
-
-fn substitute_normalise_types<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    bindings: &NameToType,
-    types: &[TypeId],
-) -> QueryResult<Vec<TypeId>>
-where
-    Q: ExternalQueries,
-{
-    types
-        .iter()
-        .map(|&type_id| substitute_normalise_type(state, context, bindings, type_id))
-        .collect()
+    let field_type = SubstituteName::many(state, context, &bindings, member.field_type)?;
+    let field_type = normalise::normalise(state, context, field_type)?;
+    Ok(Some(field_type))
 }
 
 fn substitute_kind_or_type<Q>(

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -241,27 +241,25 @@ where
                 continue;
             };
 
-            for member in members.iter() {
-                check_instance_member_group(
-                    state,
-                    context,
-                    item_id,
-                    member,
-                    (class_file, class_id),
-                    &instance,
-                )?;
-            }
+            check_instance_member_groups(
+                state,
+                context,
+                item_id,
+                members,
+                (class_file, class_id),
+                &instance,
+            )?;
         }
     }
 
     Ok(())
 }
 
-fn check_instance_member_group<Q>(
+fn check_instance_member_groups<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     instance_item_id: TermItemId,
-    member: &lowering::InstanceMemberGroup,
+    members: &[lowering::InstanceMemberGroup],
     (class_file, class_id): (FileId, TypeItemId),
     instance: &toolkit::InstanceInfo,
 ) -> QueryResult<()>
@@ -270,128 +268,120 @@ where
 {
     state.with_error_crumb(ErrorCrumb::TermDeclaration(instance_item_id), |state| {
         state.with_implication(|state| {
-            check_instance_member_group_core(
-                state,
-                context,
-                member,
-                (class_file, class_id),
-                instance,
-            )
+            let FreshenedInstanceRigids {
+                constraints: instance_constraints,
+                arguments: instance_arguments,
+                substitution,
+            } = freshen_instance_rigids(state, context, instance)?;
+
+            state.with_implicit(context, &substitution, |state| {
+                for &constraint in &instance_constraints {
+                    if !constraint::is_type_error(state, context, constraint)? {
+                        state.push_given(constraint);
+                    }
+                }
+
+                emit_instance_superclass_constraints(
+                    state,
+                    context,
+                    class_file,
+                    class_id,
+                    &instance_arguments,
+                )?;
+
+                for member in members {
+                    state.with_implication(|state| {
+                        check_instance_member_group(
+                            state,
+                            context,
+                            member,
+                            (class_file, class_id),
+                            &instance_arguments,
+                        )
+                    })?;
+                }
+
+                derive::tools::solve_and_report_constraints(state, context)
+            })
         })
     })
 }
 
-fn check_instance_member_group_core<Q>(
+fn check_instance_member_group<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     member: &lowering::InstanceMemberGroup,
     (class_file, class_id): (FileId, TypeItemId),
-    instance: &toolkit::InstanceInfo,
+    instance_arguments: &[KindOrType],
 ) -> QueryResult<()>
 where
     Q: ExternalQueries,
 {
-    let FreshenedInstanceRigids {
-        constraints: instance_constraints,
-        arguments: instance_arguments,
-        substitution,
-    } = freshen_instance_rigids(state, context, instance)?;
+    let class_member_type = if let Some(member_resolution) = member.resolution {
+        instantiate_class_member_type(
+            state,
+            context,
+            member_resolution,
+            (class_file, class_id),
+            instance_arguments,
+        )?
+    } else {
+        None
+    };
 
-    state.with_implicit(context, &substitution, |state| {
-        for &constraint in &instance_constraints {
-            if !constraint::is_type_error(state, context, constraint)? {
-                state.push_given(constraint);
+    if let Some(signature_id) = member.signature {
+        let (signature_member_type, _) =
+            types::check_kind(state, context, signature_id, context.prim.t)?;
+
+        if let Some(class_member_type) = class_member_type {
+            let unified = state.with_implication(|state| {
+                let class_member_type = normalise::normalise(state, context, class_member_type)?;
+                let class_member_type =
+                    toolkit::skolemise_forall(state, context, class_member_type)?;
+                let class_member_type = toolkit::collect_givens(state, context, class_member_type)?;
+                unification::subtype(state, context, signature_member_type, class_member_type)
+            })?;
+            if !unified {
+                let expected = class_member_type;
+                let actual = signature_member_type;
+                state.insert_error(ErrorKind::InstanceMemberTypeMismatch { expected, actual });
             }
         }
 
-        let class_member_type = if let Some(member_resolution) = member.resolution {
-            instantiate_class_member_type(
-                state,
-                context,
-                member_resolution,
-                (class_file, class_id),
-                &instance_arguments,
-            )?
-        } else {
-            None
-        };
+        let checked_equations = equations::check_value_equations(
+            state,
+            context,
+            equations::EquationTypeOrigin::Explicit(signature_id),
+            signature_member_type,
+            &member.equations,
+        )?;
+        let exhaustiveness = exhaustive::check_equation_patterns(
+            state,
+            context,
+            &checked_equations.patterns,
+            &member.equations,
+        )?;
 
-        let residuals = if let Some(signature_id) = member.signature {
-            let (signature_member_type, _) =
-                types::check_kind(state, context, signature_id, context.prim.t)?;
+        state.report_exhaustiveness(exhaustiveness);
+    } else if let Some(expected_type) = class_member_type {
+        let checked_equations = equations::check_value_equations(
+            state,
+            context,
+            equations::EquationTypeOrigin::Implicit,
+            expected_type,
+            &member.equations,
+        )?;
+        let exhaustiveness = exhaustive::check_equation_patterns(
+            state,
+            context,
+            &checked_equations.patterns,
+            &member.equations,
+        )?;
 
-            if let Some(class_member_type) = class_member_type {
-                let unified = state.with_implication(|state| {
-                    let class_member_type =
-                        normalise::normalise(state, context, class_member_type)?;
-                    let class_member_type =
-                        toolkit::skolemise_forall(state, context, class_member_type)?;
-                    let class_member_type =
-                        toolkit::collect_givens(state, context, class_member_type)?;
-                    unification::subtype(state, context, signature_member_type, class_member_type)
-                })?;
-                if !unified {
-                    let expected = class_member_type;
-                    let actual = signature_member_type;
-                    state.insert_error(ErrorKind::InstanceMemberTypeMismatch { expected, actual });
-                }
-            }
+        state.report_exhaustiveness(exhaustiveness);
+    }
 
-            let checked_equations = equations::check_value_equations(
-                state,
-                context,
-                equations::EquationTypeOrigin::Explicit(signature_id),
-                signature_member_type,
-                &member.equations,
-            )?;
-            let exhaustiveness = exhaustive::check_equation_patterns(
-                state,
-                context,
-                &checked_equations.patterns,
-                &member.equations,
-            )?;
-
-            state.report_exhaustiveness(exhaustiveness);
-            state.solve_constraints(context)?
-        } else if let Some(expected_type) = class_member_type {
-            let checked_equations = equations::check_value_equations(
-                state,
-                context,
-                equations::EquationTypeOrigin::Implicit,
-                expected_type,
-                &member.equations,
-            )?;
-            let exhaustiveness = exhaustive::check_equation_patterns(
-                state,
-                context,
-                &checked_equations.patterns,
-                &member.equations,
-            )?;
-
-            state.report_exhaustiveness(exhaustiveness);
-            state.solve_constraints(context)?
-        } else {
-            vec![]
-        };
-
-        for residual in residuals {
-            state.checked.evidence.mark_error(residual.evidence.wanted);
-            let attached = state.canonical_errors.remove(&residual.key.wanted);
-            attached.into_iter().flatten().for_each(|error| state.insert_error(error));
-
-            let given = residual
-                .key
-                .given
-                .iter()
-                .map(|given| state.canonicals.type_id(context, *given))
-                .collect::<Arc<[_]>>();
-
-            let constraint = state.canonicals.type_id(context, residual.key.wanted);
-            state.insert_error(ErrorKind::NoInstanceFound { given, constraint });
-        }
-
-        Ok(())
-    })
+    Ok(())
 }
 
 struct FreshenedInstanceRigids {
@@ -430,6 +420,34 @@ where
         .collect::<QueryResult<Vec<_>>>()?;
 
     Ok(FreshenedInstanceRigids { constraints, arguments, substitution })
+}
+
+fn emit_instance_superclass_constraints<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    class_file: FileId,
+    class_id: TypeItemId,
+    instance_arguments: &[KindOrType],
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let Some(class) = toolkit::lookup_file_class(state, context, class_file, class_id)? else {
+        return Ok(());
+    };
+    let Some(substitution) =
+        constraint::elaborate::superclass_substitutions(context, &class, instance_arguments)?
+    else {
+        return Ok(());
+    };
+
+    for superclass in &class.superclasses {
+        let constraint =
+            SubstituteName::many(state, context, &substitution, superclass.constraint)?;
+        state.push_wanted(constraint);
+    }
+
+    Ok(())
 }
 
 fn instantiate_class_member_type<Q>(

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{TypeId, constraint, signature, toolkit, unification};
+use crate::core::{TypeId, signature, toolkit, unification};
 use crate::error::ErrorKind;
 use crate::evidence::Evidence;
 use crate::source::binder;
@@ -72,10 +72,8 @@ where
 
     let mut evidences = vec![];
     for &constraint in &constraints {
-        if !constraint::is_type_error(state, context, constraint)? {
-            let evidence = state.push_given(constraint);
-            evidences.push(Evidence::Given(evidence));
-        }
+        let evidence = state.push_given(constraint);
+        evidences.push(Evidence::Given(evidence));
     }
 
     let signature = context.intern_function_list(&arguments, result);

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -39,7 +39,7 @@ pub struct CheckedValueEquations {
 }
 
 pub struct ElaboratedEquation {
-    pub source: Option<indexing::ValueEquationId>,
+    pub source: Option<indexing::EquationSourceId>,
     pub binders: Arc<[tree::BinderId]>,
     pub guarded: tree::GuardedExpression,
 }

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{TermItemId, TypeItemId, TypeItemKind};
-use itertools::Itertools;
 use lowering::{
     ClassIr, DataIr, LoweringError, NewtypeIr, RecursiveGroup, Scc, SynonymIr, TermItemIr,
     TypeItemIr, TypeVariableBinding,
@@ -17,6 +16,7 @@ use crate::core::{
     ForallBinder, Role, Type, TypeId, fd, fold, generalise, signature, toolkit, unification, zonk,
 };
 use crate::error::ErrorCrumb;
+use crate::evidence::SuperclassId;
 use crate::source::types;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop, tree};
@@ -891,7 +891,7 @@ where
             .iter()
             .copied()
             .map(|binder| context.intern_forall_binder(binder))
-            .collect_vec();
+            .collect::<Arc<[_]>>();
 
         let type_parameters = parameters
             .iter()
@@ -902,7 +902,7 @@ where
                 let binder = ForallBinder { kind, ..parameter };
                 context.intern_forall_binder(binder)
             })
-            .collect_vec();
+            .collect::<Arc<[_]>>();
 
         let mut class_head = context.queries.intern_type(Type::Constructor(context.id, item_id));
 
@@ -933,7 +933,18 @@ where
             })
             .collect::<QueryResult<Vec<_>>>()?;
 
+        let semantic_superclasses = superclasses.iter().map(|superclass| tree::ClassSuperclass {
+            id: SuperclassId {
+                file_id: context.id,
+                type_id: item_id,
+                source_id: superclass.source_id,
+            },
+            constraint: superclass.constraint,
+        });
+        let semantic_superclasses = semantic_superclasses.collect::<Arc<[_]>>();
+
         let mut checked_members = Vec::with_capacity(members.len());
+        let mut semantic_members = Vec::with_capacity(members.len());
         for (member_id, member_type) in members {
             let field_type = zonk::zonk(state, context, member_type)?;
             let mut selector_type = context.intern_constrained(class_head, field_type);
@@ -948,19 +959,33 @@ where
 
             state.checked.terms.insert(member_id, selector_type);
             checked_members.push(CheckedClassMember { item_id: member_id, field_type });
+            semantic_members.push(tree::ClassMember { source: member_id, field_type });
         }
 
         state.checked.classes.insert(
             item_id,
             CheckedClass {
-                kind_binders,
-                type_parameters,
+                kind_binders: Arc::clone(&kind_binders),
+                type_parameters: Arc::clone(&type_parameters),
                 canonical,
                 superclasses,
                 functional_dependencies,
                 members: checked_members,
             },
         );
+
+        let class = tree::ClassDeclaration {
+            kind_binders,
+            type_parameters,
+            superclasses: semantic_superclasses,
+            members: Arc::from(semantic_members),
+        };
+        let declaration = tree::TypeDeclaration {
+            kind: class_kind,
+            roles: Arc::default(),
+            declaration: tree::TypeDeclarationKind::Class(class),
+        };
+        state.checked.tree.insert_type_declaration(item_id, declaration);
     }
 
     Ok(())

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -13,8 +13,8 @@ use smol_str::SmolStr;
 
 use crate::context::CheckContext;
 use crate::core::{
-    CheckedClass, CheckedDataDeclaration, CheckedSuperclass, CheckedSynonym, ForallBinder, Role,
-    Type, TypeId, fd, fold, generalise, signature, toolkit, unification, zonk,
+    CheckedClass, CheckedClassMember, CheckedDataDeclaration, CheckedSuperclass, CheckedSynonym,
+    ForallBinder, Role, Type, TypeId, fd, fold, generalise, signature, toolkit, unification, zonk,
 };
 use crate::error::ErrorCrumb;
 use crate::source::types;
@@ -933,46 +933,22 @@ where
             })
             .collect::<QueryResult<Vec<_>>>()?;
 
-        for (member_id, member_type) in members.iter() {
-            let member_type = zonk::zonk(state, context, *member_type)?;
-
-            let signature::DecomposedSignature {
-                binders: member_binders,
-                constraints: member_constraints,
-                arguments: member_arguments,
-                result: member_result,
-            } = signature::decompose_signature(
-                state,
-                context,
-                member_type,
-                signature::DecomposeSignatureMode::Full,
-            )?;
-
-            let mut result = context.intern_function_list(&member_arguments, member_result);
-
-            for constraint in member_constraints.into_iter().rev() {
-                result = context.intern_constrained(constraint, result);
-            }
-
-            result = context.intern_constrained(class_head, result);
-
-            for member_binder in member_binders.iter().copied().rev() {
-                let binder_id = context.intern_forall_binder(member_binder);
-                result = context.intern_forall(binder_id, result);
-            }
+        let mut checked_members = Vec::with_capacity(members.len());
+        for (member_id, member_type) in members {
+            let field_type = zonk::zonk(state, context, member_type)?;
+            let mut selector_type = context.intern_constrained(class_head, field_type);
 
             for type_parameter in type_parameters.iter().rev() {
-                result = context.intern_forall(*type_parameter, result);
+                selector_type = context.intern_forall(*type_parameter, selector_type);
             }
 
             for kind_binder in kind_binders.iter().rev() {
-                result = context.intern_forall(*kind_binder, result);
+                selector_type = context.intern_forall(*kind_binder, selector_type);
             }
 
-            state.checked.terms.insert(*member_id, result);
+            state.checked.terms.insert(member_id, selector_type);
+            checked_members.push(CheckedClassMember { item_id: member_id, field_type });
         }
-
-        let members = members.into_iter().map(|(item_id, _)| item_id).collect_vec();
 
         state.checked.classes.insert(
             item_id,
@@ -982,7 +958,7 @@ where
                 canonical,
                 superclasses,
                 functional_dependencies,
-                members,
+                members: checked_members,
             },
         );
     }

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -42,6 +42,7 @@ pub struct TermDeclaration {
 pub enum TermDeclarationKind {
     Value(ValueDeclaration),
     Constructor(DataConstructor),
+    Instance(InstanceDeclaration),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -53,6 +54,36 @@ pub struct ValueDeclaration {
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataConstructor {
     pub arguments: Arc<[TypeId]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InstanceDeclaration {
+    pub class: (FileId, TypeItemId),
+    pub rigid_parameters: Arc<[TypeId]>,
+    pub evidences: Arc<[InstanceEvidence]>,
+    pub superclasses: Arc<[InstanceSuperclass]>,
+    pub members: Arc<[InstanceMember]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceEvidence {
+    pub constraint: TypeId,
+    pub evidence: Evidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InstanceSuperclass {
+    pub id: SuperclassId,
+    pub constraint: TypeId,
+    pub evidence: EvidenceVarId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceMember {
+    pub resolution: (FileId, TermItemId),
+    pub implementation_type: TypeId,
+    pub evidences: Arc<[Evidence]>,
+    pub equations: Arc<[Equation]>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -10,7 +10,7 @@ use smol_str::SmolStr;
 
 use crate::TypeId;
 use crate::core::{ForallBinderId, Role};
-use crate::evidence::{Evidence, EvidenceVarId};
+use crate::evidence::{Evidence, EvidenceVarId, SuperclassId};
 
 pub type ExpressionId = Idx<Expression>;
 pub type BinderId = Idx<Binder>;
@@ -66,12 +66,33 @@ pub struct TypeDeclaration {
 pub enum TypeDeclarationKind {
     Data(DataDeclaration),
     Newtype(DataDeclaration),
+    Class(ClassDeclaration),
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataDeclaration {
     pub parameters: Arc<[ForallBinderId]>,
     pub constructors: Arc<[TermDeclarationId]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ClassDeclaration {
+    pub kind_binders: Arc<[ForallBinderId]>,
+    pub type_parameters: Arc<[ForallBinderId]>,
+    pub superclasses: Arc<[ClassSuperclass]>,
+    pub members: Arc<[ClassMember]>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClassSuperclass {
+    pub id: SuperclassId,
+    pub constraint: TypeId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClassMember {
+    pub source: TermItemId,
+    pub field_type: TypeId,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -4,7 +4,7 @@ use std::ops::Index;
 use std::sync::Arc;
 
 use files::FileId;
-use indexing::{TermItemId, TypeItemId, ValueEquationId};
+use indexing::{EquationSourceId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
 use smol_str::SmolStr;
 
@@ -76,7 +76,7 @@ pub struct DataDeclaration {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Equation {
-    pub source: ValueEquationId,
+    pub source: EquationSourceId,
     pub binders: Arc<[BinderId]>,
     pub guarded_expression: GuardedExpression,
 }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -113,9 +113,10 @@ where
             };
 
             let declaration = &self.checked.tree[declaration_id];
-            let keyword = match &declaration.declaration {
-                TypeDeclarationKind::Data(_) => "data",
-                TypeDeclarationKind::Newtype(_) => "newtype",
+            let (keyword, is_class) = match &declaration.declaration {
+                TypeDeclarationKind::Data(_) => ("data", false),
+                TypeDeclarationKind::Newtype(_) => ("newtype", false),
+                TypeDeclarationKind::Class(_) => ("interface", true),
             };
             let kind = declaration.kind;
 
@@ -123,7 +124,11 @@ where
             let signature = self.type_pretty.render_kind_signature(name, kind);
             let signature = self.arena.text(format!("{keyword} {signature}"));
 
-            let declaration = self.data_declaration(type_id, keyword, name);
+            let declaration = if is_class {
+                self.class_declaration(type_id, name)?
+            } else {
+                self.data_declaration(type_id, keyword, name)
+            };
 
             declarations.push(signature.append(self.arena.hardline()).append(declaration));
         }
@@ -170,6 +175,9 @@ where
         let declaration = &self.checked.tree[declaration_id];
         let data = match &declaration.declaration {
             TypeDeclarationKind::Data(data) | TypeDeclarationKind::Newtype(data) => data,
+            TypeDeclarationKind::Class(_) => {
+                unreachable!("invariant violated: class is not a data declaration")
+            }
         };
 
         let mut parameter_names = vec![];
@@ -230,6 +238,66 @@ where
         }
 
         declaration
+    }
+
+    fn class_declaration(
+        &mut self,
+        type_id: indexing::TypeItemId,
+        name: &str,
+    ) -> QueryResult<Doc<'arena>> {
+        let declaration_id = self
+            .checked
+            .tree
+            .lookup_type_declaration(type_id)
+            .expect("invariant violated: missing checked type declaration");
+        let declaration = &self.checked.tree[declaration_id];
+        let TypeDeclarationKind::Class(class) = &declaration.declaration else {
+            unreachable!("invariant violated: type declaration is not a class");
+        };
+
+        for &parameter in class.kind_binders.iter() {
+            let parameter = self.queries.lookup_forall_binder(parameter);
+            self.type_pretty.display_name(parameter.name);
+        }
+
+        let mut head = self.arena.text(format!("interface {name}"));
+        for &parameter in class.type_parameters.iter() {
+            let parameter = self.queries.lookup_forall_binder(parameter);
+            let parameter = self.type_pretty.display_name(parameter.name);
+            head = head.append(self.arena.text(format!(" {parameter}")));
+        }
+        let mut declaration = head.append(self.arena.text(" where"));
+
+        let mut field_names = PrettyNames::new();
+        for member in class.members.iter() {
+            let TermItem { name: Some(name), .. } = &self.indexed.items[member.source] else {
+                continue;
+            };
+            field_names.allocate_display_name(SmolStr::clone(name));
+        }
+
+        for superclass in class.superclasses.iter() {
+            let base = self.evidence_base_name(superclass.constraint)?;
+            let field_name = field_names.allocate_display_name(base);
+            let mut type_pretty =
+                TypePretty::new(self.queries, self.checked).without_rigid_kinds().width(self.width);
+            let field_type = type_pretty.render(superclass.constraint);
+            let field = self.arena.text(format!("  superclass {field_name} :: {field_type}"));
+            declaration = declaration.append(self.arena.hardline()).append(field);
+        }
+
+        for member in class.members.iter() {
+            let TermItem { name: Some(name), .. } = &self.indexed.items[member.source] else {
+                continue;
+            };
+            let mut type_pretty =
+                TypePretty::new(self.queries, self.checked).without_rigid_kinds().width(self.width);
+            let field_type = type_pretty.render(member.field_type);
+            let field = self.arena.text(format!("  {name} :: {field_type}"));
+            declaration = declaration.append(self.arena.hardline()).append(field);
+        }
+
+        Ok(declaration)
     }
 
     fn value_declaration(

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -13,8 +13,9 @@ use crate::core::Type;
 use crate::core::pretty::{Pretty as TypePretty, PrettyNames, PrettyQueries};
 use crate::evidence::{Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId};
 use crate::tree::{
-    BinderId, BinderKind, ExpressionId, ExpressionKind, GuardedAlternative, GuardedExpression,
-    PatternGuard, RecordBinderField, TermDeclarationKind, TypeDeclarationKind,
+    BinderId, BinderKind, Equation, ExpressionId, ExpressionKind, GuardedAlternative,
+    GuardedExpression, InstanceDeclaration, PatternGuard, RecordBinderField, TermDeclarationKind,
+    TypeDeclarationKind,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -133,19 +134,38 @@ where
             declarations.push(signature.append(self.arena.hardline()).append(declaration));
         }
 
+        let mut term_names = PrettyNames::new();
+        for (_, TermItem { name, .. }) in self.indexed.items.iter_terms() {
+            if let Some(name) = name {
+                term_names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+
         for (term_id, TermItem { name, .. }) in self.indexed.items.iter_terms() {
-            let Some(name) = name else { continue };
             let Some(declaration_id) = self.checked.tree.lookup_term(term_id) else {
                 continue;
             };
             let declaration = &self.checked.tree[declaration_id];
-            let TermDeclarationKind::Value(_) = &declaration.kind else {
-                continue;
-            };
-            let Some(declaration) = self.value_declaration(term_id, name)? else {
-                continue;
-            };
-            declarations.push(declaration);
+            match &declaration.kind {
+                TermDeclarationKind::Value(_) => {
+                    let Some(name) = name else { continue };
+                    let Some(declaration) = self.value_declaration(term_id, name)? else {
+                        continue;
+                    };
+                    declarations.push(declaration);
+                }
+                TermDeclarationKind::Constructor(_) => {}
+                TermDeclarationKind::Instance(instance) => {
+                    let name = if let Some(name) = name {
+                        SmolStr::clone(name)
+                    } else {
+                        let base = self.dictionary_base_name(declaration.type_id, instance)?;
+                        term_names.allocate_display_name(base)
+                    };
+                    let declaration = self.instance_declaration(term_id, &name)?;
+                    declarations.push(declaration);
+                }
+            }
         }
 
         let mut declarations = declarations.into_iter();
@@ -269,8 +289,8 @@ where
         let mut declaration = head.append(self.arena.text(" where"));
 
         let mut field_names = PrettyNames::new();
-        for member in class.members.iter() {
-            let TermItem { name: Some(name), .. } = &self.indexed.items[member.source] else {
+        for member_id in self.indexed.class_members(type_id) {
+            let TermItem { name: Some(name), .. } = &self.indexed.items[member_id] else {
                 continue;
             };
             field_names.allocate_display_name(SmolStr::clone(name));
@@ -329,10 +349,259 @@ where
             }
         }
 
-        let mut equations = vec![];
-        for equation in value.equations.iter() {
-            let mut expression =
-                self.guarded_expression(&equation.guarded_expression, &mut evidence_names)?;
+        let Some(equations) = self.equation_declarations(
+            name,
+            "",
+            &value.evidences,
+            &value.equations,
+            &mut evidence_names,
+            &[],
+        )?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(signature.append(self.arena.hardline()).append(equations)))
+    }
+
+    fn instance_declaration(
+        &mut self,
+        term_id: indexing::TermItemId,
+        name: &str,
+    ) -> QueryResult<Doc<'arena>> {
+        let declaration_id = self
+            .checked
+            .tree
+            .lookup_term(term_id)
+            .expect("invariant violated: missing checked instance declaration");
+        let declaration = &self.checked.tree[declaration_id];
+        let TermDeclarationKind::Instance(instance) = &declaration.kind else {
+            unreachable!("invariant violated: term declaration is not an instance");
+        };
+
+        let mut outer_evidence_names = EvidenceNames::new();
+        for evidence in instance.evidences.iter() {
+            if let Evidence::Given(binder) = &evidence.evidence {
+                self.evidence_binder_name(&mut outer_evidence_names, *binder)?;
+            }
+        }
+
+        let (signature, rigid_names) = self.dictionary_signature(
+            name,
+            declaration.type_id,
+            instance,
+            &mut outer_evidence_names,
+        )?;
+        let mut declaration =
+            signature.append(self.arena.hardline()).append(self.arena.text("where"));
+
+        let superclass_names = self.instance_superclass_field_names(instance)?;
+        for (superclass, field_name) in instance.superclasses.iter().zip(superclass_names) {
+            let evidence =
+                self.evidence_variable_name(&mut outer_evidence_names, superclass.evidence)?;
+            let field = self.arena.text(format!("  superclass {field_name} = {evidence}"));
+            declaration = declaration.append(self.arena.hardline()).append(field);
+        }
+
+        for member in instance.members.iter() {
+            let Some(member_name) = self.term_name(member.resolution.0, member.resolution.1)?
+            else {
+                continue;
+            };
+
+            let mut evidence_names = EvidenceNames::new();
+            let instance_evidences = instance.evidences.iter().map(|evidence| &evidence.evidence);
+            for evidence in instance_evidences.chain(member.evidences.iter()) {
+                if let Evidence::Given(binder) = evidence {
+                    self.evidence_binder_name(&mut evidence_names, *binder)?;
+                }
+            }
+
+            let Some(equations) = self.equation_declarations(
+                &member_name,
+                "  ",
+                &member.evidences,
+                &member.equations,
+                &mut evidence_names,
+                &rigid_names,
+            )?
+            else {
+                continue;
+            };
+            declaration = declaration.append(self.arena.hardline()).append(equations);
+        }
+
+        Ok(declaration)
+    }
+
+    fn dictionary_signature(
+        &self,
+        name: &str,
+        type_id: crate::TypeId,
+        instance: &InstanceDeclaration,
+        evidence_names: &mut EvidenceNames,
+    ) -> QueryResult<(Doc<'arena>, Vec<(crate::TypeId, SmolStr)>)> {
+        let mut binders = vec![];
+        let mut current = type_id;
+        while let Type::Forall(binder, inner) = self.queries.lookup_type(current) {
+            binders.push(binder);
+            current = inner;
+        }
+        debug_assert_eq!(binders.len(), instance.rigid_parameters.len());
+
+        while let Type::Constrained(_, inner) = self.queries.lookup_type(current) {
+            current = inner;
+        }
+
+        let mut type_pretty =
+            TypePretty::new(self.queries, self.checked).without_rigid_kinds().width(self.width);
+        let binder_names = binders.iter().map(|&binder| {
+            let binder = self.queries.lookup_forall_binder(binder);
+            type_pretty.display_name(binder.name)
+        });
+        let binder_names = binder_names.collect::<Vec<_>>();
+        let rigid_names =
+            instance.rigid_parameters.iter().copied().zip(binder_names.iter().cloned());
+        let rigid_names = rigid_names.collect::<Vec<_>>();
+
+        let mut lines = vec![];
+        if !binder_names.is_empty() {
+            lines.push(format!("forall {}.", binder_names.join(" ")));
+        }
+
+        let mut fields = vec![];
+        for evidence in instance.evidences.iter() {
+            let field_name = self.evidence_name(evidence_names, &evidence.evidence)?;
+            let constraint = type_pretty.render(evidence.constraint);
+            fields.push((field_name, constraint));
+        }
+        if let [(field_name, constraint)] = fields.as_slice() {
+            lines.push(format!("{{ {field_name} :: {constraint} }} =>"));
+        } else if let Some((first_name, first_constraint)) = fields.first() {
+            lines.push(format!("{{ {first_name} :: {first_constraint}"));
+            for (field_name, constraint) in fields.iter().skip(1) {
+                lines.push(format!(", {field_name} :: {constraint}"));
+            }
+            lines.push("} =>".to_string());
+        }
+
+        lines.push(type_pretty.render(current).to_string());
+
+        let mut signature = self.arena.text(format!("dictionary {name} ::"));
+        if lines.len() == 1 {
+            signature = signature.append(self.arena.text(format!(" {}", lines[0])));
+        } else {
+            for line in lines {
+                signature = signature
+                    .append(self.arena.hardline())
+                    .append(self.arena.text(format!("  {line}")));
+            }
+        }
+        Ok((signature, rigid_names))
+    }
+
+    fn instance_superclass_field_names(
+        &self,
+        instance: &InstanceDeclaration,
+    ) -> QueryResult<Vec<SmolStr>> {
+        let indexed = if instance.class.0 == self.file_id {
+            None
+        } else {
+            Some(self.queries.indexed(instance.class.0)?)
+        };
+        let indexed = indexed.as_deref().unwrap_or(self.indexed);
+
+        let mut field_names = PrettyNames::new();
+        for member_id in indexed.class_members(instance.class.1) {
+            if let Some(name) = &indexed.items[member_id].name {
+                field_names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+
+        let mut superclasses = vec![];
+        for superclass in instance.superclasses.iter() {
+            let base = self.evidence_base_name(superclass.constraint)?;
+            superclasses.push(field_names.allocate_display_name(base));
+        }
+        Ok(superclasses)
+    }
+
+    fn dictionary_base_name(
+        &self,
+        type_id: crate::TypeId,
+        instance: &InstanceDeclaration,
+    ) -> QueryResult<SmolStr> {
+        let class_name = self.type_name(instance.class.0, instance.class.1)?;
+        let Some(class_name) = class_name else {
+            return Ok(SmolStr::new("dictionary"));
+        };
+        let mut characters = class_name.chars();
+        let Some(first) = characters.next() else {
+            return Ok(SmolStr::new("dictionary"));
+        };
+        let first = first.to_lowercase().collect::<String>();
+        let mut base = format!("{first}{}", characters.as_str());
+
+        let mut current = type_id;
+        loop {
+            match self.queries.lookup_type(current) {
+                Type::Forall(_, inner) | Type::Constrained(_, inner) | Type::Kinded(inner, _) => {
+                    current = inner;
+                }
+                Type::Application(_, argument) => {
+                    if let Some(argument_name) = self.outer_type_constructor_name(argument)? {
+                        base.push_str(&argument_name);
+                    }
+                    break;
+                }
+                Type::KindApplication(function, _) => current = function,
+                _ => break,
+            }
+        }
+
+        Ok(SmolStr::new(base))
+    }
+
+    fn outer_type_constructor_name(
+        &self,
+        mut type_id: crate::TypeId,
+    ) -> QueryResult<Option<String>> {
+        loop {
+            match self.queries.lookup_type(type_id) {
+                Type::Application(function, _)
+                | Type::KindApplication(function, _)
+                | Type::Kinded(function, _) => type_id = function,
+                Type::Constructor(file_id, item_id) => {
+                    return self.type_name(file_id, item_id);
+                }
+                _ => return Ok(None),
+            }
+        }
+    }
+
+    fn equation_declarations(
+        &self,
+        name: &str,
+        prefix: &str,
+        evidences: &[Evidence],
+        equations: &[Equation],
+        evidence_names: &mut EvidenceNames,
+        rigid_names: &[(crate::TypeId, SmolStr)],
+    ) -> QueryResult<Option<Doc<'arena>>> {
+        let mut rendered_equations = vec![];
+        let mut type_pretty =
+            TypePretty::new(self.queries, self.checked).without_rigid_kinds().width(self.width);
+        for (rigid, display) in rigid_names {
+            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
+                type_pretty.assign_display_name(name, SmolStr::clone(display));
+            }
+        }
+        for equation in equations.iter() {
+            let mut expression = self.guarded_expression(
+                &equation.guarded_expression,
+                evidence_names,
+                &mut type_pretty,
+            )?;
 
             for &binder in equation.binders.iter().rev() {
                 let binder = self.binder(binder)?;
@@ -344,8 +613,8 @@ where
                     .append(self.arena.line().append(expression).nest(2))
                     .group();
             }
-            for evidence in value.evidences.iter().rev() {
-                let binder = self.evidence_name(&mut evidence_names, evidence)?;
+            for evidence in evidences.iter().rev() {
+                let binder = self.evidence_name(evidence_names, evidence)?;
                 expression = self
                     .arena
                     .text(format!("\\{{{binder}}} ->"))
@@ -355,35 +624,43 @@ where
 
             let equation = self
                 .arena
-                .text(format!("{name} ="))
+                .text(format!("{prefix}{name} ="))
                 .append(self.arena.line().append(expression).nest(2))
                 .group();
-            equations.push(equation);
+            rendered_equations.push(equation);
         }
 
-        let mut equations = equations.into_iter();
+        let mut equations = rendered_equations.into_iter();
         let Some(first) = equations.next() else { return Ok(None) };
         let equations = equations.fold(first, |document, equation| {
             document.append(self.arena.hardline()).append(equation)
         });
-
-        Ok(Some(signature.append(self.arena.hardline()).append(equations)))
+        Ok(Some(equations))
     }
 
     fn guarded_expression(
         &self,
         guarded: &GuardedExpression,
         evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
         if let [alternative] = guarded.alternatives.as_ref()
             && alternative.pattern_guards.is_empty()
         {
-            return self.expression(alternative.where_expression.expression, evidence_names);
+            return self.expression(
+                alternative.where_expression.expression,
+                evidence_names,
+                type_pretty,
+            );
         }
 
         let mut alternatives = vec![];
         for alternative in guarded.alternatives.iter() {
-            alternatives.push(self.guarded_alternative(alternative, evidence_names)?);
+            alternatives.push(self.guarded_alternative(
+                alternative,
+                evidence_names,
+                type_pretty,
+            )?);
         }
 
         let mut alternatives = alternatives.into_iter();
@@ -400,14 +677,15 @@ where
         &self,
         alternative: &GuardedAlternative,
         evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
         let mut pattern_guards = vec![];
         for pattern_guard in alternative.pattern_guards.iter() {
-            pattern_guards.push(self.pattern_guard(pattern_guard, evidence_names)?);
+            pattern_guards.push(self.pattern_guard(pattern_guard, evidence_names, type_pretty)?);
         }
 
         let expression =
-            self.expression(alternative.where_expression.expression, evidence_names)?;
+            self.expression(alternative.where_expression.expression, evidence_names, type_pretty)?;
         let mut pattern_guards = pattern_guards.into_iter();
         let Some(first) = pattern_guards.next() else {
             return Ok(self.arena.text("| -> ").append(expression));
@@ -428,12 +706,15 @@ where
         &self,
         pattern_guard: &PatternGuard,
         evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
         match *pattern_guard {
-            PatternGuard::Boolean { expression } => self.expression(expression, evidence_names),
+            PatternGuard::Boolean { expression } => {
+                self.expression(expression, evidence_names, type_pretty)
+            }
             PatternGuard::Pattern { binder, expression } => {
                 let binder = self.binder(binder)?;
-                let expression = self.expression(expression, evidence_names)?;
+                let expression = self.expression(expression, evidence_names, type_pretty)?;
                 Ok(binder.append(self.arena.text(" <- ")).append(expression))
             }
         }
@@ -534,6 +815,7 @@ where
         &self,
         expression_id: ExpressionId,
         evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
         let expression = &self.checked.tree[expression_id];
         match expression.kind {
@@ -579,9 +861,9 @@ where
                 Ok(self.arena.text(name))
             }
             ExpressionKind::TermApplication { function, argument } => {
-                let function = self.expression(function, evidence_names)?;
+                let function = self.expression(function, evidence_names, type_pretty)?;
                 let argument_expression = &self.checked.tree[argument];
-                let argument = self.expression(argument, evidence_names)?;
+                let argument = self.expression(argument, evidence_names, type_pretty)?;
                 let argument = match argument_expression.kind {
                     ExpressionKind::TermApplication { .. }
                     | ExpressionKind::TypeApplication { .. }
@@ -593,15 +875,12 @@ where
                 Ok(function.append(self.arena.space()).append(argument))
             }
             ExpressionKind::TypeApplication { function, argument } => {
-                let function = self.expression(function, evidence_names)?;
-                let mut type_pretty = TypePretty::new(self.queries, self.checked)
-                    .without_rigid_kinds()
-                    .width(self.width);
+                let function = self.expression(function, evidence_names, type_pretty)?;
                 let argument = type_pretty.render(argument);
                 Ok(function.append(self.arena.text(format!(" @{argument}"))))
             }
             ExpressionKind::EvidenceApplication { function, evidence } => {
-                let function = self.expression(function, evidence_names)?;
+                let function = self.expression(function, evidence_names, type_pretty)?;
                 let evidence = self.evidence_variable_name(evidence_names, evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
             }

--- a/compiler-core/indexing/src/source.rs
+++ b/compiler-core/indexing/src/source.rs
@@ -28,8 +28,15 @@ pub type ValueEquationId = AstId<cst::ValueEquation>;
 pub type InstanceChainId = AstId<cst::InstanceChain>;
 pub type InstanceId = AstId<cst::InstanceDeclaration>;
 pub type InstanceMemberId = AstId<cst::InstanceMemberStatement>;
+pub type InstanceEquationId = AstId<cst::InstanceEquationStatement>;
 pub type DeriveId = AstId<cst::DeriveDeclaration>;
 
 pub type InfixId = AstId<cst::InfixDeclaration>;
 pub type ForeignDataId = AstId<cst::ForeignImportDataDeclaration>;
 pub type ForeignValueId = AstId<cst::ForeignImportValueDeclaration>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EquationSourceId {
+    Value(ValueEquationId),
+    Instance(InstanceEquationId),
+}

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 
 use files::FileId;
 use indexing::{
-    IndexedModule, TermItem, TermItemId, TermItemKind, TypeItem, TypeItemId, TypeItemKind,
-    TypeRoleId,
+    EquationSourceId, IndexedModule, TermItem, TermItemId, TermItemKind, TypeItem, TypeItemId,
+    TypeItemKind, TypeRoleId,
 };
+use indexmap::IndexMap;
 use itertools::Itertools;
 use petgraph::prelude::DiGraphMap;
 use resolving::ResolvedModule;
@@ -567,7 +568,7 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
                     Some(recursive::lower_equation_like(
                         state,
                         context,
-                        Some(*id),
+                        Some(EquationSourceId::Value(*id)),
                         cst,
                         cst::ValueEquation::function_binders,
                         cst::ValueEquation::guarded_expression,
@@ -847,7 +848,7 @@ fn lower_instance_statements(
         }),
     });
 
-    let mut in_scope = FxHashMap::default();
+    let mut in_scope: IndexMap<_, _, FxBuildHasher> = IndexMap::default();
     for (name, mut children) in children.into_iter() {
         let mut signature = None;
         let mut equations = vec![];
@@ -897,7 +898,7 @@ fn lower_instance_statements(
                         Some(recursive::lower_equation_like(
                             state,
                             context,
-                            None,
+                            Some(EquationSourceId::Instance(id)),
                             cst,
                             cst::InstanceEquationStatement::function_binders,
                             cst::InstanceEquationStatement::guarded_expression,

--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -844,7 +844,7 @@ fn lower_equation_chunk(
 pub(crate) fn lower_equation_like<T: AstNode>(
     state: &mut State,
     context: &Context,
-    source: Option<indexing::ValueEquationId>,
+    source: Option<indexing::EquationSourceId>,
     equation: T,
     binders: impl Fn(&T) -> Option<cst::FunctionBinders>,
     guarded: impl Fn(&T) -> Option<cst::GuardedExpression>,

--- a/compiler-core/lowering/src/intermediate.rs
+++ b/compiler-core/lowering/src/intermediate.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use files::FileId;
-use indexing::{TermItemId, TypeItemId, ValueEquationId};
+use indexing::{EquationSourceId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
@@ -210,7 +210,7 @@ pub enum TypeKind {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Equation {
-    pub source: Option<ValueEquationId>,
+    pub source: Option<EquationSourceId>,
     pub binders: Arc<[BinderId]>,
     pub guarded: Option<GuardedExpression>,
 }

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -61,7 +61,7 @@ impl<'a> TypeEncoder<'a> {
         class: checking::core::CheckedClass,
     ) -> Result<(schema::TypeDeclaration, Vec<schema::Type>), Error> {
         self.names.reset();
-        let binders = self.encode_forall_binders(class.type_parameters)?;
+        let binders = self.encode_forall_binders(class.type_parameters.iter().copied())?;
 
         let superclasses = class
             .superclasses

--- a/tests-integration/fixtures/checking/1771923480_class_polykind_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771923480_class_polykind_check/Main.snap
@@ -1,13 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 reflectKind ::
-  forall (k :: Type) (@a :: (k :: Type)) (p :: (k :: Type) -> Type).
+  forall (k :: Type) (@a :: (k :: Type)).
     HasKind @(k :: Type) (a :: (k :: Type)) =>
-    (p :: (k :: Type) -> Type) (a :: (k :: Type)) -> String
+    (forall (p :: (k :: Type) -> Type). (p :: (k :: Type) -> Type) (a :: (k :: Type)) -> String)
 
 Types
 HasKind :: forall (k :: Type). (k :: Type) -> Constraint
@@ -15,6 +15,6 @@ HasKind :: forall (k :: Type). (k :: Type) -> Constraint
 Classes
 class forall (k :: Type) (a :: (k :: Type)). HasKind @(k :: Type) (a :: (k :: Type))
   reflectKind ::
-  forall (k :: Type) (@a :: (k :: Type)) (p :: (k :: Type) -> Type).
+  forall (k :: Type) (@a :: (k :: Type)).
     HasKind @(k :: Type) (a :: (k :: Type)) =>
-    (p :: (k :: Type) -> Type) (a :: (k :: Type)) -> String
+    (forall (p :: (k :: Type) -> Type). (p :: (k :: Type) -> Type) (a :: (k :: Type)) -> String)

--- a/tests-integration/fixtures/checking/1771923540_class_polykind_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1771923540_class_polykind_infer/Main.snap
@@ -5,9 +5,9 @@ expression: report
 ---
 Terms
 reflectKind' ::
-  forall (t :: Type) (@a :: (t :: Type)) (p :: (t :: Type) -> Type).
+  forall (t :: Type) (@a :: (t :: Type)).
     HasKind' @(t :: Type) (a :: (t :: Type)) =>
-    (p :: (t :: Type) -> Type) (a :: (t :: Type)) -> String
+    (forall (p :: (t :: Type) -> Type). (p :: (t :: Type) -> Type) (a :: (t :: Type)) -> String)
 
 Types
 HasKind' :: forall (t :: Type). (t :: Type) -> Constraint
@@ -15,6 +15,6 @@ HasKind' :: forall (t :: Type). (t :: Type) -> Constraint
 Classes
 class forall (t :: Type) (a :: (t :: Type)). HasKind' @(t :: Type) (a :: (t :: Type))
   reflectKind' ::
-  forall (t :: Type) (@a :: (t :: Type)) (p :: (t :: Type) -> Type).
+  forall (t :: Type) (@a :: (t :: Type)).
     HasKind' @(t :: Type) (a :: (t :: Type)) =>
-    (p :: (t :: Type) -> Type) (a :: (t :: Type)) -> String
+    (forall (p :: (t :: Type) -> Type). (p :: (t :: Type) -> Type) (a :: (t :: Type)) -> String)

--- a/tests-integration/fixtures/checking/1772475720_instance_member_functor/Main.snap
+++ b/tests-integration/fixtures/checking/1772475720_instance_member_functor/Main.snap
@@ -5,11 +5,12 @@ expression: report
 ---
 Terms
 map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
 
 Types
@@ -19,11 +20,12 @@ Box :: Type -> Type
 Classes
 class forall (f :: Type -> Type). Functor (f :: Type -> Type)
   map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 
 Instances
 instance Functor Box

--- a/tests-integration/fixtures/checking/1772475960_instance_member_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772475960_instance_member_higher_kinded/Main.snap
@@ -5,11 +5,12 @@ expression: report
 ---
 Terms
 map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 Wrap ::
   forall (k :: Type) (@e :: Type) (@w :: (k :: Type) -> Type) (@a :: (k :: Type)).
     (w :: (k :: Type) -> Type) (a :: (k :: Type)) ->
@@ -22,11 +23,12 @@ Wrap :: forall (k :: Type). Type -> ((k :: Type) -> Type) -> (k :: Type) -> Type
 Classes
 class forall (f :: Type -> Type). Functor (f :: Type -> Type)
   map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 
 Instances
 instance forall (t :: Type -> Type) (t1 :: Type).

--- a/tests-integration/fixtures/checking/1772743200_class_member_prenex/Main.snap
+++ b/tests-integration/fixtures/checking/1772743200_class_member_prenex/Main.snap
@@ -1,15 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 const ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Const (f :: Type -> Type) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type) ->
-    (f :: Type -> Type) (a :: Type)
+    (forall (a :: Type).
+      (f :: Type -> Type) (a :: Type) ->
+      (forall (b :: Type). (f :: Type -> Type) (b :: Type) -> (f :: Type -> Type) (a :: Type)))
 
 Types
 Const :: (Type -> Type) -> Constraint
@@ -17,8 +17,8 @@ Const :: (Type -> Type) -> Constraint
 Classes
 class forall (f :: Type -> Type). Const (f :: Type -> Type)
   const ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Const (f :: Type -> Type) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type) ->
-    (f :: Type -> Type) (a :: Type)
+    (forall (a :: Type).
+      (f :: Type -> Type) (a :: Type) ->
+      (forall (b :: Type). (f :: Type -> Type) (b :: Type) -> (f :: Type -> Type) (a :: Type)))

--- a/tests-integration/fixtures/checking/1772818320_do_ado_constrained/Main.snap
+++ b/tests-integration/fixtures/checking/1772818320_do_ado_constrained/Main.snap
@@ -7,32 +7,37 @@ Terms
 Tuple ::
   forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
 map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 apply ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Apply (f :: Type -> Type) =>
-    (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 pure ::
-  forall (@f :: Type -> Type) (a :: Type).
-    Applicative (f :: Type -> Type) => (a :: Type) -> (f :: Type -> Type) (a :: Type)
+  forall (@f :: Type -> Type).
+    Applicative (f :: Type -> Type) =>
+    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
 discard ::
-  forall (@m :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@m :: Type -> Type).
     Discard (m :: Type -> Type) =>
-    (m :: Type -> Type) (a :: Type) ->
-    ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-    (m :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      (m :: Type -> Type) (a :: Type) ->
+      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
+      (m :: Type -> Type) (b :: Type))
 bind ::
-  forall (@m :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@m :: Type -> Type).
     Bind (m :: Type -> Type) =>
-    (m :: Type -> Type) (a :: Type) ->
-    ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-    (m :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      (m :: Type -> Type) (a :: Type) ->
+      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
+      (m :: Type -> Type) (b :: Type))
 testDo ::
   forall (m :: Type -> Type). Monad (m :: Type -> Type) => (m :: Type -> Type) (Tuple Int String)
 testDo' ::
@@ -58,36 +63,41 @@ Monad :: (Type -> Type) -> Constraint
 Classes
 class forall (f :: Type -> Type). Functor (f :: Type -> Type)
   map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 class forall (f :: Type -> Type). Functor (f :: Type -> Type) <= Apply (f :: Type -> Type)
   apply ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Apply (f :: Type -> Type) =>
-    (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 class forall (f :: Type -> Type). Apply (f :: Type -> Type) <= Applicative (f :: Type -> Type)
   pure ::
-  forall (@f :: Type -> Type) (a :: Type).
-    Applicative (f :: Type -> Type) => (a :: Type) -> (f :: Type -> Type) (a :: Type)
+  forall (@f :: Type -> Type).
+    Applicative (f :: Type -> Type) =>
+    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
 class forall (m :: Type -> Type). Applicative (m :: Type -> Type) <= Discard (m :: Type -> Type)
   discard ::
-  forall (@m :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@m :: Type -> Type).
     Discard (m :: Type -> Type) =>
-    (m :: Type -> Type) (a :: Type) ->
-    ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-    (m :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      (m :: Type -> Type) (a :: Type) ->
+      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
+      (m :: Type -> Type) (b :: Type))
 class forall (m :: Type -> Type). Applicative (m :: Type -> Type) <= Bind (m :: Type -> Type)
   bind ::
-  forall (@m :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@m :: Type -> Type).
     Bind (m :: Type -> Type) =>
-    (m :: Type -> Type) (a :: Type) ->
-    ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-    (m :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      (m :: Type -> Type) (a :: Type) ->
+      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
+      (m :: Type -> Type) (b :: Type))
 class forall (m :: Type -> Type). Bind (m :: Type -> Type) <= Monad (m :: Type -> Type)
 
 Roles

--- a/tests-integration/fixtures/checking/1772823420_application_function_subtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772823420_application_function_subtype/Main.snap
@@ -1,13 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type))
+    (forall (t :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
 test :: Function Int Int
 test' :: Int -> Int
 
@@ -17,9 +18,10 @@ Category :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> Constrai
 Classes
 class forall (k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type). Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type)
   identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type))
+    (forall (t :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
 
 Instances
 instance Category @Type Function

--- a/tests-integration/fixtures/checking/1772823480_application_function_decomposition/Main.snap
+++ b/tests-integration/fixtures/checking/1772823480_application_function_decomposition/Main.snap
@@ -7,27 +7,31 @@ Terms
 Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
 Nothing :: forall (@a :: Type). Maybe (a :: Type)
 foldMap ::
-  forall (@f :: Type -> Type) (a :: Type) (m :: Type).
+  forall (@f :: Type -> Type).
     Foldable (f :: Type -> Type) =>
-    ((a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type)
+    (forall (a :: Type) (m :: Type).
+      ((a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
 foldMapWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type) (a :: Type) (m :: Type).
+  forall (@i :: Type) (@f :: Type -> Type).
     FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    ((i :: Type) -> (a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type)
+    (forall (a :: Type) (m :: Type).
+      ((i :: Type) -> (a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
 foldlWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@i :: Type) (@f :: Type -> Type).
     FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    ((i :: Type) -> (b :: Type) -> (a :: Type) -> (b :: Type)) ->
-    (b :: Type) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((i :: Type) -> (b :: Type) -> (a :: Type) -> (b :: Type)) ->
+      (b :: Type) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (b :: Type))
 foldrWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@i :: Type) (@f :: Type -> Type).
     FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    ((i :: Type) -> (a :: Type) -> (b :: Type) -> (b :: Type)) ->
-    (b :: Type) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((i :: Type) -> (a :: Type) -> (b :: Type) -> (b :: Type)) ->
+      (b :: Type) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (b :: Type))
 NonEmpty ::
   forall (@f :: Type -> Type) (@a :: Type).
     (a :: Type) -> (f :: Type -> Type) (a :: Type) -> NonEmpty (f :: Type -> Type) (a :: Type)
@@ -41,28 +45,32 @@ NonEmpty :: (Type -> Type) -> Type -> Type
 Classes
 class forall (f :: Type -> Type). Foldable (f :: Type -> Type)
   foldMap ::
-  forall (@f :: Type -> Type) (a :: Type) (m :: Type).
+  forall (@f :: Type -> Type).
     Foldable (f :: Type -> Type) =>
-    ((a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type)
+    (forall (a :: Type) (m :: Type).
+      ((a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
 class forall (i :: Type) (f :: Type -> Type). Foldable (f :: Type -> Type) <= FoldableWithIndex (i :: Type) (f :: Type -> Type)
   foldMapWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type) (a :: Type) (m :: Type).
+  forall (@i :: Type) (@f :: Type -> Type).
     FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    ((i :: Type) -> (a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type)
+    (forall (a :: Type) (m :: Type).
+      ((i :: Type) -> (a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
   foldlWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type) (a1 :: Type) (b :: Type).
+  forall (@i :: Type) (@f :: Type -> Type).
     FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    ((i :: Type) -> (b :: Type) -> (a1 :: Type) -> (b :: Type)) ->
-    (b :: Type) ->
-    (f :: Type -> Type) (a1 :: Type) ->
-    (b :: Type)
+    (forall (a1 :: Type) (b :: Type).
+      ((i :: Type) -> (b :: Type) -> (a1 :: Type) -> (b :: Type)) ->
+      (b :: Type) ->
+      (f :: Type -> Type) (a1 :: Type) ->
+      (b :: Type))
   foldrWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type) (a2 :: Type) (b1 :: Type).
+  forall (@i :: Type) (@f :: Type -> Type).
     FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    ((i :: Type) -> (a2 :: Type) -> (b1 :: Type) -> (b1 :: Type)) ->
-    (b1 :: Type) ->
-    (f :: Type -> Type) (a2 :: Type) ->
-    (b1 :: Type)
+    (forall (a2 :: Type) (b1 :: Type).
+      ((i :: Type) -> (a2 :: Type) -> (b1 :: Type) -> (b1 :: Type)) ->
+      (b1 :: Type) ->
+      (f :: Type -> Type) (a2 :: Type) ->
+      (b1 :: Type))
 
 Instances
 instance forall (t :: Type -> Type). Foldable (t :: Type -> Type) => Foldable (NonEmpty (t :: Type -> Type))

--- a/tests-integration/fixtures/checking/1773478800_category_identity_operator_alias/Main.snap
+++ b/tests-integration/fixtures/checking/1773478800_category_identity_operator_alias/Main.snap
@@ -5,20 +5,22 @@ expression: report
 ---
 Terms
 compose ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type))
-    (c :: (k :: Type)) (d :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (c :: (k :: Type)) (d :: (k :: Type)) ->
-    (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-    (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (d :: (k :: Type))
+    (forall (b :: (k :: Type)) (c :: (k :: Type)) (d :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (c :: (k :: Type)) (d :: (k :: Type)) ->
+      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
+      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (d :: (k :: Type)))
 identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type))
+    (forall (t :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
 <<$>> ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type))
+    (forall (t :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
 test :: forall (a :: Type). (a :: Type) -> (a :: Type)
 
 Types
@@ -28,17 +30,18 @@ Category :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> Constrai
 Classes
 class forall (k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type). Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type)
   compose ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type))
-    (c :: (k :: Type)) (d :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (c :: (k :: Type)) (d :: (k :: Type)) ->
-    (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-    (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (d :: (k :: Type))
+    (forall (b :: (k :: Type)) (c :: (k :: Type)) (d :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (c :: (k :: Type)) (d :: (k :: Type)) ->
+      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
+      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (d :: (k :: Type)))
 class forall (k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type). Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) <= Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type)
   identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)).
+  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
     Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type))
+    (forall (t :: (k :: Type)).
+      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
 
 Instances
 instance Semigroupoid @Type Function

--- a/tests-integration/fixtures/checking/1773491520_instance_function_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1773491520_instance_function_unification/Main.snap
@@ -5,9 +5,10 @@ expression: report
 ---
 Terms
 identity ::
-  forall (t :: Type) (@f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)).
+  forall (t :: Type) (@f :: (t :: Type) -> (t :: Type) -> Type).
     Category @(t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type) =>
-    (f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type))
+    (forall (a :: (t :: Type)).
+      (f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type)))
 
 Types
 Category :: forall (t :: Type). ((t :: Type) -> (t :: Type) -> Type) -> Constraint
@@ -15,9 +16,10 @@ Category :: forall (t :: Type). ((t :: Type) -> (t :: Type) -> Type) -> Constrai
 Classes
 class forall (t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type). Category @(t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type)
   identity ::
-  forall (t :: Type) (@f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)).
+  forall (t :: Type) (@f :: (t :: Type) -> (t :: Type) -> Type).
     Category @(t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type) =>
-    (f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type))
+    (forall (a :: (t :: Type)).
+      (f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type)))
 
 Instances
 instance Category @Type Function

--- a/tests-integration/fixtures/checking/1773712920_visible_type_application_class/Main.snap
+++ b/tests-integration/fixtures/checking/1773712920_visible_type_application_class/Main.snap
@@ -5,11 +5,12 @@ expression: report
 ---
 Terms
 map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 testMap ::
   forall (t :: Type) (t1 :: Type).
     ((t :: Type) -> (t1 :: Type)) -> Array (t :: Type) -> Array (t1 :: Type)
@@ -20,11 +21,12 @@ Functor :: (Type -> Type) -> Constraint
 Classes
 class forall (f :: Type -> Type). Functor (f :: Type -> Type)
   map ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Functor (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
 
 Instances
 instance Functor Array

--- a/tests-integration/fixtures/checking/1774448220_section_rule_progress/Main.snap
+++ b/tests-integration/fixtures/checking/1774448220_section_rule_progress/Main.snap
@@ -9,11 +9,12 @@ Loop :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Step (a :: Type) (b :: 
 append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
 mempty :: forall (@a :: Type). Monoid (a :: Type) => (a :: Type)
 tailRecM ::
-  forall (@m :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@m :: Type -> Type).
     MonadRec (m :: Type -> Type) =>
-    ((a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))) ->
-    (a :: Type) ->
-    (m :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))) ->
+      (a :: Type) ->
+      (m :: Type -> Type) (b :: Type))
 ifM ::
   forall (m :: Type -> Type) (a :: Type).
     Bind (m :: Type -> Type) =>
@@ -82,11 +83,12 @@ class forall (a :: Type). Semigroup (a :: Type) <= Monoid (a :: Type)
   mempty :: forall (@a :: Type). Monoid (a :: Type) => (a :: Type)
 class forall (m :: Type -> Type). Applicative (m :: Type -> Type), Bind (m :: Type -> Type) <= MonadRec (m :: Type -> Type)
   tailRecM ::
-  forall (@m :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@m :: Type -> Type).
     MonadRec (m :: Type -> Type) =>
-    ((a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))) ->
-    (a :: Type) ->
-    (m :: Type -> Type) (b :: Type)
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))) ->
+      (a :: Type) ->
+      (m :: Type -> Type) (b :: Type))
 
 Roles
 Step = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1774448340_operator_result_ordering/Main.snap
+++ b/tests-integration/fixtures/checking/1774448340_operator_result_ordering/Main.snap
@@ -9,12 +9,13 @@ apply :: forall (a :: Type) (b :: Type). ((a :: Type) -> (b :: Type)) -> (a :: T
 identity :: forall (a :: Type). (a :: Type) -> (a :: Type)
 Wrap :: forall (@a :: Type). (a :: Type) -> Wrap (a :: Type)
 dimap ::
-  forall (@p :: Type -> Type -> Type) (a :: Type) (b :: Type) (c :: Type) (d :: Type).
+  forall (@p :: Type -> Type -> Type).
     Profunctor (p :: Type -> Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    ((c :: Type) -> (d :: Type)) ->
-    (p :: Type -> Type -> Type) (b :: Type) (c :: Type) ->
-    (p :: Type -> Type -> Type) (a :: Type) (d :: Type)
+    (forall (a :: Type) (b :: Type) (c :: Type) (d :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      ((c :: Type) -> (d :: Type)) ->
+      (p :: Type -> Type -> Type) (b :: Type) (c :: Type) ->
+      (p :: Type -> Type -> Type) (a :: Type) (d :: Type))
 lens ::
   forall (s :: Type) (a :: Type).
     ((a :: Type) -> (s :: Type)) -> ((s :: Type) -> (a :: Type)) -> Lens (s :: Type) (a :: Type)
@@ -37,12 +38,13 @@ type Lens s a = forall (p :: Type -> Type -> Type).
 Classes
 class forall (p :: Type -> Type -> Type). Profunctor (p :: Type -> Type -> Type)
   dimap ::
-  forall (@p :: Type -> Type -> Type) (a :: Type) (b :: Type) (c :: Type) (d :: Type).
+  forall (@p :: Type -> Type -> Type).
     Profunctor (p :: Type -> Type -> Type) =>
-    ((a :: Type) -> (b :: Type)) ->
-    ((c :: Type) -> (d :: Type)) ->
-    (p :: Type -> Type -> Type) (b :: Type) (c :: Type) ->
-    (p :: Type -> Type -> Type) (a :: Type) (d :: Type)
+    (forall (a :: Type) (b :: Type) (c :: Type) (d :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      ((c :: Type) -> (d :: Type)) ->
+      (p :: Type -> Type -> Type) (b :: Type) (c :: Type) ->
+      (p :: Type -> Type -> Type) (a :: Type) (d :: Type))
 
 Instances
 instance Profunctor Function

--- a/tests-integration/fixtures/checking/1774448520_hidden_forall_compose_application_subtype/Main.snap
+++ b/tests-integration/fixtures/checking/1774448520_hidden_forall_compose_application_subtype/Main.snap
@@ -5,12 +5,12 @@ expression: report
 ---
 Terms
 compose ::
-  forall (k :: Type) (@f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type))
-    (b :: (k :: Type)) (c :: (k :: Type)).
+  forall (k :: Type) (@f :: (k :: Type) -> (k :: Type) -> Type).
     Semigroupoid @(k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type) =>
-    (f :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-    (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (b :: (k :: Type)) ->
-    (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (c :: (k :: Type))
+    (forall (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)).
+      (f :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
+      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (b :: (k :: Type)) ->
+      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (c :: (k :: Type)))
 Tagged :: forall (@n :: Int) (@a :: Type). (a :: Type) -> Tagged (n :: Int) (a :: Type)
 make :: forall (a :: Type). (a :: Type) -> HiddenTagged (a :: Type)
 ConcreteNewtype :: forall (@a :: Type). ConcreteTagged (a :: Type) -> ConcreteNewtype (a :: Type)
@@ -30,12 +30,12 @@ type HiddenTagged a = forall (n :: Int). Tagged (n :: Int) (a :: Type)
 Classes
 class forall (k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type). Semigroupoid @(k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type)
   compose ::
-  forall (k :: Type) (@f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type))
-    (b :: (k :: Type)) (c :: (k :: Type)).
+  forall (k :: Type) (@f :: (k :: Type) -> (k :: Type) -> Type).
     Semigroupoid @(k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type) =>
-    (f :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-    (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (b :: (k :: Type)) ->
-    (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (c :: (k :: Type))
+    (forall (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)).
+      (f :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
+      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (b :: (k :: Type)) ->
+      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (c :: (k :: Type)))
 
 Instances
 instance Semigroupoid @Type Function

--- a/tests-integration/fixtures/checking/1777287480_guarded_conditionals_checking/Main.snap
+++ b/tests-integration/fixtures/checking/1777287480_guarded_conditionals_checking/Main.snap
@@ -5,12 +5,14 @@ expression: report
 ---
 Terms
 singleton ::
-  forall (@f :: Type -> Type) (a :: Type).
-    Build (f :: Type -> Type) => (a :: Type) -> (f :: Type -> Type) (a :: Type)
-produce ::
-  forall (@f :: Type -> Type) (a :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Build (f :: Type -> Type) =>
-    ((b :: Type) -> (a :: Type)) -> (b :: Type) -> (f :: Type -> Type) (a :: Type)
+    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
+produce ::
+  forall (@f :: Type -> Type).
+    Build (f :: Type -> Type) =>
+    (forall (a :: Type) (b :: Type).
+      ((b :: Type) -> (a :: Type)) -> (b :: Type) -> (f :: Type -> Type) (a :: Type))
 identity :: forall (a :: Type). (a :: Type) -> (a :: Type)
 test ::
   forall (f :: Type -> Type).
@@ -22,9 +24,11 @@ Build :: (Type -> Type) -> Constraint
 Classes
 class forall (f :: Type -> Type). Build (f :: Type -> Type)
   singleton ::
-  forall (@f :: Type -> Type) (a :: Type).
-    Build (f :: Type -> Type) => (a :: Type) -> (f :: Type -> Type) (a :: Type)
-  produce ::
-  forall (@f :: Type -> Type) (a1 :: Type) (b :: Type).
+  forall (@f :: Type -> Type).
     Build (f :: Type -> Type) =>
-    ((b :: Type) -> (a1 :: Type)) -> (b :: Type) -> (f :: Type -> Type) (a1 :: Type)
+    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
+  produce ::
+  forall (@f :: Type -> Type).
+    Build (f :: Type -> Type) =>
+    (forall (a1 :: Type) (b :: Type).
+      ((b :: Type) -> (a1 :: Type)) -> (b :: Type) -> (f :: Type -> Type) (a1 :: Type))

--- a/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
+++ b/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
@@ -5,23 +5,25 @@ expression: report
 ---
 Terms
 lift ::
-  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+  forall (@t :: (Type -> Type) -> Type -> Type).
     Transform (t :: (Type -> Type) -> Type -> Type) =>
-    Functor (f :: Type -> Type) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+    (forall (f :: Type -> Type) (a :: Type).
+      Functor (f :: Type -> Type) =>
+      (f :: Type -> Type) (a :: Type) ->
+      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
 Wrap ::
   forall (@f :: Type -> Type) (@a :: Type).
     (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)
 render :: forall (@a :: Type). Render (a :: Type) => (a :: Type) -> String
 renderer ::
-  forall (@t :: Type) (a :: Type).
-    Renderer (t :: Type) => Render (a :: Type) => (a :: Type) -> (t :: Type)
+  forall (@t :: Type).
+    Renderer (t :: Type) => (forall (a :: Type). Render (a :: Type) => (a :: Type) -> (t :: Type))
 liftPlain ::
-  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+  forall (@t :: (Type -> Type) -> Type -> Type).
     TransformPlain (t :: (Type -> Type) -> Type -> Type) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+    (forall (f :: Type -> Type) (a :: Type).
+      (f :: Type -> Type) (a :: Type) ->
+      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
 
 Types
 Transform :: ((Type -> Type) -> Type -> Type) -> Constraint
@@ -33,23 +35,25 @@ TransformPlain :: ((Type -> Type) -> Type -> Type) -> Constraint
 Classes
 class forall (t :: (Type -> Type) -> Type -> Type). Transform (t :: (Type -> Type) -> Type -> Type)
   lift ::
-  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+  forall (@t :: (Type -> Type) -> Type -> Type).
     Transform (t :: (Type -> Type) -> Type -> Type) =>
-    Functor (f :: Type -> Type) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+    (forall (f :: Type -> Type) (a :: Type).
+      Functor (f :: Type -> Type) =>
+      (f :: Type -> Type) (a :: Type) ->
+      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
 class forall (a :: Type). Render (a :: Type)
   render :: forall (@a :: Type). Render (a :: Type) => (a :: Type) -> String
 class forall (t :: Type). Renderer (t :: Type)
   renderer ::
-  forall (@t :: Type) (a :: Type).
-    Renderer (t :: Type) => Render (a :: Type) => (a :: Type) -> (t :: Type)
+  forall (@t :: Type).
+    Renderer (t :: Type) => (forall (a :: Type). Render (a :: Type) => (a :: Type) -> (t :: Type))
 class forall (t :: (Type -> Type) -> Type -> Type). TransformPlain (t :: (Type -> Type) -> Type -> Type)
   liftPlain ::
-  forall (@t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type).
+  forall (@t :: (Type -> Type) -> Type -> Type).
     TransformPlain (t :: (Type -> Type) -> Type -> Type) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type)
+    (forall (f :: Type -> Type) (a :: Type).
+      (f :: Type -> Type) (a :: Type) ->
+      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
 
 Instances
 instance Transform Wrap

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.purs
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+class Parent :: forall k. k -> Constraint
+class Parent value
+
+class Child :: forall k. k -> Constraint
+class Parent value <= Child value
+
+instance Parent value => Child value

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types
+Parent :: forall (k :: Type). (k :: Type) -> Constraint
+Child :: forall (k :: Type). (k :: Type) -> Constraint
+
+Classes
+class forall (k :: Type) (value :: (k :: Type)). Parent @(k :: Type) (value :: (k :: Type))
+class forall (k :: Type) (value :: (k :: Type)). Parent @(k :: Type) (value :: (k :: Type)) <= Child @(k :: Type) (value :: (k :: Type))
+
+Instances
+instance forall (t :: Type) (t1 :: (t :: Type)).
+  Parent @(t :: Type) (t1 :: (t :: Type)) => Child @(t :: Type) (t1 :: (t :: Type))

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_instance/Main.purs
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_instance/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+class Parent :: Type -> Constraint
+class Parent value
+
+class Child :: Type -> Constraint
+class Parent value <= Child value
+
+instance Parent Int
+
+instance Child Int

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_instance/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types
+Parent :: Type -> Constraint
+Child :: Type -> Constraint
+
+Classes
+class forall (value :: Type). Parent (value :: Type)
+class forall (value :: Type). Parent (value :: Type) <= Child (value :: Type)
+
+Instances
+instance Parent Int
+instance Child Int

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.purs
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+data Missing = Missing
+
+class Parent :: Type -> Constraint
+class Parent value
+
+class Child :: Type -> Constraint
+class Parent value <= Child value
+
+instance Child Missing

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Missing :: Missing
+
+Types
+Missing :: Type
+Parent :: Type -> Constraint
+Child :: Type -> Constraint
+
+Classes
+class forall (value :: Type). Parent (value :: Type)
+class forall (value :: Type). Parent (value :: Type) <= Child (value :: Type)
+
+Instances
+instance Child Missing
+
+Roles
+Missing = []
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Parent Missing
+  --> 11:1..11:23
+   |
+11 | instance Child Missing
+   | ^~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1784704260_automatic_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_automatic_applications/Main.snap
@@ -3,6 +3,16 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
+interface Default :: Type -> Constraint
+interface Default a where
+  default :: a
+
+interface First :: Type -> Constraint
+interface First a where
+
+interface Second :: Type -> Constraint
+interface Second a where
+
 useDefault :: forall a. Default a => a
 useDefault = \{defaultDict} -> default @a {defaultDict}
 

--- a/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
@@ -3,6 +3,12 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
+interface First :: Type -> Constraint
+interface First a where
+
+interface Second :: Type -> Constraint
+interface Second a where
+
 applyInterleaved :: forall a b. First a => Second b => a -> b -> a
 applyInterleaved =
   \{firstDict} ->

--- a/tests-integration/fixtures/semantic/1784708580_interleaved_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708580_interleaved_visible_type_application/Main.snap
@@ -3,5 +3,8 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
+interface Default :: Type -> Constraint
+interface Default a where
+
 specialize :: forall a. Default a => a -> String -> a
 specialize = \{defaultDict} -> select @a {defaultDict} @String

--- a/tests-integration/fixtures/semantic/1784738940_class_interfaces/Main.purs
+++ b/tests-integration/fixtures/semantic/1784738940_class_interfaces/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Empty :: Type -> Constraint
+class Empty a
+
+class Example :: forall k. k -> Type -> Constraint
+class Example value result where
+  identity :: result -> result
+  alternate :: forall intermediate. intermediate -> result
+  constrained :: forall intermediate. Empty intermediate => intermediate -> result

--- a/tests-integration/fixtures/semantic/1784738940_class_interfaces/Main.snap
+++ b/tests-integration/fixtures/semantic/1784738940_class_interfaces/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Empty :: Type -> Constraint
+interface Empty a where
+
+interface Example :: forall (k :: Type). k -> Type -> Constraint
+interface Example value result where
+  identity :: result -> result
+  alternate :: forall (intermediate :: Type). intermediate -> result
+  constrained :: forall (intermediate :: Type). Empty intermediate => intermediate -> result

--- a/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/First.purs
+++ b/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/First.purs
@@ -1,0 +1,4 @@
+module First where
+
+class Parent :: Type -> Constraint
+class Parent a

--- a/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Main.purs
+++ b/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+import First as First
+import Second as Second
+
+data Ordering = LT | EQ | GT
+
+class Eq a where
+  eq :: a -> a -> Boolean
+
+class Eq a <= Ord a where
+  compare :: a -> a -> Ordering
+
+class (First.Parent a, Second.Parent a) <= Child a where
+  parentDict :: a -> a

--- a/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Main.snap
+++ b/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Ordering :: Type
+data Ordering
+  | LT :: Ordering
+  | EQ :: Ordering
+  | GT :: Ordering
+
+interface Eq :: Type -> Constraint
+interface Eq a where
+  eq :: a -> a -> Boolean
+
+interface Ord :: Type -> Constraint
+interface Ord a where
+  superclass eqDict :: Eq a
+  compare :: a -> a -> Ordering
+
+interface Child :: Type -> Constraint
+interface Child a where
+  superclass parentDict1 :: Parent a
+  superclass parentDict2 :: Parent a
+  parentDict :: a -> a

--- a/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Second.purs
+++ b/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Second.purs
@@ -1,0 +1,4 @@
+module Second where
+
+class Parent :: Type -> Constraint
+class Parent a

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.purs
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+class First :: Type -> Constraint
+class First a
+
+class Second :: Type -> Constraint
+class Second b
+
+class Example a b where
+  example :: a -> b -> Boolean
+
+implementation :: forall b a. Second b => a -> b -> Boolean
+implementation _ _ = boolean
+
+foreign import boolean :: Boolean
+
+instance exampleAB :: (First a, Second b) => Example a b where
+  example = implementation

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface First :: Type -> Constraint
+interface First a where
+
+interface Second :: Type -> Constraint
+interface Second b where
+
+interface Example :: Type -> Type -> Constraint
+interface Example a b where
+  example :: a -> b -> Boolean
+
+implementation :: forall b a. Second b => a -> b -> Boolean
+implementation = \{secondDict} -> \_ -> \_ -> boolean
+
+dictionary exampleAB ::
+  forall t t1.
+  { firstDict :: First t
+  , secondDict :: Second t1
+  } =>
+  Example t t1
+where
+  example = implementation @t1 @t {secondDict}

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.purs
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+data Token = FirstToken | SecondToken
+
+class Example a where
+  first :: a
+  second :: a
+
+instance Example Token where
+  second = SecondToken
+  first = FirstToken

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Token :: Type
+data Token
+  | FirstToken :: Token
+  | SecondToken :: Token
+
+interface Example :: Type -> Constraint
+interface Example a where
+  first :: a
+  second :: a
+
+dictionary exampleToken :: Example Token
+where
+  first = FirstToken
+  second = SecondToken

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.purs
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+class Eq :: Type -> Constraint
+class Eq a
+
+class Eq a <= Ord a where
+  compare :: a -> a -> Int
+
+foreign import compareImpl :: Int -> Int -> Int
+
+instance Eq Int => Ord Int where
+  compare = compareImpl

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Eq :: Type -> Constraint
+interface Eq a where
+
+interface Ord :: Type -> Constraint
+interface Ord a where
+  superclass eqDict :: Eq a
+  compare :: a -> a -> Int
+
+dictionary ordInt ::
+  { eqDict :: Eq Int } =>
+  Ord Int
+where
+  superclass eqDict = eqDict
+  compare = compareImpl

--- a/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.purs
+++ b/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+class Required :: Type -> Constraint
+class Required value
+
+class Example a where
+  apply :: forall b. Required b => a -> b -> Boolean
+
+implementation :: forall a b. Required b => a -> b -> Boolean
+implementation _ _ = boolean
+
+foreign import boolean :: Boolean
+
+instance Example Int where
+  apply = implementation

--- a/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Required :: Type -> Constraint
+interface Required value where
+
+interface Example :: Type -> Constraint
+interface Example a where
+  apply :: forall (b :: Type). Required b => a -> b -> Boolean
+
+implementation :: forall a b. Required b => a -> b -> Boolean
+implementation = \{requiredDict} -> \_ -> \_ -> boolean
+
+dictionary exampleInt :: Example Int
+where
+  apply = \{requiredDict} -> implementation @Int @b {requiredDict}

--- a/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.purs
+++ b/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+import Prim.TypeError (class Fail, Text)
+
+class Required :: Type -> Constraint
+class Required value
+
+class Example :: Type -> Constraint
+class Example a where
+  example :: Boolean
+
+implementation ::
+  Fail (Text "first deferred error") =>
+  Required Int =>
+  Fail (Text "second deferred error") =>
+  Boolean
+implementation = boolean
+
+foreign import boolean :: Boolean
+
+instance
+  ( Fail (Text "first deferred error")
+  , Required Int
+  , Fail (Text "second deferred error")
+  ) =>
+  Example Int where
+  example = implementation

--- a/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Required :: Type -> Constraint
+interface Required value where
+
+interface Example :: Type -> Constraint
+interface Example a where
+  example :: Boolean
+
+implementation :: Fail (Text "first deferred error") => Required Int => Fail (Text "second deferred error") => Boolean
+implementation = \{failDict} -> \{requiredDict} -> \{failDict1} -> boolean
+
+dictionary exampleInt ::
+  { failDict :: Fail (Text "first deferred error")
+  , requiredDict :: Required Int
+  , failDict1 :: Fail (Text "second deferred error")
+  } =>
+  Example Int
+where
+  example = implementation {failDict} {requiredDict} {failDict1}

--- a/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Classes.purs
+++ b/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Classes.purs
@@ -1,0 +1,8 @@
+module Classes where
+
+class Parent :: Type -> Constraint
+class Parent a where
+  parent :: a
+
+class Parent a <= Child a where
+  child :: a

--- a/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.purs
+++ b/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Classes (class Child, class Parent)
+
+data Token = Token
+
+instance childToken :: Parent Token => Child Token where
+  child = Token

--- a/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Token :: Type
+data Token
+  | Token :: Token
+
+dictionary childToken ::
+  { parentDict :: Parent Token } =>
+  Child Token
+where
+  superclass parentDict = parentDict
+  child = Token

--- a/tests-integration/fixtures/semantic/1784742180_value_nullary_constraints/Main.purs
+++ b/tests-integration/fixtures/semantic/1784742180_value_nullary_constraints/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Prim.TypeError (class Fail, Text)
+
+foreign import boolean :: Boolean
+
+deferred :: Fail (Text "first deferred error") => Fail (Text "second deferred error") => Boolean
+deferred = boolean

--- a/tests-integration/fixtures/semantic/1784742180_value_nullary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742180_value_nullary_constraints/Main.snap
@@ -1,0 +1,7 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+deferred :: Fail (Text "first deferred error") => Fail (Text "second deferred error") => Boolean
+deferred = \{failDict} -> \{failDict1} -> boolean

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -297,9 +297,10 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
             writeln!(out, "class {forall_prefix}{superclasses} <= {canonical}").unwrap();
         }
 
-        for &mid in &class.members {
-            let Some(member_name) = indexed.items[mid].name.as_deref() else { continue };
-            let Some(member_type) = checked.lookup_term(mid) else { continue };
+        for member in &class.members {
+            let member_id = member.item_id;
+            let Some(member_name) = indexed.items[member_id].name.as_deref() else { continue };
+            let Some(member_type) = checked.lookup_term(member_id) else { continue };
             let signature = pretty.render_signature(member_name, member_type);
             writeln!(out, "  {signature}").unwrap();
         }


### PR DESCRIPTION
## Summary

Retain ordinary class and declared-instance structure in the checked semantic tree, with a PureScript-like dictionary view that exposes the evidence scopes needed by later compiler stages.

- preserve class member type scopes and instance equation source identities through checking
- lower class declarations to `interface` declarations with kind binders, superclasses, and members
- check each declared instance under one outer implication, including its direct superclass obligations
- retain generalized instance parameters, head evidence, superclass evidence, checked members, member-local evidence, and source equations
- print declared instances as named or generated `dictionary` declarations with Haskell-style evidence records
- preserve nullary dictionary parameters for compiler-solved constraints such as `Prim.TypeError.Fail`

## Example

```purescript
interface Example a b where
  example :: a -> b -> Boolean

dictionary exampleAB ::
  forall t t1.
  { firstDict :: First t
  , secondDict :: Second t1
  } =>
  Example t t1
where
  example = implementation @t1 @t {secondDict}
```

Superclass slots are retained explicitly:

```purescript
interface Ord a where
  superclass eqDict :: Eq a
  compare :: a -> a -> Ordering
```

## Scope

This covers ordinary declared instances. Derived instances, newtype-derived instances, class-member projection syntax, and richer rendering of resolved non-binder evidence remain follow-up work.

## Validation

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t semantic`
- `just t checking`
- `just format`
- `git diff --check`
