### PR TITLE
[checking] Retain checked case expressions in the semantic tree

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -215,8 +215,7 @@ where
             Ok(allocate_error_expression(state, type_id))
         }
         lowering::ExpressionKind::CaseOf { trunk, branches } => {
-            let type_id = forms::check_case_of(state, context, trunk, branches, expected)?;
-            Ok(allocate_error_expression(state, type_id))
+            forms::check_case_of(state, context, trunk, branches, expected)
         }
         lowering::ExpressionKind::OperatorChain { .. } => {
             let (checked, checked_type) =
@@ -386,8 +385,7 @@ where
         }
 
         lowering::ExpressionKind::CaseOf { trunk, branches } => {
-            let type_id = forms::infer_case_of(state, context, trunk, branches)?;
-            Ok(allocate_error_expression(state, type_id))
+            forms::infer_case_of(state, context, trunk, branches)
         }
 
         lowering::ExpressionKind::Do { bind, discard, statements } => {

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -1,11 +1,11 @@
 use building_types::QueryResult;
 
-use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, exhaustive, toolkit, unification};
 use crate::source::binder;
-use crate::source::terms::{application, guarded};
+use crate::source::terms::{ElaboratedExpression, application, guarded};
 use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
 
 #[derive(Copy, Clone, Debug)]
 enum IfThenElseMode {
@@ -189,7 +189,7 @@ pub fn infer_case_of<Q>(
     context: &CheckContext<Q>,
     trunk: &[lowering::ExpressionId],
     branches: &[lowering::CaseBranch],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -202,7 +202,7 @@ pub fn check_case_of<Q>(
     trunk: &[lowering::ExpressionId],
     branches: &[lowering::CaseBranch],
     expected: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -215,7 +215,7 @@ fn case_of_core<Q>(
     trunk: &[lowering::ExpressionId],
     branches: &[lowering::CaseBranch],
     mode: CaseOfMode,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -224,30 +224,44 @@ where
         CaseOfMode::Check { expected } => expected,
     };
 
+    let mut scrutinees = vec![];
     let mut trunk_types = vec![];
-    for trunk in trunk.iter() {
-        let trunk = super::infer_expression(state, context, *trunk)?;
-        let trunk = application::instantiate_expression(state, context, trunk)?;
-        trunk_types.push(trunk.type_id);
+    for &scrutinee_id in trunk.iter() {
+        let scrutinee = super::infer_expression(state, context, scrutinee_id)?;
+        let scrutinee = application::instantiate_expression(state, context, scrutinee)?;
+        trunk_types.push(scrutinee.type_id);
+        scrutinees.push(scrutinee.expression);
     }
 
     instantiate_trunk_types(state, context, &mut trunk_types, branches)?;
 
+    let mut alternatives = vec![];
     for branch in branches.iter() {
-        for (binder, trunk) in branch.binders.iter().zip(&trunk_types) {
-            binder::check_binder(state, context, *binder, *trunk)?;
+        let mut binders = vec![];
+        for (&binder_id, &trunk_type) in branch.binders.iter().zip(&trunk_types) {
+            let checked_binder = binder::check_binder(state, context, binder_id, trunk_type)?;
+            binders.push(checked_binder.binder);
         }
-        if let Some(guarded) = &branch.guarded_expression {
+
+        let guarded_expression = if let Some(guarded_source) = &branch.guarded_expression {
             match mode {
                 CaseOfMode::Infer => {
-                    let guarded = guarded::infer_guarded_expression(state, context, guarded)?;
-                    unification::subtype(state, context, guarded.type_id, expected)?;
+                    let checked_guarded =
+                        guarded::infer_guarded_expression(state, context, guarded_source)?;
+                    unification::subtype(state, context, checked_guarded.type_id, expected)?;
+                    checked_guarded.guarded_expression
                 }
                 CaseOfMode::Check { .. } => {
-                    guarded::check_guarded_expression(state, context, guarded, expected)?;
+                    guarded::check_guarded_expression(state, context, guarded_source, expected)?
+                        .guarded_expression
                 }
             }
-        }
+        } else {
+            let expression = state.allocate_error_expression(expected);
+            let where_expression = tree::WhereExpression::new(expression);
+            tree::GuardedExpression::unconditional(where_expression)
+        };
+        alternatives.push(tree::CaseAlternative { binders: binders.into(), guarded_expression });
     }
 
     let exhaustiveness = exhaustive::check_case_patterns(state, context, &trunk_types, branches)?;
@@ -255,13 +269,20 @@ where
     let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);
 
+    let kind = tree::ExpressionKind::Case {
+        scrutinees: scrutinees.into(),
+        alternatives: alternatives.into(),
+    };
+
     if has_missing {
         if let CaseOfMode::Infer = mode {
-            return Ok(context.intern_constrained(context.prim.partial, expected));
+            let result_type = context.intern_constrained(context.prim.partial, expected);
+            Ok(super::allocate_expression(state, result_type, kind))
         } else {
             state.push_wanted(context.prim.partial);
+            Ok(super::allocate_expression(state, expected, kind))
         }
+    } else {
+        Ok(super::allocate_expression(state, expected, kind))
     }
-
-    Ok(expected)
 }

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -204,6 +204,12 @@ pub struct GuardedAlternative {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct CaseAlternative {
+    pub binders: Arc<[BinderId]>,
+    pub guarded_expression: GuardedExpression,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum PatternGuard {
     Boolean { expression: ExpressionId },
     Pattern { binder: BinderId, expression: ExpressionId },
@@ -303,6 +309,7 @@ pub enum ExpressionKind {
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+    Case { scrutinees: Arc<[ExpressionId]>, alternatives: Arc<[CaseAlternative]> },
     Let { bindings: LetBindings, expression: ExpressionId },
 }
 

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -13,10 +13,10 @@ use crate::core::Type;
 use crate::core::pretty::{Pretty as TypePretty, PrettyNames, PrettyQueries};
 use crate::evidence::{Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId};
 use crate::tree::{
-    BinderId, BinderKind, Equation, ExpressionId, ExpressionKind, GuardedAlternative,
-    GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings, LocalDeclarationId,
-    PatternGuard, RecordBinderField, RecordExpressionField, TermDeclarationKind,
-    TypeDeclarationKind, WhereExpression,
+    BinderId, BinderKind, CaseAlternative, Equation, ExpressionId, ExpressionKind,
+    GuardedAlternative, GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings,
+    LocalDeclarationId, PatternGuard, RecordBinderField, RecordExpressionField,
+    TermDeclarationKind, TypeDeclarationKind, WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -620,7 +620,7 @@ where
         }
         for equation in equations.iter() {
             let has_abstraction = !equation.binders.is_empty() || !evidences.is_empty();
-            let (mut expression, where_bindings) = if let [alternative] =
+            let (mut expression, where_bindings, force_body_break) = if let [alternative] =
                 equation.guarded_expression.alternatives.as_ref()
                 && alternative.pattern_guards.is_empty()
             {
@@ -629,14 +629,16 @@ where
                     self.expression(where_expression.expression, evidence_names, &mut type_pretty)?;
                 let bindings = (!where_expression.bindings.chunks.is_empty())
                     .then_some(&where_expression.bindings);
-                (expression, bindings)
+                let force_body_break =
+                    self.expression_requires_body_break(where_expression.expression);
+                (expression, bindings, force_body_break)
             } else {
                 let expression = self.guarded_expression(
                     &equation.guarded_expression,
                     evidence_names,
                     &mut type_pretty,
                 )?;
-                (expression, None)
+                (expression, None, false)
             };
 
             let mut abstractions = vec![];
@@ -656,12 +658,20 @@ where
                 let abstractions = abstractions.fold(first, |document, abstraction| {
                     document.append(self.arena.softline().append(abstraction).nest(2))
                 });
-                let body = self.arena.line().append(expression).nest(2).group();
+                let body = if force_body_break {
+                    self.arena.hardline().append(expression).nest(2)
+                } else {
+                    self.arena.line().append(expression).nest(2).group()
+                };
                 expression = abstractions.append(body);
             }
 
             let mut equation = if has_abstraction {
                 self.arena.text(format!("{prefix}{name} = ")).append(expression)
+            } else if force_body_break {
+                self.arena
+                    .text(format!("{prefix}{name} ="))
+                    .append(self.arena.hardline().append(expression).nest(2))
             } else {
                 self.arena
                     .text(format!("{prefix}{name} ="))
@@ -838,21 +848,26 @@ where
             pattern_guards.push(self.pattern_guard(pattern_guard, evidence_names, type_pretty)?);
         }
 
-        let expression =
-            self.where_expression(&alternative.where_expression, evidence_names, type_pretty)?;
+        let where_expression = &alternative.where_expression;
+        let expression = self.where_expression(where_expression, evidence_names, type_pretty)?;
         let mut pattern_guards = pattern_guards.into_iter();
         let Some(first) = pattern_guards.next() else {
-            return Ok(self.arena.text("| -> ").append(expression));
+            let alternative = self.arena.text("| ->");
+            if self.expression_requires_body_break(where_expression.expression) {
+                return Ok(alternative.append(self.arena.hardline().append(expression).nest(2)));
+            }
+            return Ok(alternative.append(self.arena.space()).append(expression));
         };
         let pattern_guards = pattern_guards.fold(first, |document, pattern_guard| {
             document.append(self.arena.text(", ")).append(pattern_guard)
         });
-        let alternative = self
-            .arena
-            .text("| ")
-            .append(pattern_guards)
-            .append(self.arena.text(" -> "))
-            .append(expression);
+        let alternative =
+            self.arena.text("| ").append(pattern_guards).append(self.arena.text(" ->"));
+        let alternative = if self.expression_requires_body_break(where_expression.expression) {
+            alternative.append(self.arena.hardline().append(expression).nest(2))
+        } else {
+            alternative.append(self.arena.space()).append(expression)
+        };
         Ok(alternative)
     }
 
@@ -872,6 +887,97 @@ where
                 Ok(binder.append(self.arena.text(" <- ")).append(expression))
             }
         }
+    }
+
+    fn case_expression(
+        &self,
+        scrutinees: &[ExpressionId],
+        alternatives: &[CaseAlternative],
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        let mut rendered_scrutinees = vec![];
+        for &scrutinee in scrutinees {
+            rendered_scrutinees.push(self.expression(scrutinee, evidence_names, type_pretty)?);
+        }
+
+        let mut rendered_scrutinees = rendered_scrutinees.into_iter();
+        let scrutinees = if let Some(first) = rendered_scrutinees.next() {
+            rendered_scrutinees.fold(first, |document, scrutinee| {
+                document.append(self.arena.text(", ")).append(scrutinee)
+            })
+        } else {
+            self.arena.text("<error>")
+        };
+        let header = self.arena.text("case ").append(scrutinees.group()).append(" of");
+
+        let mut rendered_alternatives = vec![];
+        for alternative in alternatives {
+            rendered_alternatives.push(self.case_alternative(
+                alternative,
+                evidence_names,
+                type_pretty,
+            )?);
+        }
+
+        let mut rendered_alternatives = rendered_alternatives.into_iter();
+        let alternatives = if let Some(first) = rendered_alternatives.next() {
+            rendered_alternatives.fold(first, |document, alternative| {
+                document.append(self.arena.hardline()).append(alternative)
+            })
+        } else {
+            self.arena.text("<error>")
+        };
+        Ok(header.append(self.arena.hardline().append(alternatives).nest(2)))
+    }
+
+    fn case_alternative(
+        &self,
+        alternative: &CaseAlternative,
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        let mut rendered_binders = vec![];
+        for &binder in alternative.binders.iter() {
+            rendered_binders.push(self.binder(binder)?);
+        }
+
+        let mut rendered_binders = rendered_binders.into_iter();
+        let binders = if let Some(first) = rendered_binders.next() {
+            rendered_binders.fold(first, |document, binder| {
+                document.append(self.arena.text(", ")).append(binder)
+            })
+        } else {
+            self.arena.text("<error>")
+        };
+        let binders = binders.group();
+
+        if let [guarded] = alternative.guarded_expression.alternatives.as_ref()
+            && guarded.pattern_guards.is_empty()
+        {
+            let expression =
+                self.where_expression(&guarded.where_expression, evidence_names, type_pretty)?;
+            let alternative = binders.append(self.arena.text(" ->"));
+            if self.expression_requires_body_break(guarded.where_expression.expression) {
+                return Ok(alternative.append(self.arena.hardline().append(expression).nest(2)));
+            }
+            return Ok(alternative.append(self.arena.space()).append(expression));
+        }
+
+        let guarded_expression =
+            self.guarded_expression(&alternative.guarded_expression, evidence_names, type_pretty)?;
+        Ok(binders.append(self.arena.hardline().append(guarded_expression).nest(2)))
+    }
+
+    fn expression_requires_body_break(&self, expression_id: ExpressionId) -> bool {
+        matches!(&self.checked.tree[expression_id].kind, ExpressionKind::Case { .. })
+    }
+
+    fn expression_is_block_argument(&self, expression_id: ExpressionId) -> bool {
+        matches!(
+            &self.checked.tree[expression_id].kind,
+            ExpressionKind::Case { .. } | ExpressionKind::Let { .. }
+        )
     }
 
     fn binder(&self, binder_id: BinderId) -> QueryResult<Doc<'arena>> {
@@ -995,7 +1101,9 @@ where
     ) -> QueryResult<Doc<'arena>> {
         let expression = &self.checked.tree[expression_id];
         let precedence = match &expression.kind {
-            ExpressionKind::Let { .. } => ExpressionPrecedence::Abstraction,
+            ExpressionKind::Case { .. } | ExpressionKind::Let { .. } => {
+                ExpressionPrecedence::Abstraction
+            }
             ExpressionKind::TermApplication { .. }
             | ExpressionKind::TypeApplication { .. }
             | ExpressionKind::EvidenceApplication { .. } => ExpressionPrecedence::Application,
@@ -1142,9 +1250,14 @@ where
                     evidence_names,
                     type_pretty,
                 )?;
+                let argument_precedence = if self.expression_is_block_argument(*argument) {
+                    ExpressionPrecedence::Abstraction
+                } else {
+                    ExpressionPrecedence::RecordUpdate
+                };
                 let argument = self.expression_at(
                     *argument,
-                    ExpressionPrecedence::RecordUpdate,
+                    argument_precedence,
                     evidence_names,
                     type_pretty,
                 )?;
@@ -1169,6 +1282,9 @@ where
                 )?;
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
+            }
+            ExpressionKind::Case { scrutinees, alternatives } => {
+                self.case_expression(scrutinees, alternatives, evidence_names, type_pretty)
             }
             ExpressionKind::Let { bindings, expression } => {
                 let bindings = self.let_bindings(bindings, evidence_names, type_pretty)?;

--- a/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.purs
@@ -1,0 +1,27 @@
+module Main where
+
+data Choice a = Empty | One a | Pair a a
+
+checked :: Choice Int -> Int
+checked choice =
+  case choice of
+    Empty -> 0
+    One value -> value
+    Pair left _ -> left
+
+inferred choice =
+  case choice of
+    Empty -> 0
+    One value -> value
+    Pair left _ -> left
+
+multiple first second =
+  case first, second of
+    One left, One _ -> left
+    Pair left _, _ -> left
+    _, One right -> right
+    _, _ -> 0
+
+partial choice =
+  case choice of
+    One value -> value

--- a/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Choice :: Type -> Type
+data Choice @a
+  | Empty :: Choice a
+  | One :: a -> Choice a
+  | Pair :: a -> a -> Choice a
+
+checked :: Choice Int -> Int
+checked = \choice ->
+  case choice of
+    Empty -> 0
+    (One value) -> value
+    (Pair left _) -> left
+
+inferred :: Choice Int -> Int
+inferred = \choice ->
+  case choice of
+    Empty -> 0
+    (One value) -> value
+    (Pair left _) -> left
+
+multiple :: Choice Int -> Choice Int -> Int
+multiple = \first -> \second ->
+  case first, second of
+    (One left), (One _) -> left
+    (Pair left _), _ -> left
+    _, (One right) -> right
+    _, _ -> 0
+
+partial :: forall t. Partial => Choice t -> t
+partial = \{trivial} -> \choice ->
+  case choice of
+    (One value) -> value

--- a/tests-integration/fixtures/semantic/1784825100_guarded_case_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784825100_guarded_case_expressions/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+data Choice a = Empty | One a | Pair a a
+
+guarded condition choice =
+  case choice of
+    One nested
+      | condition, One value <- nested -> value
+    Pair left right
+      | One value <- left -> value
+      | One value <- right -> value
+    _ -> 0
+
+withWhere choice =
+  case choice of
+    One value -> local
+      where
+      local = value
+    _ -> 0

--- a/tests-integration/fixtures/semantic/1784825100_guarded_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825100_guarded_case_expressions/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Choice :: Type -> Type
+data Choice @a
+  | Empty :: Choice a
+  | One :: a -> Choice a
+  | Pair :: a -> a -> Choice a
+
+guarded :: Boolean -> Choice (Choice Int) -> Int
+guarded = \condition -> \choice ->
+  case choice of
+    (One nested)
+      | condition, (One value) <- nested -> value
+    (Pair left right)
+      | (One value) <- left -> value
+      | (One value) <- right -> value
+    _ -> 0
+
+withWhere :: Choice Int -> Int
+withWhere = \choice ->
+  case choice of
+    (One value) -> local
+      where
+      local :: Int
+      local = value
+    _ -> 0

--- a/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+data Choice a = Empty | One a | Pair a a
+
+identity :: forall a. a -> a
+identity value = value
+
+nested choice =
+  case choice of
+    One inner ->
+      case inner of
+        One value -> value
+        Pair left _ -> left
+        _ -> 0
+    _ -> 0
+
+applied choice = identity case choice of
+  One value -> value
+  _ -> 0

--- a/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Choice :: Type -> Type
+data Choice @a
+  | Empty :: Choice a
+  | One :: a -> Choice a
+  | Pair :: a -> a -> Choice a
+
+identity :: forall a. a -> a
+identity = \value -> value
+
+nested :: Choice (Choice Int) -> Int
+nested = \choice ->
+  case choice of
+    (One inner) ->
+      case inner of
+        (One value) -> value
+        (Pair left _) -> left
+        _ -> 0
+    _ -> 0
+
+applied :: Choice Int -> Int
+applied = \choice ->
+  identity @Int case choice of
+    (One value) -> value
+    _ -> 0

--- a/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+missingScrutinee = case of
+  _ -> true
+
+mismatchedBinders first second = case first, second of
+  _ -> true
+
+missingResult value = case value of
+  _ ->
+
+missingGuardResult value = case value of
+  _ | true ->
+
+missingBranchBody value = case value of
+  _

--- a/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+missingScrutinee :: Boolean
+missingScrutinee =
+  case <error> of
+    <error> -> true
+
+mismatchedBinders :: forall t t1. t -> t1 -> Boolean
+mismatchedBinders = \first -> \second ->
+  case first, second of
+    _ -> true
+
+missingResult :: forall t t1. t -> t1
+missingResult = \value ->
+  case value of
+    _ -> <error>
+
+missingGuardResult :: forall t t1. t -> t1
+missingGuardResult = \value ->
+  case value of
+    _
+      | true -> <error>
+
+missingBranchBody :: forall t t1. t -> t1
+missingBranchBody = \value ->
+  case value of
+    _ -> <error>


### PR DESCRIPTION
## Summary

Case expressions are fully type checked today, but their checked structure is discarded and represented by an error expression. This change retains that structure so downstream semantic consumers can inspect the instantiated scrutinees, checked branch binders, guards, branch-local bindings, and result expressions.

- add checked case alternatives and case expression nodes to the semantic tree
- return retained case expressions from both inference and checking while preserving existing exhaustiveness and `Partial` behavior
- print cases with block-argument precedence and forced line breaks for direct case bodies
- cover checked, inferred, multi-scrutinee, guarded, nested, partial, block-argument, and malformed cases with semantic fixtures

## Validation

- `just format`
- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo check -p tests-integration --tests`
- `cargo nextest run -p checking`
- `just t semantic`
- `just t checking`
- `git diff --check`