### PR TITLE
[checking] Lower operator expressions into applications

### DIFF
--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{TermItemId, TypeItemId};
-use lowering::TypeItemIr;
+use lowering::{TermItemIr, TypeItemIr};
 
 use rustc_hash::FxHashMap;
 
@@ -238,6 +238,29 @@ where
     let resolve = |lowered: &lowering::LoweredModule| {
         lowered.info.get_type_item(type_id).and_then(|item| match item {
             TypeItemIr::Operator { resolution, .. } => *resolution,
+            _ => None,
+        })
+    };
+
+    if file_id == context.id {
+        Ok(resolve(&context.lowered))
+    } else {
+        let lowered = context.queries.lowered(file_id)?;
+        Ok(resolve(&lowered))
+    }
+}
+
+pub fn resolve_term_operator_target<Q>(
+    context: &CheckContext<Q>,
+    file_id: FileId,
+    term_id: TermItemId,
+) -> QueryResult<Option<(FileId, TermItemId)>>
+where
+    Q: ExternalQueries,
+{
+    let resolve = |lowered: &lowering::LoweredModule| {
+        lowered.info.get_term_item(term_id).and_then(|item| match item {
+            TermItemIr::Operator { resolution, .. } => *resolution,
             _ => None,
         })
     };

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -20,6 +20,18 @@ enum OperatorKindMode {
     Check { expected_type: TypeId },
 }
 
+pub struct OperatorApplication<Elaborated> {
+    implicit: Vec<terms::application::ImplicitApplication>,
+    argument: (Elaborated, TypeId),
+    result_type: TypeId,
+}
+
+pub struct OperatorBranch<Item, Elaborated> {
+    operator: ((FileId, Item), TypeId),
+    left: OperatorApplication<Elaborated>,
+    right: OperatorApplication<Elaborated>,
+}
+
 pub fn infer_operator_chain<Q, E>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
@@ -195,16 +207,20 @@ where
         let _ = unification::subtype(state, context, result_type, expected_type)?;
     }
 
