### PR TITLE
[checking] Retain section expressions in the semantic tree

### DIFF
--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -160,34 +160,40 @@ where
 {
     let mut current = expected;
     let mut parameters = vec![];
+    let mut binders = vec![];
 
     for &section_id in section_result.iter() {
         let decomposed = toolkit::decompose_function(state, context, current)?;
-        if let Some((argument_type, result_type)) = decomposed {
-            state.checked.nodes.sections.insert(section_id, argument_type);
-            parameters.push(argument_type);
+        let parameter = if let Some((argument_type, result_type)) = decomposed {
             current = result_type;
+            argument_type
         } else {
             let parameter = state.fresh_unification(context.queries, context.prim.t);
             let result = state.fresh_unification(context.queries, context.prim.t);
 
             let function = context.intern_function(parameter, result);
-            unification::subtype(state, context, function, current)?;
+            if unification::subtype(state, context, function, current)? {
+                current = result;
+            } else {
+                unification::unify(state, context, result, current)?;
+            }
 
-            parameters.push(parameter);
-            current = result;
-
-            state.checked.nodes.sections.insert(section_id, parameter);
-        }
+            parameter
+        };
+        let binder = state.allocate_section_binder(section_id, parameter);
+        parameters.push(parameter);
+        binders.push(binder);
     }
 
     let result = infer_expression_core(state, context, expression)?;
-    let result = application::instantiate_expression(state, context, result)?;
+    let ElaboratedExpression { type_id, expression } =
+        application::instantiate_expression(state, context, result)?;
 
-    unification::subtype(state, context, result.type_id, current)?;
+    unification::subtype(state, context, type_id, current)?;
 
-    let function_type = context.intern_function_list(&parameters, result.type_id);
-    Ok(allocate_error_expression(state, function_type))
+    let function_type = context.intern_function_list(&parameters, type_id);
+    let kind = tree::ExpressionKind::Lambda { binders: Arc::from(binders), expression };
+    Ok(allocate_expression(state, function_type, kind))
 }
 
 fn check_expression_core<Q>(
@@ -282,19 +288,21 @@ fn infer_sectioned_expression<Q>(
 where
     Q: ExternalQueries,
 {
-    let parameter_types = section_result.iter().map(|&section_id| {
-        let parameter_type = state.fresh_unification(context.queries, context.prim.t);
-        state.checked.nodes.sections.insert(section_id, parameter_type);
-        parameter_type
+    let parameters = section_result.iter().map(|&section_id| {
+        let parameter = state.fresh_unification(context.queries, context.prim.t);
+        let binder = state.allocate_section_binder(section_id, parameter);
+        (parameter, binder)
     });
 
-    let parameter_types = parameter_types.collect_vec();
+    let (parameters, binders): (Vec<_>, Vec<_>) = parameters.unzip();
 
     let result = infer_expression_core(state, context, expression)?;
-    let result = application::instantiate_expression(state, context, result)?;
+    let ElaboratedExpression { type_id, expression } =
+        application::instantiate_expression(state, context, result)?;
 
-    let function_type = context.intern_function_list(&parameter_types, result.type_id);
-    Ok(allocate_error_expression(state, function_type))
+    let function_type = context.intern_function_list(&parameters, type_id);
+    let kind = tree::ExpressionKind::Lambda { binders: Arc::from(binders), expression };
+    Ok(allocate_expression(state, function_type, kind))
 }
 
 fn infer_expression_core<Q>(
@@ -422,10 +430,17 @@ where
         }
 
         lowering::ExpressionKind::Section => {
-            if let Some(type_id) = state.checked.nodes.lookup_section(expression) {
-                Ok(allocate_error_expression(state, type_id))
-            } else {
-                Ok(allocate_error_expression(state, unknown))
+            let type_id = state.checked.nodes.lookup_section(expression);
+            let binder = state.checked.tree.lookup_section_binder(expression);
+            match (type_id, binder) {
+                (Some(type_id), Some(binder)) => {
+                    let kind = tree::ExpressionKind::Section { binder };
+                    Ok(allocate_expression(state, type_id, kind))
+                }
+                (None, None) => Ok(allocate_error_expression(state, unknown)),
+                _ => {
+                    unreachable!("invariant violated: incomplete checked section provenance")
+                }
             }
         }
 

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -329,6 +329,17 @@ impl CheckState {
         self.checked.tree.allocate_binder(binder)
     }
 
+    pub fn allocate_section_binder(
+        &mut self,
+        source: lowering::ExpressionId,
+        type_id: TypeId,
+    ) -> tree::BinderId {
+        let binder = self.checked.tree.allocate_section_binder(source, type_id);
+        let previous = self.checked.nodes.sections.insert(source, type_id);
+        assert!(previous.is_none(), "invariant violated: section type inserted twice");
+        binder
+    }
+
     pub fn allocate_error_binder(
         &mut self,
         source: lowering::BinderId,

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -7,6 +7,7 @@ use files::FileId;
 use indexing::{EquationSourceId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
 use lowering::LetBindingNameGroupId;
+use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
 use crate::TypeId;
@@ -25,6 +26,7 @@ pub struct Module {
     terms: ArenaMap<TermItemId, TermDeclarationId>,
     types: ArenaMap<TypeItemId, TypeDeclarationId>,
     lets: ArenaMap<LetBindingNameGroupId, LocalDeclarationId>,
+    sections: FxHashMap<lowering::ExpressionId, BinderId>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -268,6 +270,7 @@ pub struct Binder {
 pub enum BinderSource {
     Binder(lowering::BinderId),
     DoStatement(lowering::DoStatementId),
+    Section(lowering::ExpressionId),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -314,6 +317,7 @@ pub enum ExpressionKind {
     Constructor { resolution: (FileId, TermItemId) },
     Variable { resolution: lowering::TermVariableResolution },
     RecordPun { source: lowering::RecordPunId, resolution: lowering::TermVariableResolution },
+    Section { binder: BinderId },
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },
     EvidenceApplication { function: ExpressionId, evidence: EvidenceVarId },
@@ -343,6 +347,23 @@ impl Module {
 
     pub fn allocate_binder(&mut self, binder: Binder) -> BinderId {
         self.arena.binders.alloc(binder)
+    }
+
+    pub fn allocate_section_binder(
+        &mut self,
+        source: lowering::ExpressionId,
+        type_id: TypeId,
+    ) -> BinderId {
+        let binder =
+            Binder { source: BinderSource::Section(source), type_id, kind: BinderKind::Variable };
+        let binder = self.arena.binders.alloc(binder);
+        let previous = self.sections.insert(source, binder);
+        assert!(previous.is_none(), "invariant violated: section binder allocated twice");
+        binder
+    }
+
+    pub fn lookup_section_binder(&self, source: lowering::ExpressionId) -> Option<BinderId> {
+        self.sections.get(&source).copied()
     }
 
     pub fn insert_term(&mut self, source: TermItemId, term: TermDeclaration) -> TermDeclarationId {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -54,6 +54,10 @@ fn character_literal(value: char) -> String {
     }
 }
 
+fn section_name(source: lowering::ExpressionId) -> String {
+    format!("section{}", source.into_raw().get())
+}
+
 struct EvidenceNames {
     display_by_binder: FxHashMap<EvidenceBinderId, SmolStr>,
     names: PrettyNames,
@@ -1018,20 +1022,25 @@ where
                 let value = if *negative { format!("(-{value})") } else { value.to_string() };
                 Ok(self.arena.text(value))
             }
-            BinderKind::Variable => {
-                let BinderSource::Binder(source) = binder.source else {
+            BinderKind::Variable => match binder.source {
+                BinderSource::Binder(source) => {
+                    let kind = self
+                        .lowered
+                        .info
+                        .get_binder_kind(source)
+                        .expect("invariant violated: semantic variable binder has no source");
+                    let lowering::BinderKind::Variable { variable: Some(variable) } = kind else {
+                        unreachable!(
+                            "invariant violated: semantic variable binder has invalid source"
+                        );
+                    };
+                    Ok(self.arena.text(variable.to_string()))
+                }
+                BinderSource::Section(source) => Ok(self.arena.text(section_name(source))),
+                BinderSource::DoStatement(_) => {
                     unreachable!("invariant violated: generated semantic variable binder")
-                };
-                let kind = self
-                    .lowered
-                    .info
-                    .get_binder_kind(source)
-                    .expect("invariant violated: semantic variable binder has no source");
-                let lowering::BinderKind::Variable { variable: Some(variable) } = kind else {
-                    unreachable!("invariant violated: semantic variable binder has invalid source");
-                };
-                Ok(self.arena.text(variable.to_string()))
-            }
+                }
+            },
             BinderKind::Named { name, binder } => {
                 let binder = self.binder(*binder)?;
                 Ok(self.arena.text(format!("{name}@")).append(binder))
@@ -1290,6 +1299,13 @@ where
                         }
                     };
                 Ok(self.arena.text(name))
+            }
+            ExpressionKind::Section { binder } => {
+                let binder = &self.checked.tree[*binder];
+                let BinderSource::Section(source) = binder.source else {
+                    unreachable!("invariant violated: semantic section has invalid binder")
+                };
+                Ok(self.arena.text(section_name(source)))
             }
             ExpressionKind::TermApplication { function, argument } => {
                 let function = self.expression_at(

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -55,7 +55,7 @@ fn character_literal(value: char) -> String {
 }
 
 fn section_name(source: lowering::ExpressionId) -> String {
-    format!("section{}", source.into_raw().get())
+    format!("v{}", source.into_raw().get())
 }
 
 struct EvidenceNames {

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.purs
@@ -1,0 +1,25 @@
+module Main where
+
+infixl 6 add as +
+
+add :: Int -> Int -> Int
+add left right = left
+
+use :: Int -> String -> String
+use integer string = string
+
+checked :: Int -> Int
+checked = _ + 1
+
+inferred = _ + 1
+
+ordered :: Int -> String -> String
+ordered = use _ _
+
+nested = _ (_ 1)
+
+access = _.value
+
+update = _ { first = _, second = _ }
+
+conditional = if _ then _ else _

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.purs
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.purs
@@ -23,3 +23,15 @@ access = _.value
 update = _ { first = _, second = _ }
 
 conditional = if _ then _ else _
+
+caseScrutinee = case _ of
+  true -> 1
+  false -> 0
+
+caseScrutinees = case _, _ of
+  true, value -> value
+  false, _ -> 0
+
+caseAlternatives = case _ of
+  true -> _.value
+  false -> _.value

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
@@ -32,3 +32,24 @@ conditional :: forall t. Boolean -> t -> t -> t
 conditional =
   \v98 v100 v102 ->
     if v98 then v100 else v102
+
+caseScrutinee :: Boolean -> Int
+caseScrutinee =
+  \v108 ->
+    case v108 of
+      true -> 1
+      false -> 0
+
+caseScrutinees :: Boolean -> Int -> Int
+caseScrutinees =
+  \v127 v128 ->
+    case v127, v128 of
+      true, value -> value
+      false, _ -> 0
+
+caseAlternatives :: forall t t1. Boolean -> { value :: t | t1 } -> t
+caseAlternatives =
+  \v149 ->
+    case v149 of
+      true -> \v157 -> v157.value
+      false -> \v164 -> v164.value

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+add :: Int -> Int -> Int
+add = \left -> \right -> left
+
+use :: Int -> String -> String
+use = \integer -> \string -> string
+
+checked :: Int -> Int
+checked = \v40 -> add v40 1
+
+inferred :: Int -> Int
+inferred = \v48 -> add v48 1
+
+ordered :: Int -> String -> String
+ordered = \v64 v66 -> use v64 v66
+
+nested :: forall t t1. (((Int -> t) -> t) -> t1) -> t1
+nested = \v71 -> v71 \v75 -> v75 1
+
+access :: forall t t1. { value :: t | t1 } -> t
+access = \v82 -> v82.value
+
+update :: forall t t1 t2 t3 t4.
+  { first :: t, second :: t1 | t2 } -> t3 -> t4 -> { first :: t3, second :: t4 | t2 }
+update = \v87 v90 v92 -> v87 { first = v90, second = v92 }
+
+conditional :: forall t. Boolean -> t -> t -> t
+conditional =
+  \v98 v100 v102 ->
+    if v98 then v100 else v102

--- a/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.purs
+++ b/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.purs
@@ -1,0 +1,16 @@
+module Main where
+
+identity :: forall a. a -> a
+identity value = value
+
+apply :: forall a b. (a -> b) -> a -> b
+apply function argument = function argument
+
+orphan = _
+
+orphanInLambda = \value -> _
+
+failedBody = apply _ missing
+
+invalidExpected :: Int
+invalidExpected = identity _

--- a/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+identity :: forall a. a -> a
+identity = \value -> value
+
+apply :: forall a b. (a -> b) -> a -> b
+apply = \function -> \argument -> function argument
+
+orphan :: ?[missing expression]
+orphan = <error>
+
+orphanInLambda :: forall t. t -> ?[missing expression]
+orphanInLambda = \value -> <error>
+
+failedBody :: forall t. (?[missing expression] -> t) -> t
+failedBody = \v56 -> apply @?[missing expression] @t v56 <error>
+
+invalidExpected :: Int
+invalidExpected = \v67 -> identity @Int v67

--- a/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.purs
+++ b/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.purs
@@ -1,0 +1,39 @@
+module Main where
+
+map :: forall a b. (a -> b) -> Array a -> Array b
+map f x = []
+
+apply :: forall a b. (a -> b) -> a -> b
+apply f x = f x
+
+f :: ({ foo :: Int } -> Int) -> Int
+f g = g { foo: 1 }
+
+test1 = _.prop
+
+test2 = _.a.b.c
+
+test3 = _.poly
+
+test4 = map _.prop
+
+test5 = f _.foo
+
+test6 r g = g _.bar
+
+test7 = \r -> _.nonexistent r
+
+test8 = (_ _.foo)
+
+test9 = map (_ _.prop)
+
+test10 = apply (_.a.b)
+
+test11 = { a: _, b: _.foo }
+
+test12 = [_, _.bar]
+
+test13 = case _ of
+  _ -> _.prop
+
+test14 = if _ then _.a else _.b

--- a/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
@@ -1,0 +1,60 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+map :: forall a b. (a -> b) -> Array a -> Array b
+map = \f -> \x -> []
+
+apply :: forall a b. (a -> b) -> a -> b
+apply = \f -> \x -> f x
+
+f :: ({ foo :: Int } -> Int) -> Int
+f = \g -> g { foo: 1 }
+
+test1 :: forall t t1. { prop :: t | t1 } -> t
+test1 = \v74 -> v74.prop
+
+test2 :: forall t t1 t2 t3. { a :: { b :: { c :: t | t1 } | t2 } | t3 } -> t
+test2 = \v79 -> v79.a.b.c
+
+test3 :: forall t t1. { poly :: t | t1 } -> t
+test3 = \v84 -> v84.poly
+
+test4 :: forall t t1. Array { prop :: t | t1 } -> Array t
+test4 = map @{ prop :: t | t1 } @t \v92 -> v92.prop
+
+test5 :: Int
+test5 = f \v100 -> v100.foo
+
+test6 :: forall t t1 t2 t3. t -> (({ bar :: t1 | t2 } -> t1) -> t3) -> t3
+test6 = \r -> \g -> g \v111 -> v111.bar
+
+test7 :: forall t t1. { nonexistent :: t | t1 } -> t
+test7 = \r -> (\v120 -> v120.nonexistent) r
+
+test8 :: forall t t1 t2. (({ foo :: t | t1 } -> t) -> t2) -> t2
+test8 = \v128 -> v128 \v131 -> v131.foo
+
+test9 :: forall t t1 t2. Array (({ prop :: t | t1 } -> t) -> t2) -> Array t2
+test9 = map @(({ prop :: t | t1 } -> t) -> t2) @t2 \v140 -> v140 \v143 -> v143.prop
+
+test10 :: forall t t1 t2. { a :: { b :: t | t1 } | t2 } -> t
+test10 = apply @{ a :: { b :: t | t1 } | t2 } @t \v152 -> v152.a.b
+
+test11 :: forall t t1 t2. t -> { a :: t, b :: { foo :: t1 | t2 } -> t1 }
+test11 = \v158 -> { a: v158, b: \v161 -> v161.foo }
+
+test12 :: forall t t1. ({ bar :: t | t1 } -> t) -> Array ({ bar :: t | t1 } -> t)
+test12 = \v166 -> [v166, \v168 -> v168.bar]
+
+test13 :: forall t t1 t2. t -> { prop :: t1 | t2 } -> t1
+test13 =
+  \v174 ->
+    case v174 of
+      _ -> \v182 -> v182.prop
+
+test14 :: forall t t1. Boolean -> { a :: t, b :: t | t1 } -> t
+test14 =
+  \v188 ->
+    if v188 then \v191 -> v191.a else \v194 -> v194.b

--- a/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.purs
+++ b/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.purs
@@ -1,0 +1,33 @@
+module Main where
+
+singleFieldUpdate = _ { a = 1 }
+
+multipleFieldUpdate = _ { a = 2, b = true, c = "three" }
+
+nestedRecordUpdate = _ { a { b { c = 42 } } }
+
+updateWithValueSection = _ { a = (_ + 1) }
+
+updateWithSectionInteraction = _ { a = _ }
+
+polymorphicRecordUpdate = _ { foo = 0 }
+
+higherOrderContext = map (_ { x = 10 })
+
+multipleSectionsInteraction = _ { x = _, y = _ }
+
+nestedSectionInteraction = _ { a { b = _ } }
+
+mixedSections = _ { a = _ + 1, b = 2 }
+
+recordAccessSectionUpdate = _ { a = _.b }
+
+concreteRecordUpdateSection = ({ a: 1 } { a = _ })
+
+map :: forall a b. (a -> b) -> Array a -> Array b
+map f x = []
+
+infixl 6 add as +
+
+add :: Int -> Int -> Int
+add x y = x

--- a/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
@@ -1,0 +1,47 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+singleFieldUpdate :: forall t t1. { a :: t | t1 } -> { a :: Int | t1 }
+singleFieldUpdate = \v9 -> v9 { a = 1 }
+
+multipleFieldUpdate :: forall t t1 t2 t3. { a :: t, b :: t1, c :: t2 | t3 } -> { a :: Int, b :: Boolean, c :: String | t3 }
+multipleFieldUpdate = \v17 -> v17 { a = 2, b = true, c = "three" }
+
+nestedRecordUpdate :: forall t t1 t2 t3.
+  { a :: { b :: { c :: t | t1 } | t2 } | t3 } -> { a :: { b :: { c :: Int | t1 } | t2 } | t3 }
+nestedRecordUpdate = \v29 -> v29 { a { b { c = 42 } } }
+
+updateWithValueSection :: forall t t1. { a :: t | t1 } -> { a :: Int -> Int | t1 }
+updateWithValueSection = \v41 -> v41 { a = \v46 -> add v46 1 }
+
+updateWithSectionInteraction :: forall t t1 t2. { a :: t | t1 } -> t2 -> { a :: t2 | t1 }
+updateWithSectionInteraction = \v54 v57 -> v54 { a = v57 }
+
+polymorphicRecordUpdate :: forall t t1. { foo :: t | t1 } -> { foo :: Int | t1 }
+polymorphicRecordUpdate = \v62 -> v62 { foo = 0 }
+
+higherOrderContext :: forall t t1. Array { x :: t | t1 } -> Array { x :: Int | t1 }
+higherOrderContext = map @{ x :: t | t1 } @{ x :: Int | t1 } \v74 -> v74 { x = 10 }
+
+multipleSectionsInteraction :: forall t t1 t2 t3 t4. { x :: t, y :: t1 | t2 } -> t3 -> t4 -> { x :: t3, y :: t4 | t2 }
+multipleSectionsInteraction = \v82 v85 v87 -> v82 { x = v85, y = v87 }
+
+nestedSectionInteraction :: forall t t1 t2 t3. { a :: { b :: t | t1 } | t2 } -> t3 -> { a :: { b :: t3 | t1 } | t2 }
+nestedSectionInteraction = \v92 v97 -> v92 { a { b = v97 } }
+
+mixedSections :: forall t t1 t2. { a :: t, b :: t1 | t2 } -> { a :: Int -> Int, b :: Int | t2 }
+mixedSections = \v102 -> v102 { a = \v106 -> add v106 1, b = 2 }
+
+recordAccessSectionUpdate :: forall t t1 t2 t3. { a :: t | t1 } -> { a :: { b :: t2 | t3 } -> t2 | t1 }
+recordAccessSectionUpdate = \v116 -> v116 { a = \v120 -> v120.b }
+
+concreteRecordUpdateSection :: forall t. t -> { a :: t }
+concreteRecordUpdateSection = \v131 -> { a: 1 } { a = v131 }
+
+map :: forall a b. (a -> b) -> Array a -> Array b
+map = \f -> \x -> []
+
+add :: Int -> Int -> Int
+add = \x -> \y -> x


### PR DESCRIPTION
## Summary

Section expressions already synthesize function types during checking, but their checked semantic representation was discarded as `ExpressionKind::Error`. This change retains that elaboration as proper lambda structure.

- represent each section parameter as a synthesized variable binder with its source section as provenance
- connect each checked section occurrence to its synthesized binder and retain the enclosing expression as a checked lambda
- keep `CheckedNodes.sections` as the source-node-to-type index while the checked tree separately indexes source sections to binders
- render synthesized parameters as concise lambda variables such as `v40`
- preserve higher-kinded section refinement while recovering failed non-function expectations without leaking unsolved unification variables

## Testing

- `cargo check -p checking --tests`
- `just t semantic 1784908680 1784908740`
- `just t checking 1772823960 1772824020 1774448220`
- `just format`
- `git diff --check`