### PR TITLE
[checking] Retain local let bindings in the semantic tree

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -95,6 +95,12 @@ where
     }
     state.checked.tree.arena.binders = binders;
 
+    let mut local_declarations = mem::take(&mut state.checked.tree.arena.lets);
+    for (_, declaration) in local_declarations.iter_mut() {
+        declaration.type_id = zonk(state, context, declaration.type_id)?;
+    }
+    state.checked.tree.arena.lets = local_declarations;
+
     let mut term_declarations = mem::take(&mut state.checked.tree.arena.terms);
     for (_, declaration) in term_declarations.iter_mut() {
         declaration.type_id = zonk(state, context, declaration.type_id)?;

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -447,8 +447,9 @@ fn record_instance_member(
 
     let complete = !member.equations.is_empty()
         && member.equations.len() == equations.len()
-        && std::iter::zip(member.equations.iter(), &equations)
-            .all(|(source, equation)| source.source == Some(equation.source));
+        && std::iter::zip(member.equations.iter(), &equations).all(|(source, equation)| {
+            source.source.map(tree::EquationSource::Item) == Some(equation.source)
+        });
     if !complete {
         return None;
     }
@@ -931,7 +932,8 @@ fn record_value_declaration<Q>(
     let complete = !sources.is_empty()
         && sources.len() == equations.len()
         && std::iter::zip(sources, &equations).all(|(source, equation)| {
-            equation.source == indexing::EquationSourceId::Value(*source)
+            let source = indexing::EquationSourceId::Value(*source);
+            equation.source == tree::EquationSource::Item(source)
         });
     if !complete {
         return;

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -224,8 +224,7 @@ where
             Ok(checked.unwrap_or_else(|| allocate_error_expression(state, checked_type)))
         }
         lowering::ExpressionKind::LetIn { bindings, expression } => {
-            let type_id = forms::check_let_in(state, context, bindings, *expression, expected)?;
-            Ok(allocate_error_expression(state, type_id))
+            form_let::check_let_in(state, context, bindings, *expression, expected)
         }
         lowering::ExpressionKind::Parenthesized { parenthesized } => {
             let Some(parenthesized) = parenthesized else {
@@ -378,14 +377,7 @@ where
         }
 
         lowering::ExpressionKind::LetIn { bindings, expression } => {
-            form_let::check_let_chunks(state, context, bindings)?;
-
-            let Some(expression) = expression else {
-                return Ok(allocate_error_expression(state, unknown));
-            };
-
-            let expression = infer_expression(state, context, *expression)?;
-            Ok(allocate_error_expression(state, expression.type_id))
+            form_let::infer_let_in(state, context, bindings, *expression)
         }
 
         lowering::ExpressionKind::Lambda { binders, expression } => {

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -47,6 +47,7 @@ pub struct ElaboratedEquation {
 impl ElaboratedEquation {
     pub fn into_tree(self) -> Option<tree::Equation> {
         let source = self.source?;
+        let source = tree::EquationSource::Item(source);
         Some(tree::Equation { source, binders: self.binders, guarded_expression: self.guarded })
     }
 }
@@ -203,7 +204,7 @@ where
 
 fn missing_guarded_expression(state: &mut CheckState, type_id: TypeId) -> tree::GuardedExpression {
     let expression = state.allocate_error_expression(type_id);
-    let where_expression = tree::WhereExpression { expression };
+    let where_expression = tree::WhereExpression::new(expression);
     tree::GuardedExpression::unconditional(where_expression)
 }
 

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -47,8 +47,12 @@ pub struct ElaboratedEquation {
 impl ElaboratedEquation {
     pub fn into_tree(self) -> Option<tree::Equation> {
         let source = self.source?;
-        let source = tree::EquationSource::Item(source);
-        Some(tree::Equation { source, binders: self.binders, guarded_expression: self.guarded })
+        Some(tree::Equation::item(source, self.binders, self.guarded))
+    }
+
+    pub fn into_local_tree(self, source: lowering::LetBindingEquationId) -> tree::Equation {
+        assert!(self.source.is_none(), "invariant violated: local equation has an item source");
+        tree::Equation::local(source, self.binders, self.guarded)
     }
 }
 

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -1,12 +1,12 @@
 use building_types::QueryResult;
 
-use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{Type, exhaustive, normalise, unification};
 use crate::error::ErrorCrumb;
 use crate::source::terms::{ElaboratedExpression, application, equations, guarded};
 use crate::source::{binder, types};
 use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
 
 pub fn check_let_chunks<Q>(
     state: &mut CheckState,
@@ -98,11 +98,13 @@ where
     for item in scc {
         match item {
             lowering::Scc::Base(id) | lowering::Scc::Recursive(id) => {
-                check_let_name_binding(state, context, *id)?;
+                let declaration = check_let_name_binding(state, context, *id)?;
+                state.checked.tree.insert_let(declaration);
             }
             lowering::Scc::Mutual(mutual) => {
-                for id in mutual {
-                    check_let_name_binding(state, context, *id)?;
+                for &id in mutual {
+                    let declaration = check_let_name_binding(state, context, id)?;
+                    state.checked.tree.insert_let(declaration);
                 }
             }
         }
@@ -115,7 +117,7 @@ pub fn check_let_name_binding<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     id: lowering::LetBindingNameGroupId,
-) -> QueryResult<()>
+) -> QueryResult<tree::LocalDeclaration>
 where
     Q: ExternalQueries,
 {
@@ -130,58 +132,83 @@ pub fn check_let_name_binding_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     id: lowering::LetBindingNameGroupId,
-) -> QueryResult<()>
+) -> QueryResult<tree::LocalDeclaration>
 where
     Q: ExternalQueries,
 {
-    let Some(name) = context.lowered.info.get_let_binding(id) else {
-        return Ok(());
-    };
+    let group = context.lowered.info.get_let_binding_group(id);
+    let name = context
+        .lowered
+        .info
+        .get_let_binding(id)
+        .expect("invariant violated: let binding group has no lowered binding");
+    let name_type = state
+        .checked
+        .nodes
+        .lookup_let(id)
+        .expect("invariant violated: let binding has no preallocated type");
 
-    let Some(name_type) = state.checked.nodes.lookup_let(id) else {
-        return Ok(());
-    };
-
-    if let Some(signature_id) = name.signature {
-        let checked_equations = equations::check_value_equations(
+    let checked_equations = if let Some(signature_id) = name.signature {
+        equations::check_value_equations(
             state,
             context,
             equations::EquationTypeOrigin::Explicit(signature_id),
             name_type,
             &name.equations,
-        )?;
-        let exhaustiveness = exhaustive::check_equation_patterns(
-            state,
-            context,
-            &checked_equations.patterns,
-            &name.equations,
-        )?;
-        state.report_exhaustiveness(exhaustiveness);
+        )?
     } else {
         if let [equation] = name.equations.as_ref()
+            && let [equation_source] = group.equations.as_ref()
             && equation.binders.is_empty()
             && let Some(guarded) = &equation.guarded
         {
-            let inferred_type = guarded::infer_guarded_expression(state, context, guarded)?.type_id;
+            let inferred = guarded::infer_guarded_expression(state, context, guarded)?;
+            let inferred_type = inferred.type_id;
             // Keep simple let bindings e.g. `appendLocal = append` polymorphic.
-            let name_type = normalise::expand(state, context, name_type)?;
-            if let Type::Unification(unification_id) = context.lookup_type(name_type) {
-                unification::solve(state, context, name_type, unification_id, inferred_type)?;
+            let expanded_name_type = normalise::expand(state, context, name_type)?;
+            if let Type::Unification(unification_id) = context.lookup_type(expanded_name_type) {
+                unification::solve(
+                    state,
+                    context,
+                    expanded_name_type,
+                    unification_id,
+                    inferred_type,
+                )?;
             } else {
-                unification::subtype(state, context, inferred_type, name_type)?;
+                unification::subtype(state, context, inferred_type, expanded_name_type)?;
             }
-        } else {
-            let checked_equations =
-                equations::infer_value_equations(state, context, name_type, &name.equations)?;
-            let exhaustiveness = exhaustive::check_equation_patterns(
-                state,
-                context,
-                &checked_equations.patterns,
-                &name.equations,
-            )?;
-            state.report_exhaustiveness(exhaustiveness);
-        }
-    }
 
-    Ok(())
+            let declaration = tree::LocalDeclaration::nullary(
+                id,
+                name_type,
+                *equation_source,
+                inferred.guarded_expression,
+            );
+            return Ok(declaration);
+        } else {
+            equations::infer_value_equations(state, context, name_type, &name.equations)?
+        }
+    };
+
+    let exhaustiveness = exhaustive::check_equation_patterns(
+        state,
+        context,
+        &checked_equations.patterns,
+        &name.equations,
+    )?;
+    state.report_exhaustiveness(exhaustiveness);
+
+    assert_eq!(
+        group.equations.len(),
+        checked_equations.equations.len(),
+        "invariant violated: checked local equation count does not match lowering",
+    );
+
+    let equations = std::iter::zip(group.equations.iter().copied(), checked_equations.equations)
+        .map(|(source, equation)| equation.into_local_tree(source));
+
+    let equations = equations.collect();
+    let evidences = checked_equations.evidences.into();
+
+    Ok(tree::LocalDeclaration::new(id, name_type, evidences, equations))
 }

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -18,7 +18,7 @@ where
 {
     for chunk in chunks {
         match chunk {
-            lowering::LetBindingChunk::Pattern { binder, where_expression } => {
+            lowering::LetBindingChunk::Pattern { binder, where_expression, .. } => {
                 check_pattern_let_binding(state, context, binder, where_expression)?;
             }
             lowering::LetBindingChunk::Names { bindings, scc } => {

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
@@ -12,21 +14,20 @@ pub fn check_let_chunks<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     chunks: &[lowering::LetBindingChunk],
-) -> QueryResult<()>
+) -> QueryResult<tree::LetBindings>
 where
     Q: ExternalQueries,
 {
-    for chunk in chunks {
-        match chunk {
-            lowering::LetBindingChunk::Pattern { source, binder, where_expression } => {
-                check_pattern_let_binding(state, context, *source, binder, where_expression)?;
-            }
-            lowering::LetBindingChunk::Names { bindings, scc } => {
-                check_names_chunk(state, context, bindings, scc)?;
-            }
+    let checked_chunks = chunks.iter().map(|chunk| match chunk {
+        lowering::LetBindingChunk::Pattern { source, binder, where_expression } => {
+            check_pattern_let_binding(state, context, *source, binder, where_expression)
         }
-    }
-    Ok(())
+        lowering::LetBindingChunk::Names { bindings, scc } => {
+            check_names_chunk(state, context, bindings, scc)
+        }
+    });
+    let chunks = checked_chunks.collect::<QueryResult<Arc<[_]>>>()?;
+    Ok(tree::LetBindings { chunks })
 }
 
 pub fn check_pattern_let_binding<Q>(
@@ -87,7 +88,7 @@ pub fn check_names_chunk<Q>(
     context: &CheckContext<Q>,
     bindings: &[lowering::LetBindingNameGroupId],
     scc: &[lowering::Scc<lowering::LetBindingNameGroupId>],
-) -> QueryResult<()>
+) -> QueryResult<tree::LetBindingChunk>
 where
     Q: ExternalQueries,
 {
@@ -119,7 +120,19 @@ where
         }
     }
 
-    Ok(())
+    let lookup = |source| {
+        state
+            .checked
+            .tree
+            .lookup_let(source)
+            .expect("invariant violated: checked local declaration is missing")
+    };
+
+    let declarations = bindings.iter().copied().map(lookup);
+    let declarations = declarations.collect();
+    let groups = Arc::from(scc);
+
+    Ok(tree::LetBindingChunk::Names { declarations, groups })
 }
 
 pub fn check_let_name_binding<Q>(

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -3,12 +3,72 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{Type, exhaustive, normalise, unification};
+use crate::core::{Type, TypeId, exhaustive, normalise, unification};
 use crate::error::ErrorCrumb;
 use crate::source::terms::{ElaboratedExpression, application, equations, guarded};
 use crate::source::{binder, types};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
+
+#[derive(Copy, Clone, Debug)]
+enum LetInMode {
+    Infer,
+    Check { expected: TypeId },
+}
+
+pub fn infer_let_in<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    bindings: &[lowering::LetBindingChunk],
+    expression: Option<lowering::ExpressionId>,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let_in_core(state, context, bindings, expression, LetInMode::Infer)
+}
+
+pub fn check_let_in<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    bindings: &[lowering::LetBindingChunk],
+    expression: Option<lowering::ExpressionId>,
+    expected: TypeId,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let_in_core(state, context, bindings, expression, LetInMode::Check { expected })
+}
+
+fn let_in_core<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    bindings: &[lowering::LetBindingChunk],
+    expression: Option<lowering::ExpressionId>,
+    mode: LetInMode,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let bindings = check_let_chunks(state, context, bindings)?;
+
+    let ElaboratedExpression { type_id, expression } = if let Some(expression) = expression {
+        match mode {
+            LetInMode::Infer => super::infer_expression(state, context, expression)?,
+            LetInMode::Check { expected } => {
+                super::check_expression(state, context, expression, expected)?
+            }
+        }
+    } else {
+        let type_id = context.unknown("missing let expression");
+        let expression = state.allocate_error_expression(type_id);
+        ElaboratedExpression { type_id, expression }
+    };
+
+    let kind = tree::ExpressionKind::Let { bindings, expression };
+    Ok(super::allocate_expression(state, type_id, kind))
+}
 
 pub fn check_let_chunks<Q>(
     state: &mut CheckState,

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -18,8 +18,8 @@ where
 {
     for chunk in chunks {
         match chunk {
-            lowering::LetBindingChunk::Pattern { binder, where_expression, .. } => {
-                check_pattern_let_binding(state, context, binder, where_expression)?;
+            lowering::LetBindingChunk::Pattern { source, binder, where_expression } => {
+                check_pattern_let_binding(state, context, *source, binder, where_expression)?;
             }
             lowering::LetBindingChunk::Names { bindings, scc } => {
                 check_names_chunk(state, context, bindings, scc)?;
@@ -32,31 +32,40 @@ where
 pub fn check_pattern_let_binding<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
+    source: lowering::LetBindingId,
     binder: &Option<lowering::BinderId>,
     where_expression: &Option<lowering::WhereExpression>,
-) -> QueryResult<()>
+) -> QueryResult<tree::LetBindingChunk>
 where
     Q: ExternalQueries,
 {
     let Some(where_expression) = where_expression else {
-        return Ok(());
+        return Ok(tree::LetBindingChunk::PatternError {
+            source,
+            binder_source: *binder,
+            where_expression: None,
+        });
     };
 
-    let where_expression = guarded::infer_where_expression(state, context, where_expression)?;
+    let guarded::ElaboratedWhereExpression { type_id, where_expression } =
+        guarded::infer_where_expression(state, context, where_expression)?;
 
     let Some(binder_id) = *binder else {
-        return Ok(());
+        return Ok(tree::LetBindingChunk::PatternError {
+            source,
+            binder_source: None,
+            where_expression: Some(where_expression),
+        });
     };
 
-    let expression = ElaboratedExpression {
-        type_id: where_expression.type_id,
-        expression: where_expression.where_expression.expression,
-    };
+    let expression = ElaboratedExpression { type_id, expression: where_expression.expression };
     let expression = if binder::requires_instantiation(context, binder_id) {
         application::instantiate_expression(state, context, expression)?
     } else {
         application::collect_expression_wanteds(state, context, expression)?
     };
+    let where_expression =
+        tree::WhereExpression { expression: expression.expression, ..where_expression };
 
     let binder = binder::check_binder(state, context, binder_id, expression.type_id)?;
 
@@ -70,7 +79,7 @@ where
         state.push_wanted(context.prim.partial);
     }
 
-    Ok(())
+    Ok(tree::LetBindingChunk::Pattern { source, binder: binder.binder, where_expression })
 }
 
 pub fn check_names_chunk<Q>(

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -3,8 +3,8 @@ use building_types::QueryResult;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, exhaustive, toolkit, unification};
-use crate::source::terms::{application, form_let, guarded};
-use crate::source::{binder, terms};
+use crate::source::binder;
+use crate::source::terms::{application, guarded};
 use crate::state::CheckState;
 
 #[derive(Copy, Clone, Debug)]
@@ -264,23 +264,4 @@ where
     }
 
     Ok(expected)
-}
-
-pub fn check_let_in<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    bindings: &[lowering::LetBindingChunk],
-    expression: Option<lowering::ExpressionId>,
-    expected: TypeId,
-) -> QueryResult<TypeId>
-where
-    Q: ExternalQueries,
-{
-    form_let::check_let_chunks(state, context, bindings)?;
-
-    let Some(expression) = expression else {
-        return Ok(context.unknown("missing let expression"));
-    };
-
-    Ok(terms::check_expression(state, context, expression, expected)?.type_id)
 }

--- a/compiler-core/checking/src/source/terms/guarded.rs
+++ b/compiler-core/checking/src/source/terms/guarded.rs
@@ -193,7 +193,7 @@ fn where_expression_core<Q>(
 where
     Q: ExternalQueries,
 {
-    form_let::check_let_chunks(state, context, &where_expression.bindings)?;
+    let bindings = form_let::check_let_chunks(state, context, &where_expression.bindings)?;
 
     let Some(expression) = where_expression.expression else {
         let type_id = match mode {
@@ -201,22 +201,16 @@ where
             WhereExpressionMode::Check { expected } => expected,
         };
         let expression = state.allocate_error_expression(type_id);
-        let where_expression = tree::WhereExpression::new(expression);
+        let where_expression = tree::WhereExpression { bindings, expression };
         return Ok(ElaboratedWhereExpression { type_id, where_expression });
     };
 
-    let expression = match mode {
+    let terms::ElaboratedExpression { type_id, expression } = match mode {
         WhereExpressionMode::Infer => terms::infer_expression(state, context, expression)?,
         WhereExpressionMode::Check { expected } => {
             terms::check_expression(state, context, expression, expected)?
         }
     };
-    let type_id = expression.type_id;
-    let expression = if where_expression.bindings.is_empty() {
-        expression.expression
-    } else {
-        state.allocate_error_expression(type_id)
-    };
-    let where_expression = tree::WhereExpression::new(expression);
+    let where_expression = tree::WhereExpression { bindings, expression };
     Ok(ElaboratedWhereExpression { type_id, where_expression })
 }

--- a/compiler-core/checking/src/source/terms/guarded.rs
+++ b/compiler-core/checking/src/source/terms/guarded.rs
@@ -71,7 +71,7 @@ where
                     GuardedExpressionMode::Check { expected } => expected,
                 };
                 let expression = state.allocate_error_expression(type_id);
-                let where_expression = tree::WhereExpression { expression };
+                let where_expression = tree::WhereExpression::new(expression);
                 let guarded_expression = tree::GuardedExpression::unconditional(where_expression);
                 return Ok(ElaboratedGuardedExpression { type_id, guarded_expression });
             };
@@ -110,7 +110,7 @@ where
                             .where_expression
                     } else {
                         let expression = state.allocate_error_expression(expected_type);
-                        tree::WhereExpression { expression }
+                        tree::WhereExpression::new(expression)
                     };
                 alternatives.push(tree::GuardedAlternative {
                     pattern_guards: pattern_guards.into(),
@@ -201,7 +201,7 @@ where
             WhereExpressionMode::Check { expected } => expected,
         };
         let expression = state.allocate_error_expression(type_id);
-        let where_expression = tree::WhereExpression { expression };
+        let where_expression = tree::WhereExpression::new(expression);
         return Ok(ElaboratedWhereExpression { type_id, where_expression });
     };
 
@@ -217,6 +217,6 @@ where
     } else {
         state.allocate_error_expression(type_id)
     };
-    let where_expression = tree::WhereExpression { expression };
+    let where_expression = tree::WhereExpression::new(expression);
     Ok(ElaboratedWhereExpression { type_id, where_expression })
 }

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -62,6 +62,28 @@ pub struct LocalDeclaration {
     pub value: ValueDeclaration,
 }
 
+impl LocalDeclaration {
+    pub fn new(
+        source: LetBindingNameGroupId,
+        type_id: TypeId,
+        evidences: Arc<[Evidence]>,
+        equations: Arc<[Equation]>,
+    ) -> LocalDeclaration {
+        let value = ValueDeclaration { evidences, equations };
+        LocalDeclaration { source, type_id, value }
+    }
+
+    pub fn nullary(
+        source: LetBindingNameGroupId,
+        type_id: TypeId,
+        equation_source: lowering::LetBindingEquationId,
+        guarded_expression: GuardedExpression,
+    ) -> LocalDeclaration {
+        let equation = Equation::local(equation_source, [].into(), guarded_expression);
+        LocalDeclaration::new(source, type_id, [].into(), [equation].into())
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataConstructor {
     pub arguments: Arc<[TypeId]>,
@@ -148,6 +170,26 @@ pub struct Equation {
     pub source: EquationSource,
     pub binders: Arc<[BinderId]>,
     pub guarded_expression: GuardedExpression,
+}
+
+impl Equation {
+    pub fn item(
+        source: EquationSourceId,
+        binders: Arc<[BinderId]>,
+        guarded_expression: GuardedExpression,
+    ) -> Equation {
+        let source = EquationSource::Item(source);
+        Equation { source, binders, guarded_expression }
+    }
+
+    pub fn local(
+        source: lowering::LetBindingEquationId,
+        binders: Arc<[BinderId]>,
+        guarded_expression: GuardedExpression,
+    ) -> Equation {
+        let source = EquationSource::Local(source);
+        Equation { source, binders, guarded_expression }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use files::FileId;
 use indexing::{EquationSourceId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
+use lowering::LetBindingNameGroupId;
 use smol_str::SmolStr;
 
 use crate::TypeId;
@@ -16,12 +17,14 @@ pub type ExpressionId = Idx<Expression>;
 pub type BinderId = Idx<Binder>;
 pub type TermDeclarationId = Idx<TermDeclaration>;
 pub type TypeDeclarationId = Idx<TypeDeclaration>;
+pub type LocalDeclarationId = Idx<LocalDeclaration>;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Module {
     pub(crate) arena: ModuleArena,
     terms: ArenaMap<TermItemId, TermDeclarationId>,
     types: ArenaMap<TypeItemId, TypeDeclarationId>,
+    lets: ArenaMap<LetBindingNameGroupId, LocalDeclarationId>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -30,6 +33,7 @@ pub(crate) struct ModuleArena {
     pub(crate) binders: Arena<Binder>,
     pub(crate) terms: Arena<TermDeclaration>,
     pub(crate) types: Arena<TypeDeclaration>,
+    pub(crate) lets: Arena<LocalDeclaration>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -49,6 +53,13 @@ pub enum TermDeclarationKind {
 pub struct ValueDeclaration {
     pub evidences: Arc<[Evidence]>,
     pub equations: Arc<[Equation]>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct LocalDeclaration {
+    pub source: LetBindingNameGroupId,
+    pub type_id: TypeId,
+    pub value: ValueDeclaration,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -126,9 +137,15 @@ pub struct ClassMember {
     pub field_type: TypeId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EquationSource {
+    Item(EquationSourceId),
+    Local(lowering::LetBindingEquationId),
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Equation {
-    pub source: EquationSourceId,
+    pub source: EquationSource,
     pub binders: Arc<[BinderId]>,
     pub guarded_expression: GuardedExpression,
 }
@@ -152,7 +169,37 @@ pub enum PatternGuard {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct WhereExpression {
+    pub bindings: LetBindings,
     pub expression: ExpressionId,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct LetBindings {
+    pub chunks: Arc<[LetBindingChunk]>,
+}
+
+impl WhereExpression {
+    pub fn new(expression: ExpressionId) -> WhereExpression {
+        WhereExpression { bindings: LetBindings::default(), expression }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum LetBindingChunk {
+    Pattern {
+        source: lowering::LetBindingId,
+        binder: BinderId,
+        where_expression: WhereExpression,
+    },
+    PatternError {
+        source: lowering::LetBindingId,
+        binder_source: Option<lowering::BinderId>,
+        where_expression: Option<WhereExpression>,
+    },
+    Names {
+        declarations: Arc<[LocalDeclarationId]>,
+        groups: Arc<[lowering::Scc<LetBindingNameGroupId>]>,
+    },
 }
 
 impl GuardedExpression {
@@ -214,6 +261,7 @@ pub enum ExpressionKind {
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+    Let { bindings: LetBindings, expression: ExpressionId },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -239,6 +287,18 @@ impl Module {
 
     pub fn lookup_term(&self, source: TermItemId) -> Option<TermDeclarationId> {
         self.terms.get(source).copied()
+    }
+
+    pub fn insert_let(&mut self, declaration: LocalDeclaration) -> LocalDeclarationId {
+        let source = declaration.source;
+        let declaration = self.arena.lets.alloc(declaration);
+        let previous = self.lets.insert(source, declaration);
+        assert!(previous.is_none(), "invariant violated: local declaration inserted twice");
+        declaration
+    }
+
+    pub fn lookup_let(&self, source: LetBindingNameGroupId) -> Option<LocalDeclarationId> {
+        self.lets.get(source).copied()
     }
 
     pub fn insert_type_declaration(
@@ -285,5 +345,13 @@ impl Index<TypeDeclarationId> for Module {
 
     fn index(&self, index: TypeDeclarationId) -> &TypeDeclaration {
         &self.arena.types[index]
+    }
+}
+
+impl Index<LocalDeclarationId> for Module {
+    type Output = LocalDeclaration;
+
+    fn index(&self, index: LocalDeclarationId) -> &LocalDeclaration {
+        &self.arena.lets[index]
     }
 }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -862,6 +862,7 @@ where
     ) -> QueryResult<Doc<'arena>> {
         let expression = &self.checked.tree[expression_id];
         let precedence = match &expression.kind {
+            ExpressionKind::Let { .. } => ExpressionPrecedence::Abstraction,
             ExpressionKind::TermApplication { .. }
             | ExpressionKind::TypeApplication { .. }
             | ExpressionKind::EvidenceApplication { .. } => ExpressionPrecedence::Application,
@@ -1032,6 +1033,9 @@ where
                 )?;
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
+            }
+            ExpressionKind::Let { expression, .. } => {
+                self.expression(*expression, evidence_names, type_pretty)
             }
         }
     }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -20,6 +20,14 @@ use crate::tree::{
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ExpressionPrecedence {
+    Abstraction,
+    Application,
+    RecordUpdate,
+    Atom,
+}
+
 fn character_literal(value: char) -> String {
     match value {
         '\n' => "'\\n'".to_string(),
@@ -837,6 +845,43 @@ where
         evidence_names: &mut EvidenceNames,
         type_pretty: &mut TypePretty<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
+        self.expression_at(
+            expression_id,
+            ExpressionPrecedence::Abstraction,
+            evidence_names,
+            type_pretty,
+        )
+    }
+
+    fn expression_at(
+        &self,
+        expression_id: ExpressionId,
+        required_precedence: ExpressionPrecedence,
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        let expression = &self.checked.tree[expression_id];
+        let precedence = match &expression.kind {
+            ExpressionKind::TermApplication { .. }
+            | ExpressionKind::TypeApplication { .. }
+            | ExpressionKind::EvidenceApplication { .. } => ExpressionPrecedence::Application,
+            _ => ExpressionPrecedence::Atom,
+        };
+        let expression =
+            self.expression_unparenthesized(expression_id, evidence_names, type_pretty)?;
+        if precedence < required_precedence {
+            Ok(self.arena.text("(").append(expression).append(self.arena.text(")")))
+        } else {
+            Ok(expression)
+        }
+    }
+
+    fn expression_unparenthesized(
+        &self,
+        expression_id: ExpressionId,
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
         let expression = &self.checked.tree[expression_id];
         match &expression.kind {
             ExpressionKind::Error => Ok(self.arena.text("<error>")),
@@ -954,26 +999,37 @@ where
                 Ok(self.arena.text(name))
             }
             ExpressionKind::TermApplication { function, argument } => {
-                let function = self.expression(*function, evidence_names, type_pretty)?;
-                let argument_expression = &self.checked.tree[*argument];
-                let argument = self.expression(*argument, evidence_names, type_pretty)?;
-                let argument = match argument_expression.kind {
-                    ExpressionKind::TermApplication { .. }
-                    | ExpressionKind::TypeApplication { .. }
-                    | ExpressionKind::EvidenceApplication { .. } => {
-                        self.arena.text("(").append(argument).append(self.arena.text(")"))
-                    }
-                    _ => argument,
-                };
+                let function = self.expression_at(
+                    *function,
+                    ExpressionPrecedence::Application,
+                    evidence_names,
+                    type_pretty,
+                )?;
+                let argument = self.expression_at(
+                    *argument,
+                    ExpressionPrecedence::RecordUpdate,
+                    evidence_names,
+                    type_pretty,
+                )?;
                 Ok(function.append(self.arena.space()).append(argument))
             }
             ExpressionKind::TypeApplication { function, argument } => {
-                let function = self.expression(*function, evidence_names, type_pretty)?;
+                let function = self.expression_at(
+                    *function,
+                    ExpressionPrecedence::Application,
+                    evidence_names,
+                    type_pretty,
+                )?;
                 let argument = type_pretty.render_atom(*argument);
                 Ok(function.append(self.arena.text(format!(" @{argument}"))))
             }
             ExpressionKind::EvidenceApplication { function, evidence } => {
-                let function = self.expression(*function, evidence_names, type_pretty)?;
+                let function = self.expression_at(
+                    *function,
+                    ExpressionPrecedence::Application,
+                    evidence_names,
+                    type_pretty,
+                )?;
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
             }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -619,36 +619,59 @@ where
             }
         }
         for equation in equations.iter() {
-            let mut expression = self.guarded_expression(
-                &equation.guarded_expression,
-                evidence_names,
-                &mut type_pretty,
-            )?;
+            let has_abstraction = !equation.binders.is_empty() || !evidences.is_empty();
+            let (mut expression, where_bindings) = if let [alternative] =
+                equation.guarded_expression.alternatives.as_ref()
+                && alternative.pattern_guards.is_empty()
+            {
+                let where_expression = &alternative.where_expression;
+                let expression =
+                    self.expression(where_expression.expression, evidence_names, &mut type_pretty)?;
+                let bindings = (!where_expression.bindings.chunks.is_empty())
+                    .then_some(&where_expression.bindings);
+                (expression, bindings)
+            } else {
+                let expression = self.guarded_expression(
+                    &equation.guarded_expression,
+                    evidence_names,
+                    &mut type_pretty,
+                )?;
+                (expression, None)
+            };
 
-            for &binder in equation.binders.iter().rev() {
-                let binder = self.binder(binder)?;
-                expression = self
-                    .arena
-                    .text("\\")
-                    .append(binder)
-                    .append(self.arena.text(" ->"))
-                    .append(self.arena.line().append(expression).nest(2))
-                    .group();
-            }
-            for evidence in evidences.iter().rev() {
+            let mut abstractions = vec![];
+            for evidence in evidences.iter() {
                 let binder = self.evidence_name(evidence_names, evidence)?;
-                expression = self
-                    .arena
-                    .text(format!("\\{{{binder}}} ->"))
-                    .append(self.arena.line().append(expression).nest(2))
-                    .group();
+                abstractions.push(self.arena.text(format!("\\{{{binder}}} ->")));
+            }
+            for &binder in equation.binders.iter() {
+                let binder = self.binder(binder)?;
+                let abstraction =
+                    self.arena.text("\\").append(binder).append(self.arena.text(" ->"));
+                abstractions.push(abstraction);
             }
 
-            let equation = self
-                .arena
-                .text(format!("{prefix}{name} ="))
-                .append(self.arena.line().append(expression).nest(2))
-                .group();
+            let mut abstractions = abstractions.into_iter();
+            if let Some(first) = abstractions.next() {
+                let abstractions = abstractions.fold(first, |document, abstraction| {
+                    document.append(self.arena.softline().append(abstraction).nest(2))
+                });
+                let body = self.arena.line().append(expression).nest(2).group();
+                expression = abstractions.append(body);
+            }
+
+            let mut equation = if has_abstraction {
+                self.arena.text(format!("{prefix}{name} = ")).append(expression)
+            } else {
+                self.arena
+                    .text(format!("{prefix}{name} ="))
+                    .append(self.arena.line().append(expression).nest(2))
+                    .group()
+            };
+            if let Some(bindings) = where_bindings {
+                let where_clause = self.where_clause(bindings, evidence_names, &mut type_pretty)?;
+                equation = equation.append(self.arena.hardline().append(where_clause).nest(2));
+            }
             rendered_equations.push(equation);
         }
 
@@ -742,6 +765,16 @@ where
         Ok(bindings)
     }
 
+    fn where_clause(
+        &self,
+        bindings: &LetBindings,
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        let bindings = self.let_bindings(bindings, evidence_names, type_pretty)?;
+        Ok(self.arena.text("where").append(self.arena.hardline()).append(bindings))
+    }
+
     fn where_expression(
         &self,
         where_expression: &WhereExpression,
@@ -754,9 +787,8 @@ where
             return Ok(expression);
         }
 
-        let bindings =
-            self.let_bindings(&where_expression.bindings, evidence_names, type_pretty)?;
-        let where_clause = self.arena.text("where").append(self.arena.hardline()).append(bindings);
+        let where_clause =
+            self.where_clause(&where_expression.bindings, evidence_names, type_pretty)?;
         Ok(expression.append(self.arena.hardline().append(where_clause).nest(2)))
     }
 

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -756,9 +756,8 @@ where
 
         let bindings =
             self.let_bindings(&where_expression.bindings, evidence_names, type_pretty)?;
-        let where_clause =
-            self.arena.text("where").append(self.arena.hardline().append(bindings).nest(2));
-        Ok(expression.append(self.arena.hardline()).append(where_clause))
+        let where_clause = self.arena.text("where").append(self.arena.hardline()).append(bindings);
+        Ok(expression.append(self.arena.hardline().append(where_clause).nest(2)))
     }
 
     fn guarded_expression(
@@ -1147,8 +1146,8 @@ where
                     .text("let")
                     .append(self.arena.hardline().append(bindings).nest(2))
                     .append(self.arena.hardline())
-                    .append(self.arena.text("in "))
-                    .append(expression))
+                    .append(self.arena.text("in"))
+                    .append(self.arena.hardline().append(expression).nest(2)))
             }
         }
     }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -14,8 +14,9 @@ use crate::core::pretty::{Pretty as TypePretty, PrettyNames, PrettyQueries};
 use crate::evidence::{Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId};
 use crate::tree::{
     BinderId, BinderKind, Equation, ExpressionId, ExpressionKind, GuardedAlternative,
-    GuardedExpression, InstanceDeclaration, PatternGuard, RecordBinderField, RecordExpressionField,
-    TermDeclarationKind, TypeDeclarationKind,
+    GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings, LocalDeclarationId,
+    PatternGuard, RecordBinderField, RecordExpressionField, TermDeclarationKind,
+    TypeDeclarationKind, WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -659,6 +660,107 @@ where
         Ok(Some(equations))
     }
 
+    fn local_declaration(
+        &self,
+        declaration_id: LocalDeclarationId,
+        evidence_names: &mut EvidenceNames,
+    ) -> QueryResult<Doc<'arena>> {
+        let declaration = &self.checked.tree[declaration_id];
+        let name = self.local_declaration_name(declaration.source);
+        let mut type_pretty = TypePretty::new(self.queries, self.checked)
+            .without_rigid_kinds()
+            .without_forall_kinds()
+            .width(self.width);
+        let type_id = type_pretty.render(declaration.type_id);
+        let signature = self.arena.text(format!("{name} :: {type_id}"));
+
+        for evidence in declaration.value.evidences.iter() {
+            if let Evidence::Given(binder) = evidence {
+                self.evidence_binder_name(evidence_names, *binder)?;
+            }
+        }
+
+        let equations = self.equation_declarations(
+            &name,
+            "",
+            &declaration.value.evidences,
+            &declaration.value.equations,
+            evidence_names,
+            &[],
+        )?;
+        let equations = equations.unwrap_or_else(|| self.arena.text(format!("{name} = <error>")));
+        Ok(signature.append(self.arena.hardline()).append(equations))
+    }
+
+    fn let_bindings(
+        &self,
+        bindings: &LetBindings,
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        let mut rendered = vec![];
+        for chunk in bindings.chunks.iter() {
+            match chunk {
+                LetBindingChunk::Pattern { binder, where_expression, .. } => {
+                    let binder = self.binder(*binder)?;
+                    let expression =
+                        self.where_expression(where_expression, evidence_names, type_pretty)?;
+                    rendered.push(
+                        binder
+                            .append(self.arena.text(" ="))
+                            .append(self.arena.line().append(expression).nest(2))
+                            .group(),
+                    );
+                }
+                LetBindingChunk::PatternError { where_expression, .. } => {
+                    if let Some(where_expression) = where_expression {
+                        let expression =
+                            self.where_expression(where_expression, evidence_names, type_pretty)?;
+                        rendered.push(
+                            self.arena
+                                .text("<error> =")
+                                .append(self.arena.line().append(expression).nest(2))
+                                .group(),
+                        );
+                    } else {
+                        rendered.push(self.arena.text("<error-binding>"));
+                    }
+                }
+                LetBindingChunk::Names { declarations, .. } => {
+                    for &declaration in declarations.iter() {
+                        rendered.push(self.local_declaration(declaration, evidence_names)?);
+                    }
+                }
+            }
+        }
+
+        let mut rendered = rendered.into_iter();
+        let Some(first) = rendered.next() else { return Ok(self.arena.text("<error-binding>")) };
+        let bindings = rendered.fold(first, |document, binding| {
+            document.append(self.arena.hardline()).append(binding)
+        });
+        Ok(bindings)
+    }
+
+    fn where_expression(
+        &self,
+        where_expression: &WhereExpression,
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        let expression =
+            self.expression(where_expression.expression, evidence_names, type_pretty)?;
+        if where_expression.bindings.chunks.is_empty() {
+            return Ok(expression);
+        }
+
+        let bindings =
+            self.let_bindings(&where_expression.bindings, evidence_names, type_pretty)?;
+        let where_clause =
+            self.arena.text("where").append(self.arena.hardline().append(bindings).nest(2));
+        Ok(expression.append(self.arena.hardline()).append(where_clause))
+    }
+
     fn guarded_expression(
         &self,
         guarded: &GuardedExpression,
@@ -668,8 +770,8 @@ where
         if let [alternative] = guarded.alternatives.as_ref()
             && alternative.pattern_guards.is_empty()
         {
-            return self.expression(
-                alternative.where_expression.expression,
+            return self.where_expression(
+                &alternative.where_expression,
                 evidence_names,
                 type_pretty,
             );
@@ -706,7 +808,7 @@ where
         }
 
         let expression =
-            self.expression(alternative.where_expression.expression, evidence_names, type_pretty)?;
+            self.where_expression(&alternative.where_expression, evidence_names, type_pretty)?;
         let mut pattern_guards = pattern_guards.into_iter();
         let Some(first) = pattern_guards.next() else {
             return Ok(self.arena.text("| -> ").append(expression));
@@ -964,39 +1066,42 @@ where
             }
             ExpressionKind::Variable { resolution }
             | ExpressionKind::RecordPun { resolution, .. } => {
-                let name = match *resolution {
-                    TermVariableResolution::Binder(binder) => {
-                        let kind =
-                            self.lowered.info.get_binder_kind(binder).expect(
+                let name =
+                    match *resolution {
+                        TermVariableResolution::Binder(binder) => {
+                            let kind = self.lowered.info.get_binder_kind(binder).expect(
                                 "invariant violated: variable expression binder is missing",
                             );
-                        match kind {
-                            lowering::BinderKind::Variable { variable: Some(variable) } => {
-                                variable.to_string()
-                            }
-                            lowering::BinderKind::Named { named: Some(named), .. } => {
-                                named.to_string()
-                            }
-                            _ => {
-                                let index = binder.into_raw().get();
-                                format!("<binder#{index}>")
+                            match kind {
+                                lowering::BinderKind::Variable { variable: Some(variable) } => {
+                                    variable.to_string()
+                                }
+                                lowering::BinderKind::Named { named: Some(named), .. } => {
+                                    named.to_string()
+                                }
+                                _ => {
+                                    let index = binder.into_raw().get();
+                                    format!("<binder#{index}>")
+                                }
                             }
                         }
-                    }
-                    TermVariableResolution::Reference(file_id, term_id) => {
-                        self.term_name(file_id, term_id)?.unwrap_or_else(|| "?".to_string())
-                    }
-                    TermVariableResolution::Let(let_binding) => {
-                        let index = let_binding.into_raw().into_u32();
-                        format!("<let#{index}>")
-                    }
-                    TermVariableResolution::RecordPun(record_pun) => {
-                        self.record_pun_name(record_pun).unwrap_or_else(|| {
-                            let index = record_pun.into_raw().get();
-                            format!("<pun#{index}>")
-                        })
-                    }
-                };
+                        TermVariableResolution::Reference(file_id, term_id) => {
+                            self.term_name(file_id, term_id)?.unwrap_or_else(|| "?".to_string())
+                        }
+                        TermVariableResolution::Let(let_binding) => {
+                            let declaration = self.checked.tree.lookup_let(let_binding).expect(
+                                "invariant violated: local variable declaration is missing",
+                            );
+                            let declaration = &self.checked.tree[declaration];
+                            self.local_declaration_name(declaration.source)
+                        }
+                        TermVariableResolution::RecordPun(record_pun) => {
+                            self.record_pun_name(record_pun).unwrap_or_else(|| {
+                                let index = record_pun.into_raw().get();
+                                format!("<pun#{index}>")
+                            })
+                        }
+                    };
                 Ok(self.arena.text(name))
             }
             ExpressionKind::TermApplication { function, argument } => {
@@ -1034,8 +1139,16 @@ where
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
             }
-            ExpressionKind::Let { expression, .. } => {
-                self.expression(*expression, evidence_names, type_pretty)
+            ExpressionKind::Let { bindings, expression } => {
+                let bindings = self.let_bindings(bindings, evidence_names, type_pretty)?;
+                let expression = self.expression(*expression, evidence_names, type_pretty)?;
+                Ok(self
+                    .arena
+                    .text("let")
+                    .append(self.arena.hardline().append(bindings).nest(2))
+                    .append(self.arena.hardline())
+                    .append(self.arena.text("in "))
+                    .append(expression))
             }
         }
     }
@@ -1132,6 +1245,14 @@ where
                 };
                 if *id == record_pun { name.as_ref().map(ToString::to_string) } else { None }
             })
+        })
+    }
+
+    fn local_declaration_name(&self, source: lowering::LetBindingNameGroupId) -> String {
+        let group = self.lowered.info.get_let_binding_group(source);
+        group.name.as_ref().map(ToString::to_string).unwrap_or_else(|| {
+            let index = source.into_raw().into_u32();
+            format!("<let#{index}>")
         })
     }
 

--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -694,11 +694,12 @@ fn lower_pattern_chunk(
     let cst::LetBinding::LetBindingPattern(pattern) = &pattern else {
         unreachable!("invariant violated: expected LetBindingPattern");
     };
+    let source = context.stabilized.lookup_cst(pattern).expect_id();
     let where_expression =
         pattern.where_expression().map(|cst| lower_where_expression(state, context, &cst));
     state.push_binder_scope();
     let binder = pattern.binder().map(|cst| lower_binder(state, context, &cst));
-    LetBindingChunk::Pattern { binder, where_expression }
+    LetBindingChunk::Pattern { source, binder, where_expression }
 }
 
 struct PendingLetBinding {
@@ -767,12 +768,12 @@ fn lower_equation_chunk(
     let mut groups = vec![];
 
     for PendingLetBinding { name, signature, equations } in pending {
-        let group = LetBindingNameGroup { signature, equations };
+        let group = LetBindingNameGroup { name: name.clone(), signature, equations };
 
         let id = state.alloc_let_binding(group);
 
-        if let Some(ref name) = name {
-            let_bound.insert(name.clone(), id);
+        if let Some(name) = name {
+            let_bound.insert(name, id);
         }
 
         groups.push(id);

--- a/compiler-core/lowering/src/intermediate.rs
+++ b/compiler-core/lowering/src/intermediate.rs
@@ -233,6 +233,7 @@ pub struct WhereExpression {
 /// value declarations, where the declaration group is assigned a stable ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LetBindingNameGroup {
+    pub name: Option<SmolStr>,
     pub signature: Option<LetBindingSignatureId>,
     pub equations: Arc<[LetBindingEquationId]>,
 }
@@ -256,7 +257,11 @@ pub struct LetBindingName {
 #[derive(Debug, PartialEq, Eq)]
 pub enum LetBindingChunk {
     /// Pattern binding (acts as boundary between name binding groups)
-    Pattern { binder: Option<BinderId>, where_expression: Option<WhereExpression> },
+    Pattern {
+        source: LetBindingId,
+        binder: Option<BinderId>,
+        where_expression: Option<WhereExpression>,
+    },
     /// Group of name bindings with SCC ordering for type checking
     Names { bindings: Arc<[LetBindingNameGroupId]>, scc: Vec<Scc<LetBindingNameGroupId>> },
 }

--- a/tests-integration/fixtures/semantic/1784704260_guarded_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_guarded_expressions/Main.snap
@@ -9,8 +9,6 @@ data Maybe @a
   | Nothing :: Maybe a
 
 recover :: forall a. a -> Maybe a -> a
-recover =
-  \fallback ->
-    \input ->
-      | (Just value) <- input -> value
-      | true -> fallback
+recover = \fallback -> \input ->
+  | (Just value) <- input -> value
+  | true -> fallback

--- a/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
@@ -10,6 +10,5 @@ interface Second :: Type -> Constraint
 interface Second a where
 
 applyInterleaved :: forall a b. First a => Second b => a -> b -> a
-applyInterleaved =
-  \{firstDict} ->
-    \{secondDict} -> \first -> \second -> interleaved @a {firstDict} first @b {secondDict} second
+applyInterleaved = \{firstDict} -> \{secondDict} -> \first -> \second ->
+  interleaved @a {firstDict} first @b {secondDict} second

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
@@ -13,12 +13,12 @@ interface Capability :: (Type -> Type) -> Constraint
 interface Capability m where
 
 inferredPun :: forall t t1. First t => Second t1 => { interleaved :: t -> t1 }
-inferredPun =
-  \{firstDict} -> \{secondDict} -> { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
+inferredPun = \{firstDict} -> \{secondDict} ->
+  { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
 
 inferredExplicit :: forall t t1. First t => Second t1 => { interleaved :: t -> t1 }
-inferredExplicit =
-  \{firstDict} -> \{secondDict} -> { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
+inferredExplicit = \{firstDict} -> \{secondDict} ->
+  { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
 
 aliased :: Alias
 aliased = 1

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
@@ -28,6 +28,5 @@ rightAssociative :: Int
 rightAssociative = append 1 (append 2 3)
 
 implicitApplications :: forall a b. First a => Second b => a -> b -> a
-implicitApplications =
-  \{firstDict} ->
-    \{secondDict} -> \left -> \right -> interleaved @a {firstDict} left @b {secondDict} right
+implicitApplications = \{firstDict} -> \{secondDict} -> \left -> \right ->
+  interleaved @a {firstDict} left @b {secondDict} right

--- a/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.purs
+++ b/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.purs
@@ -1,0 +1,23 @@
+module Main where
+
+data Identity a = Identity a
+
+letBinding :: forall a. a -> a
+letBinding value =
+  let
+    local = value
+  in
+    local
+
+whereBinding :: forall a. a -> a
+whereBinding value = local
+  where
+  local :: a
+  local = value
+
+unIdentity :: forall a. Identity a -> a
+unIdentity value =
+  let
+    Identity inner = value
+  in
+    inner

--- a/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
+++ b/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Identity :: Type -> Type
+data Identity @a
+  | Identity :: a -> Identity a
+
+letBinding :: forall a. a -> a
+letBinding =
+  \value ->
+    let
+      local :: a
+      local = value
+    in
+      local
+
+whereBinding :: forall a. a -> a
+whereBinding =
+  \value ->
+    local
+      where
+      local :: a
+      local = value
+
+unIdentity :: forall a. Identity a -> a
+unIdentity =
+  \value ->
+    let
+      (Identity inner) = value
+    in
+      inner

--- a/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
+++ b/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
@@ -8,26 +8,22 @@ data Identity @a
   | Identity :: a -> Identity a
 
 letBinding :: forall a. a -> a
-letBinding =
-  \value ->
-    let
-      local :: a
-      local = value
-    in
-      local
+letBinding = \value ->
+  let
+    local :: a
+    local = value
+  in
+    local
 
 whereBinding :: forall a. a -> a
-whereBinding =
-  \value ->
-    local
-      where
-      local :: a
-      local = value
+whereBinding = \value -> local
+  where
+  local :: a
+  local = value
 
 unIdentity :: forall a. Identity a -> a
-unIdentity =
-  \value ->
-    let
-      (Identity inner) = value
-    in
-      inner
+unIdentity = \value ->
+  let
+    (Identity inner) = value
+  in
+    inner

--- a/tests-integration/fixtures/semantic/1784821260_lambda_abstraction_wrapping/Main.purs
+++ b/tests-integration/fixtures/semantic/1784821260_lambda_abstraction_wrapping/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+wrap :: forall a. a -> a -> a -> a -> a -> a -> a
+wrap firstArgument secondArgument thirdArgument fourthArgument fifthArgument sixthArgument =
+  firstArgument

--- a/tests-integration/fixtures/semantic/1784821260_lambda_abstraction_wrapping/Main.snap
+++ b/tests-integration/fixtures/semantic/1784821260_lambda_abstraction_wrapping/Main.snap
@@ -1,0 +1,11 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall a. a -> a
+identity = \value -> value
+
+wrap :: forall a. a -> a -> a -> a -> a -> a -> a
+wrap = \firstArgument -> \secondArgument -> \thirdArgument -> \fourthArgument -> \fifthArgument ->
+  \sixthArgument -> firstArgument


### PR DESCRIPTION
## Summary

Local let declarations were checked but not retained as owned semantic-tree structure. This left `let/in` and `where` expressions pointing only at their checked bodies, while local declaration provenance, equations, pattern bindings, and lexical ordering remained available only through lowering or checker side tables.

This change:

- gives local name groups and pattern bindings stable lowering provenance;
- arena-allocates completed local declarations and indexes them by `lowering::LetBindingNameGroupId`;
- retains lexical let chunks on checked `let/in` and `where` expressions while preserving lowering SCC metadata for dependency information;
- stores checked named equations, pattern binders, recovery chunks, and the post-instantiation pattern RHS;
- zonks local declaration types through the semantic tree;
- prints retained lets, where clauses, patterns, and local references with width-aware abstraction formatting.

The semantic tree owns completed local declarations once. Recursive checking continues to use the existing preallocated local type markers, avoiding partially initialized semantic declarations.

## Validation

- `cargo check -p checking --tests`
- `just t checking`
- `just t semantic`
- focused semantic fixtures for named `let/in`, `where`, constructor-pattern bindings, short abstractions, and width-dependent abstraction wrapping