### PR TITLE
[checking] Retain checked if-then-else expressions in the semantic tree

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -210,8 +210,7 @@ where
             forms::check_lambda(state, context, binders, *expression, expected)
         }
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
-            let type_id = forms::check_if_then_else(state, context, *if_, *then, *else_, expected)?;
-            Ok(allocate_error_expression(state, type_id))
+            forms::check_if_then_else(state, context, *if_, *then, *else_, expected)
         }
         lowering::ExpressionKind::CaseOf { trunk, branches } => {
             forms::check_case_of(state, context, trunk, branches, expected)
@@ -370,8 +369,7 @@ where
         }
 
         lowering::ExpressionKind::IfThenElse { if_, then, else_ } => {
-            let type_id = forms::infer_if_then_else(state, context, *if_, *then, *else_)?;
-            Ok(allocate_error_expression(state, type_id))
+            forms::infer_if_then_else(state, context, *if_, *then, *else_)
         }
 
         lowering::ExpressionKind::LetIn { bindings, expression } => {

--- a/compiler-core/checking/src/source/terms/forms.rs
+++ b/compiler-core/checking/src/source/terms/forms.rs
@@ -25,7 +25,7 @@ pub fn infer_if_then_else<Q>(
     if_: Option<lowering::ExpressionId>,
     then: Option<lowering::ExpressionId>,
     else_: Option<lowering::ExpressionId>,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -39,7 +39,7 @@ pub fn check_if_then_else<Q>(
     then: Option<lowering::ExpressionId>,
     else_: Option<lowering::ExpressionId>,
     expected: TypeId,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
@@ -53,28 +53,35 @@ fn if_then_else_core<Q>(
     then: Option<lowering::ExpressionId>,
     else_: Option<lowering::ExpressionId>,
     mode: IfThenElseMode,
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    if let Some(if_) = if_ {
-        super::check_expression(state, context, if_, context.prim.boolean)?;
-    }
+    let condition = if let Some(condition) = if_ {
+        super::check_expression(state, context, condition, context.prim.boolean)?.expression
+    } else {
+        state.allocate_error_expression(context.prim.boolean)
+    };
 
     let result_type = match mode {
         IfThenElseMode::Infer => state.fresh_unification(context.queries, context.prim.t),
         IfThenElseMode::Check { expected } => expected,
     };
 
-    if let Some(then) = then {
-        super::check_expression(state, context, then, result_type)?;
-    }
+    let then = if let Some(then) = then {
+        super::check_expression(state, context, then, result_type)?.expression
+    } else {
+        state.allocate_error_expression(result_type)
+    };
 
-    if let Some(else_) = else_ {
-        super::check_expression(state, context, else_, result_type)?;
-    }
+    let else_ = if let Some(else_) = else_ {
+        super::check_expression(state, context, else_, result_type)?.expression
+    } else {
+        state.allocate_error_expression(result_type)
+    };
 
-    Ok(result_type)
+    let kind = tree::ExpressionKind::IfThenElse { condition, then, else_ };
+    Ok(super::allocate_expression(state, result_type, kind))
 }
 
 pub fn infer_lambda<Q>(

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -316,6 +316,7 @@ pub enum ExpressionKind {
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
     Lambda { binders: Arc<[BinderId]>, expression: ExpressionId },
+    IfThenElse { condition: ExpressionId, then: ExpressionId, else_: ExpressionId },
     Case { scrutinees: Arc<[ExpressionId]>, alternatives: Arc<[CaseAlternative]> },
     Let { bindings: LetBindings, expression: ExpressionId },
 }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -977,13 +977,17 @@ where
     }
 
     fn expression_requires_body_break(&self, expression_id: ExpressionId) -> bool {
-        matches!(&self.checked.tree[expression_id].kind, ExpressionKind::Case { .. })
+        matches!(
+            &self.checked.tree[expression_id].kind,
+            ExpressionKind::IfThenElse { .. } | ExpressionKind::Case { .. }
+        )
     }
 
     fn expression_is_block_argument(&self, expression_id: ExpressionId) -> bool {
         matches!(
             &self.checked.tree[expression_id].kind,
             ExpressionKind::Lambda { .. }
+                | ExpressionKind::IfThenElse { .. }
                 | ExpressionKind::Case { .. }
                 | ExpressionKind::Let { .. }
         )
@@ -1114,6 +1118,7 @@ where
         let expression = &self.checked.tree[expression_id];
         let precedence = match &expression.kind {
             ExpressionKind::Lambda { .. }
+            | ExpressionKind::IfThenElse { .. }
             | ExpressionKind::Case { .. }
             | ExpressionKind::Let { .. } => ExpressionPrecedence::Abstraction,
             ExpressionKind::TermApplication { .. }
@@ -1328,6 +1333,21 @@ where
                 } else {
                     Ok(lambda.append(self.arena.line().append(body).nest(2)).group())
                 }
+            }
+            ExpressionKind::IfThenElse { condition, then, else_ } => {
+                let condition = self.expression(*condition, evidence_names, type_pretty)?;
+                let then = self.expression(*then, evidence_names, type_pretty)?;
+                let else_ = self.expression(*else_, evidence_names, type_pretty)?;
+                Ok(self
+                    .arena
+                    .text("if ")
+                    .append(condition)
+                    .append(self.arena.text(" then"))
+                    .append(self.arena.line().append(then).nest(2))
+                    .append(self.arena.line())
+                    .append(self.arena.text("else"))
+                    .append(self.arena.line().append(else_).nest(2))
+                    .group())
             }
             ExpressionKind::Case { scrutinees, alternatives } => {
                 self.case_expression(scrutinees, alternatives, evidence_names, type_pretty)

--- a/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.purs
@@ -1,0 +1,28 @@
+module Main where
+
+class Predicate a where
+  predicate :: a -> Boolean
+
+class Default value where
+  defaultValue :: value
+
+checked :: Boolean -> Int
+checked condition = if condition then 1 else 2
+
+inferred condition = if condition then "yes" else "no"
+
+constrained :: forall value. Predicate value => value -> Int
+constrained value = if predicate value then 1 else 2
+
+constrainedBranches :: forall value. Default value => Boolean -> value
+constrainedBranches condition = if condition then defaultValue else defaultValue
+
+higherRank :: Boolean -> (forall value. value -> value)
+higherRank condition = if condition then identity else identity
+
+nested first second = if first then if second then 1 else 2 else 3
+
+asArgument condition = identity (if condition then 1 else 2)
+
+identity :: forall value. value -> value
+identity value = value

--- a/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.snap
@@ -1,0 +1,42 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+interface Predicate :: Type -> Constraint
+interface Predicate a where
+  predicate :: a -> Boolean
+
+interface Default :: Type -> Constraint
+interface Default value where
+  defaultValue :: value
+
+checked :: Boolean -> Int
+checked = \condition ->
+  if condition then 1 else 2
+
+inferred :: Boolean -> String
+inferred = \condition ->
+  if condition then "yes" else "no"
+
+constrained :: forall value. Predicate value => value -> Int
+constrained = \{predicateDict} -> \value ->
+  if predicate @value {predicateDict} value then 1 else 2
+
+constrainedBranches :: forall value. Default value => Boolean -> value
+constrainedBranches = \{defaultDict} -> \condition ->
+  if condition then defaultValue @value {defaultDict} else defaultValue @value {defaultDict}
+
+higherRank :: Boolean -> (forall value. value -> value)
+higherRank = \condition ->
+  if condition then identity @value else identity @value
+
+nested :: Boolean -> Boolean -> Int
+nested = \first -> \second ->
+  if first then if second then 1 else 2 else 3
+
+asArgument :: Boolean -> Int
+asArgument = \condition -> identity @Int if condition then 1 else 2
+
+identity :: forall value. value -> value
+identity = \value -> value

--- a/tests-integration/fixtures/semantic/1784882060_if_then_else_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784882060_if_then_else_recovery/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+missingCondition = if then 1 else 2
+
+missingThen = if true then else 2
+
+missingElse = if true then 1 else

--- a/tests-integration/fixtures/semantic/1784882060_if_then_else_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784882060_if_then_else_recovery/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+missingCondition :: Int
+missingCondition =
+  if <error> then 1 else 2
+
+missingThen :: Int
+missingThen =
+  if true then <error> else 2
+
+missingElse :: Int
+missingElse =
+  if true then 1 else <error>


### PR DESCRIPTION
## Summary

Retain the checked condition and branches of if-then-else expressions in the semantic tree instead of replacing the expression with an error node after type checking.

This follows the retain-then-assemble discipline introduced for do and ado expressions: each child is checked once, its elaborated tree is preserved, and missing children are represented by connected typed error nodes. Type and evidence applications introduced while checking conditions and branches therefore remain visible in semantic output.

## Test plan

- Added semantic fixtures covering checked, inferred, constrained, higher-rank, nested, and argument-position conditionals.
- Added semantic recovery coverage for missing conditions and branches.
- Ran the existing if-heavy checking fixtures without snapshot changes.
- Ran `cargo check -p checking --tests`.
- Ran `cargo nextest run -p checking` (28 passed).
- Ran the full semantic fixture suite.
- Ran `just format --check` and `git diff --check`.

## Stack

Stacked on #204. Only the final commit belongs to this PR.