### PR TITLE
[checking] Retain record access and update expressions in the semantic tree

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -499,16 +499,14 @@ where
             let Some(labels) = labels else {
                 return Ok(allocate_error_expression(state, unknown));
             };
-            let type_id = collections::infer_record_access(state, context, record, labels)?;
-            Ok(allocate_error_expression(state, type_id))
+            collections::infer_record_access(state, context, record, labels)
         }
 
         lowering::ExpressionKind::RecordUpdate { record, updates } => {
             let Some(record) = *record else {
                 return Ok(allocate_error_expression(state, unknown));
             };
-            let type_id = collections::infer_record_update(state, context, record, updates)?;
-            Ok(allocate_error_expression(state, type_id))
+            collections::infer_record_update(state, context, record, updates)
         }
     }
 }

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -350,11 +350,12 @@ pub fn infer_record_access<Q>(
     context: &CheckContext<Q>,
     record: lowering::ExpressionId,
     labels: &[SmolStr],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    let mut current_type = super::infer_expression(state, context, record)?.type_id;
+    let record = super::infer_expression(state, context, record)?;
+    let mut current_type = record.type_id;
 
     for label in labels.iter() {
         let label = SmolStr::clone(label);
@@ -369,7 +370,9 @@ where
         current_type = field_type;
     }
 
-    Ok(current_type)
+    let kind =
+        tree::ExpressionKind::RecordAccess { record: record.expression, labels: Arc::from(labels) };
+    Ok(super::allocate_expression(state, current_type, kind))
 }
 
 pub fn infer_record_update<Q>(
@@ -377,11 +380,12 @@ pub fn infer_record_update<Q>(
     context: &CheckContext<Q>,
     record: lowering::ExpressionId,
     updates: &[lowering::RecordUpdate],
-) -> QueryResult<TypeId>
+) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    let (input_fields, output_fields, tail) = infer_record_updates(state, context, updates)?;
+    let updates = infer_record_updates(state, context, updates)?;
+    let ElaboratedRecordUpdates { input_fields, output_fields, tail, updates } = updates;
 
     let input_row = context.intern_row(input_fields, Some(tail));
     let input_record = context.intern_application(context.prim.record, input_row);
@@ -389,57 +393,91 @@ where
     let output_row = context.intern_row(output_fields, Some(tail));
     let output_record = context.intern_application(context.prim.record, output_row);
 
-    super::check_expression(state, context, record, input_record)?;
+    let record = super::check_expression(state, context, record, input_record)?;
 
-    Ok(output_record)
+    let kind = tree::ExpressionKind::RecordUpdate { record: record.expression, updates };
+    Ok(super::allocate_expression(state, output_record, kind))
 }
 
