### PR TITLE
Retain checked lambda expressions in the semantic tree

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -207,8 +207,7 @@ where
 
     match kind {
         lowering::ExpressionKind::Lambda { binders, expression } => {
-            let type_id = forms::check_lambda(state, context, binders, *expression, expected)?;
-            Ok(allocate_error_expression(state, type_id))
+            forms::check_lambda(state, context, binders, *expression, expected)
         }
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
             let type_id = forms::check_if_then_else(state, context, *if_, *then, *else_, expected)?;
@@ -380,8 +379,7 @@ where
         }
 
         lowering::ExpressionKind::Lambda { binders, expression } => {
-            let type_id = forms::infer_lambda(state, context, binders, *expression)?;
-            Ok(allocate_error_expression(state, type_id))
+            forms::infer_lambda(state, context, binders, *expression)
         }
 
         lowering::ExpressionKind::CaseOf { trunk, branches } => {

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -82,26 +82,30 @@ pub fn infer_lambda<Q>(
     context: &CheckContext<Q>,
     binders: &[lowering::BinderId],
     expression: Option<lowering::ExpressionId>,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
     let mut argument_types = vec![];
+    let mut checked_binders = vec![];
 
     for &binder_id in binders.iter() {
         let argument_type = state.fresh_unification(context.queries, context.prim.t);
-        binder::check_binder(state, context, binder_id, argument_type)?;
+        let checked_binder = binder::check_binder(state, context, binder_id, argument_type)?;
         argument_types.push(argument_type);
+        checked_binders.push(checked_binder.binder);
     }
 
-    let result_type = if let Some(body) = expression {
+    let body = if let Some(body) = expression {
         let body = super::infer_expression(state, context, body)?;
-        application::instantiate_expression(state, context, body)?.type_id
+        application::instantiate_expression(state, context, body)?
     } else {
-        state.fresh_unification(context.queries, context.prim.t)
+        let type_id = state.fresh_unification(context.queries, context.prim.t);
+        let expression = state.allocate_error_expression(type_id);
+        ElaboratedExpression { type_id, expression }
     };
 
-    let function_type = context.intern_function_list(&argument_types, result_type);
+    let function_type = context.intern_function_list(&argument_types, body.type_id);
 
     let exhaustiveness =
         exhaustive::check_lambda_patterns(state, context, &argument_types, binders)?;
@@ -109,10 +113,16 @@ where
     let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);
 
+    let kind = tree::ExpressionKind::Lambda {
+        binders: checked_binders.into(),
+        expression: body.expression,
+    };
+
     if has_missing {
-        Ok(context.intern_constrained(context.prim.partial, function_type))
+        let type_id = context.intern_constrained(context.prim.partial, function_type);
+        Ok(super::allocate_expression(state, type_id, kind))
     } else {
-        Ok(function_type)
+        Ok(super::allocate_expression(state, function_type, kind))
     }
 }
 
@@ -122,49 +132,58 @@ pub fn check_lambda<Q>(
     binders: &[lowering::BinderId],
     expression: Option<lowering::ExpressionId>,
     expected: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
     let mut arguments = vec![];
+    let mut checked_binders = vec![];
     let mut remaining = expected;
 
     for &binder_id in binders.iter() {
         let decomposed = toolkit::decompose_function(state, context, remaining)?;
-        if let Some((argument, result)) = decomposed {
+        let argument = if let Some((argument, result)) = decomposed {
             let argument = if binder::requires_instantiation(context, binder_id) {
                 toolkit::instantiate_unifications(state, context, argument)?
             } else {
                 argument
             };
-            binder::check_binder(state, context, binder_id, argument)?;
-            arguments.push(argument);
             remaining = result;
+            argument
         } else {
-            let argument_type = state.fresh_unification(context.queries, context.prim.t);
-            binder::check_binder(state, context, binder_id, argument_type)?;
-            arguments.push(argument_type);
-        }
+            state.fresh_unification(context.queries, context.prim.t)
+        };
+        let checked_binder = binder::check_binder(state, context, binder_id, argument)?;
+        arguments.push(argument);
+        checked_binders.push(checked_binder.binder);
     }
 
-    let result_type = if let Some(body) = expression {
-        super::check_expression(state, context, body, remaining)?.type_id
+    let body = if let Some(body) = expression {
+        super::check_expression(state, context, body, remaining)?
     } else {
-        state.fresh_unification(context.queries, context.prim.t)
+        let type_id = state.fresh_unification(context.queries, context.prim.t);
+        let expression = state.allocate_error_expression(type_id);
+        ElaboratedExpression { type_id, expression }
     };
 
-    let function_type = context.intern_function_list(&arguments, result_type);
+    let function_type = context.intern_function_list(&arguments, body.type_id);
 
     let exhaustiveness = exhaustive::check_lambda_patterns(state, context, &arguments, binders)?;
 
     let has_missing = exhaustiveness.missing.is_some();
     state.report_exhaustiveness(exhaustiveness);
 
+    let kind = tree::ExpressionKind::Lambda {
+        binders: checked_binders.into(),
+        expression: body.expression,
+    };
+
     if has_missing {
         state.push_wanted(context.prim.partial);
+        Ok(super::allocate_expression(state, function_type, kind))
+    } else {
+        Ok(super::allocate_expression(state, function_type, kind))
     }
-
-    Ok(function_type)
 }
 
 pub fn instantiate_trunk_types<Q>(

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -309,6 +309,7 @@ pub enum ExpressionKind {
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
+    Lambda { binders: Arc<[BinderId]>, expression: ExpressionId },
     Case { scrutinees: Arc<[ExpressionId]>, alternatives: Arc<[CaseAlternative]> },
     Let { bindings: LetBindings, expression: ExpressionId },
 }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1101,9 +1101,9 @@ where
     ) -> QueryResult<Doc<'arena>> {
         let expression = &self.checked.tree[expression_id];
         let precedence = match &expression.kind {
-            ExpressionKind::Case { .. } | ExpressionKind::Let { .. } => {
-                ExpressionPrecedence::Abstraction
-            }
+            ExpressionKind::Lambda { .. }
+            | ExpressionKind::Case { .. }
+            | ExpressionKind::Let { .. } => ExpressionPrecedence::Abstraction,
             ExpressionKind::TermApplication { .. }
             | ExpressionKind::TypeApplication { .. }
             | ExpressionKind::EvidenceApplication { .. } => ExpressionPrecedence::Application,
@@ -1283,6 +1283,7 @@ where
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
             }
+            ExpressionKind::Lambda { .. } => Ok(self.arena.text("<lambda>")),
             ExpressionKind::Case { scrutinees, alternatives } => {
                 self.case_expression(scrutinees, alternatives, evidence_names, type_pretty)
             }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -976,7 +976,9 @@ where
     fn expression_is_block_argument(&self, expression_id: ExpressionId) -> bool {
         matches!(
             &self.checked.tree[expression_id].kind,
-            ExpressionKind::Case { .. } | ExpressionKind::Let { .. }
+            ExpressionKind::Lambda { .. }
+                | ExpressionKind::Case { .. }
+                | ExpressionKind::Let { .. }
         )
     }
 
@@ -1283,7 +1285,27 @@ where
                 let evidence = self.evidence_variable_name(evidence_names, *evidence)?;
                 Ok(function.append(self.arena.text(format!(" {{{evidence}}}"))))
             }
-            ExpressionKind::Lambda { .. } => Ok(self.arena.text("<lambda>")),
+            ExpressionKind::Lambda { binders, expression } => {
+                let mut lambda = self.arena.text("\\");
+                if binders.is_empty() {
+                    lambda = lambda.append(self.arena.text("<error>"));
+                } else {
+                    for (position, &binder) in binders.iter().enumerate() {
+                        if position > 0 {
+                            lambda = lambda.append(self.arena.space());
+                        }
+                        lambda = lambda.append(self.binder(binder)?);
+                    }
+                }
+
+                let body = self.expression(*expression, evidence_names, type_pretty)?;
+                lambda = lambda.append(self.arena.text(" ->"));
+                if self.expression_requires_body_break(*expression) {
+                    Ok(lambda.append(self.arena.hardline().append(body).nest(2)))
+                } else {
+                    Ok(lambda.append(self.arena.space()).append(body))
+                }
+            }
             ExpressionKind::Case { scrutinees, alternatives } => {
                 self.case_expression(scrutinees, alternatives, evidence_names, type_pretty)
             }

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+missingBinder = \ -> true
+
+missingBody = \value ->
+
+missingBinderAndBody = \ ->

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+missingBinder :: Boolean
+missingBinder = \<error> -> true
+
+missingBody :: forall t t1. t -> t1
+missingBody = \value -> <error>
+
+missingBinderAndBody :: forall t. t
+missingBinderAndBody = \<error> -> <error>

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expressions/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+checked :: forall a. a -> a
+checked = \value -> value
+
+inferred = \value -> value
+
+multiple = \first second -> first

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expressions/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+checked :: forall a. a -> a
+checked = \value -> value
+
+inferred :: forall t. t -> t
+inferred = \value -> value
+
+multiple :: forall t t1. t -> t1 -> t
+multiple = \first second -> first

--- a/tests-integration/fixtures/semantic/1784828400_lambda_application_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784828400_lambda_application_expressions/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+apply :: forall a b. (a -> b) -> a -> b
+apply function value = function value
+
+argument = apply \value -> value
+
+functionPosition = (\function -> function) apply

--- a/tests-integration/fixtures/semantic/1784828400_lambda_application_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_lambda_application_expressions/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+apply :: forall a b. (a -> b) -> a -> b
+apply = \function -> \value -> function value
+
+argument :: forall t. t -> t
+argument = apply @t @t \value -> value
+
+functionPosition :: forall t t1. (t -> t1) -> t -> t1
+functionPosition = (\function -> function) (apply @t @t1)

--- a/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+data Maybe a = Nothing | Just a
+
+nested = \first -> \second -> first
+
+caseBody = \maybe -> case maybe of
+  Nothing -> 0
+  Just value -> value

--- a/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Type -> Type
+data Maybe @a
+  | Nothing :: Maybe a
+  | Just :: a -> Maybe a
+
+nested :: forall t t1. t -> t1 -> t
+nested = \first -> \second -> first
+
+caseBody :: Maybe Int -> Int
+caseBody =
+  \maybe ->
+    case maybe of
+      Nothing -> 0
+      (Just value) -> value

--- a/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+data Maybe a = Nothing | Just a
+
+checked :: Partial => Maybe Int -> Int
+checked = \(Just value) -> value
+
+inferred = \(Just value) -> value

--- a/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Type -> Type
+data Maybe @a
+  | Nothing :: Maybe a
+  | Just :: a -> Maybe a
+
+checked :: Partial => Maybe Int -> Int
+checked = \{partialDict} -> \(Just value) -> value
+
+inferred :: forall t. Partial => Maybe t -> t
+inferred = \{trivial} -> \(Just value) -> value


### PR DESCRIPTION
## Summary

- represent source lambda expressions in the checked semantic tree
- retain checked binders and the already-elaborated body during both checking and inference
- preserve exhaustiveness and `Partial` behavior while localizing malformed binders and bodies to error children
- render lambdas with correct abstraction and application precedence
- cover basic, nested, application, partial, and recovery behavior with focused semantic fixtures

## Stack

This PR is stacked on #202. Its diff is limited to the three lambda-retention commits on top of `checked-case-expressions`.

## Validation

- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo check -p tests-integration --tests`
- `cargo nextest run -p checking`
- `just t semantic`
- `just t checking`
- `git diff --check`