### PR TITLE
[checking] Retain checked do and ado expressions in the semantic tree

### DIFF
--- a/compiler-core/checking/src/core/unification.rs
+++ b/compiler-core/checking/src/core/unification.rs
@@ -11,6 +11,7 @@ use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
 use crate::core::{Depth, Name, RowField, RowType, RowTypeId, Type, TypeId, normalise, toolkit};
 use crate::error::ErrorKind;
+use crate::evidence::EvidenceVarId;
 use crate::source::types;
 use crate::state::{CheckState, UnificationEntry};
 
@@ -25,6 +26,12 @@ impl CanUnify {
     pub fn and_then(self, f: impl FnOnce() -> QueryResult<CanUnify>) -> QueryResult<CanUnify> {
         if let CanUnify::Equal = self { f() } else { Ok(self) }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubtypeApplication {
+    Type { argument: TypeId, result: TypeId },
+    Evidence { evidence: EvidenceVarId, result: TypeId },
 }
 
 /// Strategy for handling constrained types during [`subtype_with`].
@@ -98,6 +105,62 @@ where
     Q: ExternalQueries,
 {
     subtype_with::<Elaborating, Q>(state, context, t1, t2)
+}
+
+/// Checks subtyping and returns implicit applications introduced by outer
+/// `forall` and constrained types on the inferred side.
+///
+/// Applications introduced while checking an expected `forall` are omitted,
+/// because the inferred expression remains polymorphic at that boundary.
+pub fn subtype_with_applications<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    t1: TypeId,
+    t2: TypeId,
+) -> QueryResult<Vec<SubtypeApplication>>
+where
+    Q: ExternalQueries,
+{
+    let mut applications = vec![];
+    subtype_with_applications_core(state, context, t1, t2, &mut applications)?;
+    Ok(applications)
+}
+
+fn subtype_with_applications_core<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    t1: TypeId,
+    t2: TypeId,
+    applications: &mut Vec<SubtypeApplication>,
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    let t1 = normalise::expand(state, context, t1)?;
+    let t2 = normalise::expand(state, context, t2)?;
+
+    if t1 == t2 {
+        return Ok(true);
+    }
+
+    match (context.lookup_type(t1), context.lookup_type(t2)) {
+        // The inferred expression remains polymorphic at this boundary, so
+        // ordinary subtyping handles it without collecting applications.
+        (_, Type::Forall(_, _)) => subtype(state, context, t1, t2),
+        (Type::Forall(binder_id, inner), _) => {
+            let binder = context.lookup_forall_binder(binder_id);
+            let argument = state.fresh_unification(context.queries, binder.kind);
+            let result = SubstituteName::one(state, context, binder.name, argument, inner)?;
+            applications.push(SubtypeApplication::Type { argument, result });
+            subtype_with_applications_core(state, context, result, t2, applications)
+        }
+        (Type::Constrained(constraint, result), _) => {
+            let evidence = state.push_wanted(constraint);
+            applications.push(SubtypeApplication::Evidence { evidence, result });
+            subtype_with_applications_core(state, context, result, t2, applications)
+        }
+        (_, _) => subtype(state, context, t1, t2),
+    }
 }
 
 pub fn subtype_with<P, Q>(

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -391,9 +391,7 @@ where
         }
 
         lowering::ExpressionKind::Ado { map, apply, pure, statements, expression } => {
-            let type_id =
-                form_ado::infer_ado(state, context, *map, *apply, *pure, statements, *expression)?;
-            Ok(allocate_error_expression(state, type_id))
+            form_ado::infer_ado(state, context, *map, *apply, *pure, statements, *expression)
         }
 
         lowering::ExpressionKind::Constructor { resolution } => {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -387,8 +387,7 @@ where
         }
 
         lowering::ExpressionKind::Do { bind, discard, statements } => {
-            let type_id = form_do::infer_do(state, context, *bind, *discard, statements)?;
-            Ok(allocate_error_expression(state, type_id))
+            form_do::infer_do(state, context, *bind, *discard, statements)
         }
 
         lowering::ExpressionKind::Ado { map, apply, pure, statements, expression } => {

--- a/compiler-core/checking/src/source/terms/application.rs
+++ b/compiler-core/checking/src/source/terms/application.rs
@@ -216,33 +216,65 @@ where
     }
 }
 