-pub fn infer_record_updates<Q>(
+struct ElaboratedRecordUpdates {
+    input_fields: Vec<RowField>,
+    output_fields: Vec<RowField>,
+    tail: TypeId,
+    updates: Arc<[tree::RecordExpressionUpdate]>,
+}
+
+fn infer_record_updates<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     updates: &[lowering::RecordUpdate],
-) -> QueryResult<(Vec<RowField>, Vec<RowField>, TypeId)>
+) -> QueryResult<ElaboratedRecordUpdates>
 where
     Q: ExternalQueries,
 {
     let mut input_fields = vec![];
     let mut output_fields = vec![];
+    let mut checked_updates = vec![];
 
     for update in updates {
         match update {
             lowering::RecordUpdate::Leaf { name, expression } => {
-                let Some(name) = name else { continue };
+                let Some(name) = name else {
+                    checked_updates.push(tree::RecordExpressionUpdate::Error);
+                    continue;
+                };
                 let label = SmolStr::clone(name);
 
                 let input_id = state.fresh_unification(context.queries, context.prim.t);
-                let output_id = if let Some(expression) = expression {
-                    infer_record_field_expression(state, context, *expression)?.field_type
+                let (output_id, expression) = if let Some(expression) = expression {
+                    let inferred = infer_record_field_expression(state, context, *expression)?;
+                    (inferred.field_type, inferred.elaborated.expression)
                 } else {
-                    context.unknown("missing record update expression")
+                    let output_id = context.unknown("missing record update expression");
+                    let expression = super::allocate_error_expression(state, output_id);
+                    (output_id, expression.expression)
                 };
+
+                let update = tree::RecordExpressionUpdate::Leaf {
+                    label: SmolStr::clone(&label),
+                    expression,
+                };
+                checked_updates.push(update);
 
                 input_fields.push(RowField { label: label.clone(), id: input_id });
                 output_fields.push(RowField { label, id: output_id });
             }
             lowering::RecordUpdate::Branch { name, updates } => {
-                let Some(name) = name else { continue };
+                let Some(name) = name else {
+                    checked_updates.push(tree::RecordExpressionUpdate::Error);
+                    continue;
+                };
                 let label = SmolStr::clone(name);
 
-                let (in_f, out_f, tail) = infer_record_updates(state, context, updates)?;
+                let updates = infer_record_updates(state, context, updates)?;
+                let ElaboratedRecordUpdates {
+                    input_fields: branch_input_fields,
+                    output_fields: branch_output_fields,
+                    tail,
+                    updates,
+                } = updates;
 
-                let in_row = context.intern_row(in_f, Some(tail));
+                let in_row = context.intern_row(branch_input_fields, Some(tail));
                 let in_id = context.intern_application(context.prim.record, in_row);
 
-                let out_row = context.intern_row(out_f, Some(tail));
+                let out_row = context.intern_row(branch_output_fields, Some(tail));
                 let out_id = context.intern_application(context.prim.record, out_row);
 
                 input_fields.push(RowField { label: label.clone(), id: in_id });
-                output_fields.push(RowField { label, id: out_id });
+                output_fields.push(RowField { label: label.clone(), id: out_id });
+
+                let update = tree::RecordExpressionUpdate::Branch { label, updates };
+                checked_updates.push(update);
             }
         }
     }
 
     let tail = state.fresh_unification(context.queries, context.prim.row_type);
 
-    Ok((input_fields, output_fields, tail))
+    let updates = checked_updates.into();
+    Ok(ElaboratedRecordUpdates { input_fields, output_fields, tail, updates })
 }

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -309,6 +309,8 @@ pub enum ExpressionKind {
     Number { value: SmolStr },
     Array { elements: Arc<[ExpressionId]> },
     Record { fields: Arc<[RecordExpressionField]> },
+    RecordAccess { record: ExpressionId, labels: Arc<[SmolStr]> },
+    RecordUpdate { record: ExpressionId, updates: Arc<[RecordExpressionUpdate]> },
     Constructor { resolution: (FileId, TermItemId) },
     Variable { resolution: lowering::TermVariableResolution },
     RecordPun { source: lowering::RecordPunId, resolution: lowering::TermVariableResolution },
@@ -325,6 +327,13 @@ pub enum ExpressionKind {
 pub enum RecordExpressionField {
     Field { label: SmolStr, expression: ExpressionId },
     Pun { source: lowering::RecordPunId, label: SmolStr, expression: ExpressionId },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecordExpressionUpdate {
+    Error,
+    Leaf { label: SmolStr, expression: ExpressionId },
+    Branch { label: SmolStr, updates: Arc<[RecordExpressionUpdate]> },
 }
 
 impl Module {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -21,7 +21,7 @@ use crate::tree::{
     BinderId, BinderKind, BinderSource, CaseAlternative, Equation, ExpressionId, ExpressionKind,
     GuardedAlternative, GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings,
     LocalDeclarationId, PatternGuard, RecordBinderField, RecordExpressionField,
-    TermDeclarationKind, TypeDeclarationKind, WhereExpression,
+    RecordExpressionUpdate, TermDeclarationKind, TypeDeclarationKind, WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -1124,6 +1124,7 @@ where
             ExpressionKind::TermApplication { .. }
             | ExpressionKind::TypeApplication { .. }
             | ExpressionKind::EvidenceApplication { .. } => ExpressionPrecedence::Application,
+            ExpressionKind::RecordUpdate { .. } => ExpressionPrecedence::RecordUpdate,
             _ => ExpressionPrecedence::Atom,
         };
         let allow_block_argument = required_precedence != ExpressionPrecedence::Application;
@@ -1220,6 +1221,30 @@ where
                     }
                 }
                 Ok(record.append(self.arena.text(" }")))
+            }
+            ExpressionKind::RecordAccess { record, labels } => {
+                let mut record = self.expression_at(
+                    *record,
+                    ExpressionPrecedence::Atom,
+                    evidence_names,
+                    type_pretty,
+                )?;
+                for label in labels.iter() {
+                    let label = format!(".{label}");
+                    record = record.append(self.arena.text(label));
+                }
+                Ok(record)
+            }
+            ExpressionKind::RecordUpdate { record, updates } => {
+                let record = self.expression_at(
+                    *record,
+                    ExpressionPrecedence::Atom,
+                    evidence_names,
+                    type_pretty,
+                )?;
+                let updates =
+                    self.record_expression_updates(updates, evidence_names, type_pretty)?;
+                Ok(record.append(self.arena.space()).append(updates))
             }
             ExpressionKind::Constructor { resolution } => {
                 let name = self.term_name(resolution.0, resolution.1)?;
@@ -1364,6 +1389,42 @@ where
                     .append(self.arena.hardline().append(expression).nest(2)))
             }
         }
