### PR TITLE
[checking] Retain array and record expression structure

### DIFF
--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -178,20 +178,30 @@ where
 
     pub fn render(&mut self, id: TypeId) -> SmolStr {
         self.names.set_default_name("t");
-        self.render_with_signature(None, id)
+        self.render_with_signature(None, id, Precedence::Top)
+    }
+
+    pub(crate) fn render_atom(&mut self, id: TypeId) -> SmolStr {
+        self.names.set_default_name("t");
+        self.render_with_signature(None, id, Precedence::Atom)
     }
 
     pub fn render_signature(&mut self, name: &str, id: TypeId) -> SmolStr {
         self.names.set_default_name("t");
-        self.render_with_signature(Some(name), id)
+        self.render_with_signature(Some(name), id, Precedence::Top)
     }
 
     pub fn render_kind_signature(&mut self, name: &str, id: TypeId) -> SmolStr {
         self.names.set_default_name("k");
-        self.render_with_signature(Some(name), id)
+        self.render_with_signature(Some(name), id, Precedence::Top)
     }
 
-    fn render_with_signature(&mut self, signature: Option<&str>, id: TypeId) -> SmolStr {
+    fn render_with_signature(
+        &mut self,
+        signature: Option<&str>,
+        id: TypeId,
+        precedence: Precedence,
+    ) -> SmolStr {
         let arena = Arena::new();
         let mut printer = Printer::new(
             &arena,
@@ -205,7 +215,7 @@ where
         let document = if let Some(name) = signature {
             printer.signature(name, id)
         } else {
-            printer.traverse(Precedence::Top, id)
+            printer.traverse(precedence, id)
         };
 
         let mut output = SmolStrBuilder::new();

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -71,15 +71,53 @@ fn check_expression_quiet<Q>(
 where
     Q: ExternalQueries,
 {
-    let expected = normalise::normalise(state, context, expected)?;
-    let expected = toolkit::skolemise_forall(state, context, expected)?;
-    let expected = toolkit::collect_givens(state, context, expected)?;
+    let expected = prepare_expected_expression(state, context, expected)?;
 
     if let Some(section_result) = context.sectioned.expressions.get(&expression) {
         check_sectioned_expression(state, context, expression, section_result, expected)
     } else {
         check_expression_core(state, context, expression, expected)
     }
+}
+
+fn prepare_expected_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    expected: TypeId,
+) -> QueryResult<TypeId>
+where
+    Q: ExternalQueries,
+{
+    let expected = normalise::normalise(state, context, expected)?;
+    let expected = toolkit::skolemise_forall(state, context, expected)?;
+    toolkit::collect_givens(state, context, expected)
+}
+
+pub(super) fn check_elaborated_expression<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    inferred: ElaboratedExpression,
+    expected: TypeId,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let expected = prepare_expected_expression(state, context, expected)?;
+    check_elaborated_expression_quiet(state, context, inferred, expected)
+}
+
+fn check_elaborated_expression_quiet<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    inferred: ElaboratedExpression,
+    expected: TypeId,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let inferred = application::instantiate_expression(state, context, inferred)?;
+    unification::subtype(state, context, inferred.type_id, expected)?;
+    Ok(inferred)
 }
 
 fn check_sectioned_expression<Q>(
@@ -168,18 +206,14 @@ where
             check_expression(state, context, *parenthesized, expected)
         }
         lowering::ExpressionKind::Array { array } => {
-            let type_id = collections::check_array(state, context, array, expected)?;
-            Ok(allocate_error_expression(state, type_id))
+            collections::check_array(state, context, array, expected)
         }
         lowering::ExpressionKind::Record { record } => {
-            let type_id = collections::check_record(state, context, record, expected)?;
-            Ok(allocate_error_expression(state, type_id))
+            collections::check_record(state, context, record, expected)
         }
         _ => {
             let inferred = infer_expression_quiet(state, context, expression)?;
-            let inferred = application::instantiate_expression(state, context, inferred)?;
-            unification::subtype(state, context, inferred.type_id, expected)?;
-            Ok(inferred)
+            check_elaborated_expression_quiet(state, context, inferred, expected)
         }
     }
 }