-pub fn materialize_application(
+/// Checks an expression against an expected type while retaining implicit
+/// applications introduced on the inferred side.
+pub fn subtype_expression<Q>(
     state: &mut CheckState,
-    mut function: ElaboratedExpression,
-    implicit: Vec<ImplicitApplication>,
-    result: TypeId,
-    argument: ElaboratedExpression,
+    context: &CheckContext<Q>,
+    expression: ElaboratedExpression,
+    expected: TypeId,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let applications =
+        unification::subtype_with_applications(state, context, expression.type_id, expected)?;
+    let applications = applications.into_iter().map(|application| match application {
+        unification::SubtypeApplication::Type { argument, result } => {
+            ImplicitApplication::Type { argument, result }
+        }
+        unification::SubtypeApplication::Evidence { evidence, result } => {
+            ImplicitApplication::Evidence { evidence, result }
+        }
+    });
+    Ok(materialize_implicit_applications(state, expression, applications))
+}
+
+fn materialize_implicit_applications(
+    state: &mut CheckState,
+    mut expression: ElaboratedExpression,
+    implicit: impl IntoIterator<Item = ImplicitApplication>,
 ) -> ElaboratedExpression {
     for application in implicit {
         let (type_id, kind) = match application {
             ImplicitApplication::Type { argument, result } => {
                 let kind = tree::ExpressionKind::TypeApplication {
-                    function: function.expression,
+                    function: expression.expression,
                     argument,
                 };
                 (result, kind)
             }
             ImplicitApplication::Evidence { evidence, result } => {
                 let kind = tree::ExpressionKind::EvidenceApplication {
-                    function: function.expression,
+                    function: expression.expression,
                     evidence,
                 };
                 (result, kind)
             }
         };
-        function = super::allocate_expression(state, type_id, kind);
+        expression = super::allocate_expression(state, type_id, kind);
     }
+    expression
+}
 
+pub fn materialize_application(
+    state: &mut CheckState,
+    function: ElaboratedExpression,
+    implicit: Vec<ImplicitApplication>,
+    result: TypeId,
+    argument: ElaboratedExpression,
+) -> ElaboratedExpression {
+    let function = materialize_implicit_applications(state, function, implicit);
     let kind = tree::ExpressionKind::TermApplication {
         function: function.expression,
         argument: argument.expression,

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -1,23 +1,82 @@
 use building_types::QueryResult;
 
-use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::source::binder;
-use crate::source::terms::{application, form_do, form_let};
+use crate::source::terms::{ElaboratedExpression, application, form_do, form_let};
 use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
 
 enum AdoStep<'a> {
     Action {
         statement: lowering::DoStatementId,
         binder_type: TypeId,
+        binder: tree::BinderId,
         expression: lowering::ExpressionId,
     },
     Let {
         statement: lowering::DoStatementId,
         statements: &'a [lowering::LetBindingChunk],
     },
+}
+
+enum CheckedAdoApplication {
+    Application {
+        function: ElaboratedExpression,
+        first_implicit: Vec<application::ImplicitApplication>,
+        first_result: TypeId,
+        second_implicit: Vec<application::ImplicitApplication>,
+        argument: ElaboratedExpression,
+        result: TypeId,
+    },
+    Error {
+        result: TypeId,
+    },
+}
+
+impl CheckedAdoApplication {
+    fn type_id(&self) -> TypeId {
+        match self {
+            CheckedAdoApplication::Application { result, .. }
+            | CheckedAdoApplication::Error { result } => *result,
+        }
+    }
+
+    fn materialize(
+        self,
+        state: &mut CheckState,
+        first_argument: ElaboratedExpression,
+    ) -> ElaboratedExpression {
+        match self {
+            CheckedAdoApplication::Application {
+                function,
+                first_implicit,
+                first_result,
+                second_implicit,
+                argument,
+                result,
+            } => {
+                let function = application::materialize_application(
+                    state,
+                    function,
+                    first_implicit,
+                    first_result,
+                    first_argument,
+                );
+                application::materialize_application(
+                    state,
+                    function,
+                    second_implicit,
+                    result,
+                    argument,
+                )
+            }
+            CheckedAdoApplication::Error { result } => {
+                super::allocate_error_expression(state, result)
+            }
+        }
+    }
 }
 
 pub fn infer_ado<Q>(
@@ -28,7 +87,7 @@ pub fn infer_ado<Q>(
     pure: Option<lowering::TermVariableResolution>,
     statement_ids: &[lowering::DoStatementId],
     expression: Option<lowering::ExpressionId>,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -37,38 +96,71 @@ where
     // avoid premature solving of unification variables. Instead, they
     // are checked inline during the statement checking loop.
     let mut steps = vec![];
+    let mut has_missing_action = false;
     for &statement_id in statement_ids.iter() {
         let Some(statement) = context.lowered.info.get_do_statement(statement_id) else {
             continue;
         };
         match statement {
             lowering::DoStatement::Bind { binder, expression } => {
-                let binder_type = if let Some(binder) = binder {
-                    binder::infer_binder(state, context, *binder)?.type_id
+                let (binder_type, binder) = if let Some(binder) = binder {
+                    let binder = binder::infer_binder(state, context, *binder)?;
+                    (binder.type_id, binder.binder)
                 } else {
-                    state.fresh_unification(context.queries, context.prim.t)
+                    let binder_type = state.fresh_unification(context.queries, context.prim.t);
+                    let binder = state.allocate_generated_binder(
+                        statement_id,
+                        binder_type,
+                        tree::BinderKind::Error,
+                    );
+                    (binder_type, binder)
                 };
-                let Some(expression) = *expression else { continue };
-                steps.push(AdoStep::Action { statement: statement_id, binder_type, expression });
+                let Some(expression) = *expression else {
+                    has_missing_action = true;
+                    continue;
+                };
+                steps.push(AdoStep::Action {
+                    statement: statement_id,
+                    binder_type,
+                    binder,
+                    expression,
+                });
             }
             lowering::DoStatement::Let { statements } => {
                 steps.push(AdoStep::Let { statement: statement_id, statements });
             }
             lowering::DoStatement::Discard { expression } => {
                 let binder_type = state.fresh_unification(context.queries, context.prim.t);
-                let Some(expression) = *expression else { continue };
-                steps.push(AdoStep::Action { statement: statement_id, binder_type, expression });
+                let binder = state.allocate_generated_binder(
+                    statement_id,
+                    binder_type,
+                    tree::BinderKind::Wildcard,
+                );
+                let Some(expression) = *expression else {
+                    has_missing_action = true;
+                    continue;
+                };
+                steps.push(AdoStep::Action {
+                    statement: statement_id,
+                    binder_type,
+                    binder,
+                    expression,
+                });
             }
         }
     }
 
-    let binder_types: Vec<_> = steps
-        .iter()
-        .filter_map(|step| match step {
-            AdoStep::Action { binder_type, .. } => Some(*binder_type),
-            AdoStep::Let { .. } => None,
-        })
-        .collect();
+    let binder_types = steps.iter().filter_map(|step| match step {
+        AdoStep::Action { binder_type, .. } => Some(*binder_type),
+        AdoStep::Let { .. } => None,
+    });
+    let binder_types = binder_types.collect::<Vec<_>>();
+
+    let binders = steps.iter().filter_map(|step| match step {
+        AdoStep::Action { binder, .. } => Some(*binder),
+        AdoStep::Let { .. } => None,
+    });
+    let binders = binders.collect::<Vec<_>>();
 
     // For ado blocks with no bindings, we check let statements and then
     // apply pure to the expression.
@@ -76,19 +168,40 @@ where
     //   pure_type  := a -> f a
     //   expression := t
     if binder_types.is_empty() {
+        let mut checked_lets = vec![];
         for step in &steps {
             if let AdoStep::Let { statement, statements } = step {
-                state.with_error_crumb(ErrorCrumb::CheckingAdoLet(*statement), |state| {
-                    form_let::check_let_chunks(state, context, statements)
-                })?;
+                let bindings = state
+                    .with_error_crumb(ErrorCrumb::CheckingAdoLet(*statement), |state| {
+                        form_let::check_let_chunks(state, context, statements)
+                    })?;
+                checked_lets.push(bindings);
             }
         }
         return if let Some(expression) = expression {
-            let pure_type = form_do::lookup_or_synthesise_pure(state, context, pure)?.type_id();
-            application::check_function_term_application(state, context, pure_type, expression)
+            let function = form_do::lookup_or_synthesise_pure(state, context, pure)?;
+            let Some(application::UnanchoredApplication { implicit, argument, result }) =
+                application::check_unanchored_application(state, context, function.type_id())?
+            else {
+                let type_id = context.unknown("invalid function application");
+                let expression = super::allocate_error_expression(state, type_id);
+                return Ok(wrap_ado_lets(state, checked_lets, expression));
+            };
+            let argument = super::check_expression(state, context, expression, argument)?;
+            let argument = if has_missing_action {
+                super::allocate_error_expression(state, argument.type_id)
+            } else {
+                argument
+            };
+            let function = function.allocate_expression(state);
+            let expression =
+                application::materialize_application(state, function, implicit, result, argument);
+            Ok(wrap_ado_lets(state, checked_lets, expression))
         } else {
             state.insert_error(ErrorKind::EmptyAdoBlock);
-            Ok(context.unknown("empty ado block"))
+            let type_id = context.unknown("empty ado block");
+            let expression = super::allocate_error_expression(state, type_id);
+            Ok(wrap_ado_lets(state, checked_lets, expression))
         };
     }
 
@@ -134,25 +247,29 @@ where
     // - 2+ actions: map and apply are needed
     let action_count = binder_types.len();
 
-    let map_type = form_do::lookup_or_synthesise_map(state, context, map)?.type_id();
+    let map_function = form_do::lookup_or_synthesise_map(state, context, map)?;
 
-    let apply_type = if action_count > 1 {
-        form_do::lookup_or_synthesise_apply(state, context, apply)?.type_id()
+    let apply_function = if action_count > 1 {
+        Some(form_do::lookup_or_synthesise_apply(state, context, apply)?)
     } else {
-        context.unknown("unused apply")
+        None
     };
 
     let mut continuation_type = None;
+    let mut checked_actions = vec![];
+    let mut checked_lets = vec![];
 
     for step in &steps {
         match step {
             AdoStep::Let { statement, statements } => {
-                state.with_error_crumb(ErrorCrumb::CheckingAdoLet(*statement), |state| {
-                    form_let::check_let_chunks(state, context, statements)
-                })?;
+                let bindings = state
+                    .with_error_crumb(ErrorCrumb::CheckingAdoLet(*statement), |state| {
+                        form_let::check_let_chunks(state, context, statements)
+                    })?;
+                checked_lets.push(bindings);
             }
             AdoStep::Action { statement, expression, .. } => {
-                let statement_type = if let Some(continuation_type) = continuation_type {
+                let application = if let Some(continuation_type) = continuation_type {
                     // Then, the infer_ado_apply rule applies `apply` to the inferred
                     // expression type and the continuation type that is a function
                     // contained within some container, like Effect.
@@ -167,20 +284,29 @@ where
                     //
                     //   continuation_type := Effect ?in_expression
                     state.with_error_crumb(ErrorCrumb::InferringAdoApply(*statement), |state| {
-                        infer_ado_apply_core(
+                        infer_ado_application_core(
                             state,
                             context,
-                            apply_type,
+                            apply_function.as_ref().expect(
+                                "invariant violated: desugared apply function was not initialised",
+                            ),
                             continuation_type,
                             *expression,
                         )
                     })?
                 } else {
                     state.with_error_crumb(ErrorCrumb::InferringAdoMap(*statement), |state| {
-                        infer_ado_map_core(state, context, map_type, lambda_type, *expression)
+                        infer_ado_application_core(
+                            state,
+                            context,
+                            &map_function,
+                            lambda_type,
+                            *expression,
+                        )
                     })?
                 };
-                continuation_type = Some(statement_type);
+                continuation_type = Some(application.type_id());
+                checked_actions.push(application);
             }
         }
     }
@@ -193,71 +319,88 @@ where
     //   in_expression_type := Effect ?in_expression
     //                      >>
     //                      >> ?in_expression := Message
-    if let Some(expression) = expression {
-        super::check_expression(state, context, expression, in_expression_type)?;
+    let expression = if let Some(expression) = expression {
+        super::check_expression(state, context, expression, in_expression_type)?
+    } else {
+        super::allocate_error_expression(state, in_expression_type)
+    };
+    let expression = if has_missing_action {
+        super::allocate_error_expression(state, in_expression_type)
+    } else {
+        expression
+    };
+    let expression = ElaboratedExpression { type_id: in_expression_type, ..expression };
+    let body = wrap_ado_lets(state, checked_lets, expression);
+
+    let kind =
+        tree::ExpressionKind::Lambda { binders: binders.into(), expression: body.expression };
+    let lambda = super::allocate_expression(state, lambda_type, kind);
+
+    let mut checked_actions = checked_actions.into_iter();
+    let first_action =
+        checked_actions.next().expect("invariant violated: ado has no checked map application");
+    let mut expression = first_action.materialize(state, lambda);
+    for action in checked_actions {
+        expression = action.materialize(state, expression);
     }
 
     let Some(continuation_type) = continuation_type else {
         unreachable!("invariant violated: impossible empty steps");
     };
 
-    Ok(continuation_type)
+    Ok(ElaboratedExpression { type_id: continuation_type, ..expression })
 }
 
-pub fn infer_ado_map_core<Q>(
+fn infer_ado_application_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    map_type: TypeId,
-    lambda_type: TypeId,
+    function: &form_do::DesugaredFunction,
+    first_argument_type: TypeId,
     expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
+) -> QueryResult<CheckedAdoApplication>
 where
     Q: ExternalQueries,
 {
-    let expression_type = super::infer_expression(state, context, expression)?.type_id;
+    let expression = super::infer_expression(state, context, expression)?;
 
-    let Some(application::UnanchoredApplication { argument, result, .. }) =
-        application::check_unanchored_application(state, context, map_type)?
+    let Some(application::UnanchoredApplication {
+        implicit: first_implicit,
+        argument,
+        result: first_result,
+    }) = application::check_unanchored_application(state, context, function.type_id())?
     else {
-        return Ok(context.unknown("invalid function application"));
+        let result = context.unknown("invalid function application");
+        return Ok(CheckedAdoApplication::Error { result });
     };
-    unification::subtype(state, context, lambda_type, argument)?;
+    unification::subtype(state, context, first_argument_type, argument)?;
 
-    let Some(application::UnanchoredApplication { argument, result, .. }) =
-        application::check_unanchored_application(state, context, result)?
+    let Some(application::UnanchoredApplication { implicit: second_implicit, argument, result }) =
+        application::check_unanchored_application(state, context, first_result)?
     else {
-        return Ok(context.unknown("invalid function application"));
+        let result = context.unknown("invalid function application");
+        return Ok(CheckedAdoApplication::Error { result });
     };
-    unification::subtype(state, context, expression_type, argument)?;
+    let argument = application::subtype_expression(state, context, expression, argument)?;
+    let function = function.allocate_expression(state);
 
-    Ok(result)
+    Ok(CheckedAdoApplication::Application {
+        function,
+        first_implicit,
+        first_result,
+        second_implicit,
+        argument,
+        result,
+    })
 }
 
-pub fn infer_ado_apply_core<Q>(
+fn wrap_ado_lets(
     state: &mut CheckState,
-    context: &CheckContext<Q>,
-    apply_type: TypeId,
-    continuation_type: TypeId,
-    expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
-where
-    Q: ExternalQueries,
-{
-    let expression_type = super::infer_expression(state, context, expression)?.type_id;
-
-    let Some(application::UnanchoredApplication { argument, result, .. }) =
-        application::check_unanchored_application(state, context, apply_type)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, continuation_type, argument)?;
-
-    let Some(application::UnanchoredApplication { argument, result, .. }) =
-        application::check_unanchored_application(state, context, result)?
-    else {
-        return Ok(context.unknown("invalid function application"));
-    };
-    unification::subtype(state, context, expression_type, argument)?;
-
-    Ok(result)
+    bindings: Vec<tree::LetBindings>,
+    mut expression: ElaboratedExpression,
+) -> ElaboratedExpression {
+    for bindings in bindings.into_iter().rev() {
+        let kind = tree::ExpressionKind::Let { bindings, expression: expression.expression };
+        expression = super::allocate_expression(state, expression.type_id, kind);
+    }
+    expression
 }

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -84,7 +84,7 @@ where
             }
         }
         return if let Some(expression) = expression {
-            let pure_type = form_do::lookup_or_synthesise_pure(state, context, pure)?;
+            let pure_type = form_do::lookup_or_synthesise_pure(state, context, pure)?.type_id();
             application::check_function_term_application(state, context, pure_type, expression)
         } else {
             state.insert_error(ErrorKind::EmptyAdoBlock);
@@ -134,10 +134,10 @@ where
     // - 2+ actions: map and apply are needed
     let action_count = binder_types.len();
 
-    let map_type = form_do::lookup_or_synthesise_map(state, context, map)?;
+    let map_type = form_do::lookup_or_synthesise_map(state, context, map)?.type_id();
 
     let apply_type = if action_count > 1 {
-        form_do::lookup_or_synthesise_apply(state, context, apply)?
+        form_do::lookup_or_synthesise_apply(state, context, apply)?.type_id()
     } else {
         context.unknown("unused apply")
     };

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -3,18 +3,39 @@ use std::iter;
 use building_types::QueryResult;
 use itertools::{Itertools, Position};
 
-use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::{TypeId, toolkit, unification};
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::source::binder;
-use crate::source::terms::{application, form_let};
+use crate::source::terms::{ElaboratedExpression, application, form_let};
 use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+pub struct DesugaredFunction {
+    resolution: Option<lowering::TermVariableResolution>,
+    type_id: TypeId,
+}
+
+impl DesugaredFunction {
+    pub fn type_id(&self) -> TypeId {
+        self.type_id
+    }
+
+    pub fn allocate_expression(&self, state: &mut CheckState) -> ElaboratedExpression {
+        if let Some(resolution) = self.resolution {
+            let kind = tree::ExpressionKind::Variable { resolution };
+            super::allocate_expression(state, self.type_id, kind)
+        } else {
+            super::allocate_error_expression(state, self.type_id)
+        }
+    }
+}
 
 enum DoStep<'a> {
     Bind {
         statement: lowering::DoStatementId,
         binder_type: TypeId,
+        binder: tree::BinderId,
         expression: Option<lowering::ExpressionId>,
     },
     Discard {
@@ -31,6 +52,19 @@ impl DoStep<'_> {
     fn is_action(&self) -> bool {
         matches!(self, Self::Bind { .. } | Self::Discard { .. })
     }
+}
+
+struct CheckedDoApplication {
+    function: ElaboratedExpression,
+    implicit: Vec<application::ImplicitApplication>,
+    result: TypeId,
+    lambda_type: TypeId,
+}
+
+enum CheckedDoStep {
+    Application { application: CheckedDoApplication, binder: tree::BinderId },
+    MissingApplication { binder: tree::BinderId, lambda_type: TypeId, result: TypeId },
+    Let { bindings: tree::LetBindings },
 }
 
 enum DoBlockFinalStep {
@@ -51,11 +85,11 @@ pub fn lookup_or_synthesise_bind<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     resolution: Option<lowering::TermVariableResolution>,
-) -> QueryResult<TypeId>
+) -> QueryResult<DesugaredFunction>
 where
     Q: ExternalQueries,
 {
-    if let Some(resolution) = resolution {
+    let type_id = if let Some(resolution) = resolution {
         toolkit::lookup_term_variable(state, context, resolution)
     } else {
         let m = state.fresh_unification(context.queries, context.prim.type_to_type);
@@ -65,7 +99,8 @@ where
         let m_b = context.intern_application(m, b);
         let a_to_m_b = context.intern_function(a, m_b);
         Ok(context.intern_function_list(&[m_a, a_to_m_b], m_b))
-    }
+    }?;
+    Ok(DesugaredFunction { resolution, type_id })
 }
 
 /// Lookup `discard` from resolution, or synthesize `?m ?a -> (?a -> ?m ?b) -> ?m ?b`.
@@ -73,7 +108,7 @@ pub fn lookup_or_synthesise_discard<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     resolution: Option<lowering::TermVariableResolution>,
-) -> QueryResult<TypeId>
+) -> QueryResult<DesugaredFunction>
 where
     Q: ExternalQueries,
 {
@@ -86,11 +121,11 @@ pub fn lookup_or_synthesise_map<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     resolution: Option<lowering::TermVariableResolution>,
-) -> QueryResult<TypeId>
+) -> QueryResult<DesugaredFunction>
 where
     Q: ExternalQueries,
 {
-    if let Some(resolution) = resolution {
+    let type_id = if let Some(resolution) = resolution {
         toolkit::lookup_term_variable(state, context, resolution)
     } else {
         let f = state.fresh_unification(context.queries, context.prim.type_to_type);
@@ -100,7 +135,8 @@ where
         let f_b = context.intern_application(f, b);
         let a_to_b = context.intern_function(a, b);
         Ok(context.intern_function_list(&[a_to_b, f_a], f_b))
-    }
+    }?;
+    Ok(DesugaredFunction { resolution, type_id })
 }
 
 /// Lookup `apply` from resolution, or synthesize `?f (?a -> ?b) -> ?f ?a -> ?f ?b`.
@@ -108,11 +144,11 @@ pub fn lookup_or_synthesise_apply<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     resolution: Option<lowering::TermVariableResolution>,
-) -> QueryResult<TypeId>
+) -> QueryResult<DesugaredFunction>
 where
     Q: ExternalQueries,
 {
-    if let Some(resolution) = resolution {
+    let type_id = if let Some(resolution) = resolution {
         toolkit::lookup_term_variable(state, context, resolution)
     } else {
         let f = state.fresh_unification(context.queries, context.prim.type_to_type);
@@ -123,7 +159,8 @@ where
         let f_a = context.intern_application(f, a);
         let f_b = context.intern_application(f, b);
         Ok(context.intern_function_list(&[f_a_to_b, f_a], f_b))
-    }
+    }?;
+    Ok(DesugaredFunction { resolution, type_id })
 }
 
 /// Lookup `pure` from resolution, or synthesize `?a -> ?f ?a`.
@@ -131,18 +168,19 @@ pub fn lookup_or_synthesise_pure<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     resolution: Option<lowering::TermVariableResolution>,
-) -> QueryResult<TypeId>
+) -> QueryResult<DesugaredFunction>
 where
     Q: ExternalQueries,
 {
-    if let Some(resolution) = resolution {
+    let type_id = if let Some(resolution) = resolution {
         toolkit::lookup_term_variable(state, context, resolution)
     } else {
         let f = state.fresh_unification(context.queries, context.prim.type_to_type);
         let a = state.fresh_unification(context.queries, context.prim.t);
         let f_a = context.intern_application(f, a);
         Ok(context.intern_function(a, f_a))
-    }
+    }?;
+    Ok(DesugaredFunction { resolution, type_id })
 }
 
 pub fn infer_do<Q>(
@@ -151,7 +189,7 @@ pub fn infer_do<Q>(
     bind: Option<lowering::TermVariableResolution>,
     discard: Option<lowering::TermVariableResolution>,
     statement_id: &[lowering::DoStatementId],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -166,14 +204,22 @@ where
         };
         match statement {
             lowering::DoStatement::Bind { binder, expression } => {
-                let binder_type = if let Some(binder) = binder {
-                    binder::infer_binder(state, context, *binder)?.type_id
+                let (binder_type, binder) = if let Some(binder) = binder {
+                    let binder = binder::infer_binder(state, context, *binder)?;
+                    (binder.type_id, binder.binder)
                 } else {
-                    state.fresh_unification(context.queries, context.prim.t)
+                    let binder_type = state.fresh_unification(context.queries, context.prim.t);
+                    let binder = state.allocate_generated_binder(
+                        statement_id,
+                        binder_type,
+                        tree::BinderKind::Error,
+                    );
+                    (binder_type, binder)
                 };
                 steps.push(DoStep::Bind {
                     statement: statement_id,
                     binder_type,
+                    binder,
                     expression: *expression,
                 });
             }
@@ -213,22 +259,20 @@ where
         (has_bind, has_discard)
     };
 
-    let bind_type = if has_bind_step {
-        lookup_or_synthesise_bind(state, context, bind)?
-    } else {
-        context.unknown("unused bind")
-    };
+    let bind_function =
+        if has_bind_step { Some(lookup_or_synthesise_bind(state, context, bind)?) } else { None };
 
-    let discard_type = if has_discard_step {
-        lookup_or_synthesise_discard(state, context, discard)?
+    let discard_function = if has_discard_step {
+        Some(lookup_or_synthesise_discard(state, context, discard)?)
     } else {
-        context.unknown("unused discard")
+        None
     };
 
     let final_expression = match final_step {
         DoBlockFinalStep::Empty => {
             state.insert_error(ErrorKind::EmptyDoBlock);
-            return Ok(context.unknown("empty do block"));
+            let type_id = context.unknown("empty do block");
+            return Ok(super::allocate_error_expression(state, type_id));
         }
         // Technically valid, syntactically disallowed. This allows
         // partially-written do expressions to infer, with a friendly
@@ -239,14 +283,16 @@ where
             });
             let Some(expression) = expression else {
                 state.insert_error(ErrorKind::EmptyDoBlock);
-                return Ok(context.unknown("empty do block"));
+                let type_id = context.unknown("empty do block");
+                return Ok(super::allocate_error_expression(state, type_id));
             };
             Some(expression)
         }
         DoBlockFinalStep::Discard { expression } => {
             let Some(expression) = expression else {
                 state.insert_error(ErrorKind::EmptyDoBlock);
-                return Ok(context.unknown("empty do block"));
+                let type_id = context.unknown("empty do block");
+                return Ok(super::allocate_error_expression(state, type_id));
             };
             Some(expression)
         }
@@ -339,47 +385,83 @@ where
     // to the previous approach that emulated desugared checking.
 
     let mut continuations = continuation_types.iter().tuple_windows::<(_, _)>();
+    let mut checked_steps = vec![];
 
     for step in &steps {
         match step {
             DoStep::Let { statement, statements } => {
-                state.with_error_crumb(ErrorCrumb::CheckingDoLet(*statement), |state| {
-                    form_let::check_let_chunks(state, context, statements)
-                })?;
+                let bindings = state
+                    .with_error_crumb(ErrorCrumb::CheckingDoLet(*statement), |state| {
+                        form_let::check_let_chunks(state, context, statements)
+                    })?;
+                checked_steps.push(CheckedDoStep::Let { bindings });
             }
-            DoStep::Bind { statement, binder_type, expression } => {
+            DoStep::Bind { statement, binder_type, binder, expression } => {
                 let Some((&now_type, &next_type)) = continuations.next() else {
                     continue;
                 };
                 let Some(expression) = *expression else {
+                    let lambda_type = context.intern_function(*binder_type, next_type);
+                    checked_steps.push(CheckedDoStep::MissingApplication {
+                        binder: *binder,
+                        lambda_type,
+                        result: now_type,
+                    });
                     continue;
                 };
-                state.with_error_crumb(ErrorCrumb::InferringDoBind(*statement), |state| {
-                    let statement_type = infer_do_bind_core(
-                        state,
-                        context,
-                        bind_type,
-                        next_type,
-                        expression,
-                        *binder_type,
-                    )?;
-                    unification::subtype(state, context, statement_type, now_type)?;
-                    Ok(())
-                })?;
+                let function = bind_function
+                    .as_ref()
+                    .expect("invariant violated: desugared bind function was not initialised");
+                let mut application =
+                    state.with_error_crumb(ErrorCrumb::InferringDoBind(*statement), |state| {
+                        let application = infer_do_bind_core(
+                            state,
+                            context,
+                            function,
+                            next_type,
+                            expression,
+                            *binder_type,
+                        )?;
+                        unification::subtype(state, context, application.result, now_type)?;
+                        Ok(application)
+                    })?;
+                application.result = now_type;
+                checked_steps.push(CheckedDoStep::Application { application, binder: *binder });
             }
             DoStep::Discard { statement, expression } => {
                 let Some((&now_type, &next_type)) = continuations.next() else {
                     continue;
                 };
                 let Some(expression) = *expression else {
+                    let binder_type = context.unknown("missing do discard binder");
+                    let binder = state.allocate_generated_binder(
+                        *statement,
+                        binder_type,
+                        tree::BinderKind::Wildcard,
+                    );
+                    let lambda_type = context.intern_function(binder_type, next_type);
+                    checked_steps.push(CheckedDoStep::MissingApplication {
+                        binder,
+                        lambda_type,
+                        result: now_type,
+                    });
                     continue;
                 };
-                state.with_error_crumb(ErrorCrumb::InferringDoDiscard(*statement), |state| {
-                    let statement_type =
-                        infer_do_discard_core(state, context, discard_type, next_type, expression)?;
-                    unification::subtype(state, context, statement_type, now_type)?;
-                    Ok(())
-                })?;
+                let function = discard_function
+                    .as_ref()
+                    .expect("invariant violated: desugared discard function was not initialised");
+                let (binder, mut application) = state.with_error_crumb(
+                    ErrorCrumb::InferringDoDiscard(*statement),
+                    |state| {
+                        let (binder, application) = infer_do_discard_core(
+                            state, context, function, next_type, expression, *statement,
+                        )?;
+                        unification::subtype(state, context, application.result, now_type)?;
+                        Ok((binder, application))
+                    },
+                )?;
+                application.result = now_type;
+                checked_steps.push(CheckedDoStep::Application { application, binder });
             }
         }
     }
@@ -394,54 +476,111 @@ where
     let final_continuation =
         *continuation_types.last().expect("invariant violated: empty continuation_types");
 
-    if let Some(final_expression) = final_expression {
-        super::check_expression(state, context, final_expression, final_continuation)?;
+    let final_expression = if let Some(final_expression) = final_expression {
+        super::check_expression(state, context, final_expression, final_continuation)?
+    } else {
+        super::allocate_error_expression(state, final_continuation)
+    };
+    let mut continuation = ElaboratedExpression { type_id: final_continuation, ..final_expression };
+
+    for step in checked_steps.into_iter().rev() {
+        match step {
+            CheckedDoStep::Application { application, binder } => {
+                let kind = tree::ExpressionKind::Lambda {
+                    binders: vec![binder].into(),
+                    expression: continuation.expression,
+                };
+                let lambda = super::allocate_expression(state, application.lambda_type, kind);
+                continuation = application::materialize_application(
+                    state,
+                    application.function,
+                    application.implicit,
+                    application.result,
+                    lambda,
+                );
+            }
+            CheckedDoStep::MissingApplication { binder, lambda_type, result } => {
+                let kind = tree::ExpressionKind::Lambda {
+                    binders: vec![binder].into(),
+                    expression: continuation.expression,
+                };
+                let lambda = super::allocate_expression(state, lambda_type, kind);
+                let function_type = context.intern_function(lambda_type, result);
+                let function = super::allocate_error_expression(state, function_type);
+                continuation =
+                    application::materialize_application(state, function, vec![], result, lambda);
+            }
+            CheckedDoStep::Let { bindings } => {
+                let kind =
+                    tree::ExpressionKind::Let { bindings, expression: continuation.expression };
+                continuation = super::allocate_expression(state, continuation.type_id, kind);
+            }
+        }
     }
 
-    Ok(first_continuation)
+    Ok(ElaboratedExpression { type_id: first_continuation, ..continuation })
 }
 
-pub fn infer_do_bind_core<Q>(
+fn infer_do_bind_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    bind_type: TypeId,
+    function: &DesugaredFunction,
     continuation_type: TypeId,
     expression: lowering::ExpressionId,
     binder_type: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<CheckedDoApplication>
 where
     Q: ExternalQueries,
 {
-    let expression_type = super::infer_expression(state, context, expression)?.type_id;
+    let expression = super::infer_expression(state, context, expression)?;
     let lambda_type = context.intern_function(binder_type, continuation_type);
 
-    let Some(application::UnanchoredApplication { argument, result, .. }) =
-        application::check_unanchored_application(state, context, bind_type)?
+    let Some(application::UnanchoredApplication { implicit, argument, result }) =
+        application::check_unanchored_application(state, context, function.type_id())?
     else {
-        return Ok(context.unknown("invalid function application"));
+        return Ok(invalid_do_application(state, context, lambda_type));
     };
-    unification::subtype(state, context, expression_type, argument)?;
+    let expression = application::subtype_expression(state, context, expression, argument)?;
+    let function = function.allocate_expression(state);
+    let function =
+        application::materialize_application(state, function, implicit, result, expression);
 
-    let Some(application::UnanchoredApplication { argument, result, .. }) =
-        application::check_unanchored_application(state, context, result)?
+    let Some(application::UnanchoredApplication { implicit, argument, result }) =
+        application::check_unanchored_application(state, context, function.type_id)?
     else {
-        return Ok(context.unknown("invalid function application"));
+        return Ok(invalid_do_application(state, context, lambda_type));
     };
     unification::subtype(state, context, lambda_type, argument)?;
 
-    Ok(result)
+    Ok(CheckedDoApplication { function, implicit, result, lambda_type })
 }
 
-pub fn infer_do_discard_core<Q>(
+fn infer_do_discard_core<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    discard_type: TypeId,
+    function: &DesugaredFunction,
     continuation_type: TypeId,
     expression: lowering::ExpressionId,
-) -> QueryResult<TypeId>
+    statement: lowering::DoStatementId,
+) -> QueryResult<(tree::BinderId, CheckedDoApplication)>
 where
     Q: ExternalQueries,
 {
     let binder_type = state.fresh_unification(context.queries, context.prim.t);
-    infer_do_bind_core(state, context, discard_type, continuation_type, expression, binder_type)
+    let binder =
+        state.allocate_generated_binder(statement, binder_type, tree::BinderKind::Wildcard);
+    let application =
+        infer_do_bind_core(state, context, function, continuation_type, expression, binder_type)?;
+    Ok((binder, application))
+}
+
+fn invalid_do_application(
+    state: &mut CheckState,
+    context: &CheckContext<impl ExternalQueries>,
+    lambda_type: TypeId,
+) -> CheckedDoApplication {
+    let result = context.unknown("invalid function application");
+    let function_type = context.intern_function(lambda_type, result);
+    let function = super::allocate_error_expression(state, function_type);
+    CheckedDoApplication { function, implicit: vec![], result, lambda_type }
 }

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -313,6 +313,18 @@ impl CheckState {
         type_id: TypeId,
         kind: tree::BinderKind,
     ) -> tree::BinderId {
+        let source = tree::BinderSource::Binder(source);
+        let binder = tree::Binder { source, type_id, kind };
+        self.checked.tree.allocate_binder(binder)
+    }
+
+    pub fn allocate_generated_binder(
+        &mut self,
+        source: lowering::DoStatementId,
+        type_id: TypeId,
+        kind: tree::BinderKind,
+    ) -> tree::BinderId {
+        let source = tree::BinderSource::DoStatement(source);
         let binder = tree::Binder { source, type_id, kind };
         self.checked.tree.allocate_binder(binder)
     }

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -259,9 +259,15 @@ impl GuardedExpression {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Binder {
-    pub source: lowering::BinderId,
+    pub source: BinderSource,
     pub type_id: TypeId,
     pub kind: BinderKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinderSource {
+    Binder(lowering::BinderId),
+    DoStatement(lowering::DoStatementId),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -426,15 +426,14 @@ where
             instance,
             &mut outer_evidence_names,
         )?;
-        let mut declaration =
-            signature.append(self.arena.hardline()).append(self.arena.text("where"));
+        let mut fields = vec![];
 
         let superclass_names = self.instance_superclass_field_names(instance)?;
         for (superclass, field_name) in instance.superclasses.iter().zip(superclass_names) {
             let evidence =
                 self.evidence_variable_name(&mut outer_evidence_names, superclass.evidence)?;
             let field = self.arena.text(format!("  superclass {field_name} = {evidence}"));
-            declaration = declaration.append(self.arena.hardline()).append(field);
+            fields.push(field);
         }
 
         for member in instance.members.iter() {
@@ -462,10 +461,16 @@ where
             else {
                 continue;
             };
-            declaration = declaration.append(self.arena.hardline()).append(equations);
+            fields.push(equations);
         }
 
-        Ok(declaration)
+        let mut fields = fields.into_iter();
+        let Some(first) = fields.next() else { return Ok(signature) };
+        let fields = fields
+            .fold(first, |document, field| document.append(self.arena.hardline()).append(field));
+        let where_clause = self.arena.line().append(self.arena.text("where")).nest(2);
+        let header = signature.append(where_clause).group();
+        Ok(header.append(self.arena.hardline()).append(fields))
     }
 
     fn dictionary_signature(
@@ -503,34 +508,24 @@ where
             lines.push(format!("forall {}.", binder_names.join(" ")));
         }
 
-        let mut fields = vec![];
         for evidence in instance.evidences.iter() {
             let field_name = self.evidence_name(evidence_names, &evidence.evidence)?;
             let constraint = type_pretty.render(evidence.constraint);
-            fields.push((field_name, constraint));
-        }
-        if let [(field_name, constraint)] = fields.as_slice() {
             lines.push(format!("{{ {field_name} :: {constraint} }} =>"));
-        } else if let Some((first_name, first_constraint)) = fields.first() {
-            lines.push(format!("{{ {first_name} :: {first_constraint}"));
-            for (field_name, constraint) in fields.iter().skip(1) {
-                lines.push(format!(", {field_name} :: {constraint}"));
-            }
-            lines.push("} =>".to_string());
         }
 
         lines.push(type_pretty.render(current).to_string());
 
-        let mut signature = self.arena.text(format!("dictionary {name} ::"));
-        if lines.len() == 1 {
-            signature = signature.append(self.arena.text(format!(" {}", lines[0])));
-        } else {
-            for line in lines {
-                signature = signature
-                    .append(self.arena.hardline())
-                    .append(self.arena.text(format!("  {line}")));
-            }
-        }
+        let mut lines = lines.into_iter();
+        let first = lines.next().expect("invariant violated: dictionary signature is empty");
+        let lines = lines.fold(self.arena.text(first), |document, line| {
+            document.append(self.arena.line()).append(self.arena.text(line))
+        });
+        let signature = self
+            .arena
+            .text(format!("dictionary {name} ::"))
+            .append(self.arena.line().append(lines).nest(2))
+            .group();
         Ok((signature, rigid_names))
     }
 

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1,17 +1,22 @@
 //! Implements the pretty printer for the checked semantic tree.
 
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItem, TypeItem};
+use indexing::{TermItem, TermItemKind, TypeItem};
 use lowering::TermVariableResolution;
 use pretty::{Arena, DocAllocator, DocBuilder};
 use rustc_hash::FxHashMap;
-use smol_str::{SmolStr, SmolStrBuilder};
+use smol_str::{SmolStr, SmolStrBuilder, format_smolstr};
 
 use crate::CheckedModule;
 use crate::core::Type;
 use crate::core::pretty::{Pretty as TypePretty, PrettyNames, PrettyQueries};
-use crate::evidence::{Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId};
+use crate::evidence::{
+    Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId, InstanceCandidateOrigin,
+    ReflectableEvidence, ReflectableOrdering, SuperclassId, SynthesizedEvidence,
+};
 use crate::tree::{
     BinderId, BinderKind, BinderSource, CaseAlternative, Equation, ExpressionId, ExpressionKind,
     GuardedAlternative, GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings,
@@ -20,6 +25,13 @@ use crate::tree::{
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
+
+const UNKNOWN_INSTANCE_EVIDENCE: SmolStr = SmolStr::new_static("<instance>");
+const UNKNOWN_SUPERCLASS_EVIDENCE: SmolStr = SmolStr::new_static("<superclass>");
+const EVIDENCE_DICTIONARY_NAME: SmolStr = SmolStr::new_static("evidenceDict");
+const REFLECTABLE_LESS_EVIDENCE: SmolStr = SmolStr::new_static("reflectable(LT)");
+const REFLECTABLE_EQUAL_EVIDENCE: SmolStr = SmolStr::new_static("reflectable(EQ)");
+const REFLECTABLE_GREATER_EVIDENCE: SmolStr = SmolStr::new_static("reflectable(GT)");
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum ExpressionPrecedence {
@@ -61,7 +73,7 @@ pub struct Pretty<'a, Q: ?Sized> {
 
 impl<'a, Q> Pretty<'a, Q>
 where
-    Q: PrettyQueries + ?Sized,
+    Q: PrettyQueries<Checked = Arc<CheckedModule>> + ?Sized,
 {
     pub fn new(queries: &'a Q, checked: &'a CheckedModule) -> Pretty<'a, Q> {
         Pretty { queries, width: 100, checked }
@@ -97,7 +109,7 @@ where
 
 struct Printer<'arena, 'context, 'module, Q>
 where
-    Q: PrettyQueries + ?Sized,
+    Q: PrettyQueries<Checked = Arc<CheckedModule>> + ?Sized,
 {
     arena: &'arena Arena<'arena>,
     queries: &'context Q,
@@ -111,7 +123,7 @@ where
 
 impl<'arena, 'context, 'module, Q> Printer<'arena, 'context, 'module, Q>
 where
-    Q: PrettyQueries + ?Sized,
+    Q: PrettyQueries<Checked = Arc<CheckedModule>> + ?Sized,
 {
     fn new(
         arena: &'arena Arena<'arena>,
@@ -1355,11 +1367,122 @@ where
         match evidence {
             Evidence::Variable(evidence) => self.evidence_variable_name(names, *evidence),
             Evidence::Given(binder) => self.evidence_binder_name(names, *binder),
-            Evidence::Instance { .. } => Ok(SmolStr::new("instance")),
-            Evidence::Superclass { .. } => Ok(SmolStr::new("superclass")),
+            Evidence::Instance { origin, subgoals } => {
+                let mut instance = self.instance_dictionary_name(*origin)?;
+                for subgoal in subgoals {
+                    let subgoal = self.evidence_variable_name(names, *subgoal)?;
+                    instance = format_smolstr!("{instance} {{{subgoal}}}");
+                }
+                Ok(instance)
+            }
+            Evidence::Superclass { parent, superclass } => {
+                let parent_evidence = &self.checked.evidence[*parent];
+                let parent = self.evidence_name(names, parent_evidence)?;
+                let field = self.superclass_field_name(*superclass)?;
+                if parent.contains(' ') {
+                    Ok(format_smolstr!("({parent}).{field}"))
+                } else {
+                    Ok(format_smolstr!("{parent}.{field}"))
+                }
+            }
             Evidence::Trivial => Ok(SmolStr::new("trivial")),
-            Evidence::Synthesized(_) => Ok(SmolStr::new("synthesized")),
+            Evidence::Synthesized(evidence) => Ok(synthesized_evidence_name(evidence)),
         }
+    }
+
+    fn instance_dictionary_name(&self, origin: InstanceCandidateOrigin) -> QueryResult<SmolStr> {
+        let file_id = match origin {
+            InstanceCandidateOrigin::Instance(file_id, _)
+            | InstanceCandidateOrigin::Derive(file_id, _) => file_id,
+        };
+        let indexed =
+            if file_id == self.file_id { None } else { Some(self.queries.indexed(file_id)?) };
+        let indexed = indexed.as_deref().unwrap_or(self.indexed);
+        let mut term_items = indexed.items.iter_terms();
+        let term_id = term_items.find_map(|(term_id, item)| {
+            let matches = match (&item.kind, origin) {
+                (
+                    TermItemKind::Instance { id },
+                    InstanceCandidateOrigin::Instance(_, origin_id),
+                ) => *id == origin_id,
+                (TermItemKind::Derive { id }, InstanceCandidateOrigin::Derive(_, origin_id)) => {
+                    *id == origin_id
+                }
+                (_, _) => false,
+            };
+            matches.then_some(term_id)
+        });
+        let Some(term_id) = term_id else {
+            return Ok(UNKNOWN_INSTANCE_EVIDENCE);
+        };
+        if let Some(name) = &indexed.items[term_id].name {
+            return Ok(SmolStr::clone(name));
+        }
+
+        let checked =
+            if file_id == self.file_id { None } else { Some(self.queries.checked(file_id)?) };
+        let checked = checked.as_deref().unwrap_or(self.checked);
+        let mut names = PrettyNames::new();
+        for (_, item) in indexed.items.iter_terms() {
+            if let Some(name) = &item.name {
+                names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+        for (candidate_id, candidate) in indexed.items.iter_terms() {
+            if candidate.name.is_some() {
+                continue;
+            }
+            let Some(declaration_id) = checked.tree.lookup_term(candidate_id) else {
+                continue;
+            };
+            let declaration = &checked.tree[declaration_id];
+            let TermDeclarationKind::Instance(instance) = &declaration.kind else {
+                continue;
+            };
+            let base = self.dictionary_base_name(declaration.type_id, instance)?;
+            let name = names.allocate_display_name(base);
+            if candidate_id == term_id {
+                return Ok(name);
+            }
+        }
+        Ok(UNKNOWN_INSTANCE_EVIDENCE)
+    }
+
+    fn superclass_field_name(&self, superclass: SuperclassId) -> QueryResult<SmolStr> {
+        let indexed = if superclass.file_id == self.file_id {
+            None
+        } else {
+            Some(self.queries.indexed(superclass.file_id)?)
+        };
+        let indexed = indexed.as_deref().unwrap_or(self.indexed);
+        let checked = if superclass.file_id == self.file_id {
+            None
+        } else {
+            Some(self.queries.checked(superclass.file_id)?)
+        };
+        let checked = checked.as_deref().unwrap_or(self.checked);
+        let Some(declaration_id) = checked.tree.lookup_type_declaration(superclass.type_id) else {
+            return Ok(UNKNOWN_SUPERCLASS_EVIDENCE);
+        };
+        let declaration = &checked.tree[declaration_id];
+        let TypeDeclarationKind::Class(class) = &declaration.declaration else {
+            return Ok(UNKNOWN_SUPERCLASS_EVIDENCE);
+        };
+
+        let mut names = PrettyNames::new();
+        for member_id in indexed.class_members(superclass.type_id) {
+            if let Some(name) = &indexed.items[member_id].name {
+                names.allocate_display_name(SmolStr::clone(name));
+            }
+        }
+        for candidate in class.superclasses.iter() {
+            let base = self.evidence_base_name(candidate.constraint)?;
+            let name = names.allocate_display_name(base);
+            if candidate.id == superclass {
+                return Ok(name);
+            }
+        }
+        Ok(UNKNOWN_SUPERCLASS_EVIDENCE)
     }
 
     fn evidence_binder_name(
@@ -1391,14 +1514,14 @@ where
             }
         };
         let Some(class_name) = class_name else {
-            return Ok(SmolStr::new("evidenceDict"));
+            return Ok(EVIDENCE_DICTIONARY_NAME);
         };
         let mut characters = class_name.chars();
         let Some(first) = characters.next() else {
-            return Ok(SmolStr::new("evidenceDict"));
+            return Ok(EVIDENCE_DICTIONARY_NAME);
         };
         let first = first.to_lowercase().collect::<String>();
-        Ok(SmolStr::new(format!("{first}{}Dict", characters.as_str())))
+        Ok(format_smolstr!("{first}{}Dict", characters.as_str()))
     }
 
     fn term_name(
@@ -1447,5 +1570,29 @@ where
 
         let indexed = self.queries.indexed(file_id)?;
         Ok(indexed.items[type_id].name.as_ref().map(ToString::to_string))
+    }
+}
+
+fn synthesized_evidence_name(evidence: &SynthesizedEvidence) -> SmolStr {
+    match evidence {
+        SynthesizedEvidence::IsSymbol(symbol) => format_smolstr!("isSymbol({symbol:?})"),
+        SynthesizedEvidence::Reflectable(ReflectableEvidence::Integer(value)) => {
+            format_smolstr!("reflectable({value})")
+        }
+        SynthesizedEvidence::Reflectable(ReflectableEvidence::String(value)) => {
+            format_smolstr!("reflectable({value:?})")
+        }
+        SynthesizedEvidence::Reflectable(ReflectableEvidence::Boolean(value)) => {
+            format_smolstr!("reflectable({value})")
+        }
+        SynthesizedEvidence::Reflectable(ReflectableEvidence::Ordering(
+            ReflectableOrdering::Less,
+        )) => REFLECTABLE_LESS_EVIDENCE,
+        SynthesizedEvidence::Reflectable(ReflectableEvidence::Ordering(
+            ReflectableOrdering::Equal,
+        )) => REFLECTABLE_EQUAL_EVIDENCE,
+        SynthesizedEvidence::Reflectable(ReflectableEvidence::Ordering(
+            ReflectableOrdering::Greater,
+        )) => REFLECTABLE_GREATER_EVIDENCE,
     }
 }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1273,19 +1273,25 @@ where
                     evidence_names,
                     type_pretty,
                 )?;
-                let argument_precedence =
-                    if allow_block_argument && self.expression_is_block_argument(*argument) {
-                        ExpressionPrecedence::Abstraction
-                    } else {
-                        ExpressionPrecedence::RecordUpdate
-                    };
+                let is_block_argument =
+                    allow_block_argument && self.expression_is_block_argument(*argument);
+                let argument_precedence = if is_block_argument {
+                    ExpressionPrecedence::Abstraction
+                } else {
+                    ExpressionPrecedence::RecordUpdate
+                };
                 let argument = self.expression_at(
                     *argument,
                     argument_precedence,
                     evidence_names,
                     type_pretty,
                 )?;
-                Ok(function.append(self.arena.space()).append(argument))
+                if is_block_argument {
+                    Ok(function.append(self.arena.space()).append(argument))
+                } else {
+                    let argument = self.arena.line().append(argument);
+                    Ok(function.append(argument.nest(2)).group())
+                }
             }
             ExpressionKind::TypeApplication { function, argument } => {
                 let function = self.expression_at(
@@ -1325,7 +1331,7 @@ where
                 if self.expression_requires_body_break(*expression) {
                     Ok(lambda.append(self.arena.hardline().append(body).nest(2)))
                 } else {
-                    Ok(lambda.append(self.arena.space()).append(body))
+                    Ok(lambda.append(self.arena.line().append(body).nest(2)).group())
                 }
             }
             ExpressionKind::Case { scrutinees, alternatives } => {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1114,8 +1114,13 @@ where
             | ExpressionKind::EvidenceApplication { .. } => ExpressionPrecedence::Application,
             _ => ExpressionPrecedence::Atom,
         };
-        let expression =
-            self.expression_unparenthesized(expression_id, evidence_names, type_pretty)?;
+        let allow_block_argument = required_precedence != ExpressionPrecedence::Application;
+        let expression = self.expression_unparenthesized(
+            expression_id,
+            allow_block_argument,
+            evidence_names,
+            type_pretty,
+        )?;
         if precedence < required_precedence {
             Ok(self.arena.text("(").append(expression).append(self.arena.text(")")))
         } else {
@@ -1126,6 +1131,7 @@ where
     fn expression_unparenthesized(
         &self,
         expression_id: ExpressionId,
+        allow_block_argument: bool,
         evidence_names: &mut EvidenceNames,
         type_pretty: &mut TypePretty<'context, Q>,
     ) -> QueryResult<Doc<'arena>> {
@@ -1255,11 +1261,12 @@ where
                     evidence_names,
                     type_pretty,
                 )?;
-                let argument_precedence = if self.expression_is_block_argument(*argument) {
-                    ExpressionPrecedence::Abstraction
-                } else {
-                    ExpressionPrecedence::RecordUpdate
-                };
+                let argument_precedence =
+                    if allow_block_argument && self.expression_is_block_argument(*argument) {
+                        ExpressionPrecedence::Abstraction
+                    } else {
+                        ExpressionPrecedence::RecordUpdate
+                    };
                 let argument = self.expression_at(
                     *argument,
                     argument_precedence,

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -13,7 +13,7 @@ use crate::core::Type;
 use crate::core::pretty::{Pretty as TypePretty, PrettyNames, PrettyQueries};
 use crate::evidence::{Evidence, EvidenceBinderId, EvidenceState, EvidenceVarId};
 use crate::tree::{
-    BinderId, BinderKind, CaseAlternative, Equation, ExpressionId, ExpressionKind,
+    BinderId, BinderKind, BinderSource, CaseAlternative, Equation, ExpressionId, ExpressionKind,
     GuardedAlternative, GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings,
     LocalDeclarationId, PatternGuard, RecordBinderField, RecordExpressionField,
     TermDeclarationKind, TypeDeclarationKind, WhereExpression,
@@ -1008,10 +1008,13 @@ where
                 Ok(self.arena.text(value))
             }
             BinderKind::Variable => {
+                let BinderSource::Binder(source) = binder.source else {
+                    unreachable!("invariant violated: generated semantic variable binder")
+                };
                 let kind = self
                     .lowered
                     .info
-                    .get_binder_kind(binder.source)
+                    .get_binder_kind(source)
                     .expect("invariant violated: semantic variable binder has no source");
                 let lowering::BinderKind::Variable { variable: Some(variable) } = kind else {
                     unreachable!("invariant violated: semantic variable binder has invalid source");

--- a/tests-integration/fixtures/checking/1784872200_do_higher_rank_action/Main.purs
+++ b/tests-integration/fixtures/checking/1784872200_do_higher_rank_action/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+foreign import data Box :: Type -> Type
+
+foreign import polymorphic :: forall value. Box value
+
+foreign import bind ::
+  forall result.
+  (forall value. Box value) ->
+  ((forall value. Box value) -> result) ->
+  result
+
+test :: Int
+test = do
+  value <- polymorphic
+  42
+
+test' = do
+  value <- polymorphic
+  42

--- a/tests-integration/fixtures/checking/1784872200_do_higher_rank_action/Main.snap
+++ b/tests-integration/fixtures/checking/1784872200_do_higher_rank_action/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+polymorphic :: forall (value :: Type). Box (value :: Type)
+bind ::
+  forall (result :: Type).
+    (forall (value :: Type). Box (value :: Type)) ->
+    ((forall (value1 :: Type). Box (value1 :: Type)) -> (result :: Type)) ->
+    (result :: Type)
+test :: Int
+test' :: Int
+
+Types
+Box :: Type -> Type
+
+Roles
+Box = [Nominal]

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
@@ -18,9 +18,8 @@ implementation = \{secondDict} -> \_ -> \_ -> boolean
 
 dictionary exampleAB ::
   forall t t1.
-  { firstDict :: First t
-  , secondDict :: Second t1
-  } =>
+  { firstDict :: First t } =>
+  { secondDict :: Second t1 } =>
   Example t t1
-where
+  where
   example = implementation @t1 @t {secondDict}

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
@@ -13,7 +13,6 @@ interface Example a where
   first :: a
   second :: a
 
-dictionary exampleToken :: Example Token
-where
+dictionary exampleToken :: Example Token where
   first = FirstToken
   second = SecondToken

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
@@ -11,9 +11,6 @@ interface Ord a where
   superclass eqDict :: Eq a
   compare :: a -> a -> Int
 
-dictionary ordInt ::
-  { eqDict :: Eq Int } =>
-  Ord Int
-where
+dictionary ordInt :: { eqDict :: Eq Int } => Ord Int where
   superclass eqDict = eqDict
   compare = compareImpl

--- a/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
@@ -13,6 +13,5 @@ interface Example a where
 implementation :: forall a b. Required b => a -> b -> Boolean
 implementation = \{requiredDict} -> \_ -> \_ -> boolean
 
-dictionary exampleInt :: Example Int
-where
+dictionary exampleInt :: Example Int where
   apply = \{requiredDict} -> implementation @Int @b {requiredDict}

--- a/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
@@ -14,10 +14,9 @@ implementation :: Fail (Text "first deferred error") => Required Int => Fail (Te
 implementation = \{failDict} -> \{requiredDict} -> \{failDict1} -> boolean
 
 dictionary exampleInt ::
-  { failDict :: Fail (Text "first deferred error")
-  , requiredDict :: Required Int
-  , failDict1 :: Fail (Text "second deferred error")
-  } =>
+  { failDict :: Fail (Text "first deferred error") } =>
+  { requiredDict :: Required Int } =>
+  { failDict1 :: Fail (Text "second deferred error") } =>
   Example Int
-where
+  where
   example = implementation {failDict} {requiredDict} {failDict1}

--- a/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
@@ -7,9 +7,6 @@ data Token :: Type
 data Token
   | Token :: Token
 
-dictionary childToken ::
-  { parentDict :: Parent Token } =>
-  Child Token
-where
+dictionary childToken :: { parentDict :: Parent Token } => Child Token where
   superclass parentDict = parentDict
   child = Token

--- a/tests-integration/fixtures/semantic/1784872680_do_action_applications/Main.purs
+++ b/tests-integration/fixtures/semantic/1784872680_do_action_applications/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+foreign import data Effect :: Type -> Type
+
+class Select value
+
+foreign import constrained :: forall value. Select value => Effect value
+
+foreign import pure :: forall value. value -> Effect value
+
+foreign import bind ::
+  forall value result.
+  Effect value ->
+  (value -> Effect result) ->
+  Effect result
+
+selected :: Select Int => Effect Int
+selected = do
+  value <- constrained
+  pure value

--- a/tests-integration/fixtures/semantic/1784872680_do_action_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872680_do_action_applications/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Select :: forall (k :: Type). k -> Constraint
+interface Select value where
+
+selected :: Select @Type Int => Effect Int
+selected = \{selectDict} -> bind @Int @Int (constrained @Int {selectDict}) \value -> pure @Int value

--- a/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.purs
@@ -1,0 +1,37 @@
+module Main where
+
+foreign import data Effect :: Type -> Type
+
+foreign import pure :: forall value. value -> Effect value
+
+foreign import bind ::
+  forall value result.
+  Effect value ->
+  (value -> Effect result) ->
+  Effect result
+
+foreign import discard ::
+  forall value result.
+  Effect value ->
+  (value -> Effect result) ->
+  Effect result
+
+bound :: Effect Int
+bound = do
+  value <- pure 1
+  pure value
+
+discarded = do
+  pure 1
+  pure "done"
+
+withLet = do
+  value <- pure 1
+  let next = value
+  pure next
+
+nested = do
+  value <- do
+    inner <- pure 1
+    pure inner
+  pure value

--- a/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.snap
@@ -11,11 +11,12 @@ discarded = discard @Int @String (pure @Int 1) \_ -> pure @String "done"
 
 withLet :: Effect Int
 withLet =
-  bind @Int @Int (pure @Int 1) \value -> let
-    next :: Int
-    next = value
-  in
-    pure @Int next
+  bind @Int @Int (pure @Int 1) \value ->
+    let
+      next :: Int
+      next = value
+    in
+      pure @Int next
 
 nested :: Effect Int
 nested =

--- a/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+bound :: Effect Int
+bound = bind @Int @Int (pure @Int 1) \value -> pure @Int value
+
+discarded :: Effect String
+discarded = discard @Int @String (pure @Int 1) \_ -> pure @String "done"
+
+withLet :: Effect Int
+withLet =
+  bind @Int @Int (pure @Int 1) \value -> let
+    next :: Int
+    next = value
+  in
+    pure @Int next
+
+nested :: Effect Int
+nested =
+  bind @Int @Int (bind @Int @Int (pure @Int 1) \inner -> pure @Int inner) \value -> pure @Int value

--- a/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.purs
@@ -1,0 +1,52 @@
+module Main where
+
+foreign import data Effect :: Type -> Type
+
+data Tuple first second = Tuple first second
+
+foreign import pure :: forall value. value -> Effect value
+
+foreign import map ::
+  forall value result.
+  (value -> result) ->
+  Effect value ->
+  Effect result
+
+foreign import apply ::
+  forall value result.
+  Effect (value -> result) ->
+  Effect value ->
+  Effect result
+
+zero = ado
+  in 1
+
+zeroWithLet = ado
+  let value = 1
+  in value
+
+one = ado
+  value <- pure 1
+  in value
+
+multiple = ado
+  first <- pure 1
+  second <- pure "two"
+  in Tuple first second
+
+discarded = ado
+  pure 1
+  value <- pure "kept"
+  in value
+
+withLet = ado
+  first <- pure 1
+  let next = first
+  second <- pure 2
+  in Tuple next second
+
+nested = ado
+  value <- ado
+    inner <- pure 1
+    in inner
+  in value

--- a/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.snap
@@ -23,19 +23,28 @@ one = map @Int @Int (\value -> value) (pure @Int 1)
 
 multiple :: Effect (Tuple Int String)
 multiple =
-  apply @String @(Tuple Int String) (map @Int @(String -> Tuple Int String) (\first second -> Tuple @Int @String first second) (pure @Int 1)) (pure @String "two")
+  apply @String @(Tuple Int String)
+    (map @Int @(String -> Tuple Int String) (\first second -> Tuple @Int @String first second)
+      (pure @Int 1))
+    (pure @String "two")
 
 discarded :: Effect String
 discarded =
-  apply @String @String (map @Int @(String -> String) (\_ value -> value) (pure @Int 1)) (pure @String "kept")
+  apply @String @String (map @Int @(String -> String) (\_ value -> value) (pure @Int 1))
+    (pure @String "kept")
 
 withLet :: Effect (Tuple Int Int)
 withLet =
-  apply @Int @(Tuple Int Int) (map @Int @(Int -> Tuple Int Int) (\first second -> let
-    next :: Int
-    next = first
-  in
-    Tuple @Int @Int next second) (pure @Int 1)) (pure @Int 2)
+  apply @Int @(Tuple Int Int)
+    (map @Int @(Int -> Tuple Int Int)
+      (\first second ->
+        let
+          next :: Int
+          next = first
+        in
+          Tuple @Int @Int next second)
+      (pure @Int 1))
+    (pure @Int 2)
 
 nested :: Effect Int
 nested = map @Int @Int (\value -> value) (map @Int @Int (\inner -> inner) (pure @Int 1))

--- a/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Tuple :: Type -> Type -> Type
+data Tuple @first @second
+  | Tuple :: first -> second -> Tuple first second
+
+zero :: Effect Int
+zero = pure @Int 1
+
+zeroWithLet :: Effect Int
+zeroWithLet =
+  let
+    value :: Int
+    value = 1
+  in
+    pure @Int value
+
+one :: Effect Int
+one = map @Int @Int (\value -> value) (pure @Int 1)
+
+multiple :: Effect (Tuple Int String)
+multiple =
+  apply @String @(Tuple Int String) (map @Int @(String -> Tuple Int String) (\first second -> Tuple @Int @String first second) (pure @Int 1)) (pure @String "two")
+
+discarded :: Effect String
+discarded =
+  apply @String @String (map @Int @(String -> String) (\_ value -> value) (pure @Int 1)) (pure @String "kept")
+
+withLet :: Effect (Tuple Int Int)
+withLet =
+  apply @Int @(Tuple Int Int) (map @Int @(Int -> Tuple Int Int) (\first second -> let
+    next :: Int
+    next = first
+  in
+    Tuple @Int @Int next second) (pure @Int 1)) (pure @Int 2)
+
+nested :: Effect Int
+nested = map @Int @Int (\value -> value) (map @Int @Int (\inner -> inner) (pure @Int 1))

--- a/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+foreign import data Effect :: Type -> Type
+
+foreign import pure :: forall value. value -> Effect value
+foreign import bind :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+foreign import discard :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+
+emptyDo = do
+
+finalBind = do
+  value <- pure 1
+
+finalLet = do
+  let value = 1
+
+missingDoAction = do
+  value <-
+  pure value

--- a/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+emptyDo :: ?[empty do block]
+emptyDo = <error>
+
+finalBind :: Effect Int
+finalBind = pure @Int 1
+
+finalLet :: forall t. t
+finalLet =
+  let
+    value :: Int
+    value = 1
+  in
+    <error>
+
+missingDoAction :: forall t. t
+missingDoAction = <error> \value -> pure @?21 value

--- a/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+foreign import data Effect :: Type -> Type
+
+foreign import pure :: forall value. value -> Effect value
+foreign import map :: forall value result. (value -> result) -> Effect value -> Effect result
+foreign import apply :: forall value result. Effect (value -> result) -> Effect value -> Effect result
+
+emptyAdo = ado
+
+missingAdoAction = ado
+  value <-
+  in value
+
+missingAdoResult = ado
+  value <- pure 1
+  in

--- a/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+emptyAdo :: ?[empty ado block]
+emptyAdo = <error>
+
+missingAdoAction :: forall t t1. t t1
+missingAdoAction = <error> <error>
+
+missingAdoResult :: forall t. Effect t
+missingAdoResult = map @Int @t (\value -> <error>) (pure @Int 1)

--- a/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+class Operations :: (Type -> Type) -> Constraint
+class Operations effect where
+  pure :: forall value. value -> effect value
+  bind :: forall value result. effect value -> (value -> effect result) -> effect result
+  discard :: forall value result. effect value -> (value -> effect result) -> effect result
+
+usingBind :: forall effect. Operations effect => effect Int
+usingBind = do
+  value <- pure 1
+  pure value
+
+usingDiscard :: forall effect. Operations effect => effect Int
+usingDiscard = do
+  pure "ignored"
+  pure 1

--- a/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Operations :: (Type -> Type) -> Constraint
+interface Operations effect where
+  pure :: forall (value :: Type). value -> effect value
+  bind :: forall (value :: Type) (result :: Type). effect value -> (value -> effect result) -> effect result
+  discard :: forall (value :: Type) (result :: Type). effect value -> (value -> effect result) -> effect result
+
+usingBind :: forall effect. Operations effect => effect Int
+usingBind = \{operationsDict} ->
+  bind @effect {operationsDict} @Int @Int (pure @effect {operationsDict} @Int 1) \value -> pure @effect {operationsDict} @Int value
+
+usingDiscard :: forall effect. Operations effect => effect Int
+usingDiscard = \{operationsDict} ->
+  discard @effect {operationsDict} @String @Int (pure @effect {operationsDict} @String "ignored") \_ -> pure @effect {operationsDict} @Int 1

--- a/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
@@ -11,8 +11,10 @@ interface Operations effect where
 
 usingBind :: forall effect. Operations effect => effect Int
 usingBind = \{operationsDict} ->
-  bind @effect {operationsDict} @Int @Int (pure @effect {operationsDict} @Int 1) \value -> pure @effect {operationsDict} @Int value
+  bind @effect {operationsDict} @Int @Int (pure @effect {operationsDict} @Int 1) \value ->
+    pure @effect {operationsDict} @Int value
 
 usingDiscard :: forall effect. Operations effect => effect Int
 usingDiscard = \{operationsDict} ->
-  discard @effect {operationsDict} @String @Int (pure @effect {operationsDict} @String "ignored") \_ -> pure @effect {operationsDict} @Int 1
+  discard @effect {operationsDict} @String @Int
+    (pure @effect {operationsDict} @String "ignored") \_ -> pure @effect {operationsDict} @Int 1

--- a/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+data Tuple first second = Tuple first second
+
+class Operations :: (Type -> Type) -> Constraint
+class Operations effect where
+  pure :: forall value. value -> effect value
+  map :: forall value result. (value -> result) -> effect value -> effect result
+  apply :: forall value result. effect (value -> result) -> effect value -> effect result
+
+usingMapApply :: forall effect. Operations effect => effect (Tuple Int String)
+usingMapApply = ado
+  first <- pure 1
+  second <- pure "two"
+  in Tuple first second
+
+usingPure :: forall effect. Operations effect => effect Int
+usingPure = ado
+  in 1

--- a/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Tuple :: Type -> Type -> Type
+data Tuple @first @second
+  | Tuple :: first -> second -> Tuple first second
+
+interface Operations :: (Type -> Type) -> Constraint
+interface Operations effect where
+  pure :: forall (value :: Type). value -> effect value
+  map :: forall (value :: Type) (result :: Type). (value -> result) -> effect value -> effect result
+  apply :: forall (value :: Type) (result :: Type). effect (value -> result) -> effect value -> effect result
+
+usingMapApply :: forall effect. Operations effect => effect (Tuple Int String)
+usingMapApply = \{operationsDict} ->
+  apply @effect {operationsDict} @String @(Tuple Int String) (map @effect {operationsDict} @Int @(String -> Tuple Int String) (\first second -> Tuple @Int @String first second) (pure @effect {operationsDict} @Int 1)) (pure @effect {operationsDict} @String "two")
+
+usingPure :: forall effect. Operations effect => effect Int
+usingPure = \{operationsDict} -> pure @effect {operationsDict} @Int 1

--- a/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
@@ -15,7 +15,11 @@ interface Operations effect where
 
 usingMapApply :: forall effect. Operations effect => effect (Tuple Int String)
 usingMapApply = \{operationsDict} ->
-  apply @effect {operationsDict} @String @(Tuple Int String) (map @effect {operationsDict} @Int @(String -> Tuple Int String) (\first second -> Tuple @Int @String first second) (pure @effect {operationsDict} @Int 1)) (pure @effect {operationsDict} @String "two")
+  apply @effect {operationsDict} @String @(Tuple Int String)
+    (map @effect {operationsDict} @Int @(String -> Tuple Int String)
+      (\first second -> Tuple @Int @String first second)
+      (pure @effect {operationsDict} @Int 1))
+    (pure @effect {operationsDict} @String "two")
 
 usingPure :: forall effect. Operations effect => effect Int
 usingPure = \{operationsDict} -> pure @effect {operationsDict} @Int 1

--- a/tests-integration/fixtures/semantic/1784873340_do_unresolved_functions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873340_do_unresolved_functions/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+unresolvedBind = do
+  value <- 1
+  value
+
+unresolvedDiscard = do
+  1
+  2

--- a/tests-integration/fixtures/semantic/1784873340_do_unresolved_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873340_do_unresolved_functions/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+unresolvedBind :: forall t t1. t t1
+unresolvedBind = <error> 1 \value -> value
+
+unresolvedDiscard :: forall t t1. t t1
+unresolvedDiscard = <error> 1 \_ -> 2

--- a/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+unresolvedMap = ado
+  value <- 1
+  in value
+
+unresolvedApply = ado
+  first <- 1
+  second <- 2
+  in first
+
+unresolvedPure = ado
+  in 1

--- a/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+unresolvedMap :: forall t t1. t t1
+unresolvedMap = <error> (\value -> value) 1
+
+unresolvedApply :: forall t t1. t t1
+unresolvedApply = <error> (<error> (\first second -> first) 1) 2
+
+unresolvedPure :: forall t. t Int
+unresolvedPure = <error> 1

--- a/tests-integration/fixtures/semantic/1784873460_do_higher_rank_action/Main.purs
+++ b/tests-integration/fixtures/semantic/1784873460_do_higher_rank_action/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+foreign import data Box :: Type -> Type
+
+foreign import polymorphic :: forall value. Box value
+
+foreign import bind ::
+  forall result.
+  (forall value. Box value) ->
+  ((forall value. Box value) -> result) ->
+  result
+
+higherRank :: Int
+higherRank = do
+  value <- polymorphic
+  42

--- a/tests-integration/fixtures/semantic/1784873460_do_higher_rank_action/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873460_do_higher_rank_action/Main.snap
@@ -1,0 +1,7 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+higherRank :: Int
+higherRank = bind @Int polymorphic \value -> 42

--- a/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.purs
+++ b/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+class Parent :: Type -> Constraint
+class Parent value
+
+class Parent value <= Child value
+
+instance parentInt :: Parent Int
+
+instance childInt :: Parent Int => Child Int
+
+foreign import useParent :: forall value. Parent value => value -> value
+
+foreign import useChild :: forall value. Child value => value -> value
+
+instanceEvidence :: Int
+instanceEvidence = useChild 1
+
+superclassEvidence :: forall value. Child value => value -> value
+superclassEvidence = useParent

--- a/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
+++ b/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Parent :: Type -> Constraint
+interface Parent value where
+
+interface Child :: Type -> Constraint
+interface Child value where
+  superclass parentDict :: Parent value
+
+dictionary parentInt :: Parent Int
+where
+
+dictionary childInt ::
+  { parentDict :: Parent Int } =>
+  Child Int
+where
+  superclass parentDict = parentDict
+
+instanceEvidence :: Int
+instanceEvidence = useChild @Int {childInt {parentInt}} 1
+
+superclassEvidence :: forall value. Child value => value -> value
+superclassEvidence = \{childDict} -> useParent @value {childDict.parentDict}

--- a/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
+++ b/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
@@ -11,12 +11,8 @@ interface Child value where
   superclass parentDict :: Parent value
 
 dictionary parentInt :: Parent Int
-where
 
-dictionary childInt ::
-  { parentDict :: Parent Int } =>
-  Child Int
-where
+dictionary childInt :: { parentDict :: Parent Int } => Child Int where
   superclass parentDict = parentDict
 
 instanceEvidence :: Int

--- a/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.purs
@@ -1,0 +1,53 @@
+module Main where
+
+foreign import data Action :: Int -> Type -> Type
+
+class OnStep :: Int -> Constraint
+class OnStep step
+
+instance onZero :: OnStep 0
+else instance onTwo :: OnStep 2
+else instance onDefault :: OnStep step
+
+foreign import map ::
+  forall step.
+  OnStep step =>
+  forall value result.
+  (value -> result) ->
+  Action step value ->
+  Action step result
+
+foreign import apply ::
+  forall step.
+  OnStep step =>
+  forall previous value result.
+  Action previous (value -> result) ->
+  Action step value ->
+  Action step result
+
+foreign import pure ::
+  forall step.
+  OnStep step =>
+  forall value.
+  value ->
+  Action step value
+
+foreign import stepZero :: Action 0 Int
+
+foreign import stepOne :: Action 1 String
+
+foreign import stepTwo :: Action 2 Boolean
+
+foreign import stepThree :: Action 3 String
+
+indexedApply :: Action 3 String
+indexedApply = ado
+  zero <- stepZero
+  one <- stepOne
+  two <- stepTwo
+  three <- stepThree
+  in three
+
+indexedPure :: Action 2 Int
+indexedPure = ado
+  in 1

--- a/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface OnStep :: Int -> Constraint
+interface OnStep step where
+
+dictionary onZero :: OnStep 0
+where
+
+dictionary onTwo :: OnStep 2
+where
+
+dictionary onDefault ::
+  forall t.
+  OnStep t
+where
+
+indexedApply :: Action 3 String
+indexedApply =
+  apply @3 {onDefault} @2 @String @String
+    (apply @2 {onTwo} @1 @Boolean @(String -> String)
+      (apply @1 {onDefault} @0 @String @(Boolean -> String -> String)
+        (map @0 {onZero} @Int @(String -> Boolean -> String -> String)
+          (\zero one two three -> three)
+          stepZero)
+        stepOne)
+      stepTwo)
+    stepThree
+
+indexedPure :: Action 2 Int
+indexedPure = pure @2 {onTwo} @Int 1

--- a/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
@@ -7,15 +7,10 @@ interface OnStep :: Int -> Constraint
 interface OnStep step where
 
 dictionary onZero :: OnStep 0
-where
 
 dictionary onTwo :: OnStep 2
-where
 
-dictionary onDefault ::
-  forall t.
-  OnStep t
-where
+dictionary onDefault :: forall t. OnStep t
 
 indexedApply :: Action 3 String
 indexedApply =

--- a/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.purs
@@ -1,0 +1,49 @@
+module Main where
+
+foreign import data Action :: Int -> Type -> Type
+
+class OnStep :: Int -> Constraint
+class OnStep step
+
+instance onZero :: OnStep 0
+else instance onTwo :: OnStep 2
+else instance onDefault :: OnStep step
+
+foreign import bind ::
+  forall step.
+  OnStep step =>
+  forall next value result.
+  Action step value ->
+  (value -> Action next result) ->
+  Action step result
+
+foreign import discard ::
+  forall step.
+  OnStep step =>
+  forall next value result.
+  Action step value ->
+  (value -> Action next result) ->
+  Action step result
+
+foreign import stepZero :: Action 0 Int
+
+foreign import stepOne :: Action 1 String
+
+foreign import stepTwo :: Action 2 Boolean
+
+foreign import stepThree :: Action 3 String
+
+foreign import stepFour :: Action 4 Number
+
+indexedBind :: Action 0 Number
+indexedBind = do
+  zero <- stepZero
+  one <- stepOne
+  two <- stepTwo
+  three <- stepThree
+  stepFour
+
+indexedDiscard :: Action 4 Boolean
+indexedDiscard = do
+  stepFour
+  stepTwo

--- a/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface OnStep :: Int -> Constraint
+interface OnStep step where
+
+dictionary onZero :: OnStep 0
+where
+
+dictionary onTwo :: OnStep 2
+where
+
+dictionary onDefault ::
+  forall t.
+  OnStep t
+where
+
+indexedBind :: Action 0 Number
+indexedBind =
+  bind @0 {onZero} @1 @Int @Number stepZero \zero ->
+    bind @1 {onDefault} @2 @String @Number stepOne \one ->
+      bind @2 {onTwo} @3 @Boolean @Number stepTwo \two ->
+        bind @3 {onDefault} @4 @String @Number stepThree \three -> stepFour
+
+indexedDiscard :: Action 4 Boolean
+indexedDiscard = discard @4 {onDefault} @2 @Number @Boolean stepFour \_ -> stepTwo

--- a/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
@@ -7,15 +7,10 @@ interface OnStep :: Int -> Constraint
 interface OnStep step where
 
 dictionary onZero :: OnStep 0
-where
 
 dictionary onTwo :: OnStep 2
-where
 
-dictionary onDefault ::
-  forall t.
-  OnStep t
-where
+dictionary onDefault :: forall t. OnStep t
 
 indexedBind :: Action 0 Number
 indexedBind =


### PR DESCRIPTION
## Motivation

Do and ado checking already inferred the types of rebindable `bind`, `discard`, `map`, `apply`, and `pure` calls, but it did not retain those desugared calls in the checked semantic tree. That left downstream consumers without the elaborated expression, including the type and evidence applications selected from each function's actual signature.

## Changes

- Retain implicit type and evidence applications introduced while subtyping action arguments.
- Represent generated do/ado continuation binders in the checked tree with their source provenance.
- Lower do blocks to nested `bind` and `discard` applications and ado blocks to incremental `map`, `apply`, and `pure` applications.
- Instantiate every generated call from the resolved desugaring function's signature, including higher-rank action boundaries.
- Render solved instance and superclass evidence in semantic expressions.
- Add indexed do and ado fixtures that exercise per-step type applications and overlapping instance-chain evidence.
- Make long semantic applications width-aware and simplify dictionary output, including curried evidence arguments and omission of empty `where` blocks.

## Validation

- `just format --check`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (28 passed)
- `just t semantic` (no pending snapshots)
- `git diff --check`