+    }
+
+    fn record_expression_updates(
+        &self,
+        updates: &[RecordExpressionUpdate],
+        evidence_names: &mut EvidenceNames,
+        type_pretty: &mut TypePretty<'context, Q>,
+    ) -> QueryResult<Doc<'arena>> {
+        if updates.is_empty() {
+            return Ok(self.arena.text("{ }"));
+        }
+
+        let mut rendered = self.arena.text("{ ");
+        for (position, update) in updates.iter().enumerate() {
+            if position > 0 {
+                rendered = rendered.append(self.arena.text(", "));
+            }
+
+            match update {
+                RecordExpressionUpdate::Error => {
+                    rendered = rendered.append(self.arena.text("<error>"));
+                }
+                RecordExpressionUpdate::Leaf { label, expression } => {
+                    let expression = self.expression(*expression, evidence_names, type_pretty)?;
+                    let label = format!("{label} = ");
+                    rendered = rendered.append(self.arena.text(label)).append(expression);
+                }
+                RecordExpressionUpdate::Branch { label, updates } => {
+                    let updates =
+                        self.record_expression_updates(updates, evidence_names, type_pretty)?;
+                    let label = format!("{label} ");
+                    rendered = rendered.append(self.arena.text(label)).append(updates);
+                }
+            }
+        }
+        Ok(rendered.append(self.arena.text(" }")))
     }
 
     fn evidence_variable_name(

--- a/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+record :: { function :: Int -> Int, nested :: { value :: Int } }
+record = { function: identity, nested: { value: 42 } }
+
+direct = record.nested
+
+chained = record.nested.value
+
+functionPosition = record.function 1
+
+argument = identity record.nested
+
+applicationBase = (identity record).nested.value

--- a/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall a. a -> a
+identity = \value -> value
+
+record :: { function :: Int -> Int, nested :: { value :: Int } }
+record = { function: identity @Int, nested: { value: 42 } }
+
+direct :: { value :: Int }
+direct = record.nested
+
+chained :: Int
+chained = record.nested.value
+
+functionPosition :: Int
+functionPosition = record.function 1
+
+argument :: { value :: Int }
+argument = identity @{ value :: Int } record.nested
+
+applicationBase :: Int
+applicationBase =
+  (identity @{ function :: Int -> Int, nested :: { value :: Int } } record).nested.value

--- a/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+record :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+record = { first: 1, nested: { value: 2 }, transform: identity }
+
+leaf = record { first = 2 }
+
+typeChanging = record { first = "two" }
+
+multiple = record { first = 2, transform = identity }
+
+nested = record { nested { value = 3 } }
+
+accessValue = record { first = record.nested.value }
+
+applicationBase = (identity record) { first = 2 }
+
+argument = identity record { first = 2 }

--- a/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall a. a -> a
+identity = \value -> value
+
+record :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+record = { first: 1, nested: { value: 2 }, transform: identity @Int }
+
+leaf :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+leaf = record { first = 2 }
+
+typeChanging :: { first :: String, nested :: { value :: Int }, transform :: Int -> Int }
+typeChanging = record { first = "two" }
+
+multiple :: forall t. { first :: Int, nested :: { value :: Int }, transform :: t -> t }
+multiple = record { first = 2, transform = identity @t }
+
+nested :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+nested = record { nested { value = 3 } }
+
+accessValue :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+accessValue = record { first = record.nested.value }
+
+applicationBase :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+applicationBase =
+  (identity @{ first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+    record) { first = 2 }
+
+argument :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+argument =
+  identity @{ first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+    record { first = 2 }

--- a/tests-integration/fixtures/semantic/1784906400_record_update_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784906400_record_update_recovery/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+record :: { nested :: { value :: Int }, value :: Int }
+record = { nested: { value: 1 }, value: 2 }
+
+missingValue = record { value = }
+
+nestedMissingValue = record { nested { value = } }
+
+validSibling = record { nested { value = }, value = 3 }

--- a/tests-integration/fixtures/semantic/1784906400_record_update_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906400_record_update_recovery/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+record :: { nested :: { value :: Int }, value :: Int }
+record = { nested: { value: 1 }, value: 2 }
+
+missingValue :: { nested :: { value :: Int }, value :: ?[missing record update expression] }
+missingValue = record { value = <error> }
+
+nestedMissingValue :: { nested :: { value :: ?[missing record update expression] }, value :: Int }
+nestedMissingValue = record { nested { value = <error> } }
+
+validSibling :: { nested :: { value :: ?[missing record update expression] }, value :: Int }
+validSibling = record { nested { value = <error> }, value = 3 }


### PR DESCRIPTION
## Summary

Record access and update expressions were already type-checked, but successful expressions were represented as `ExpressionKind::Error` in the checked semantic tree. This meant later consumers could observe their result types but not the operations or their elaborated children.

This change:

- adds checked-tree representations and precedence-aware rendering for record access and recursive record updates;
- retains elaborated record operands and update values without changing the existing open-row inference rules;
- preserves type and evidence applications introduced while inferring update values; and
- localizes recovery to malformed updates, retaining valid branches and siblings with explicit error children.

## Testing

- `cargo check -p checking --tests`
- `just t semantic 1784906340 1784906400`
- `just t checking 1772823960 1772824020`