@@ -428,13 +462,11 @@ where
         }
 
         lowering::ExpressionKind::Array { array } => {
-            let type_id = collections::infer_array(state, context, array)?;
-            Ok(allocate_error_expression(state, type_id))
+            collections::infer_array(state, context, array)
         }
 
         lowering::ExpressionKind::Record { record } => {
-            let type_id = collections::infer_record(state, context, record)?;
-            Ok(allocate_error_expression(state, type_id))
+            collections::infer_record(state, context, record)
         }
 
         lowering::ExpressionKind::Parenthesized { parenthesized } => {

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -1,26 +1,43 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use smol_str::SmolStr;
 
-use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{RowField, Type, TypeId, normalise, toolkit, unification};
 use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+use super::ElaboratedExpression;
+
+struct InferredRecordFieldExpression {
+    elaborated: ElaboratedExpression,
+    field_type: TypeId,
+}
 
 fn infer_record_field_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
+) -> QueryResult<InferredRecordFieldExpression>
 where
     Q: ExternalQueries,
 {
     let inferred = super::infer_expression(state, context, expression)?;
 
-    if should_instantiate_record_field(context, expression) {
-        Ok(super::application::instantiate_expression(state, context, inferred)?.type_id)
+    let (elaborated, expand) = if should_instantiate_record_field(context, expression) {
+        let elaborated = super::application::instantiate_expression(state, context, inferred)?;
+        (elaborated, true)
     } else {
-        Ok(inferred.type_id)
-    }
+        (inferred, false)
+    };
+
+    let field_type = if expand {
+        normalise::expand(state, context, elaborated.type_id)?
+    } else {
+        elaborated.type_id
+    };
+    Ok(InferredRecordFieldExpression { elaborated, field_type })
 }
 
 fn should_instantiate_record_field<Q>(
@@ -58,23 +75,24 @@ where
     false
 }
 
-fn instantiate_variable<Q>(
+fn record_pun_expression<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source: lowering::RecordPunId,
     resolution: lowering::TermVariableResolution,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    let id = toolkit::lookup_term_variable(state, context, resolution)?;
-    let id = toolkit::instantiate_unifications(state, context, id)?;
-    toolkit::collect_wanteds(state, context, id)
+    let type_id = toolkit::lookup_term_variable(state, context, resolution)?;
+    let kind = tree::ExpressionKind::RecordPun { source, resolution };
+    Ok(super::allocate_expression(state, type_id, kind))
 }
 
 #[derive(Copy, Clone, Debug)]
 enum ArrayMode {
     Infer,
-    Check { element: TypeId },
+    Check,
 }
 
 #[derive(Copy, Clone)]
@@ -87,11 +105,15 @@ pub fn infer_array<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     array: &[lowering::ExpressionId],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    array_core(state, context, array, ArrayMode::Infer)
+    let element = state.fresh_unification(context.queries, context.prim.t);
+    let elements = array_core(state, context, array, ArrayMode::Infer, element)?;
+    let type_id = context.intern_application(context.prim.array, element);
+    let kind = tree::ExpressionKind::Array { elements };
+    Ok(super::allocate_expression(state, type_id, kind))
 }
 
 pub fn check_array<Q>(
@@ -99,17 +121,18 @@ pub fn check_array<Q>(
     context: &CheckContext<Q>,
     array: &[lowering::ExpressionId],
     expected: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
     if let Some(element) = expected_array_element(state, context, expected)? {
-        array_core(state, context, array, ArrayMode::Check { element })?;
-        return Ok(expected);
+        let elements = array_core(state, context, array, ArrayMode::Check, element)?;
+        let kind = tree::ExpressionKind::Array { elements };
+        return Ok(super::allocate_expression(state, expected, kind));
     }
 
-    let inferred = array_core(state, context, array, ArrayMode::Infer)?;
-    unification::subtype(state, context, inferred, expected)?;
+    let inferred = infer_array(state, context, array)?;
+    unification::subtype(state, context, inferred.type_id, expected)?;
     Ok(inferred)
 }
 
@@ -135,39 +158,43 @@ fn array_core<Q>(
     context: &CheckContext<Q>,
     array: &[lowering::ExpressionId],
     mode: ArrayMode,
-) -> QueryResult<TypeId>
+    element: TypeId,
+) -> QueryResult<Arc<[tree::ExpressionId]>>
 where
     Q: ExternalQueries,
 {
-    let element = match mode {
-        ArrayMode::Infer => state.fresh_unification(context.queries, context.prim.t),
-        ArrayMode::Check { element } => element,
-    };
+    let mut elements = vec![];
 
     for expression in array {
-        match mode {
+        let checked = match mode {
             ArrayMode::Infer => {
                 let inferred = super::infer_expression(state, context, *expression)?;
                 unification::subtype(state, context, inferred.type_id, element)?;
+                inferred
             }
-            ArrayMode::Check { .. } => {
-                super::check_expression(state, context, *expression, element)?;
-            }
-        }
+            ArrayMode::Check => super::check_expression(state, context, *expression, element)?,
+        };
+        elements.push(checked.expression);
     }
 
-    Ok(context.intern_application(context.prim.array, element))
+    Ok(elements.into())
 }
 
 pub fn infer_record<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     record: &[lowering::ExpressionRecordItem],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    record_core(state, context, record, RecordMode::Infer)