-    E::build(
-        state,
-        context,
-        operator,
-        operator_type,
-        (left_implicit, right_implicit),
-        (left, right),
-        (left_type, right_type),
-        (right_function_type, result_type),
-    )
+    let branch = OperatorBranch {
+        operator: (operator, operator_type),
+        left: OperatorApplication {
+            implicit: left_implicit,
+            argument: (left, left_type),
+            result_type: right_function_type,
+        },
+        right: OperatorApplication {
+            implicit: right_implicit,
+            argument: (right, right_type),
+            result_type,
+        },
+    };
+    E::build(state, context, branch)
 }
 
 pub trait IsOperator<Q: ExternalQueries>: IsElement {
@@ -254,15 +270,7 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
     fn build(
         state: &mut CheckState,
         context: &CheckContext<Q>,
-        operator: (FileId, Self::ItemId),
-        operator_type: TypeId,
-        applications: (
-            Vec<terms::application::ImplicitApplication>,
-            Vec<terms::application::ImplicitApplication>,
-        ),
-        result_tree: (Self::Elaborated, Self::Elaborated),
-        argument_types: (TypeId, TypeId),
-        result_types: (TypeId, TypeId),
+        branch: OperatorBranch<Self::ItemId, Self::Elaborated>,
     ) -> QueryResult<(Self::Elaborated, TypeId)>;
 
     fn record_branch_types(
@@ -327,22 +335,22 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
     fn build(
         state: &mut CheckState,
         context: &CheckContext<Q>,
-        (file_id, item_id): (FileId, Self::ItemId),
-        operator_type: TypeId,
-        (left_implicit, right_implicit): (
-            Vec<terms::application::ImplicitApplication>,
-            Vec<terms::application::ImplicitApplication>,
-        ),
-        (left, right): (Self::Elaborated, Self::Elaborated),
-        (_, _): (TypeId, TypeId),
-        (right_function_type, result_type): (TypeId, TypeId),
+        OperatorBranch { operator: (operator, operator_type), left, right }: OperatorBranch<
+            Self::ItemId,
+            Self::Elaborated,
+        >,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
-        let Some(left) = left else { return Ok((None, result_type)) };
-        let Some(right) = right else { return Ok((None, result_type)) };
+        let (file_id, item_id) = operator;
+        let (Some(left_argument), _) = left.argument else {
+            return Ok((None, right.result_type));
+        };
+        let (Some(right_argument), _) = right.argument else {
+            return Ok((None, right.result_type));
+        };
         let Some((target_file_id, target_item_id)) =
             toolkit::resolve_term_operator_target(context, file_id, item_id)?
         else {
-            return Ok((None, result_type));
+            return Ok((None, right.result_type));
         };
 
         let operator = terms::allocate_term_reference(
@@ -355,18 +363,18 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         let left = terms::application::materialize_application(
             state,
             operator,
-            left_implicit,
-            right_function_type,
-            left,
+            left.implicit,
+            left.result_type,
+            left_argument,
         );
         let expression = terms::application::materialize_application(
             state,
             left,
-            right_implicit,
-            result_type,
-            right,
+            right.implicit,
+            right.result_type,
+            right_argument,
         );
-        Ok((Some(expression), result_type))
+        Ok((Some(expression), right.result_type))
     }
 
     fn record_branch_types(
@@ -448,16 +456,14 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
     fn build(
         state: &mut CheckState,
         context: &CheckContext<Q>,
-        (file_id, item_id): (FileId, Self::ItemId),
-        _operator_type: TypeId,
-        (_left_implicit, _right_implicit): (
-            Vec<terms::application::ImplicitApplication>,
-            Vec<terms::application::ImplicitApplication>,
-        ),
-        (left, right): (Self::Elaborated, Self::Elaborated),
-        (left_kind, right_kind): (TypeId, TypeId),
-        (_, result_kind): (TypeId, TypeId),
+        OperatorBranch { operator: (operator, _), left, right }: OperatorBranch<
+            Self::ItemId,
+            Self::Elaborated,
+        >,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
+        let (file_id, item_id) = operator;
+        let (left_argument, left_kind) = left.argument;
+        let (right_argument, right_kind) = right.argument;
         let Some((target_file_id, target_item_id)) =
             toolkit::resolve_type_operator_target(context, file_id, item_id)?
         else {
@@ -472,7 +478,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
             context,
             (target_file_id, target_item_id),
             operator_kind,
-            &[(left, left_kind), (right, right_kind)],
+            &[(left_argument, left_kind), (right_argument, right_kind)],
         )? {
             let result_kind = normalise::normalise(state, context, result_kind)?;
             return Ok((elaborated_type, result_kind));
@@ -483,8 +489,8 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
 
         let function: application::FnTypeKind = (function_type, operator_kind);
         let arguments = [
-            application::Argument::Core(left, left_kind),
-            application::Argument::Core(right, right_kind),
+            application::Argument::Core(left_argument, left_kind),
+            application::Argument::Core(right_argument, right_kind),
         ];
 
         let ((elaborated_type, _), _) = application::infer_application_arguments(
@@ -496,7 +502,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
             application::Records::Ignore,
         )?;
 
-        let result_kind = normalise::normalise(state, context, result_kind)?;
+        let result_kind = normalise::normalise(state, context, right.result_type)?;
         Ok((elaborated_type, result_kind))
     }
 
@@ -566,17 +572,9 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
     fn build(
         _state: &mut CheckState,
         _context: &CheckContext<Q>,
-        (_, _): (FileId, Self::ItemId),
-        _operator_type: TypeId,
-        (_left_implicit, _right_implicit): (
-            Vec<terms::application::ImplicitApplication>,
-            Vec<terms::application::ImplicitApplication>,
-        ),
-        (_, _): (Self::Elaborated, Self::Elaborated),
-        (_, _): (TypeId, TypeId),
-        (_, result_type): (TypeId, TypeId),
+        OperatorBranch { right, .. }: OperatorBranch<Self::ItemId, Self::Elaborated>,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
-        Ok(((), result_type))
+        Ok(((), right.result_type))
     }
 
     fn record_branch_types(

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -142,14 +142,20 @@ where
         OperatorKindMode::Check { expected_type } => (unknown_elaborated, expected_type),
     };
 
-    let Some(terms::application::GenericApplication { argument: left_type, result: operator_type }) =
-        terms::application::check_generic_application(state, context, operator_type)?
+    let Some(terms::application::GenericApplication {
+        automatic: left_automatic,
+        argument: left_type,
+        result: right_function_type,
+    }) = terms::application::check_generic_application(state, context, operator_type)?
     else {
         return Ok(unknown);
     };
 
-    let Some(terms::application::GenericApplication { argument: right_type, result: result_type }) =
-        terms::application::check_generic_application(state, context, operator_type)?
+    let Some(terms::application::GenericApplication {
+        automatic: right_automatic,
+        argument: right_type,
+        result: result_type,
+    }) = terms::application::check_generic_application(state, context, right_function_type)?
     else {
         return Ok(unknown);
     };
@@ -189,7 +195,16 @@ where
         let _ = unification::subtype(state, context, result_type, expected_type)?;
     }
 
-    E::build(state, context, operator, (left, right), (left_type, right_type), result_type)
+    E::build(
+        state,
+        context,
+        operator,
+        operator_type,
+        (left_automatic, right_automatic),
+        (left, right),
+        (left_type, right_type),
+        (right_function_type, result_type),
+    )
 }
 
 pub trait IsOperator<Q: ExternalQueries>: IsElement {
@@ -240,9 +255,14 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
         state: &mut CheckState,
         context: &CheckContext<Q>,
         operator: (FileId, Self::ItemId),
+        operator_type: TypeId,
+        applications: (
+            Vec<terms::application::AutomaticApplication>,
+            Vec<terms::application::AutomaticApplication>,
+        ),
         result_tree: (Self::Elaborated, Self::Elaborated),
         argument_types: (TypeId, TypeId),
-        result_type: TypeId,
+        result_types: (TypeId, TypeId),
     ) -> QueryResult<(Self::Elaborated, TypeId)>;
 
     fn record_branch_types(
@@ -256,9 +276,11 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
 
 impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
     type ItemId = TermItemId;
-    type Elaborated = ();
+    type Elaborated = Option<terms::ElaboratedExpression>;
 
-    fn unknown_elaborated(_context: &CheckContext<Q>) -> Self::Elaborated {}
+    fn unknown_elaborated(_context: &CheckContext<Q>) -> Self::Elaborated {
+        None
+    }
 
     fn lookup_tree<'q>(
         context: &'q CheckContext<Q>,
@@ -289,7 +311,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         id: Self,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let inferred = terms::infer_expression(state, context, id)?;
-        Ok(((), inferred.type_id))
+        Ok((Some(inferred), inferred.type_id))
     }
 
     fn check_surface(
@@ -299,18 +321,52 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         expected: TypeId,
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let checked = terms::check_expression(state, context, id, expected)?;
-        Ok(((), checked.type_id))
+        Ok((Some(checked), checked.type_id))
     }
 
     fn build(
-        _state: &mut CheckState,
-        _context: &CheckContext<Q>,
-        (_, _): (FileId, Self::ItemId),
-        (_, _): (Self::Elaborated, Self::Elaborated),
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        (file_id, item_id): (FileId, Self::ItemId),
+        operator_type: TypeId,
+        (left_automatic, right_automatic): (
+            Vec<terms::application::AutomaticApplication>,
+            Vec<terms::application::AutomaticApplication>,
+        ),
+        (left, right): (Self::Elaborated, Self::Elaborated),
         (_, _): (TypeId, TypeId),
-        result_type: TypeId,
+        (right_function_type, result_type): (TypeId, TypeId),
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
-        Ok(((), result_type))
+        let Some(left) = left else { return Ok((None, result_type)) };
+        let Some(right) = right else { return Ok((None, result_type)) };
+        let Some((target_file_id, target_item_id)) =
+            toolkit::resolve_term_operator_target(context, file_id, item_id)?
+        else {
+            return Ok((None, result_type));
+        };
+
+        let operator = terms::allocate_term_reference(
+            state,
+            context,
+            target_file_id,
+            target_item_id,
+            operator_type,
+        )?;
+        let left = terms::application::materialize_generic_application(
+            state,
+            operator,
+            left_automatic,
+            right_function_type,
+            left,
+        );
+        let expression = terms::application::materialize_generic_application(
+            state,
+            left,
+            right_automatic,
+            result_type,
+            right,
+        );
+        Ok((Some(expression), result_type))
     }
 
     fn record_branch_types(
@@ -393,9 +449,14 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
         state: &mut CheckState,
         context: &CheckContext<Q>,
         (file_id, item_id): (FileId, Self::ItemId),
+        _operator_type: TypeId,
+        (_left_automatic, _right_automatic): (
+            Vec<terms::application::AutomaticApplication>,
+            Vec<terms::application::AutomaticApplication>,
+        ),
         (left, right): (Self::Elaborated, Self::Elaborated),
         (left_kind, right_kind): (TypeId, TypeId),
-        result_kind: TypeId,
+        (_, result_kind): (TypeId, TypeId),
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         let Some((target_file_id, target_item_id)) =
             toolkit::resolve_type_operator_target(context, file_id, item_id)?
@@ -506,9 +567,14 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
         _state: &mut CheckState,
         _context: &CheckContext<Q>,
         (_, _): (FileId, Self::ItemId),
+        _operator_type: TypeId,
+        (_left_automatic, _right_automatic): (
+            Vec<terms::application::AutomaticApplication>,
+            Vec<terms::application::AutomaticApplication>,
+        ),
         (_, _): (Self::Elaborated, Self::Elaborated),
         (_, _): (TypeId, TypeId),
-        result_type: TypeId,
+        (_, result_type): (TypeId, TypeId),
     ) -> QueryResult<(Self::Elaborated, TypeId)> {
         Ok(((), result_type))
     }

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -142,20 +142,20 @@ where
         OperatorKindMode::Check { expected_type } => (unknown_elaborated, expected_type),
     };
 
-    let Some(terms::application::GenericApplication {
-        automatic: left_automatic,
+    let Some(terms::application::UnanchoredApplication {
+        implicit: left_implicit,
         argument: left_type,
         result: right_function_type,
-    }) = terms::application::check_generic_application(state, context, operator_type)?
+    }) = terms::application::check_unanchored_application(state, context, operator_type)?
     else {
         return Ok(unknown);
     };
 
-    let Some(terms::application::GenericApplication {
-        automatic: right_automatic,
+    let Some(terms::application::UnanchoredApplication {
+        implicit: right_implicit,
         argument: right_type,
         result: result_type,
-    }) = terms::application::check_generic_application(state, context, right_function_type)?
+    }) = terms::application::check_unanchored_application(state, context, right_function_type)?
     else {
         return Ok(unknown);
     };
@@ -200,7 +200,7 @@ where
         context,
         operator,
         operator_type,
-        (left_automatic, right_automatic),
+        (left_implicit, right_implicit),
         (left, right),
         (left_type, right_type),
         (right_function_type, result_type),
@@ -257,8 +257,8 @@ pub trait IsOperator<Q: ExternalQueries>: IsElement {
         operator: (FileId, Self::ItemId),
         operator_type: TypeId,
         applications: (
-            Vec<terms::application::AutomaticApplication>,
-            Vec<terms::application::AutomaticApplication>,
+            Vec<terms::application::ImplicitApplication>,
+            Vec<terms::application::ImplicitApplication>,
         ),
         result_tree: (Self::Elaborated, Self::Elaborated),
         argument_types: (TypeId, TypeId),
@@ -329,9 +329,9 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         context: &CheckContext<Q>,
         (file_id, item_id): (FileId, Self::ItemId),
         operator_type: TypeId,
-        (left_automatic, right_automatic): (
-            Vec<terms::application::AutomaticApplication>,
-            Vec<terms::application::AutomaticApplication>,
+        (left_implicit, right_implicit): (
+            Vec<terms::application::ImplicitApplication>,
+            Vec<terms::application::ImplicitApplication>,
         ),
         (left, right): (Self::Elaborated, Self::Elaborated),
         (_, _): (TypeId, TypeId),
@@ -352,17 +352,17 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
             target_item_id,
             operator_type,
         )?;
-        let left = terms::application::materialize_generic_application(
+        let left = terms::application::materialize_application(
             state,
             operator,
-            left_automatic,
+            left_implicit,
             right_function_type,
             left,
         );
-        let expression = terms::application::materialize_generic_application(
+        let expression = terms::application::materialize_application(
             state,
             left,
-            right_automatic,
+            right_implicit,
             result_type,
             right,
         );
@@ -450,9 +450,9 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
         context: &CheckContext<Q>,
         (file_id, item_id): (FileId, Self::ItemId),
         _operator_type: TypeId,
-        (_left_automatic, _right_automatic): (
-            Vec<terms::application::AutomaticApplication>,
-            Vec<terms::application::AutomaticApplication>,
+        (_left_implicit, _right_implicit): (
+            Vec<terms::application::ImplicitApplication>,
+            Vec<terms::application::ImplicitApplication>,
         ),
         (left, right): (Self::Elaborated, Self::Elaborated),
         (left_kind, right_kind): (TypeId, TypeId),
@@ -568,9 +568,9 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
         _context: &CheckContext<Q>,
         (_, _): (FileId, Self::ItemId),
         _operator_type: TypeId,
-        (_left_automatic, _right_automatic): (
-            Vec<terms::application::AutomaticApplication>,
-            Vec<terms::application::AutomaticApplication>,
+        (_left_implicit, _right_implicit): (
+            Vec<terms::application::ImplicitApplication>,
+            Vec<terms::application::ImplicitApplication>,
         ),
         (_, _): (Self::Elaborated, Self::Elaborated),
         (_, _): (TypeId, TypeId),

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -354,15 +354,13 @@ where
             let negate_type = toolkit::lookup_term_variable(state, context, *negate)?;
             let kind = tree::ExpressionKind::Variable { resolution: *negate };
             let negate = allocate_expression(state, negate_type, kind);
-            let Some(application::GenericApplication { automatic, argument, result }) =
-                application::check_generic_application(state, context, negate_type)?
+            let Some(application::UnanchoredApplication { implicit, argument, result }) =
+                application::check_unanchored_application(state, context, negate_type)?
             else {
                 return Ok(allocate_error_expression(state, unknown));
             };
             let operand = check_expression(state, context, *expression, argument)?;
-            Ok(application::materialize_generic_application(
-                state, negate, automatic, result, operand,
-            ))
+            Ok(application::materialize_application(state, negate, implicit, result, operand))
         }
 
         lowering::ExpressionKind::Application { function, arguments } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -45,6 +45,34 @@ fn allocate_error_expression(state: &mut CheckState, type_id: TypeId) -> Elabora
     ElaboratedExpression { type_id, expression }
 }
 
+pub(super) fn allocate_term_reference<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    file_id: FileId,
+    term_id: TermItemId,
+    type_id: TypeId,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let is_constructor = if file_id == context.id {
+        let item = context.lowered.info.get_term_item(term_id);
+        matches!(item, Some(lowering::TermItemIr::Constructor { .. }))
+    } else {
+        let lowered = context.queries.lowered(file_id)?;
+        let item = lowered.info.get_term_item(term_id);
+        matches!(item, Some(lowering::TermItemIr::Constructor { .. }))
+    };
+
+    let kind = if is_constructor {
+        tree::ExpressionKind::Constructor { resolution: (file_id, term_id) }
+    } else {
+        let resolution = lowering::TermVariableResolution::Reference(file_id, term_id);
+        tree::ExpressionKind::Variable { resolution }
+    };
+    Ok(allocate_expression(state, type_id, kind))
+}
+
 /// Checks the type of an expression.
 pub fn check_expression<Q>(
     state: &mut CheckState,
@@ -191,9 +219,9 @@ where
             Ok(allocate_error_expression(state, type_id))
         }
         lowering::ExpressionKind::OperatorChain { .. } => {
-            let (_, checked_type) =
+            let (checked, checked_type) =
                 operator::check_operator_chain(state, context, expression, expected)?;
-            Ok(allocate_error_expression(state, checked_type))
+            Ok(checked.unwrap_or_else(|| allocate_error_expression(state, checked_type)))
         }
         lowering::ExpressionKind::LetIn { bindings, expression } => {
             let type_id = forms::check_let_in(state, context, bindings, *expression, expected)?;
@@ -303,16 +331,16 @@ where
         }
 
         lowering::ExpressionKind::OperatorChain { .. } => {
-            let (_, inferred_type) = operator::infer_operator_chain(state, context, expression)?;
-            Ok(allocate_error_expression(state, inferred_type))
+            let (inferred, inferred_type) =
+                operator::infer_operator_chain(state, context, expression)?;
+            Ok(inferred.unwrap_or_else(|| allocate_error_expression(state, inferred_type)))
         }
 
         lowering::ExpressionKind::InfixChain { head, tail } => {
             let Some(head) = *head else {
                 return Ok(allocate_error_expression(state, unknown));
             };
-            let type_id = application::infer_infix_chain(state, context, head, tail)?;
-            Ok(allocate_error_expression(state, type_id))
+            application::infer_infix_chain(state, context, head, tail)
         }
 
         lowering::ExpressionKind::Negate { negate, expression } => {
@@ -324,13 +352,17 @@ where
             };
 
             let negate_type = toolkit::lookup_term_variable(state, context, *negate)?;
-            let type_id = application::check_function_term_application(
-                state,
-                context,
-                negate_type,
-                *expression,
-            )?;
-            Ok(allocate_error_expression(state, type_id))
+            let kind = tree::ExpressionKind::Variable { resolution: *negate };
+            let negate = allocate_expression(state, negate_type, kind);
+            let Some(application::GenericApplication { automatic, argument, result }) =
+                application::check_generic_application(state, context, negate_type)?
+            else {
+                return Ok(allocate_error_expression(state, unknown));
+            };
+            let operand = check_expression(state, context, *expression, argument)?;
+            Ok(application::materialize_generic_application(
+                state, negate, automatic, result, operand,
+            ))
         }
 
         lowering::ExpressionKind::Application { function, arguments } => {
@@ -402,7 +434,12 @@ where
                 return Ok(allocate_error_expression(state, unknown));
             };
             let type_id = toolkit::lookup_file_term(state, context, *file_id, *term_id)?;
-            Ok(allocate_error_expression(state, type_id))
+            let Some((target_file_id, target_term_id)) =
+                toolkit::resolve_term_operator_target(context, *file_id, *term_id)?
+            else {
+                return Ok(allocate_error_expression(state, type_id));
+            };
+            allocate_term_reference(state, context, target_file_id, target_term_id, type_id)
         }
 
         lowering::ExpressionKind::Section => {

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -4,6 +4,7 @@ use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
 use crate::core::{ForallBinder, Type, TypeId, normalise, unification};
 use crate::error::ErrorKind;
+use crate::evidence::EvidenceVarId;
 use crate::source::types;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop, tree};
@@ -11,8 +12,19 @@ use crate::{ExternalQueries, safe_loop, tree};
 use super::ElaboratedExpression;
 
 pub struct GenericApplication {
+    pub automatic: Vec<AutomaticApplication>,
     pub argument: TypeId,
     pub result: TypeId,
+}
+
+pub enum AutomaticApplication {
+    Type { argument: TypeId, result: TypeId },
+    Evidence { evidence: EvidenceVarId, result: TypeId },
+}
+
+enum PendingAutomaticApplication {
+    Type { argument: TypeId, result: TypeId },
+    Constraint { constraint: TypeId, result: TypeId },
 }
 
 enum ApplicationStep {
@@ -173,26 +185,69 @@ where
     Q: ExternalQueries,
 {
     let mut function = function;
-    let mut constraints = vec![];
+    let mut automatic = vec![];
     safe_loop! {
         match analyse_callable_head(state, context, function)? {
             CallableAnalysis::Forall { binder, body } => {
-                let (_, result) = instantiate_callable_forall(state, context, binder, body)?;
+                let (argument, result) =
+                    instantiate_callable_forall(state, context, binder, body)?;
+                automatic.push(PendingAutomaticApplication::Type { argument, result });
                 function = result;
             }
             CallableAnalysis::Constraint { constraint, result } => {
-                constraints.push(constraint);
+                automatic.push(PendingAutomaticApplication::Constraint { constraint, result });
                 function = result;
             }
             CallableAnalysis::Function { argument, result } => {
-                for constraint in constraints {
-                    state.push_wanted(constraint);
-                }
-                break Ok(Some(GenericApplication { argument, result }));
+                let automatic = automatic.into_iter().map(|application| match application {
+                    PendingAutomaticApplication::Type { argument, result } => {
+                        AutomaticApplication::Type { argument, result }
+                    }
+                    PendingAutomaticApplication::Constraint { constraint, result } => {
+                        let evidence = state.push_wanted(constraint);
+                        AutomaticApplication::Evidence { evidence, result }
+                    }
+                });
+                let automatic = automatic.collect();
+                break Ok(Some(GenericApplication { automatic, argument, result }));
             }
             CallableAnalysis::NotCallable => break Ok(None),
         }
     }
+}
+
+pub fn materialize_generic_application(
+    state: &mut CheckState,
+    mut function: ElaboratedExpression,
+    automatic: Vec<AutomaticApplication>,
+    result: TypeId,
+    argument: ElaboratedExpression,
+) -> ElaboratedExpression {
+    for application in automatic {
+        let (type_id, kind) = match application {
+            AutomaticApplication::Type { argument, result } => {
+                let kind = tree::ExpressionKind::TypeApplication {
+                    function: function.expression,
+                    argument,
+                };
+                (result, kind)
+            }
+            AutomaticApplication::Evidence { evidence, result } => {
+                let kind = tree::ExpressionKind::EvidenceApplication {
+                    function: function.expression,
+                    evidence,
+                };
+                (result, kind)
+            }
+        };
+        function = super::allocate_expression(state, type_id, kind);
+    }
+
+    let kind = tree::ExpressionKind::TermApplication {
+        function: function.expression,
+        argument: argument.expression,
+    };
+    super::allocate_expression(state, result, kind)
 }
 
 pub fn check_expression_application<Q>(
@@ -341,7 +396,7 @@ pub fn check_function_term_application<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(GenericApplication { argument, result }) =
+    let Some(GenericApplication { argument, result, .. }) =
         check_generic_application(state, context, function)?
     else {
         return Ok(context.unknown("invalid function application"));
@@ -355,27 +410,41 @@ pub fn infer_infix_chain<Q>(
     context: &CheckContext<Q>,
     head: lowering::ExpressionId,
     tail: &[lowering::InfixPair<lowering::ExpressionId>],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    let mut infix_type = super::infer_expression(state, context, head)?.type_id;
+    let mut infix = super::infer_expression(state, context, head)?;
 
     for lowering::InfixPair { tick, element } in tail.iter() {
-        let Some(tick) = tick else { return Ok(context.unknown("missing infix tick")) };
-        let Some(element) = element else { return Ok(context.unknown("missing infix element")) };
-
-        let tick_type = super::infer_expression(state, context, *tick)?.type_id;
-        let Some(GenericApplication { argument, result }) =
-            check_generic_application(state, context, tick_type)?
-        else {
-            return Ok(context.unknown("invalid function application"));
+        let Some(tick) = tick else {
+            let unknown = context.unknown("missing infix tick");
+            return Ok(super::allocate_error_expression(state, unknown));
         };
-        unification::subtype(state, context, infix_type, argument)?;
-        let applied_tick = result;
+        let Some(element) = element else {
+            let unknown = context.unknown("missing infix element");
+            return Ok(super::allocate_error_expression(state, unknown));
+        };
 
-        infix_type = check_function_term_application(state, context, applied_tick, *element)?;
+        let tick = super::infer_expression(state, context, *tick)?;
+        let Some(GenericApplication { automatic, argument, result }) =
+            check_generic_application(state, context, tick.type_id)?
+        else {
+            let unknown = context.unknown("invalid function application");
+            return Ok(super::allocate_error_expression(state, unknown));
+        };
+        unification::subtype(state, context, infix.type_id, argument)?;
+        let applied_tick = materialize_generic_application(state, tick, automatic, result, infix);
+
+        let Some(GenericApplication { automatic, argument, result }) =
+            check_generic_application(state, context, applied_tick.type_id)?
+        else {
+            let unknown = context.unknown("invalid function application");
+            return Ok(super::allocate_error_expression(state, unknown));
+        };
+        let element = super::check_expression(state, context, *element, argument)?;
+        infix = materialize_generic_application(state, applied_tick, automatic, result, element);
     }
 
-    Ok(infix_type)
+    Ok(infix)
 }

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -11,18 +11,18 @@ use crate::{ExternalQueries, safe_loop, tree};
 
 use super::ElaboratedExpression;
 
-pub struct GenericApplication {
-    pub automatic: Vec<AutomaticApplication>,
+pub struct UnanchoredApplication {
+    pub implicit: Vec<ImplicitApplication>,
     pub argument: TypeId,
     pub result: TypeId,
 }
 
-pub enum AutomaticApplication {
+pub enum ImplicitApplication {
     Type { argument: TypeId, result: TypeId },
     Evidence { evidence: EvidenceVarId, result: TypeId },
 }
 
-enum PendingAutomaticApplication {
+enum PendingImplicitApplication {
     Type { argument: TypeId, result: TypeId },
     Constraint { constraint: TypeId, result: TypeId },
 }
@@ -176,63 +176,63 @@ where
     }
 }
 
-pub fn check_generic_application<Q>(
+pub fn check_unanchored_application<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     function: TypeId,
-) -> QueryResult<Option<GenericApplication>>
+) -> QueryResult<Option<UnanchoredApplication>>
 where
     Q: ExternalQueries,
 {
     let mut function = function;
-    let mut automatic = vec![];
+    let mut implicit = vec![];
     safe_loop! {
         match analyse_callable_head(state, context, function)? {
             CallableAnalysis::Forall { binder, body } => {
                 let (argument, result) =
                     instantiate_callable_forall(state, context, binder, body)?;
-                automatic.push(PendingAutomaticApplication::Type { argument, result });
+                implicit.push(PendingImplicitApplication::Type { argument, result });
                 function = result;
             }
             CallableAnalysis::Constraint { constraint, result } => {
-                automatic.push(PendingAutomaticApplication::Constraint { constraint, result });
+                implicit.push(PendingImplicitApplication::Constraint { constraint, result });
                 function = result;
             }
             CallableAnalysis::Function { argument, result } => {
-                let automatic = automatic.into_iter().map(|application| match application {
-                    PendingAutomaticApplication::Type { argument, result } => {
-                        AutomaticApplication::Type { argument, result }
+                let implicit = implicit.into_iter().map(|application| match application {
+                    PendingImplicitApplication::Type { argument, result } => {
+                        ImplicitApplication::Type { argument, result }
                     }
-                    PendingAutomaticApplication::Constraint { constraint, result } => {
+                    PendingImplicitApplication::Constraint { constraint, result } => {
                         let evidence = state.push_wanted(constraint);
-                        AutomaticApplication::Evidence { evidence, result }
+                        ImplicitApplication::Evidence { evidence, result }
                     }
                 });
-                let automatic = automatic.collect();
-                break Ok(Some(GenericApplication { automatic, argument, result }));
+                let implicit = implicit.collect();
+                break Ok(Some(UnanchoredApplication { implicit, argument, result }));
             }
             CallableAnalysis::NotCallable => break Ok(None),
         }
     }
 }
 
-pub fn materialize_generic_application(
+pub fn materialize_application(
     state: &mut CheckState,
     mut function: ElaboratedExpression,
-    automatic: Vec<AutomaticApplication>,
+    implicit: Vec<ImplicitApplication>,
     result: TypeId,
     argument: ElaboratedExpression,
 ) -> ElaboratedExpression {
-    for application in automatic {
+    for application in implicit {
         let (type_id, kind) = match application {
-            AutomaticApplication::Type { argument, result } => {
+            ImplicitApplication::Type { argument, result } => {
                 let kind = tree::ExpressionKind::TypeApplication {
                     function: function.expression,
                     argument,
                 };
                 (result, kind)
             }
-            AutomaticApplication::Evidence { evidence, result } => {
+            ImplicitApplication::Evidence { evidence, result } => {
                 let kind = tree::ExpressionKind::EvidenceApplication {
                     function: function.expression,
                     evidence,
@@ -396,8 +396,8 @@ pub fn check_function_term_application<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(GenericApplication { argument, result, .. }) =
-        check_generic_application(state, context, function)?
+    let Some(UnanchoredApplication { argument, result, .. }) =
+        check_unanchored_application(state, context, function)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
@@ -427,23 +427,23 @@ where
         };
 
         let tick = super::infer_expression(state, context, *tick)?;
-        let Some(GenericApplication { automatic, argument, result }) =
-            check_generic_application(state, context, tick.type_id)?
+        let Some(UnanchoredApplication { implicit, argument, result }) =
+            check_unanchored_application(state, context, tick.type_id)?
         else {
             let unknown = context.unknown("invalid function application");
             return Ok(super::allocate_error_expression(state, unknown));
         };
         unification::subtype(state, context, infix.type_id, argument)?;
-        let applied_tick = materialize_generic_application(state, tick, automatic, result, infix);
+        let applied_tick = materialize_application(state, tick, implicit, result, infix);
 
-        let Some(GenericApplication { automatic, argument, result }) =
-            check_generic_application(state, context, applied_tick.type_id)?
+        let Some(UnanchoredApplication { implicit, argument, result }) =
+            check_unanchored_application(state, context, applied_tick.type_id)?
         else {
             let unknown = context.unknown("invalid function application");
             return Ok(super::allocate_error_expression(state, unknown));
         };
         let element = super::check_expression(state, context, *element, argument)?;
-        infix = materialize_generic_application(state, applied_tick, automatic, result, element);
+        infix = materialize_application(state, applied_tick, implicit, result, element);
     }
 
     Ok(infix)

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -216,14 +216,14 @@ where
 {
     let expression_type = super::infer_expression(state, context, expression)?.type_id;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, map_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, lambda_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));
@@ -245,14 +245,14 @@ where
 {
     let expression_type = super::infer_expression(state, context, expression)?.type_id;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, apply_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, continuation_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -216,15 +216,15 @@ where
 {
     let expression_type = super::infer_expression(state, context, expression)?.type_id;
 
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, map_type)?
+    let Some(application::UnanchoredApplication { argument, result, .. }) =
+        application::check_unanchored_application(state, context, map_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, lambda_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, result)?
+    let Some(application::UnanchoredApplication { argument, result, .. }) =
+        application::check_unanchored_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
@@ -245,15 +245,15 @@ where
 {
     let expression_type = super::infer_expression(state, context, expression)?.type_id;
 
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, apply_type)?
+    let Some(application::UnanchoredApplication { argument, result, .. }) =
+        application::check_unanchored_application(state, context, apply_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, continuation_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, result)?
+    let Some(application::UnanchoredApplication { argument, result, .. }) =
+        application::check_unanchored_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));
     };

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -415,14 +415,14 @@ where
     let expression_type = super::infer_expression(state, context, expression)?.type_id;
     let lambda_type = context.intern_function(binder_type, continuation_type);
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, bind_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, expression_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result }) =
+    let Some(application::GenericApplication { argument, result, .. }) =
         application::check_generic_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -415,15 +415,15 @@ where
     let expression_type = super::infer_expression(state, context, expression)?.type_id;
     let lambda_type = context.intern_function(binder_type, continuation_type);
 
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, bind_type)?
+    let Some(application::UnanchoredApplication { argument, result, .. }) =
+        application::check_unanchored_application(state, context, bind_type)?
     else {
         return Ok(context.unknown("invalid function application"));
     };
     unification::subtype(state, context, expression_type, argument)?;
 
-    let Some(application::GenericApplication { argument, result, .. }) =
-        application::check_generic_application(state, context, result)?
+    let Some(application::UnanchoredApplication { argument, result, .. }) =
+        application::check_unanchored_application(state, context, result)?
     else {
         return Ok(context.unknown("invalid function application"));
     };

--- a/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+choose :: forall a b. a -> b -> a
+choose left right = left
+
+singleInfix :: Int
+singleInfix = 1 `choose` "text"
+
+multipleInfix :: Int
+multipleInfix = 1 `choose` "first" `choose` true
+
+identity :: forall a. a -> a
+identity value = value
+
+polymorphicHead = identity `choose` 1

--- a/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+choose :: forall a b. a -> b -> a
+choose = \left -> \right -> left
+
+singleInfix :: Int
+singleInfix = choose @Int @String 1 "text"
+
+multipleInfix :: Int
+multipleInfix = choose @Int @Boolean (choose @Int @String 1 "first") true
+
+identity :: forall a. a -> a
+identity = \value -> value
+
+polymorphicHead :: forall t. t -> t
+polymorphicHead = choose @(t -> t) @Int identity 1

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.purs
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.purs
@@ -1,0 +1,37 @@
+module Main where
+
+add :: Int -> Int -> Int
+add left right = left
+
+multiply :: Int -> Int -> Int
+multiply left right = right
+
+infixl 5 add as +
+infixl 6 multiply as *
+
+precedence :: Int
+precedence = 1 + 2 * 3
+
+leftAssociative :: Int
+leftAssociative = 1 + 2 + 3
+
+append :: Int -> Int -> Int
+append left right = left
+
+infixr 4 append as <+>
+
+rightAssociative :: Int
+rightAssociative = 1 <+> 2 <+> 3
+
+class First :: Type -> Constraint
+class First a
+
+class Second :: Type -> Constraint
+class Second a
+
+foreign import interleaved :: forall a. First a => a -> (forall b. Second b => b -> a)
+
+infixr 3 interleaved as <*>
+
+automaticApplications :: forall a b. First a => Second b => a -> b -> a
+automaticApplications left right = left <*> right

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.purs
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.purs
@@ -33,5 +33,5 @@ foreign import interleaved :: forall a. First a => a -> (forall b. Second b => b
 
 infixr 3 interleaved as <*>
 
-automaticApplications :: forall a b. First a => Second b => a -> b -> a
-automaticApplications left right = left <*> right
+implicitApplications :: forall a b. First a => Second b => a -> b -> a
+implicitApplications left right = left <*> right

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface First :: Type -> Constraint
+interface First a where
+
+interface Second :: Type -> Constraint
+interface Second a where
+
+add :: Int -> Int -> Int
+add = \left -> \right -> left
+
+multiply :: Int -> Int -> Int
+multiply = \left -> \right -> right
+
+precedence :: Int
+precedence = add 1 (multiply 2 3)
+
+leftAssociative :: Int
+leftAssociative = add (add 1 2) 3
+
+append :: Int -> Int -> Int
+append = \left -> \right -> left
+
+rightAssociative :: Int
+rightAssociative = append 1 (append 2 3)
+
+automaticApplications :: forall a b. First a => Second b => a -> b -> a
+automaticApplications =
+  \{firstDict} ->
+    \{secondDict} -> \left -> \right -> interleaved @a {firstDict} left @b {secondDict} right

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
@@ -27,7 +27,7 @@ append = \left -> \right -> left
 rightAssociative :: Int
 rightAssociative = append 1 (append 2 3)
 
-automaticApplications :: forall a b. First a => Second b => a -> b -> a
-automaticApplications =
+implicitApplications :: forall a b. First a => Second b => a -> b -> a
+implicitApplications =
   \{firstDict} ->
     \{secondDict} -> \left -> \right -> interleaved @a {firstDict} left @b {secondDict} right

--- a/tests-integration/fixtures/semantic/1784789520_operator_names/Main.purs
+++ b/tests-integration/fixtures/semantic/1784789520_operator_names/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+class Combine :: Type -> Constraint
+class Combine a where
+  combine :: a -> a -> a
+
+infixr 5 combine as <>
+
+operatorName :: forall a. Combine a => a -> a -> a
+operatorName = (<>)
+
+operatorApplication :: forall a. Combine a => a -> a -> a
+operatorApplication left right = (<>) left right
+
+data List a = Cons a (List a) | Nil
+
+infixr 5 Cons as :
+
+constructorOperator = (:)

--- a/tests-integration/fixtures/semantic/1784789520_operator_names/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_names/Main.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Combine :: Type -> Constraint
+interface Combine a where
+  combine :: a -> a -> a
+
+data List :: Type -> Type
+data List @a
+  | Cons :: a -> List a -> List a
+  | Nil :: List a
+
+operatorName :: forall a. Combine a => a -> a -> a
+operatorName = \{combineDict} -> combine @a {combineDict}
+
+operatorApplication :: forall a. Combine a => a -> a -> a
+operatorApplication = \{combineDict} -> \left -> \right -> combine @a {combineDict} left right
+
+constructorOperator :: forall t. t -> List t -> List t
+constructorOperator = Cons @t

--- a/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+class Negative :: Type -> Constraint
+class Negative a
+
+foreign import negate :: forall a. Negative a => a -> a
+
+negative :: forall a. Negative a => a -> a
+negative value = -value
+
+shadowedNegate :: (Int -> Int) -> Int -> Int
+shadowedNegate negate value = -value

--- a/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Negative :: Type -> Constraint
+interface Negative a where
+
+negative :: forall a. Negative a => a -> a
+negative = \{negativeDict} -> \value -> negate @a {negativeDict} value
+
+shadowedNegate :: (Int -> Int) -> Int -> Int
+shadowedNegate = \negate -> \value -> negate value

--- a/tests-integration/fixtures/semantic/1784789700_operator_chain_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784789700_operator_chain_recovery/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+add :: Int -> Int -> Int
+add left right = left
+
+infixl 5 add as +
+
+missingRightOperand = 1 +

--- a/tests-integration/fixtures/semantic/1784789700_operator_chain_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789700_operator_chain_recovery/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+add :: Int -> Int -> Int
+add = \left -> \right -> left
+
+missingRightOperand :: Int
+missingRightOperand = <error>


### PR DESCRIPTION
## Summary

- retain checked semantic structure for operator names, symbolic operator chains, backtick infix chains, and negation
- normalize operator aliases and negation into ordinary target variable/constructor applications
- preserve ordered implicit type and evidence applications without repeating inference or wanted creation
- clarify anchored versus unanchored application terminology
- keep malformed operator chains as opaque error expressions

## Testing

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t semantic`
- `just t checking`
- `git diff --check`