+    let (type_id, fields, complete) = record_core(state, context, record, RecordMode::Infer)?;
+    if complete {
+        let kind = tree::ExpressionKind::Record { fields };
+        Ok(super::allocate_expression(state, type_id, kind))
+    } else {
+        Ok(super::allocate_error_expression(state, type_id))
+    }
 }
 
 pub fn check_record<Q>(
@@ -175,7 +202,7 @@ pub fn check_record<Q>(
     context: &CheckContext<Q>,
     record: &[lowering::ExpressionRecordItem],
     expected: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -186,20 +213,25 @@ where
             let row_type = normalise::expand(state, context, row_type)?;
             if let Type::Row(row_id) = context.lookup_type(row_type) {
                 let expected_fields = context.lookup_row_type(row_id);
-                let record_type = record_core(
+                let (record_type, fields, complete) = record_core(
                     state,
                     context,
                     record,
                     RecordMode::Check { expected_fields: &expected_fields.fields },
                 )?;
                 unification::subtype(state, context, record_type, expected)?;
-                return Ok(record_type);
+                if complete {
+                    let kind = tree::ExpressionKind::Record { fields };
+                    return Ok(super::allocate_expression(state, record_type, kind));
+                } else {
+                    return Ok(super::allocate_error_expression(state, record_type));
+                }
             }
         }
     }
 
     let inferred = infer_record(state, context, record)?;
-    unification::subtype(state, context, inferred, expected)?;
+    unification::subtype(state, context, inferred.type_id, expected)?;
     Ok(inferred)
 }
 
@@ -214,57 +246,63 @@ fn expected_record_field(mode: RecordMode<'_>, label: &SmolStr) -> Option<TypeId
     }
 }
 
-fn record_field_type<Q>(
+struct ElaboratedRecordField {
+    row: RowField,
+    checked: tree::RecordExpressionField,
+}
+
+fn elaborate_record_field<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     name: &SmolStr,
     value: lowering::ExpressionId,
     mode: RecordMode<'_>,
-) -> QueryResult<RowField>
+) -> QueryResult<ElaboratedRecordField>
 where
     Q: ExternalQueries,
 {
     let label = SmolStr::clone(name);
 
-    let id = if let Some(expected_type) = expected_record_field(mode, &label) {
-        super::check_expression(state, context, value, expected_type)?;
-        expected_type
+    let (id, expression) = if let Some(expected_type) = expected_record_field(mode, &label) {
+        let checked = super::check_expression(state, context, value, expected_type)?;
+        (expected_type, checked.expression)
     } else {
-        infer_record_field_expression(state, context, value)?
+        let inferred = infer_record_field_expression(state, context, value)?;
+        (inferred.field_type, inferred.elaborated.expression)
     };
 
-    Ok(RowField { label, id })
+    let checked = tree::RecordExpressionField::Field { label: SmolStr::clone(&label), expression };
+    Ok(ElaboratedRecordField { row: RowField { label, id }, checked })
 }
 
-fn record_pun_type<Q>(
+fn elaborate_record_pun<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     pun: lowering::RecordPunId,
     name: &SmolStr,
     resolution: lowering::TermVariableResolution,
     mode: RecordMode<'_>,
-) -> QueryResult<RowField>
+) -> QueryResult<ElaboratedRecordField>
 where
     Q: ExternalQueries,
 {
     let label = SmolStr::clone(name);
+    let variable = record_pun_expression(state, context, pun, resolution)?;
 
-    let id = if let Some(expected_type) = expected_record_field(mode, &label) {
-        let id = toolkit::lookup_term_variable(state, context, resolution)?;
-
-        let checked_type = normalise::expand(state, context, expected_type)?;
-        let checked_type = toolkit::skolemise_forall(state, context, checked_type)?;
-        let checked_type = toolkit::collect_givens(state, context, checked_type)?;
-        unification::subtype(state, context, id, checked_type)?;
-
-        expected_type
+    let (id, expression) = if let Some(expected_type) = expected_record_field(mode, &label) {
+        let checked = super::check_elaborated_expression(state, context, variable, expected_type)?;
+        (expected_type, checked.expression)
     } else {
-        instantiate_variable(state, context, resolution)?
+        let inferred = super::application::instantiate_expression(state, context, variable)?;
+        let field_type = normalise::expand(state, context, inferred.type_id)?;
+        (field_type, inferred.expression)
     };
 
     state.checked.nodes.puns.insert(pun, id);
 
-    Ok(RowField { label, id })
+    let checked =
+        tree::RecordExpressionField::Pun { source: pun, label: SmolStr::clone(&label), expression };
+    Ok(ElaboratedRecordField { row: RowField { label, id }, checked })
 }
 
 fn record_core<Q>(
@@ -272,31 +310,39 @@ fn record_core<Q>(
     context: &CheckContext<Q>,
     record: &[lowering::ExpressionRecordItem],
     mode: RecordMode<'_>,
-) -> QueryResult<TypeId>
+) -> QueryResult<(TypeId, Arc<[tree::RecordExpressionField]>, bool)>
 where
     Q: ExternalQueries,
 {
     let mut fields = vec![];
+    let mut checked_fields = vec![];
+    let mut complete = true;
 
     for field in record.iter() {
         let field = match field {
             lowering::ExpressionRecordItem::RecordField { name, value } => {
-                let Some(name) = name else { continue };
-                let Some(value) = value else { continue };
-                record_field_type(state, context, name, *value, mode)?
+                let (Some(name), Some(value)) = (name, value) else {
+                    complete = false;
+                    continue;
+                };
+                elaborate_record_field(state, context, name, *value, mode)?
             }
             lowering::ExpressionRecordItem::RecordPun { id, name, resolution } => {
-                let Some(name) = name else { continue };
-                let Some(resolution) = resolution else { continue };
-                record_pun_type(state, context, *id, name, *resolution, mode)?
+                let (Some(name), Some(resolution)) = (name, resolution) else {
+                    complete = false;
+                    continue;
+                };
+                elaborate_record_pun(state, context, *id, name, *resolution, mode)?
             }
         };
 
-        fields.push(field);
+        fields.push(field.row);
+        checked_fields.push(field.checked);
     }
 
     let row_type = context.intern_row(fields, None);
-    Ok(context.intern_application(context.prim.record, row_type))
+    let type_id = context.intern_application(context.prim.record, row_type);
+    Ok((type_id, checked_fields.into(), complete))
 }
 
 pub fn infer_record_access<Q>(
@@ -367,7 +413,7 @@ where
 
                 let input_id = state.fresh_unification(context.queries, context.prim.t);
                 let output_id = if let Some(expression) = expression {
-                    infer_record_field_expression(state, context, *expression)?
+                    infer_record_field_expression(state, context, *expression)?.field_type
                 } else {
                     context.unknown("missing record update expression")
                 };

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -206,11 +206,20 @@ pub enum ExpressionKind {
     Boolean { value: bool },
     Integer { value: i32 },
     Number { value: SmolStr },
+    Array { elements: Arc<[ExpressionId]> },
+    Record { fields: Arc<[RecordExpressionField]> },
     Constructor { resolution: (FileId, TermItemId) },
     Variable { resolution: lowering::TermVariableResolution },
+    RecordPun { source: lowering::RecordPunId, resolution: lowering::TermVariableResolution },
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecordExpressionField {
+    Field { label: SmolStr, expression: ExpressionId },
+    Pun { source: lowering::RecordPunId, label: SmolStr, expression: ExpressionId },
 }
 
 impl Module {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -14,8 +14,8 @@ use crate::core::pretty::{Pretty as TypePretty, PrettyNames, PrettyQueries};
 use crate::evidence::{Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId};
 use crate::tree::{
     BinderId, BinderKind, Equation, ExpressionId, ExpressionKind, GuardedAlternative,
-    GuardedExpression, InstanceDeclaration, PatternGuard, RecordBinderField, TermDeclarationKind,
-    TypeDeclarationKind,
+    GuardedExpression, InstanceDeclaration, PatternGuard, RecordBinderField, RecordExpressionField,
+    TermDeclarationKind, TypeDeclarationKind,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -866,12 +866,58 @@ where
                 let text = value.to_string();
                 Ok(self.arena.text(text))
             }
+            ExpressionKind::Array { elements } => {
+                let mut array = self.arena.text("[");
+                for (position, element) in elements.iter().enumerate() {
+                    if position > 0 {
+                        array = array.append(self.arena.text(", "));
+                    }
+                    let element = self.expression(*element, evidence_names, type_pretty)?;
+                    array = array.append(element);
+                }
+                Ok(array.append(self.arena.text("]")))
+            }
+            ExpressionKind::Record { fields } => {
+                if fields.is_empty() {
+                    return Ok(self.arena.text("{ }"));
+                }
+
+                let mut record = self.arena.text("{ ");
+                for (position, field) in fields.iter().enumerate() {
+                    if position > 0 {
+                        record = record.append(self.arena.text(", "));
+                    }
+
+                    let (label, expression, shorthand) = match field {
+                        RecordExpressionField::Field { label, expression } => {
+                            (label, expression, false)
+                        }
+                        RecordExpressionField::Pun { label, expression, .. } => {
+                            let expression_kind = &self.checked.tree[*expression].kind;
+                            let shorthand =
+                                matches!(expression_kind, ExpressionKind::RecordPun { .. });
+                            (label, expression, shorthand)
+                        }
+                    };
+
+                    if shorthand {
+                        record = record.append(self.arena.text(label.to_string()));
+                    } else {
+                        let expression =
+                            self.expression(*expression, evidence_names, type_pretty)?;
+                        let text = format!("{label}: ");
+                        record = record.append(self.arena.text(text)).append(expression);
+                    }
+                }
+                Ok(record.append(self.arena.text(" }")))
+            }
             ExpressionKind::Constructor { resolution } => {
                 let name = self.term_name(resolution.0, resolution.1)?;
                 let text = name.unwrap_or_else(|| "?".to_string());
                 Ok(self.arena.text(text))
             }
-            ExpressionKind::Variable { resolution } => {
+            ExpressionKind::Variable { resolution }
+            | ExpressionKind::RecordPun { resolution, .. } => {
                 let name = match *resolution {
                     TermVariableResolution::Binder(binder) => {
                         let kind =
@@ -923,7 +969,7 @@ where
             }
             ExpressionKind::TypeApplication { function, argument } => {
                 let function = self.expression(*function, evidence_names, type_pretty)?;
-                let argument = type_pretty.render(*argument);
+                let argument = type_pretty.render_atom(*argument);
                 Ok(function.append(self.arena.text(format!(" @{argument}"))))
             }
             ExpressionKind::EvidenceApplication { function, evidence } => {

--- a/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.purs
@@ -1,0 +1,26 @@
+module Main where
+
+identity value = value
+
+empty :: Array Int
+empty = []
+
+values :: Array Int
+values = [1, 2]
+
+nested :: Array (Array Int)
+nested = [[1], [2, 3]]
+
+inferredFunctions = [identity]
+
+checkedFunctions :: Array (Int -> Int)
+checkedFunctions = [identity]
+
+checkedIdentity :: Array Int -> Array Int
+checkedIdentity = identity
+
+consume :: Array Int -> Array Int
+consume value = value
+
+application :: Array Int
+application = consume [1, 2]

--- a/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall t. t -> t
+identity = \value -> value
+
+empty :: Array Int
+empty = []
+
+values :: Array Int
+values = [1, 2]
+
+nested :: Array (Array Int)
+nested = [[1], [2, 3]]
+
+inferredFunctions :: forall t. Array (t -> t)
+inferredFunctions = [identity]
+
+checkedFunctions :: Array (Int -> Int)
+checkedFunctions = [identity @Int]
+
+checkedIdentity :: Array Int -> Array Int
+checkedIdentity = identity @(Array Int)
+
+consume :: Array Int -> Array Int
+consume = \value -> value
+
+application :: Array Int
+application = consume [1, 2]

--- a/tests-integration/fixtures/semantic/1784779800_record_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784779800_record_expressions/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+value :: Int
+value = 42
+
+empty :: {}
+empty = {}
+
+explicit :: { z :: Int, a :: String }
+explicit = { z: 1, a: "text" }
+
+punned :: { value :: Int }
+punned = { value }
+
+nested :: { array :: Array Int, record :: { boolean :: Boolean } }
+nested = { array: [1, 2], record: { boolean: true } }
+
+consume :: { value :: Int } -> Int
+consume { value: inner } = inner
+
+application :: Int
+application = consume { value: 1 }

--- a/tests-integration/fixtures/semantic/1784779800_record_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_expressions/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+value :: Int
+value = 42
+
+empty :: {}
+empty = { }
+
+explicit :: { a :: String, z :: Int }
+explicit = { z: 1, a: "text" }
+
+punned :: { value :: Int }
+punned = { value }
+
+nested :: { array :: Array Int, record :: { boolean :: Boolean } }
+nested = { array: [1, 2], record: { boolean: true } }
+
+consume :: { value :: Int } -> Int
+consume = \{ value: inner } -> inner
+
+application :: Int
+application = consume { value: 1 }

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.purs
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.purs
@@ -1,0 +1,37 @@
+module Main where
+
+class First :: Type -> Constraint
+class First a
+
+class Second :: Type -> Constraint
+class Second a
+
+foreign import interleaved :: forall a. First a => (forall b. Second b => a -> b)
+
+inferredPun = { interleaved }
+
+inferredExplicit = { interleaved: interleaved }
+
+type Alias = Int
+
+aliased :: Alias
+aliased = 1
+
+inferredAliasPun = { aliased }
+
+inferredAliasExplicit = { aliased: aliased }
+
+class Capability :: (Type -> Type) -> Constraint
+class Capability m
+
+foreign import fetch :: forall m. Capability m => Int -> m Int
+
+type Setup =
+  { fetch :: forall m. Capability m => Int -> m Int
+  }
+
+expectedPun :: Setup
+expectedPun = { fetch }
+
+expectedExplicit :: Setup
+expectedExplicit = { fetch: fetch }

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
@@ -1,0 +1,36 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface First :: Type -> Constraint
+interface First a where
+
+interface Second :: Type -> Constraint
+interface Second a where
+
+interface Capability :: (Type -> Type) -> Constraint
+interface Capability m where
+
+inferredPun :: forall t t1. First t => Second t1 => { interleaved :: t -> t1 }
+inferredPun =
+  \{firstDict} -> \{secondDict} -> { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
+
+inferredExplicit :: forall t t1. First t => Second t1 => { interleaved :: t -> t1 }
+inferredExplicit =
+  \{firstDict} -> \{secondDict} -> { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
+
+aliased :: Alias
+aliased = 1
+
+inferredAliasPun :: { aliased :: Int }
+inferredAliasPun = { aliased }
+
+inferredAliasExplicit :: { aliased :: Int }
+inferredAliasExplicit = { aliased: aliased }
+
+expectedPun :: Setup
+expectedPun = { fetch: fetch @m {capabilityDict} }
+
+expectedExplicit :: Setup
+expectedExplicit = { fetch: fetch @m {capabilityDict} }

--- a/tests-integration/fixtures/semantic/1784779860_record_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784779860_record_expression_recovery/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+missingField :: { valid :: Int }
+missingField = { valid: 1, missing: }
+
+unresolvedPun = { missing }

--- a/tests-integration/fixtures/semantic/1784779860_record_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779860_record_expression_recovery/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+missingField :: { valid :: Int }
+missingField = <error>
+
+unresolvedPun :: {}
+unresolvedPun = <error>


### PR DESCRIPTION
## Summary

Retain arrays and records in the checked semantic tree instead of collapsing their outer expressions to error nodes.

- preserve checked child expressions for inferred and contextually checked arrays
- retain record fields in source order with their checked value expressions
- retain record-pun provenance through `RecordPunId`
- elaborate puns through the same variable-field pipeline as equivalent explicit fields
- keep incomplete recovered records as error nodes
- print nested collections and generated compound type applications unambiguously

## Provenance and checking

An expression pun such as `{ fetch }` has a lowering `RecordPunId`, but its implicit value does not have a lowering `ExpressionId`. The checked tree therefore uses a provenance-bearing `RecordPun` leaf rather than fabricating an ordinary source variable. Generated type and evidence applications can wrap that leaf while remaining anchored to the pun occurrence.

The original `purescript/purescript` compiler removes the syntax distinction before type checking by converting `{ fetch }` to the same variable-valued object field as `{ fetch: fetch }`. Alexandrite now follows the same semantic rule: puns and explicit variable fields share expected checking, full forall/constraint instantiation during inference, synonym expansion, and evidence insertion. Focused semantic fixtures compare both forms directly.

Array and record nodes contain checked expression IDs rather than duplicate field or element types. Existing expression zonking therefore covers their outer and child types without collection-specific zonking.

## Scope

Record access and record update expressions remain opaque and are outside this change.

This is a stacked PR based on #199 (`expression-literal-lowering`). Its branch contains one curated commit.

## Validation

- `just format`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t semantic`
- `just t checking`
- `git diff --check`