### PR TITLE
[checking] Implement semantic deriving for Eq, Ord, Eq1, Ord1

### DIFF
--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -778,13 +778,21 @@ impl KnownGeneric {
 
 pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
+    pub eq: Option<(FileId, TermItemId)>,
+    pub compare: Option<(FileId, TermItemId)>,
+    pub ordering_lt: Option<(FileId, TermItemId)>,
     pub ordering_eq: Option<(FileId, TermItemId)>,
+    pub ordering_gt: Option<(FileId, TermItemId)>,
 }
 
 impl KnownTermsCore {
     fn collect(queries: &impl ExternalQueries) -> QueryResult<KnownTermsCore> {
         let otherwise = fetch_known_term(queries, "Data.Boolean", "otherwise")?;
+        let eq = fetch_known_term(queries, "Data.Eq", "eq")?;
+        let compare = fetch_known_term(queries, "Data.Ord", "compare")?;
+        let ordering_lt = fetch_known_term(queries, "Data.Ordering", "LT")?;
         let ordering_eq = fetch_known_term(queries, "Data.Ordering", "EQ")?;
-        Ok(KnownTermsCore { otherwise, ordering_eq })
+        let ordering_gt = fetch_known_term(queries, "Data.Ordering", "GT")?;
+        Ok(KnownTermsCore { otherwise, eq, compare, ordering_lt, ordering_eq, ordering_gt })
     }
 }

--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -779,7 +779,9 @@ impl KnownGeneric {
 pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
     pub eq: Option<(FileId, TermItemId)>,
+    pub eq1: Option<(FileId, TermItemId)>,
     pub compare: Option<(FileId, TermItemId)>,
+    pub compare1: Option<(FileId, TermItemId)>,
     pub ordering_lt: Option<(FileId, TermItemId)>,
     pub ordering_eq: Option<(FileId, TermItemId)>,
     pub ordering_gt: Option<(FileId, TermItemId)>,
@@ -789,10 +791,21 @@ impl KnownTermsCore {
     fn collect(queries: &impl ExternalQueries) -> QueryResult<KnownTermsCore> {
         let otherwise = fetch_known_term(queries, "Data.Boolean", "otherwise")?;
         let eq = fetch_known_term(queries, "Data.Eq", "eq")?;
+        let eq1 = fetch_known_term(queries, "Data.Eq", "eq1")?;
         let compare = fetch_known_term(queries, "Data.Ord", "compare")?;
+        let compare1 = fetch_known_term(queries, "Data.Ord", "compare1")?;
         let ordering_lt = fetch_known_term(queries, "Data.Ordering", "LT")?;
         let ordering_eq = fetch_known_term(queries, "Data.Ordering", "EQ")?;
         let ordering_gt = fetch_known_term(queries, "Data.Ordering", "GT")?;
-        Ok(KnownTermsCore { otherwise, eq, compare, ordering_lt, ordering_eq, ordering_gt })
+        Ok(KnownTermsCore {
+            otherwise,
+            eq,
+            eq1,
+            compare,
+            compare1,
+            ordering_lt,
+            ordering_eq,
+            ordering_gt,
+        })
     }
 }

--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -778,11 +778,13 @@ impl KnownGeneric {
 
 pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
+    pub ordering_eq: Option<(FileId, TermItemId)>,
 }
 
 impl KnownTermsCore {
     fn collect(queries: &impl ExternalQueries) -> QueryResult<KnownTermsCore> {
         let otherwise = fetch_known_term(queries, "Data.Boolean", "otherwise")?;
-        Ok(KnownTermsCore { otherwise })
+        let ordering_eq = fetch_known_term(queries, "Data.Ordering", "EQ")?;
+        Ok(KnownTermsCore { otherwise, ordering_eq })
     }
 }

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -10,7 +10,9 @@ use crate::core::{Type, TypeId};
 use crate::error::{CheckingError, ErrorKind};
 use crate::holes::{HoleBinding, TermHole, TypeHole};
 use crate::state::CheckState;
-use crate::tree::{BinderKind, ExpressionKind, TermDeclarationKind, TypeDeclarationKind};
+use crate::tree::{
+    BinderKind, ExpressionKind, InstanceImplementation, TermDeclarationKind, TypeDeclarationKind,
+};
 use crate::{ExternalQueries, OperatorBranchTypes, holes};
 
 struct Zonk;
@@ -121,8 +123,16 @@ where
                 for superclass in Arc::make_mut(&mut instance.superclasses) {
                     superclass.constraint = zonk(state, context, superclass.constraint)?;
                 }
-                for member in Arc::make_mut(&mut instance.members) {
-                    member.implementation_type = zonk(state, context, member.implementation_type)?;
+                match &mut instance.implementation {
+                    InstanceImplementation::Members(members) => {
+                        for member in Arc::make_mut(members) {
+                            member.implementation_type =
+                                zonk(state, context, member.implementation_type)?;
+                        }
+                    }
+                    InstanceImplementation::Delegate { constraint, .. } => {
+                        *constraint = zonk(state, context, *constraint)?;
+                    }
                 }
             }
         }

--- a/compiler-core/checking/src/source/derive.rs
+++ b/compiler-core/checking/src/source/derive.rs
@@ -1,12 +1,14 @@
 pub mod head;
 pub mod member;
 
+pub mod builder;
 pub mod contravariant;
 pub mod eq1_ord1;
 pub mod eq_ord;
 pub mod field;
 pub mod foldable;
 pub mod functor;
+pub mod generate;
 pub mod generic;
 pub mod newtype;
 pub mod tools;
@@ -67,7 +69,9 @@ pub(super) enum DeriveStrategy {
 }
 
 pub struct DeriveHeadResult {
+    derive_id: indexing::DeriveId,
     item_id: TermItemId,
+    signature: TypeId,
     constraints: Vec<TypeId>,
     class_file: FileId,
     class_id: TypeItemId,

--- a/compiler-core/checking/src/source/derive/builder.rs
+++ b/compiler-core/checking/src/source/derive/builder.rs
@@ -30,6 +30,10 @@ where
         self.allocate_binder(name, type_id, tree::BinderKind::Variable)
     }
 
+    pub fn wildcard_pattern(&mut self, name: &str, type_id: TypeId) -> tree::BinderId {
+        self.allocate_binder(name, type_id, tree::BinderKind::Wildcard)
+    }
+
     pub fn constructor_pattern(
         &mut self,
         name: &str,
@@ -65,6 +69,46 @@ where
         expected: TypeId,
     ) -> QueryResult<ElaboratedExpression> {
         application::subtype_expression(self.state, self.context, expression, expected)
+    }
+
+    pub fn apply(
+        &mut self,
+        function: ElaboratedExpression,
+        argument: ElaboratedExpression,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some(application) =
+            application::check_unanchored_application(self.state, self.context, function.type_id)?
+        else {
+            return Ok(None);
+        };
+        let argument = application::subtype_expression(
+            self.state,
+            self.context,
+            argument,
+            application.argument,
+        )?;
+        Ok(Some(application::materialize_application(
+            self.state,
+            function,
+            application.implicit,
+            application.result,
+            argument,
+        )))
+    }
+
+    pub fn if_then_else(
+        &mut self,
+        result_type: TypeId,
+        condition: ElaboratedExpression,
+        then_expression: ElaboratedExpression,
+        else_expression: ElaboratedExpression,
+    ) -> ElaboratedExpression {
+        let kind = tree::ExpressionKind::IfThenElse {
+            condition: condition.expression,
+            then: then_expression.expression,
+            else_: else_expression.expression,
+        };
+        self.allocate_expression(result_type, kind)
     }
 
     pub fn alternative(

--- a/compiler-core/checking/src/source/derive/builder.rs
+++ b/compiler-core/checking/src/source/derive/builder.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
+use building_types::QueryResult;
+
 use crate::context::CheckContext;
-use crate::core::TypeId;
-use crate::source::terms::ElaboratedExpression;
+use crate::core::{TypeId, toolkit};
+use crate::source::terms::{self, ElaboratedExpression, application};
 use crate::state::CheckState;
 use crate::{ExternalQueries, tree};
 
@@ -47,6 +49,22 @@ where
 
     pub fn boolean(&mut self, type_id: TypeId, value: bool) -> ElaboratedExpression {
         self.allocate_expression(type_id, tree::ExpressionKind::Boolean { value })
+    }
+
+    pub fn term_reference(
+        &mut self,
+        (file_id, term_id): (files::FileId, indexing::TermItemId),
+    ) -> QueryResult<ElaboratedExpression> {
+        let type_id = toolkit::lookup_file_term(self.state, self.context, file_id, term_id)?;
+        terms::allocate_term_reference(self.state, self.context, file_id, term_id, type_id)
+    }
+
+    pub fn subtype(
+        &mut self,
+        expression: ElaboratedExpression,
+        expected: TypeId,
+    ) -> QueryResult<ElaboratedExpression> {
+        application::subtype_expression(self.state, self.context, expression, expected)
     }
 
     pub fn alternative(

--- a/compiler-core/checking/src/source/derive/builder.rs
+++ b/compiler-core/checking/src/source/derive/builder.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use crate::context::CheckContext;
+use crate::core::TypeId;
+use crate::source::terms::ElaboratedExpression;
+use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+pub struct DerivedTreeBuilder<'state, 'context, 'query, Q: ExternalQueries> {
+    state: &'state mut CheckState,
+    context: &'context CheckContext<'query, Q>,
+    derive_id: indexing::DeriveId,
+}
+
+impl<'state, 'context, 'query, Q> DerivedTreeBuilder<'state, 'context, 'query, Q>
+where
+    Q: ExternalQueries,
+{
+    pub fn new(
+        state: &'state mut CheckState,
+        context: &'context CheckContext<'query, Q>,
+        derive_id: indexing::DeriveId,
+    ) -> DerivedTreeBuilder<'state, 'context, 'query, Q> {
+        DerivedTreeBuilder { state, context, derive_id }
+    }
+
+    pub fn variable_binder(&mut self, name: &str, type_id: TypeId) -> tree::BinderId {
+        self.allocate_binder(name, type_id, tree::BinderKind::Variable)
+    }
+
+    pub fn constructor_pattern(
+        &mut self,
+        name: &str,
+        type_id: TypeId,
+        resolution: (files::FileId, indexing::TermItemId),
+        arguments: Vec<tree::BinderId>,
+    ) -> tree::BinderId {
+        let kind = tree::BinderKind::Constructor { resolution, arguments: Arc::from(arguments) };
+        self.allocate_binder(name, type_id, kind)
+    }
+
+    pub fn variable(&mut self, binder: tree::BinderId) -> ElaboratedExpression {
+        let type_id = self.state.checked.tree[binder].type_id;
+        let resolution = tree::VariableResolution::Generated(binder);
+        self.allocate_expression(type_id, tree::ExpressionKind::Variable { resolution })
+    }
+
+    pub fn boolean(&mut self, type_id: TypeId, value: bool) -> ElaboratedExpression {
+        self.allocate_expression(type_id, tree::ExpressionKind::Boolean { value })
+    }
+
+    pub fn alternative(
+        &self,
+        patterns: Vec<tree::BinderId>,
+        body: ElaboratedExpression,
+    ) -> tree::CaseAlternative {
+        let where_expression = tree::WhereExpression::new(body.expression);
+        let guarded_expression = tree::GuardedExpression::unconditional(where_expression);
+        tree::CaseAlternative { binders: Arc::from(patterns), guarded_expression }
+    }
+
+    pub fn case(
+        &mut self,
+        result_type: TypeId,
+        scrutinees: Vec<ElaboratedExpression>,
+        alternatives: Vec<tree::CaseAlternative>,
+    ) -> ElaboratedExpression {
+        let scrutinees = scrutinees.into_iter().map(|scrutinee| scrutinee.expression);
+        let scrutinees = scrutinees.collect();
+        let kind = tree::ExpressionKind::Case { scrutinees, alternatives: Arc::from(alternatives) };
+        self.allocate_expression(result_type, kind)
+    }
+
+    pub fn lambda(
+        &mut self,
+        implementation_type: TypeId,
+        binders: Vec<tree::BinderId>,
+        body: ElaboratedExpression,
+    ) -> ElaboratedExpression {
+        let kind = tree::ExpressionKind::Lambda {
+            binders: Arc::from(binders),
+            expression: body.expression,
+        };
+        self.allocate_expression(implementation_type, kind)
+    }
+
+    fn allocate_binder(
+        &mut self,
+        name: &str,
+        type_id: TypeId,
+        kind: tree::BinderKind,
+    ) -> tree::BinderId {
+        let name = self.context.queries.intern_smol_str(name.into());
+        self.state.allocate_derived_binder(self.derive_id, name, type_id, kind)
+    }
+
+    fn allocate_expression(
+        &mut self,
+        type_id: TypeId,
+        kind: tree::ExpressionKind,
+    ) -> ElaboratedExpression {
+        let expression = self.state.allocate_expression(type_id, kind);
+        ElaboratedExpression { type_id, expression }
+    }
+}

--- a/compiler-core/checking/src/source/derive/eq1_ord1.rs
+++ b/compiler-core/checking/src/source/derive/eq1_ord1.rs
@@ -4,11 +4,10 @@ use indexing::TypeItemId;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::toolkit;
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 
-use super::DeriveStrategy;
+use super::{DeriveStrategy, tools};
 
 pub fn check_derive_eq1<Q>(
     state: &mut CheckState,
@@ -67,7 +66,7 @@ where
         return Ok(None);
     };
 
-    if toolkit::extract_type_constructor(state, context, *derived_type)?.is_none() {
+    if tools::extract_local_algebraic_data(state, context, *derived_type)?.is_none() {
         state.insert_error(ErrorKind::CannotDeriveForType { type_id: *derived_type });
         return Ok(None);
     }

--- a/compiler-core/checking/src/source/derive/eq_ord.rs
+++ b/compiler-core/checking/src/source/derive/eq_ord.rs
@@ -8,7 +8,7 @@ use crate::core::toolkit;
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 
-use super::DeriveStrategy;
+use super::{DeriveStrategy, tools};
 
 pub fn check_derive_eq<Q>(
     state: &mut CheckState,
@@ -62,6 +62,12 @@ where
         state.insert_error(ErrorKind::CannotDeriveForType { type_id: *derived_type });
         return Ok(None);
     };
+
+    let declaration = tools::classify_data_declaration(context, data_file, data_id)?;
+    if let tools::DataDeclarationKind::Unsupported = declaration {
+        state.insert_error(ErrorKind::CannotDeriveForType { type_id: *derived_type });
+        return Ok(None);
+    }
 
     Ok(Some(DeriveStrategy::FieldConstraints {
         data_file,

--- a/compiler-core/checking/src/source/derive/eq_ord.rs
+++ b/compiler-core/checking/src/source/derive/eq_ord.rs
@@ -4,7 +4,6 @@ use indexing::TypeItemId;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
-use crate::core::toolkit;
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 
@@ -57,17 +56,11 @@ where
     };
 
     let Some((data_file, data_id)) =
-        toolkit::extract_type_constructor(state, context, *derived_type)?
+        tools::extract_local_algebraic_data(state, context, *derived_type)?
     else {
         state.insert_error(ErrorKind::CannotDeriveForType { type_id: *derived_type });
         return Ok(None);
     };
-
-    let declaration = tools::classify_data_declaration(context, data_file, data_id)?;
-    if let tools::DataDeclarationKind::Unsupported = declaration {
-        state.insert_error(ErrorKind::CannotDeriveForType { type_id: *derived_type });
-        return Ok(None);
-    }
 
     Ok(Some(DeriveStrategy::FieldConstraints {
         data_file,

--- a/compiler-core/checking/src/source/derive/field.rs
+++ b/compiler-core/checking/src/source/derive/field.rs
@@ -10,6 +10,12 @@ use crate::state::CheckState;
 
 use super::tools;
 
+#[derive(Clone, Copy)]
+pub enum ComparisonStyle {
+    Direct,
+    Lifted,
+}
+
 pub fn generate_field_constraints<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
@@ -93,13 +99,16 @@ where
             let function = normalise::expand(state, context, function)?;
             if function == context.prim.record {
                 generate_constraint(state, context, argument, class, class1)?;
-            } else if is_type_to_type_variable(state, context, function)? {
-                if let Some(class1) = class1 {
-                    tools::emit_constraint(context, state, class1, function);
-                }
-                tools::emit_constraint(context, state, class, argument);
             } else {
-                tools::emit_constraint(context, state, class, type_id);
+                let comparison = comparison_style_for_function(state, context, function)?;
+                if let ComparisonStyle::Lifted = comparison {
+                    if let Some(class1) = class1 {
+                        tools::emit_constraint(context, state, class1, function);
+                    }
+                    tools::emit_constraint(context, state, class, argument);
+                } else {
+                    tools::emit_constraint(context, state, class, type_id);
+                }
             }
         }
         Type::Row(row_id) => {
@@ -117,35 +126,41 @@ where
     Ok(())
 }
 
-fn is_type_to_type_variable<Q>(
+pub fn comparison_style<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     type_id: TypeId,
-) -> QueryResult<bool>
-where
-    Q: ExternalQueries,
-{
-    let type_id = normalise::expand(state, context, type_id)?;
-    let kind = match context.lookup_type(type_id) {
-        Type::Rigid(_, _, kind) => kind,
-        Type::Unification(unification_id) => state.unifications.get(unification_id).kind,
-        _ => return Ok(false),
-    };
-
-    Ok(normalise::expand(state, context, kind)? == context.prim.type_to_type)
-}
-
-pub fn requires_lifted_comparison<Q>(
-    state: &mut CheckState,
-    context: &CheckContext<Q>,
-    type_id: TypeId,
-) -> QueryResult<bool>
+) -> QueryResult<ComparisonStyle>
 where
     Q: ExternalQueries,
 {
     let type_id = normalise::expand(state, context, type_id)?;
     let Type::Application(function, _) = context.lookup_type(type_id) else {
-        return Ok(false);
+        return Ok(ComparisonStyle::Direct);
     };
-    is_type_to_type_variable(state, context, function)
+    comparison_style_for_function(state, context, function)
+}
+
+fn comparison_style_for_function<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    function: TypeId,
+) -> QueryResult<ComparisonStyle>
+where
+    Q: ExternalQueries,
+{
+    let function = normalise::expand(state, context, function)?;
+    let kind = match context.lookup_type(function) {
+        Type::Rigid(_, _, kind) => kind,
+        Type::Unification(unification_id) => state.unifications.get(unification_id).kind,
+        _ => return Ok(ComparisonStyle::Direct),
+    };
+
+    let kind = normalise::expand(state, context, kind)?;
+    let comparison = if kind == context.prim.type_to_type {
+        ComparisonStyle::Lifted
+    } else {
+        ComparisonStyle::Direct
+    };
+    Ok(comparison)
 }

--- a/compiler-core/checking/src/source/derive/field.rs
+++ b/compiler-core/checking/src/source/derive/field.rs
@@ -43,7 +43,7 @@ where
     Ok(())
 }
 
-fn instantiate_constructor_fields<Q>(
+pub fn instantiate_constructor_fields<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     constructor_t: TypeId,
@@ -133,4 +133,19 @@ where
     };
 
     Ok(normalise::expand(state, context, kind)? == context.prim.type_to_type)
+}
+
+pub fn requires_lifted_comparison<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    type_id: TypeId,
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    let type_id = normalise::expand(state, context, type_id)?;
+    let Type::Application(function, _) = context.lookup_type(type_id) else {
+        return Ok(false);
+    };
+    is_type_to_type_variable(state, context, function)
 }

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -4,7 +4,7 @@ use building_types::QueryResult;
 use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
-use crate::core::{KindOrType, TypeId, toolkit};
+use crate::core::{KindOrType, TypeId, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::{field, tools};
@@ -27,7 +27,7 @@ where
 {
     let dispatch = derive_dispatch(context, result.class_file, result.class_id);
     match dispatch {
-        DeriveDispatch::Eq | DeriveDispatch::Ord => {
+        DeriveDispatch::Eq | DeriveDispatch::Eq1 | DeriveDispatch::Ord | DeriveDispatch::Ord1 => {
             generate_known_instance(state, context, result, dispatch)
         }
         _ => Ok(()),
@@ -73,9 +73,23 @@ where
 
         let member = match dispatch {
             DeriveDispatch::Eq => generate_eq_member(state, context, result, &freshened.arguments)?,
+            DeriveDispatch::Eq1 => generate_delegated_member(
+                state,
+                context,
+                result,
+                &freshened.arguments,
+                context.known_terms.eq,
+            )?,
             DeriveDispatch::Ord => {
                 generate_ord_member(state, context, result, &freshened.arguments)?
             }
+            DeriveDispatch::Ord1 => generate_delegated_member(
+                state,
+                context,
+                result,
+                &freshened.arguments,
+                context.known_terms.compare,
+            )?,
             _ => None,
         };
 
@@ -101,15 +115,25 @@ where
 }
 
 struct ComparisonMember {
-    resolution: (files::FileId, indexing::TermItemId),
-    implementation_type: TypeId,
+    member: ResolvedMember,
     constructors: Vec<AppliedConstructor>,
+}
+
+struct ResolvedMember {
+    file_id: files::FileId,
+    item_id: indexing::TermItemId,
+    implementation_type: TypeId,
 }
 
 struct AppliedConstructor {
     file_id: files::FileId,
     item_id: indexing::TermItemId,
-    fields: Vec<TypeId>,
+    fields: Vec<AppliedField>,
+}
+
+struct AppliedField {
+    type_id: TypeId,
+    comparison: field::ComparisonStyle,
 }
 
 fn resolve_comparison_member<Q>(
@@ -137,16 +161,17 @@ where
         let constructor_type =
             toolkit::lookup_file_term(state, context, data_file, constructor_id)?;
 
-        let fields = field::instantiate_constructor_fields(
+        let field_types = field::instantiate_constructor_fields(
             state,
             context,
             constructor_type,
             &type_arguments,
         )?;
-        for &field in &fields {
-            if field::requires_lifted_comparison(state, context, field)? {
-                return Ok(None);
-            }
+
+        let mut fields = Vec::with_capacity(field_types.len());
+        for type_id in field_types {
+            let comparison = field::comparison_style(state, context, type_id)?;
+            fields.push(AppliedField { type_id, comparison });
         }
 
         constructors.push(AppliedConstructor {
@@ -156,6 +181,22 @@ where
         });
     }
 
+    let Some(member) = resolve_member(state, context, result, instance_arguments)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(ComparisonMember { member, constructors }))
+}
+
+fn resolve_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+) -> QueryResult<Option<ResolvedMember>>
+where
+    Q: ExternalQueries,
+{
     let Some(class) =
         toolkit::lookup_file_class(state, context, result.class_file, result.class_id)?
     else {
@@ -166,11 +207,12 @@ where
         return Ok(None);
     };
 
-    let resolution = (result.class_file, member.item_id);
+    let file_id = result.class_file;
+    let item_id = member.item_id;
     let Some(implementation_type) = instantiate_class_member_type(
         state,
         context,
-        resolution,
+        (file_id, item_id),
         (result.class_file, result.class_id),
         instance_arguments,
     )?
@@ -178,7 +220,7 @@ where
         return Ok(None);
     };
 
-    Ok(Some(ComparisonMember { resolution, implementation_type, constructors }))
+    Ok(Some(ResolvedMember { file_id, item_id, implementation_type }))
 }
 
 fn generate_eq_member<Q>(
@@ -194,18 +236,19 @@ where
     else {
         return Ok(None);
     };
-    let Some(operation) = context.known_terms.eq else {
+    let Some(direct) = context.known_terms.eq else {
         return Ok(None);
     };
+    let operations = ComparisonOperations { direct, lifted: context.known_terms.eq1 };
 
-    let Some(body) = emit_eq(state, context, result.derive_id, &member, operation)? else {
+    let Some(body) = emit_eq(state, context, result.derive_id, &member, operations)? else {
         return Ok(None);
     };
 
     let member = generated_member(
         result.derive_id,
-        member.resolution,
-        member.implementation_type,
+        (member.member.file_id, member.member.item_id),
+        member.member.implementation_type,
         vec![],
         body,
     );
@@ -225,9 +268,10 @@ where
     else {
         return Ok(None);
     };
-    let Some(operation) = context.known_terms.compare else {
+    let Some(direct) = context.known_terms.compare else {
         return Ok(None);
     };
+    let operations = ComparisonOperations { direct, lifted: context.known_terms.compare1 };
     let Some(equal) = context.known_terms.ordering_eq else {
         return Ok(None);
     };
@@ -248,7 +292,7 @@ where
         context,
         result.derive_id,
         &member,
-        operation,
+        operations,
         equal,
         constructor_ordering,
     )?
@@ -258,12 +302,59 @@ where
 
     let member = generated_member(
         result.derive_id,
-        member.resolution,
-        member.implementation_type,
+        (member.member.file_id, member.member.item_id),
+        member.member.implementation_type,
         vec![],
         body,
     );
     Ok(Some(member))
+}
+
+fn generate_delegated_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    operation: Option<(files::FileId, indexing::TermItemId)>,
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    state.with_implication(|state| {
+        let DeriveStrategy::DelegateConstraint { .. } = result.strategy else {
+            return Ok(None);
+        };
+        let Some(operation) = operation else {
+            return Ok(None);
+        };
+        let Some(member) = resolve_member(state, context, result, instance_arguments)? else {
+            return Ok(None);
+        };
+
+        let signature::SkolemisedSignature { substitution, constraints, result: body_type, .. } =
+            signature::expect_term_signature(state, context, member.implementation_type, 0)?;
+
+        let mut evidences = Vec::with_capacity(constraints.len());
+        for constraint in constraints {
+            let evidence = Evidence::Given(state.push_given(constraint));
+            evidences.push(evidence);
+        }
+
+        let body = state.with_implicit(context, &substitution, |state| {
+            let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+            let body = builder.term_reference(operation)?;
+            builder.subtype(body, body_type)
+        })?;
+
+        let member = generated_member(
+            result.derive_id,
+            (member.file_id, member.item_id),
+            member.implementation_type,
+            evidences,
+            body,
+        );
+        Ok(Some(member))
+    })
 }
 
 fn generated_member(
@@ -289,6 +380,12 @@ fn generated_member(
 struct ConstructorOrdering {
     less: (files::FileId, indexing::TermItemId),
     greater: (files::FileId, indexing::TermItemId),
+}
+
+#[derive(Clone, Copy)]
+struct ComparisonOperations {
+    direct: (files::FileId, indexing::TermItemId),
+    lifted: Option<(files::FileId, indexing::TermItemId)>,
 }
 
 struct BinaryComparisonMember {
@@ -345,13 +442,16 @@ fn emit_eq<Q>(
     context: &CheckContext<Q>,
     derive_id: indexing::DeriveId,
     comparison_member: &ComparisonMember,
-    operation: (files::FileId, indexing::TermItemId),
+    operations: ComparisonOperations,
 ) -> QueryResult<Option<ElaboratedExpression>>
 where
     Q: ExternalQueries,
 {
-    let Some(member) =
-        BinaryComparisonMember::decode(state, context, comparison_member.implementation_type)?
+    let Some(member) = BinaryComparisonMember::decode(
+        state,
+        context,
+        comparison_member.member.implementation_type,
+    )?
     else {
         return Ok(None);
     };
@@ -362,7 +462,7 @@ where
     let mut alternatives = vec![];
     for constructor in &comparison_member.constructors {
         let Some(comparison) =
-            emit_constructor_comparison(&mut builder, constructor, &member, operation)?
+            emit_constructor_comparison(&mut builder, constructor, &member, operations)?
         else {
             return Ok(None);
         };
@@ -407,15 +507,18 @@ fn emit_ord<Q>(
     context: &CheckContext<Q>,
     derive_id: indexing::DeriveId,
     comparison_member: &ComparisonMember,
-    operation: (files::FileId, indexing::TermItemId),
+    operations: ComparisonOperations,
     equal: (files::FileId, indexing::TermItemId),
     constructor_ordering: Option<ConstructorOrdering>,
 ) -> QueryResult<Option<ElaboratedExpression>>
 where
     Q: ExternalQueries,
 {
-    let Some(member) =
-        BinaryComparisonMember::decode(state, context, comparison_member.implementation_type)?
+    let Some(member) = BinaryComparisonMember::decode(
+        state,
+        context,
+        comparison_member.member.implementation_type,
+    )?
     else {
         return Ok(None);
     };
@@ -436,7 +539,7 @@ where
         &mut builder,
         &comparison_member.constructors,
         &member,
-        operation,
+        operations,
         equal,
         constructor_ordering,
     )?
@@ -452,7 +555,7 @@ fn emit_ord_alternatives<Q>(
     builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
     constructors: &[AppliedConstructor],
     member: &BinaryComparisonMember,
-    operation: (files::FileId, indexing::TermItemId),
+    operations: ComparisonOperations,
     equal: (files::FileId, indexing::TermItemId),
     constructor_ordering: Option<ConstructorOrdering>,
 ) -> QueryResult<Option<Vec<tree::CaseAlternative>>>
@@ -463,7 +566,7 @@ where
     let mut remaining = constructors;
     while let Some((constructor, later_constructors)) = remaining.split_first() {
         let Some(comparison) =
-            emit_constructor_comparison(builder, constructor, member, operation)?
+            emit_constructor_comparison(builder, constructor, member, operations)?
         else {
             return Ok(None);
         };
@@ -529,14 +632,14 @@ fn emit_constructor_comparison<Q>(
     builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
     constructor: &AppliedConstructor,
     member: &BinaryComparisonMember,
-    operation: (files::FileId, indexing::TermItemId),
+    operations: ComparisonOperations,
 ) -> QueryResult<Option<ConstructorComparison>>
 where
     Q: ExternalQueries,
 {
     let mut fields = Vec::with_capacity(constructor.fields.len());
-    for (index, &field_type) in constructor.fields.iter().enumerate() {
-        let Some(field) = emit_field_comparison(builder, operation, index, field_type)? else {
+    for (index, field) in constructor.fields.iter().enumerate() {
+        let Some(field) = emit_field_comparison(builder, operations, index, field)? else {
             return Ok(None);
         };
         fields.push(field);
@@ -567,15 +670,25 @@ where
 
 fn emit_field_comparison<Q>(
     builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
-    operation: (files::FileId, indexing::TermItemId),
+    operations: ComparisonOperations,
     index: usize,
-    field_type: TypeId,
+    field: &AppliedField,
 ) -> QueryResult<Option<GeneratedFieldPair>>
 where
     Q: ExternalQueries,
 {
-    let left = builder.variable_binder(&format_smolstr!("left{index}"), field_type);
-    let right = builder.variable_binder(&format_smolstr!("right{index}"), field_type);
+    let operation = match field.comparison {
+        field::ComparisonStyle::Direct => operations.direct,
+        field::ComparisonStyle::Lifted => {
+            let Some(operation) = operations.lifted else {
+                return Ok(None);
+            };
+            operation
+        }
+    };
+
+    let left = builder.variable_binder(&format_smolstr!("left{index}"), field.type_id);
+    let right = builder.variable_binder(&format_smolstr!("right{index}"), field.type_id);
     let left_value = builder.variable(left);
     let right_value = builder.variable(right);
     let Some(comparison) = emit_comparison(builder, operation, left_value, right_value)? else {
@@ -608,11 +721,9 @@ fn emit_constructor_wildcard<Q>(
 where
     Q: ExternalQueries,
 {
-    let fields = constructor
-        .fields
-        .iter()
-        .map(|&field_type| builder.wildcard_pattern("field", field_type))
-        .collect();
+    let fields =
+        constructor.fields.iter().map(|field| builder.wildcard_pattern("field", field.type_id));
+    let fields = fields.collect();
     builder.constructor_pattern(
         "constructor",
         type_id,

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -471,11 +471,12 @@ where
         let patterns = vec![comparison.left_pattern, comparison.right_pattern];
         alternatives.push(builder.alternative(patterns, body));
 
-        if let Some(ordering) = constructor_ordering {
+        if let Some(ordering) = constructor_ordering
+            && !later_constructors.is_empty()
+        {
             emit_constructor_ordering_alternatives(
                 builder,
                 constructor,
-                later_constructors,
                 member,
                 ordering,
                 &mut alternatives,
@@ -490,7 +491,6 @@ where
 fn emit_constructor_ordering_alternatives<Q>(
     builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
     constructor: &AppliedConstructor,
-    later_constructors: &[AppliedConstructor],
     member: &BinaryComparisonMember,
     ordering: ConstructorOrdering,
     alternatives: &mut Vec<tree::CaseAlternative>,
@@ -498,17 +498,15 @@ fn emit_constructor_ordering_alternatives<Q>(
 where
     Q: ExternalQueries,
 {
-    for later in later_constructors {
-        let left = emit_constructor_wildcard(builder, constructor, member.left_type);
-        let right = emit_constructor_wildcard(builder, later, member.right_type);
-        let body = emit_ordering_constant(builder, ordering.less, member.result_type)?;
-        alternatives.push(builder.alternative(vec![left, right], body));
+    let left = emit_constructor_wildcard(builder, constructor, member.left_type);
+    let right = builder.wildcard_pattern("right", member.right_type);
+    let body = emit_ordering_constant(builder, ordering.less, member.result_type)?;
+    alternatives.push(builder.alternative(vec![left, right], body));
 
-        let left = emit_constructor_wildcard(builder, later, member.left_type);
-        let right = emit_constructor_wildcard(builder, constructor, member.right_type);
-        let body = emit_ordering_constant(builder, ordering.greater, member.result_type)?;
-        alternatives.push(builder.alternative(vec![left, right], body));
-    }
+    let left = builder.wildcard_pattern("left", member.left_type);
+    let right = emit_constructor_wildcard(builder, constructor, member.right_type);
+    let body = emit_ordering_constant(builder, ordering.greater, member.result_type)?;
+    alternatives.push(builder.alternative(vec![left, right], body));
 
     Ok(())
 }

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{KindOrType, toolkit};
+use crate::core::{KindOrType, TypeId, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::tools;
@@ -24,16 +24,20 @@ pub(crate) fn generate_instance<Q>(
 where
     Q: ExternalQueries,
 {
-    match derive_dispatch(context, result.class_file, result.class_id) {
-        DeriveDispatch::Eq => generate_eq_instance(state, context, result),
+    let dispatch = derive_dispatch(context, result.class_file, result.class_id);
+    match dispatch {
+        DeriveDispatch::Eq | DeriveDispatch::Ord => {
+            generate_known_instance(state, context, result, dispatch)
+        }
         _ => Ok(()),
     }
 }
 
-fn generate_eq_instance<Q>(
+fn generate_known_instance<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
+    dispatch: DeriveDispatch,
 ) -> QueryResult<()>
 where
     Q: ExternalQueries,
@@ -66,9 +70,16 @@ where
             &freshened.arguments,
         )?;
 
-        let Some(member) =
-            generate_nullary_eq_member(state, context, result, &freshened.arguments)?
-        else {
+        let member = match dispatch {
+            DeriveDispatch::Eq => {
+                generate_nullary_eq_member(state, context, result, &freshened.arguments)?
+            }
+            DeriveDispatch::Ord => {
+                generate_nullary_ord_member(state, context, result, &freshened.arguments)?
+            }
+            _ => None,
+        };
+        let Some(member) = member else {
             return Ok(());
         };
 
@@ -89,12 +100,18 @@ where
     })
 }
 
-fn generate_nullary_eq_member<Q>(
+struct NullaryMember {
+    resolution: (files::FileId, indexing::TermItemId),
+    implementation_type: TypeId,
+    constructor: (files::FileId, indexing::TermItemId),
+}
+
+fn resolve_nullary_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
     instance_arguments: &[KindOrType],
-) -> QueryResult<Option<tree::InstanceMember>>
+) -> QueryResult<Option<NullaryMember>>
 where
     Q: ExternalQueries,
 {
@@ -135,23 +152,84 @@ where
         return Ok(None);
     };
 
-    let body = generate_nullary_eq_body(
+    Ok(Some(NullaryMember {
+        resolution,
+        implementation_type,
+        constructor: (data_file, *constructor_id),
+    }))
+}
+
+fn generate_nullary_eq_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    let Some(member) = resolve_nullary_member(state, context, result, instance_arguments)? else {
+        return Ok(None);
+    };
+
+    let body = generate_nullary_body(
         state,
         context,
-        result,
-        implementation_type,
-        (data_file, *constructor_id),
+        result.derive_id,
+        member.implementation_type,
+        member.constructor,
+        NullaryResult::Boolean(true),
     )?;
 
-    let member =
-        generated_member(result.derive_id, resolution, implementation_type, Vec::new(), body);
+    let member = generated_member(
+        result.derive_id,
+        member.resolution,
+        member.implementation_type,
+        vec![],
+        body,
+    );
+    Ok(Some(member))
+}
+
+fn generate_nullary_ord_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    let Some(member) = resolve_nullary_member(state, context, result, instance_arguments)? else {
+        return Ok(None);
+    };
+    let Some(equal) = context.known_terms.ordering_eq else {
+        return Ok(None);
+    };
+
+    let body = generate_nullary_body(
+        state,
+        context,
+        result.derive_id,
+        member.implementation_type,
+        member.constructor,
+        NullaryResult::Reference(equal),
+    )?;
+
+    let member = generated_member(
+        result.derive_id,
+        member.resolution,
+        member.implementation_type,
+        vec![],
+        body,
+    );
     Ok(Some(member))
 }
 
 fn generated_member(
     derive_id: indexing::DeriveId,
     resolution: (files::FileId, indexing::TermItemId),
-    implementation_type: crate::core::TypeId,
+    implementation_type: TypeId,
     evidences: Vec<Evidence>,
     body: ElaboratedExpression,
 ) -> tree::InstanceMember {
@@ -167,12 +245,18 @@ fn generated_member(
     }
 }
 
-fn generate_nullary_eq_body<Q>(
+enum NullaryResult {
+    Boolean(bool),
+    Reference((files::FileId, indexing::TermItemId)),
+}
+
+fn generate_nullary_body<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    result: &DeriveHeadResult,
-    implementation_type: crate::core::TypeId,
+    derive_id: indexing::DeriveId,
+    implementation_type: TypeId,
     constructor: (files::FileId, indexing::TermItemId),
+    nullary_result: NullaryResult,
 ) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
@@ -180,22 +264,27 @@ where
     let toolkit::InspectFunction { arguments, result: result_type } =
         toolkit::inspect_function(state, context, implementation_type)?;
     let [left_type, right_type] = arguments.as_slice() else {
-        panic!("Eq member must have exactly two value arguments")
+        panic!("comparison member must have exactly two value arguments")
     };
 
-    let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
     let left = builder.variable_binder("left", *left_type);
     let right = builder.variable_binder("right", *right_type);
 
     let left_expression = builder.variable(left);
     let right_expression = builder.variable(right);
 
-    let left_pattern =
-        builder.constructor_pattern("constructor", *left_type, constructor, Vec::new());
+    let left_pattern = builder.constructor_pattern("constructor", *left_type, constructor, vec![]);
     let right_pattern =
-        builder.constructor_pattern("constructor", *right_type, constructor, Vec::new());
+        builder.constructor_pattern("constructor", *right_type, constructor, vec![]);
 
-    let equal = builder.boolean(result_type, true);
+    let equal = match nullary_result {
+        NullaryResult::Boolean(value) => builder.boolean(result_type, value),
+        NullaryResult::Reference(resolution) => {
+            let reference = builder.term_reference(resolution)?;
+            builder.subtype(reference, result_type)?
+        }
+    };
     let alternative = builder.alternative(vec![left_pattern, right_pattern], equal);
     let case =
         builder.case(result_type, vec![left_expression, right_expression], vec![alternative]);

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use building_types::QueryResult;
+use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
 use crate::core::{KindOrType, TypeId, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
-use crate::source::derive::tools;
+use crate::source::derive::{field, tools};
 use crate::source::term_items::{
     emit_instance_superclass_constraints, freshen_instance_rigids, instantiate_class_member_type,
 };
@@ -71,14 +72,13 @@ where
         )?;
 
         let member = match dispatch {
-            DeriveDispatch::Eq => {
-                generate_nullary_eq_member(state, context, result, &freshened.arguments)?
-            }
+            DeriveDispatch::Eq => generate_eq_member(state, context, result, &freshened.arguments)?,
             DeriveDispatch::Ord => {
-                generate_nullary_ord_member(state, context, result, &freshened.arguments)?
+                generate_ord_member(state, context, result, &freshened.arguments)?
             }
             _ => None,
         };
+
         let Some(member) = member else {
             return Ok(());
         };
@@ -100,34 +100,60 @@ where
     })
 }
 
-struct NullaryMember {
+struct ComparisonMember {
     resolution: (files::FileId, indexing::TermItemId),
     implementation_type: TypeId,
-    constructor: (files::FileId, indexing::TermItemId),
+    constructors: Vec<AppliedConstructor>,
 }
 
-fn resolve_nullary_member<Q>(
+struct AppliedConstructor {
+    file_id: files::FileId,
+    item_id: indexing::TermItemId,
+    fields: Vec<TypeId>,
+}
+
+fn resolve_comparison_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
     instance_arguments: &[KindOrType],
-) -> QueryResult<Option<NullaryMember>>
+) -> QueryResult<Option<ComparisonMember>>
 where
     Q: ExternalQueries,
 {
     let DeriveStrategy::FieldConstraints { data_file, data_id, .. } = result.strategy else {
         return Ok(None);
     };
-
-    let constructors = tools::lookup_data_constructors(context, data_file, data_id)?;
-    let [constructor_id] = constructors.as_slice() else {
+    let Some(KindOrType::Type(derived_type)) = instance_arguments.last() else {
         return Ok(None);
     };
 
-    let constructor_type = toolkit::lookup_file_term(state, context, data_file, *constructor_id)?;
-    let constructor = toolkit::inspect_function(state, context, constructor_type)?;
-    if !constructor.arguments.is_empty() {
-        return Ok(None);
+    let (_, type_arguments) = toolkit::extract_all_applications(state, context, *derived_type)?;
+
+    let constructor_ids = tools::lookup_data_constructors(context, data_file, data_id)?;
+    let mut constructors = Vec::with_capacity(constructor_ids.len());
+
+    for constructor_id in constructor_ids {
+        let constructor_type =
+            toolkit::lookup_file_term(state, context, data_file, constructor_id)?;
+
+        let fields = field::instantiate_constructor_fields(
+            state,
+            context,
+            constructor_type,
+            &type_arguments,
+        )?;
+        for &field in &fields {
+            if field::requires_lifted_comparison(state, context, field)? {
+                return Ok(None);
+            }
+        }
+
+        constructors.push(AppliedConstructor {
+            file_id: data_file,
+            item_id: constructor_id,
+            fields,
+        });
     }
 
     let Some(class) =
@@ -152,14 +178,10 @@ where
         return Ok(None);
     };
 
-    Ok(Some(NullaryMember {
-        resolution,
-        implementation_type,
-        constructor: (data_file, *constructor_id),
-    }))
+    Ok(Some(ComparisonMember { resolution, implementation_type, constructors }))
 }
 
-fn generate_nullary_eq_member<Q>(
+fn generate_eq_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
@@ -168,18 +190,17 @@ fn generate_nullary_eq_member<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(member) = resolve_nullary_member(state, context, result, instance_arguments)? else {
+    let Some(member) = resolve_comparison_member(state, context, result, instance_arguments)?
+    else {
+        return Ok(None);
+    };
+    let Some(operation) = context.known_terms.eq else {
         return Ok(None);
     };
 
-    let body = generate_nullary_body(
-        state,
-        context,
-        result.derive_id,
-        member.implementation_type,
-        member.constructor,
-        NullaryResult::Boolean(true),
-    )?;
+    let Some(body) = emit_eq(state, context, result.derive_id, &member, operation)? else {
+        return Ok(None);
+    };
 
     let member = generated_member(
         result.derive_id,
@@ -191,7 +212,7 @@ where
     Ok(Some(member))
 }
 
-fn generate_nullary_ord_member<Q>(
+fn generate_ord_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
@@ -200,21 +221,40 @@ fn generate_nullary_ord_member<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(member) = resolve_nullary_member(state, context, result, instance_arguments)? else {
+    let Some(member) = resolve_comparison_member(state, context, result, instance_arguments)?
+    else {
+        return Ok(None);
+    };
+    let Some(operation) = context.known_terms.compare else {
         return Ok(None);
     };
     let Some(equal) = context.known_terms.ordering_eq else {
         return Ok(None);
     };
+    let constructor_ordering = if member.constructors.len() >= 2 {
+        let Some(less) = context.known_terms.ordering_lt else {
+            return Ok(None);
+        };
+        let Some(greater) = context.known_terms.ordering_gt else {
+            return Ok(None);
+        };
+        Some(ConstructorOrdering { less, greater })
+    } else {
+        None
+    };
 
-    let body = generate_nullary_body(
+    let Some(body) = emit_ord(
         state,
         context,
         result.derive_id,
-        member.implementation_type,
-        member.constructor,
-        NullaryResult::Reference(equal),
-    )?;
+        &member,
+        operation,
+        equal,
+        constructor_ordering,
+    )?
+    else {
+        return Ok(None);
+    };
 
     let member = generated_member(
         result.derive_id,
@@ -245,49 +285,413 @@ fn generated_member(
     }
 }
 
-enum NullaryResult {
-    Boolean(bool),
-    Reference((files::FileId, indexing::TermItemId)),
+#[derive(Clone, Copy)]
+struct ConstructorOrdering {
+    less: (files::FileId, indexing::TermItemId),
+    greater: (files::FileId, indexing::TermItemId),
 }
 
-fn generate_nullary_body<Q>(
+struct BinaryComparisonMember {
+    implementation_type: TypeId,
+    left_type: TypeId,
+    right_type: TypeId,
+    result_type: TypeId,
+}
+
+impl BinaryComparisonMember {
+    fn decode<Q>(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        implementation_type: TypeId,
+    ) -> QueryResult<Option<BinaryComparisonMember>>
+    where
+        Q: ExternalQueries,
+    {
+        let toolkit::InspectFunction { arguments, result } =
+            toolkit::inspect_function(state, context, implementation_type)?;
+        let [left_type, right_type] = arguments.as_slice() else {
+            return Ok(None);
+        };
+        Ok(Some(BinaryComparisonMember {
+            implementation_type,
+            left_type: *left_type,
+            right_type: *right_type,
+            result_type: result,
+        }))
+    }
+}
+
+struct ComparisonParameters {
+    left_binder: tree::BinderId,
+    right_binder: tree::BinderId,
+    left_expression: ElaboratedExpression,
+    right_expression: ElaboratedExpression,
+}
+
+struct ConstructorComparison {
+    left_pattern: tree::BinderId,
+    right_pattern: tree::BinderId,
+    comparisons: Vec<ElaboratedExpression>,
+}
+
+struct GeneratedFieldPair {
+    left: tree::BinderId,
+    right: tree::BinderId,
+    comparison: ElaboratedExpression,
+}
+
+fn emit_eq<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     derive_id: indexing::DeriveId,
-    implementation_type: TypeId,
-    constructor: (files::FileId, indexing::TermItemId),
-    nullary_result: NullaryResult,
+    comparison_member: &ComparisonMember,
+    operation: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let Some(member) =
+        BinaryComparisonMember::decode(state, context, comparison_member.implementation_type)?
+    else {
+        return Ok(None);
+    };
+
+    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
+    let parameters = emit_parameters(&mut builder, &member);
+
+    let mut alternatives = vec![];
+    for constructor in &comparison_member.constructors {
+        let Some(comparison) =
+            emit_constructor_comparison(&mut builder, constructor, &member, operation)?
+        else {
+            return Ok(None);
+        };
+
+        let body = emit_conjunction(&mut builder, member.result_type, comparison.comparisons);
+        let patterns = vec![comparison.left_pattern, comparison.right_pattern];
+
+        alternatives.push(builder.alternative(patterns, body));
+    }
+
+    if let Some(alternative) = emit_mismatched_constructor_alternative(
+        &mut builder,
+        &comparison_member.constructors,
+        &member,
+    ) {
+        alternatives.push(alternative);
+    }
+
+    let body = emit_lambda_case(&mut builder, member, parameters, alternatives);
+    Ok(Some(body))
+}
+
+fn emit_mismatched_constructor_alternative<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    constructors: &[AppliedConstructor],
+    member: &BinaryComparisonMember,
+) -> Option<tree::CaseAlternative>
+where
+    Q: ExternalQueries,
+{
+    let ([] | [_, _, ..]) = constructors else {
+        return None;
+    };
+    let left = builder.wildcard_pattern("left", member.left_type);
+    let right = builder.wildcard_pattern("right", member.right_type);
+    let body = builder.boolean(member.result_type, false);
+    Some(builder.alternative(vec![left, right], body))
+}
+
+fn emit_ord<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    derive_id: indexing::DeriveId,
+    comparison_member: &ComparisonMember,
+    operation: (files::FileId, indexing::TermItemId),
+    equal: (files::FileId, indexing::TermItemId),
+    constructor_ordering: Option<ConstructorOrdering>,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let Some(member) =
+        BinaryComparisonMember::decode(state, context, comparison_member.implementation_type)?
+    else {
+        return Ok(None);
+    };
+
+    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
+    let parameters = emit_parameters(&mut builder, &member);
+    if comparison_member.constructors.is_empty() {
+        let body = emit_ordering_constant(&mut builder, equal, member.result_type)?;
+        let body = builder.lambda(
+            member.implementation_type,
+            vec![parameters.left_binder, parameters.right_binder],
+            body,
+        );
+        return Ok(Some(body));
+    }
+
+    let Some(alternatives) = emit_ord_alternatives(
+        &mut builder,
+        &comparison_member.constructors,
+        &member,
+        operation,
+        equal,
+        constructor_ordering,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let body = emit_lambda_case(&mut builder, member, parameters, alternatives);
+    Ok(Some(body))
+}
+
+fn emit_ord_alternatives<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    constructors: &[AppliedConstructor],
+    member: &BinaryComparisonMember,
+    operation: (files::FileId, indexing::TermItemId),
+    equal: (files::FileId, indexing::TermItemId),
+    constructor_ordering: Option<ConstructorOrdering>,
+) -> QueryResult<Option<Vec<tree::CaseAlternative>>>
+where
+    Q: ExternalQueries,
+{
+    let mut alternatives = vec![];
+    let mut remaining = constructors;
+    while let Some((constructor, later_constructors)) = remaining.split_first() {
+        let Some(comparison) =
+            emit_constructor_comparison(builder, constructor, member, operation)?
+        else {
+            return Ok(None);
+        };
+        let body = emit_lexicographic(builder, comparison.comparisons, member.result_type, equal)?;
+        let patterns = vec![comparison.left_pattern, comparison.right_pattern];
+        alternatives.push(builder.alternative(patterns, body));
+
+        if let Some(ordering) = constructor_ordering {
+            emit_constructor_ordering_alternatives(
+                builder,
+                constructor,
+                later_constructors,
+                member,
+                ordering,
+                &mut alternatives,
+            )?;
+        }
+
+        remaining = later_constructors;
+    }
+    Ok(Some(alternatives))
+}
+
+fn emit_constructor_ordering_alternatives<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    constructor: &AppliedConstructor,
+    later_constructors: &[AppliedConstructor],
+    member: &BinaryComparisonMember,
+    ordering: ConstructorOrdering,
+    alternatives: &mut Vec<tree::CaseAlternative>,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    for later in later_constructors {
+        let left = emit_constructor_wildcard(builder, constructor, member.left_type);
+        let right = emit_constructor_wildcard(builder, later, member.right_type);
+        let body = emit_ordering_constant(builder, ordering.less, member.result_type)?;
+        alternatives.push(builder.alternative(vec![left, right], body));
+
+        let left = emit_constructor_wildcard(builder, later, member.left_type);
+        let right = emit_constructor_wildcard(builder, constructor, member.right_type);
+        let body = emit_ordering_constant(builder, ordering.greater, member.result_type)?;
+        alternatives.push(builder.alternative(vec![left, right], body));
+    }
+
+    Ok(())
+}
+
+fn emit_parameters<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    member: &BinaryComparisonMember,
+) -> ComparisonParameters
+where
+    Q: ExternalQueries,
+{
+    let left_binder = builder.variable_binder("left", member.left_type);
+    let right_binder = builder.variable_binder("right", member.right_type);
+    let left_expression = builder.variable(left_binder);
+    let right_expression = builder.variable(right_binder);
+    ComparisonParameters { left_binder, right_binder, left_expression, right_expression }
+}
+
+fn emit_constructor_comparison<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    constructor: &AppliedConstructor,
+    member: &BinaryComparisonMember,
+    operation: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<ConstructorComparison>>
+where
+    Q: ExternalQueries,
+{
+    let mut fields = Vec::with_capacity(constructor.fields.len());
+    for (index, &field_type) in constructor.fields.iter().enumerate() {
+        let Some(field) = emit_field_comparison(builder, operation, index, field_type)? else {
+            return Ok(None);
+        };
+        fields.push(field);
+    }
+
+    let left_fields = fields.iter().map(|field| field.left);
+    let left_fields = left_fields.collect();
+    let left_pattern = builder.constructor_pattern(
+        "constructor",
+        member.left_type,
+        (constructor.file_id, constructor.item_id),
+        left_fields,
+    );
+
+    let right_fields = fields.iter().map(|field| field.right);
+    let right_fields = right_fields.collect();
+    let right_pattern = builder.constructor_pattern(
+        "constructor",
+        member.right_type,
+        (constructor.file_id, constructor.item_id),
+        right_fields,
+    );
+
+    let comparisons = fields.into_iter().map(|field| field.comparison);
+    let comparisons = comparisons.collect();
+    Ok(Some(ConstructorComparison { left_pattern, right_pattern, comparisons }))
+}
+
+fn emit_field_comparison<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    operation: (files::FileId, indexing::TermItemId),
+    index: usize,
+    field_type: TypeId,
+) -> QueryResult<Option<GeneratedFieldPair>>
+where
+    Q: ExternalQueries,
+{
+    let left = builder.variable_binder(&format_smolstr!("left{index}"), field_type);
+    let right = builder.variable_binder(&format_smolstr!("right{index}"), field_type);
+    let left_value = builder.variable(left);
+    let right_value = builder.variable(right);
+    let Some(comparison) = emit_comparison(builder, operation, left_value, right_value)? else {
+        return Ok(None);
+    };
+    Ok(Some(GeneratedFieldPair { left, right, comparison }))
+}
+
+fn emit_comparison<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    operation: (files::FileId, indexing::TermItemId),
+    left: ElaboratedExpression,
+    right: ElaboratedExpression,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let comparison = builder.term_reference(operation)?;
+    let Some(comparison) = builder.apply(comparison, left)? else {
+        return Ok(None);
+    };
+    builder.apply(comparison, right)
+}
+
+fn emit_constructor_wildcard<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    constructor: &AppliedConstructor,
+    type_id: TypeId,
+) -> tree::BinderId
+where
+    Q: ExternalQueries,
+{
+    let fields = constructor
+        .fields
+        .iter()
+        .map(|&field_type| builder.wildcard_pattern("field", field_type))
+        .collect();
+    builder.constructor_pattern(
+        "constructor",
+        type_id,
+        (constructor.file_id, constructor.item_id),
+        fields,
+    )
+}
+
+fn emit_conjunction<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    result_type: TypeId,
+    comparisons: Vec<ElaboratedExpression>,
+) -> ElaboratedExpression
+where
+    Q: ExternalQueries,
+{
+    let mut result = builder.boolean(result_type, true);
+    for comparison in comparisons.into_iter().rev() {
+        let false_ = builder.boolean(result_type, false);
+        result = builder.if_then_else(result_type, comparison, result, false_);
+    }
+    result
+}
+
+fn emit_lexicographic<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    comparisons: Vec<ElaboratedExpression>,
+    result_type: TypeId,
+    equal: (files::FileId, indexing::TermItemId),
 ) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
-    let toolkit::InspectFunction { arguments, result: result_type } =
-        toolkit::inspect_function(state, context, implementation_type)?;
-    let [left_type, right_type] = arguments.as_slice() else {
-        panic!("comparison member must have exactly two value arguments")
-    };
+    let mut result = emit_ordering_constant(builder, equal, result_type)?;
+    for comparison in comparisons.into_iter().rev() {
+        let equal_pattern = builder.constructor_pattern("EQ", result_type, equal, vec![]);
+        let other = builder.variable_binder("ordering", result_type);
+        let other_expression = builder.variable(other);
+        let alternatives = vec![
+            builder.alternative(vec![equal_pattern], result),
+            builder.alternative(vec![other], other_expression),
+        ];
+        result = builder.case(result_type, vec![comparison], alternatives);
+    }
+    Ok(result)
+}
 
-    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
-    let left = builder.variable_binder("left", *left_type);
-    let right = builder.variable_binder("right", *right_type);
+fn emit_ordering_constant<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    resolution: (files::FileId, indexing::TermItemId),
+    expected: TypeId,
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let expression = builder.term_reference(resolution)?;
+    builder.subtype(expression, expected)
+}
 
-    let left_expression = builder.variable(left);
-    let right_expression = builder.variable(right);
+fn emit_lambda_case<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    member: BinaryComparisonMember,
+    parameters: ComparisonParameters,
+    alternatives: Vec<tree::CaseAlternative>,
+) -> ElaboratedExpression
+where
+    Q: ExternalQueries,
+{
+    let body = builder.case(
+        member.result_type,
+        vec![parameters.left_expression, parameters.right_expression],
+        alternatives,
+    );
 
-    let left_pattern = builder.constructor_pattern("constructor", *left_type, constructor, vec![]);
-    let right_pattern =
-        builder.constructor_pattern("constructor", *right_type, constructor, vec![]);
-
-    let equal = match nullary_result {
-        NullaryResult::Boolean(value) => builder.boolean(result_type, value),
-        NullaryResult::Reference(resolution) => {
-            let reference = builder.term_reference(resolution)?;
-            builder.subtype(reference, result_type)?
-        }
-    };
-    let alternative = builder.alternative(vec![left_pattern, right_pattern], equal);
-    let case =
-        builder.case(result_type, vec![left_expression, right_expression], vec![alternative]);
-
-    Ok(builder.lambda(implementation_type, vec![left, right], case))
+    builder.lambda(
+        member.implementation_type,
+        vec![parameters.left_binder, parameters.right_binder],
+        body,
+    )
 }

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -1,0 +1,204 @@
+use std::sync::Arc;
+
+use building_types::QueryResult;
+
+use crate::context::CheckContext;
+use crate::core::{KindOrType, toolkit};
+use crate::evidence::Evidence;
+use crate::source::derive::builder::DerivedTreeBuilder;
+use crate::source::derive::tools;
+use crate::source::term_items::{
+    emit_instance_superclass_constraints, freshen_instance_rigids, instantiate_class_member_type,
+};
+use crate::source::terms::ElaboratedExpression;
+use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+use super::{DeriveDispatch, DeriveHeadResult, DeriveStrategy, derive_dispatch};
+
+pub(crate) fn generate_instance<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    match derive_dispatch(context, result.class_file, result.class_id) {
+        DeriveDispatch::Eq => generate_eq_instance(state, context, result),
+        _ => Ok(()),
+    }
+}
+
+fn generate_eq_instance<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let Some(instance) = toolkit::instance_info(
+        state,
+        context,
+        result.signature,
+        (result.class_file, result.class_id),
+    )?
+    else {
+        return Ok(());
+    };
+
+    let freshened = freshen_instance_rigids(state, context, &instance)?;
+    state.with_implicit(context, &freshened.substitution, |state| {
+        let mut evidences = Vec::with_capacity(freshened.constraints.len());
+        for (&constraint, &signature_constraint) in
+            std::iter::zip(&freshened.constraints, &instance.constraints)
+        {
+            let evidence = Evidence::Given(state.push_given(constraint));
+            evidences.push(tree::InstanceEvidence { constraint: signature_constraint, evidence });
+        }
+
+        let superclasses = emit_instance_superclass_constraints(
+            state,
+            context,
+            result.class_file,
+            result.class_id,
+            &freshened.arguments,
+        )?;
+
+        let Some(member) =
+            generate_nullary_eq_member(state, context, result, &freshened.arguments)?
+        else {
+            return Ok(());
+        };
+
+        let instance = tree::InstanceDeclaration {
+            class: (result.class_file, result.class_id),
+            rigid_parameters: Arc::from(freshened.rigids),
+            evidences: Arc::from(evidences),
+            superclasses: Arc::from(superclasses),
+            implementation: tree::InstanceImplementation::Members(Arc::from([member])),
+        };
+        let declaration = tree::TermDeclaration {
+            type_id: result.signature,
+            kind: tree::TermDeclarationKind::Instance(instance),
+        };
+        state.checked.tree.insert_term(result.item_id, declaration);
+
+        Ok(())
+    })
+}
+
+fn generate_nullary_eq_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    let DeriveStrategy::FieldConstraints { data_file, data_id, .. } = result.strategy else {
+        return Ok(None);
+    };
+
+    let constructors = tools::lookup_data_constructors(context, data_file, data_id)?;
+    let [constructor_id] = constructors.as_slice() else {
+        return Ok(None);
+    };
+
+    let constructor_type = toolkit::lookup_file_term(state, context, data_file, *constructor_id)?;
+    let constructor = toolkit::inspect_function(state, context, constructor_type)?;
+    if !constructor.arguments.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(class) =
+        toolkit::lookup_file_class(state, context, result.class_file, result.class_id)?
+    else {
+        return Ok(None);
+    };
+
+    let [member] = class.members.as_slice() else {
+        return Ok(None);
+    };
+
+    let resolution = (result.class_file, member.item_id);
+    let Some(implementation_type) = instantiate_class_member_type(
+        state,
+        context,
+        resolution,
+        (result.class_file, result.class_id),
+        instance_arguments,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let body = generate_nullary_eq_body(
+        state,
+        context,
+        result,
+        implementation_type,
+        (data_file, *constructor_id),
+    )?;
+
+    let member =
+        generated_member(result.derive_id, resolution, implementation_type, Vec::new(), body);
+    Ok(Some(member))
+}
+
+fn generated_member(
+    derive_id: indexing::DeriveId,
+    resolution: (files::FileId, indexing::TermItemId),
+    implementation_type: crate::core::TypeId,
+    evidences: Vec<Evidence>,
+    body: ElaboratedExpression,
+) -> tree::InstanceMember {
+    let where_expression = tree::WhereExpression::new(body.expression);
+    let guarded_expression = tree::GuardedExpression::unconditional(where_expression);
+    let equation =
+        tree::Equation::generated(derive_id, resolution.1, Arc::from([]), guarded_expression);
+    tree::InstanceMember {
+        resolution,
+        implementation_type,
+        evidences: Arc::from(evidences),
+        equations: Arc::from([equation]),
+    }
+}
+
+fn generate_nullary_eq_body<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    implementation_type: crate::core::TypeId,
+    constructor: (files::FileId, indexing::TermItemId),
+) -> QueryResult<ElaboratedExpression>
+where
+    Q: ExternalQueries,
+{
+    let toolkit::InspectFunction { arguments, result: result_type } =
+        toolkit::inspect_function(state, context, implementation_type)?;
+    let [left_type, right_type] = arguments.as_slice() else {
+        panic!("Eq member must have exactly two value arguments")
+    };
+
+    let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+    let left = builder.variable_binder("left", *left_type);
+    let right = builder.variable_binder("right", *right_type);
+
+    let left_expression = builder.variable(left);
+    let right_expression = builder.variable(right);
+
+    let left_pattern =
+        builder.constructor_pattern("constructor", *left_type, constructor, Vec::new());
+    let right_pattern =
+        builder.constructor_pattern("constructor", *right_type, constructor, Vec::new());
+
+    let equal = builder.boolean(result_type, true);
+    let alternative = builder.alternative(vec![left_pattern, right_pattern], equal);
+    let case =
+        builder.case(result_type, vec![left_expression, right_expression], vec![alternative]);
+
+    Ok(builder.lambda(implementation_type, vec![left, right], case))
+}

--- a/compiler-core/checking/src/source/derive/head.rs
+++ b/compiler-core/checking/src/source/derive/head.rs
@@ -286,7 +286,9 @@ where
     state.checked.derived.insert(derive_id, checked);
 
     Ok(strategy.map(|strategy| DeriveHeadResult {
+        derive_id,
         item_id,
+        signature,
         constraints: checked_constraints,
         class_file,
         class_id,

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -6,7 +6,7 @@ use crate::core::Type;
 use crate::error::ErrorCrumb;
 use crate::state::CheckState;
 
-use super::{DeriveHeadResult, DeriveStrategy, field, tools, variance};
+use super::{DeriveHeadResult, DeriveStrategy, field, generate, tools, variance};
 
 pub fn check_derive_members<Q>(
     state: &mut CheckState,
@@ -53,7 +53,6 @@ where
                 derived_type,
                 class,
             )?;
-            tools::solve_and_report_constraints(state, context)?;
         }
         DeriveStrategy::DelegateConstraint { derived_type, class } => {
             tools::emit_superclass_constraints(
@@ -64,11 +63,9 @@ where
                 &result.arguments,
             )?;
             generate_delegate_constraint(state, context, derived_type, class);
-            tools::solve_and_report_constraints(state, context)?;
         }
         DeriveStrategy::NewtypeDeriveConstraint { delegate_constraint } => {
             state.push_wanted(delegate_constraint);
-            tools::solve_and_report_constraints(state, context)?;
         }
         DeriveStrategy::HeadOnly => {
             tools::emit_superclass_constraints(
@@ -78,7 +75,6 @@ where
                 result.class_id,
                 &result.arguments,
             )?;
-            tools::solve_and_report_constraints(state, context)?;
         }
         DeriveStrategy::VarianceConstraints { data_file, data_id, derived_type, config } => {
             tools::emit_superclass_constraints(
@@ -96,9 +92,14 @@ where
                 derived_type,
                 config,
             )?;
-            tools::solve_and_report_constraints(state, context)?;
         }
     }
+
+    if let tools::ConstraintReport::Solved = tools::solve_and_report_constraints(state, context)? {
+        generate::generate_instance(state, context, result)?;
+        tools::solve_and_report_constraints(state, context)?;
+    }
+
     Ok(())
 }
 

--- a/compiler-core/checking/src/source/derive/tools.rs
+++ b/compiler-core/checking/src/source/derive/tools.rs
@@ -74,31 +74,28 @@ where
     }
 }
 
-pub enum DataDeclarationKind {
-    Algebraic,
-    Unsupported,
-}
-
-pub fn classify_data_declaration<Q>(
+pub fn extract_local_algebraic_data<Q>(
+    state: &mut CheckState,
     context: &CheckContext<Q>,
-    data_file: FileId,
-    data_id: TypeItemId,
-) -> QueryResult<DataDeclarationKind>
+    derived_type: TypeId,
+) -> QueryResult<Option<(FileId, TypeItemId)>>
 where
     Q: ExternalQueries,
 {
-    let indexed = if data_file == context.id {
-        &context.indexed
-    } else {
-        &context.queries.indexed(data_file)?
+    let Some((data_file, data_id)) =
+        toolkit::extract_type_constructor(state, context, derived_type)?
+    else {
+        return Ok(None);
     };
+    if data_file != context.id {
+        return Ok(None);
+    }
 
-    let kind = &indexed.items[data_id].kind;
-    let declaration = match kind {
-        TypeItemKind::Data { .. } | TypeItemKind::Newtype { .. } => DataDeclarationKind::Algebraic,
-        _ => DataDeclarationKind::Unsupported,
-    };
-    Ok(declaration)
+    let kind = &context.indexed.items[data_id].kind;
+    match kind {
+        TypeItemKind::Data { .. } | TypeItemKind::Newtype { .. } => Ok(Some((data_file, data_id))),
+        _ => Ok(None),
+    }
 }
 
 pub enum ConstraintReport {

--- a/compiler-core/checking/src/source/derive/tools.rs
+++ b/compiler-core/checking/src/source/derive/tools.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TypeItemId};
+use indexing::{TermItemId, TypeItemId, TypeItemKind};
 use rustc_hash::FxHashMap;
 
 use crate::ExternalQueries;
@@ -72,6 +72,33 @@ where
         let indexed = context.queries.indexed(data_file)?;
         Ok(indexed.data_constructors(data_id).collect())
     }
+}
+
+pub enum DataDeclarationKind {
+    Algebraic,
+    Unsupported,
+}
+
+pub fn classify_data_declaration<Q>(
+    context: &CheckContext<Q>,
+    data_file: FileId,
+    data_id: TypeItemId,
+) -> QueryResult<DataDeclarationKind>
+where
+    Q: ExternalQueries,
+{
+    let indexed = if data_file == context.id {
+        &context.indexed
+    } else {
+        &context.queries.indexed(data_file)?
+    };
+
+    let kind = &indexed.items[data_id].kind;
+    let declaration = match kind {
+        TypeItemKind::Data { .. } | TypeItemKind::Newtype { .. } => DataDeclarationKind::Algebraic,
+        _ => DataDeclarationKind::Unsupported,
+    };
+    Ok(declaration)
 }
 
 pub enum ConstraintReport {

--- a/compiler-core/checking/src/source/derive/tools.rs
+++ b/compiler-core/checking/src/source/derive/tools.rs
@@ -74,14 +74,22 @@ where
     }
 }
 
+pub enum ConstraintReport {
+    Solved,
+    Unsolved,
+}
+
 pub fn solve_and_report_constraints<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-) -> QueryResult<()>
+) -> QueryResult<ConstraintReport>
 where
     Q: ExternalQueries,
 {
-    for residual in state.solve_constraints(context)? {
+    let residuals = state.solve_constraints(context)?;
+    let report =
+        if residuals.is_empty() { ConstraintReport::Solved } else { ConstraintReport::Unsolved };
+    for residual in residuals {
         state.checked.evidence.mark_error(residual.evidence.wanted);
         let attached = state.canonical_errors.remove(&residual.key.wanted);
         attached.into_iter().flatten().for_each(|error| state.insert_error(error));
@@ -96,5 +104,5 @@ where
         let constraint = state.canonicals.type_id(context, residual.key.wanted);
         state.insert_error(ErrorKind::NoInstanceFound { given, constraint });
     }
-    Ok(())
+    Ok(report)
 }

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -344,7 +344,9 @@ where
                     rigid_parameters: Arc::from(rigids),
                     evidences: Arc::from(instance_evidences),
                     superclasses: Arc::from(superclasses),
-                    members: Arc::from(checked_members),
+                    implementation: tree::InstanceImplementation::Members(Arc::from(
+                        checked_members,
+                    )),
                 };
                 let declaration = tree::TermDeclaration {
                     type_id: instance_signature,
@@ -462,14 +464,14 @@ fn record_instance_member(
     })
 }
 
-struct FreshenedInstanceRigids {
-    constraints: Vec<TypeId>,
-    arguments: Vec<KindOrType>,
-    substitution: NameToType,
-    rigids: Vec<TypeId>,
+pub(crate) struct FreshenedInstanceRigids {
+    pub(crate) constraints: Vec<TypeId>,
+    pub(crate) arguments: Vec<KindOrType>,
+    pub(crate) substitution: NameToType,
+    pub(crate) rigids: Vec<TypeId>,
 }
 
-fn freshen_instance_rigids<Q>(
+pub(crate) fn freshen_instance_rigids<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     instance: &toolkit::InstanceInfo,
@@ -503,7 +505,7 @@ where
     Ok(FreshenedInstanceRigids { constraints, arguments, substitution, rigids })
 }
 
-fn emit_instance_superclass_constraints<Q>(
+pub(crate) fn emit_instance_superclass_constraints<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     class_file: FileId,
@@ -538,7 +540,7 @@ where
     Ok(checked_superclasses)
 }
 
-fn instantiate_class_member_type<Q>(
+pub(crate) fn instantiate_class_member_type<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     (member_file, member_id): (FileId, TermItemId),

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -68,6 +68,7 @@ where
         tree::ExpressionKind::Constructor { resolution: (file_id, term_id) }
     } else {
         let resolution = lowering::TermVariableResolution::Reference(file_id, term_id);
+        let resolution = tree::VariableResolution::Source(resolution);
         tree::ExpressionKind::Variable { resolution }
     };
     Ok(allocate_expression(state, type_id, kind))
@@ -354,7 +355,8 @@ where
             };
 
             let negate_type = toolkit::lookup_term_variable(state, context, *negate)?;
-            let kind = tree::ExpressionKind::Variable { resolution: *negate };
+            let resolution = tree::VariableResolution::Source(*negate);
+            let kind = tree::ExpressionKind::Variable { resolution };
             let negate = allocate_expression(state, negate_type, kind);
             let Some(application::UnanchoredApplication { implicit, argument, result }) =
                 application::check_unanchored_application(state, context, negate_type)?
@@ -412,6 +414,7 @@ where
                 return Ok(allocate_error_expression(state, unknown));
             };
             let type_id = toolkit::lookup_term_variable(state, context, resolution)?;
+            let resolution = tree::VariableResolution::Source(resolution);
             let kind = tree::ExpressionKind::Variable { resolution };
             Ok(allocate_expression(state, type_id, kind))
         }

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -85,6 +85,7 @@ where
     Q: ExternalQueries,
 {
     let type_id = toolkit::lookup_term_variable(state, context, resolution)?;
+    let resolution = tree::VariableResolution::Source(resolution);
     let kind = tree::ExpressionKind::RecordPun { source, resolution };
     Ok(super::allocate_expression(state, type_id, kind))
 }

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -23,6 +23,7 @@ impl DesugaredFunction {
 
     pub fn allocate_expression(&self, state: &mut CheckState) -> ElaboratedExpression {
         if let Some(resolution) = self.resolution {
+            let resolution = tree::VariableResolution::Source(resolution);
             let kind = tree::ExpressionKind::Variable { resolution };
             super::allocate_expression(state, self.type_id, kind)
         } else {

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -329,6 +329,18 @@ impl CheckState {
         self.checked.tree.allocate_binder(binder)
     }
 
+    pub fn allocate_derived_binder(
+        &mut self,
+        derive: indexing::DeriveId,
+        name: SmolStrId,
+        type_id: TypeId,
+        kind: tree::BinderKind,
+    ) -> tree::BinderId {
+        let source = tree::BinderSource::Generated { derive, name };
+        let binder = tree::Binder { source, type_id, kind };
+        self.checked.tree.allocate_binder(binder)
+    }
+
     pub fn allocate_operator_binder(
         &mut self,
         source: lowering::TermOperatorId,

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -4,14 +4,14 @@ use std::ops::Index;
 use std::sync::Arc;
 
 use files::FileId;
-use indexing::{EquationSourceId, TermItemId, TypeItemId};
+use indexing::{DeriveId, EquationSourceId, TermItemId, TypeItemId};
 use la_arena::{Arena, ArenaMap, Idx};
 use lowering::LetBindingNameGroupId;
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
 use crate::TypeId;
-use crate::core::{ForallBinderId, Role};
+use crate::core::{ForallBinderId, Role, SmolStrId};
 use crate::evidence::{Evidence, EvidenceVarId, SuperclassId};
 
 pub type ExpressionId = Idx<Expression>;
@@ -98,7 +98,13 @@ pub struct InstanceDeclaration {
     pub rigid_parameters: Arc<[TypeId]>,
     pub evidences: Arc<[InstanceEvidence]>,
     pub superclasses: Arc<[InstanceSuperclass]>,
-    pub members: Arc<[InstanceMember]>,
+    pub implementation: InstanceImplementation,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InstanceImplementation {
+    Members(Arc<[InstanceMember]>),
+    Delegate { constraint: TypeId, evidence: EvidenceVarId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -166,6 +172,7 @@ pub struct ClassMember {
 pub enum EquationSource {
     Item(EquationSourceId),
     Local(lowering::LetBindingEquationId),
+    Generated { derive: DeriveId, member: TermItemId },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -191,6 +198,16 @@ impl Equation {
         guarded_expression: GuardedExpression,
     ) -> Equation {
         let source = EquationSource::Local(source);
+        Equation { source, binders, guarded_expression }
+    }
+
+    pub fn generated(
+        derive: DeriveId,
+        member: TermItemId,
+        binders: Arc<[BinderId]>,
+        guarded_expression: GuardedExpression,
+    ) -> Equation {
+        let source = EquationSource::Generated { derive, member };
         Equation { source, binders, guarded_expression }
     }
 }
@@ -273,6 +290,7 @@ pub enum BinderSource {
     DoStatement(lowering::DoStatementId),
     Operator(lowering::TermOperatorId),
     Section(lowering::ExpressionId),
+    Generated { derive: DeriveId, name: SmolStrId },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -304,6 +322,12 @@ pub struct Expression {
     pub kind: ExpressionKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariableResolution {
+    Source(lowering::TermVariableResolution),
+    Generated(BinderId),
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ExpressionKind {
     Error,
@@ -317,8 +341,8 @@ pub enum ExpressionKind {
     RecordAccess { record: ExpressionId, labels: Arc<[SmolStr]> },
     RecordUpdate { record: ExpressionId, updates: Arc<[RecordExpressionUpdate]> },
     Constructor { resolution: (FileId, TermItemId) },
-    Variable { resolution: lowering::TermVariableResolution },
-    RecordPun { source: lowering::RecordPunId, resolution: lowering::TermVariableResolution },
+    Variable { resolution: VariableResolution },
+    RecordPun { source: lowering::RecordPunId, resolution: VariableResolution },
     Section { binder: BinderId },
     TermApplication { function: ExpressionId, argument: ExpressionId },
     TypeApplication { function: ExpressionId, argument: TypeId },

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -22,9 +22,10 @@ use crate::evidence::{
 };
 use crate::tree::{
     BinderId, BinderKind, BinderSource, CaseAlternative, Equation, ExpressionId, ExpressionKind,
-    GuardedAlternative, GuardedExpression, InstanceDeclaration, LetBindingChunk, LetBindings,
-    LocalDeclarationId, PatternGuard, RecordBinderField, RecordExpressionField,
-    RecordExpressionUpdate, TermDeclarationKind, TypeDeclarationKind, WhereExpression,
+    GuardedAlternative, GuardedExpression, InstanceDeclaration, InstanceImplementation,
+    LetBindingChunk, LetBindings, LocalDeclarationId, PatternGuard, RecordBinderField,
+    RecordExpressionField, RecordExpressionUpdate, TermDeclarationKind, TypeDeclarationKind,
+    VariableResolution, WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -485,38 +486,48 @@ where
             fields.push(field);
         }
 
-        for member in instance.members.iter() {
-            let Some(member_name) = self.term_name(member.resolution.0, member.resolution.1)?
-            else {
-                continue;
-            };
+        match &instance.implementation {
+            InstanceImplementation::Members(members) => {
+                for member in members.iter() {
+                    let Some(member_name) =
+                        self.term_name(member.resolution.0, member.resolution.1)?
+                    else {
+                        continue;
+                    };
 
-            let mut evidence_names = EvidenceNames::new();
-            let instance_evidences = instance.evidences.iter().map(|evidence| &evidence.evidence);
-            for evidence in instance_evidences.chain(member.evidences.iter()) {
-                if let Evidence::Given(binder) = evidence {
-                    self.evidence_binder_name(&mut evidence_names, *binder)?;
+                    let mut evidence_names = EvidenceNames::new();
+                    let instance_evidences =
+                        instance.evidences.iter().map(|evidence| &evidence.evidence);
+                    for evidence in instance_evidences.chain(member.evidences.iter()) {
+                        if let Evidence::Given(binder) = evidence {
+                            self.evidence_binder_name(&mut evidence_names, *binder)?;
+                        }
+                    }
+
+                    let Some(equations) = self.equation_declarations(
+                        &member_name,
+                        "  ",
+                        &member.evidences,
+                        &member.equations,
+                        &mut evidence_names,
+                        &rigid_names,
+                    )?
+                    else {
+                        continue;
+                    };
+
+                    let signature = self.instance_member_signature(
+                        &member_name,
+                        member.implementation_type,
+                        &rigid_names,
+                    );
+                    fields.push(signature.append(self.arena.hardline()).append(equations));
                 }
             }
-
-            let Some(equations) = self.equation_declarations(
-                &member_name,
-                "  ",
-                &member.evidences,
-                &member.equations,
-                &mut evidence_names,
-                &rigid_names,
-            )?
-            else {
-                continue;
-            };
-
-            let signature = self.instance_member_signature(
-                &member_name,
-                member.implementation_type,
-                &rigid_names,
-            );
-            fields.push(signature.append(self.arena.hardline()).append(equations));
+            InstanceImplementation::Delegate { evidence, .. } => {
+                let evidence = self.evidence_variable_name(&mut outer_evidence_names, *evidence)?;
+                fields.push(self.arena.text(format!("  delegate = {evidence}")));
+            }
         }
 
         let mut fields = fields.into_iter();
@@ -1099,6 +1110,9 @@ where
                     Ok(self.arena.text(variable.to_string()))
                 }
                 BinderSource::Section(source) => Ok(self.arena.text(section_name(source))),
+                BinderSource::Generated { ref name, .. } => {
+                    Ok(self.arena.text(self.queries.lookup_smol_str(*name).to_string()))
+                }
                 BinderSource::DoStatement(_) | BinderSource::Operator(_) => {
                     unreachable!("invariant violated: generated semantic variable binder")
                 }
@@ -1324,8 +1338,20 @@ where
             }
             ExpressionKind::Variable { resolution }
             | ExpressionKind::RecordPun { resolution, .. } => {
-                let name =
-                    match *resolution {
+                let name = match *resolution {
+                    VariableResolution::Generated(binder) => {
+                        let generated = &self.checked.tree[binder];
+                        match &generated.source {
+                            BinderSource::Generated { name, .. } => {
+                                self.queries.lookup_smol_str(*name).to_string()
+                            }
+                            _ => {
+                                let index = binder.into_raw().into_u32();
+                                format!("<generated#{index}>")
+                            }
+                        }
+                    }
+                    VariableResolution::Source(resolution) => match resolution {
                         TermVariableResolution::Binder(binder) => {
                             let kind = self.lowered.info.get_binder_kind(binder).expect(
                                 "invariant violated: variable expression binder is missing",
@@ -1359,7 +1385,8 @@ where
                                 format!("<pun#{index}>")
                             })
                         }
-                    };
+                    },
+                };
                 Ok(self.arena.text(name))
             }
             ExpressionKind::Section { binder } => {

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -510,7 +510,13 @@ where
             else {
                 continue;
             };
-            fields.push(equations);
+
+            let signature = self.instance_member_signature(
+                &member_name,
+                member.implementation_type,
+                &rigid_names,
+            );
+            fields.push(signature.append(self.arena.hardline()).append(equations));
         }
 
         let mut fields = fields.into_iter();
@@ -520,6 +526,23 @@ where
         let where_clause = self.arena.line().append(self.arena.text("where")).nest(2);
         let header = signature.append(where_clause).group();
         Ok(header.append(self.arena.hardline()).append(fields))
+    }
+
+    fn instance_member_signature(
+        &self,
+        name: &str,
+        type_id: crate::TypeId,
+        rigid_names: &[(crate::TypeId, SmolStr)],
+    ) -> Doc<'arena> {
+        let mut type_pretty = self.type_pretty.state();
+        for (rigid, display) in rigid_names {
+            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
+                type_pretty.assign_display_name(name, SmolStr::clone(display));
+            }
+        }
+
+        let type_id = type_pretty.render(type_id);
+        self.arena.text(format!("  {name} :: {type_id}"))
     }
 
     fn dictionary_signature(
@@ -671,7 +694,7 @@ where
         }
         for equation in equations.iter() {
             let has_abstraction = !equation.binders.is_empty() || !evidences.is_empty();
-            let (mut expression, where_bindings, force_body_break) = if let [alternative] =
+            let (mut expression, where_bindings, force_body_break, is_lambda) = if let [alternative] =
                 equation.guarded_expression.alternatives.as_ref()
                 && alternative.pattern_guards.is_empty()
             {
@@ -682,14 +705,18 @@ where
                     .then_some(&where_expression.bindings);
                 let force_body_break =
                     self.expression_requires_body_break(where_expression.expression);
-                (expression, bindings, force_body_break)
+                let is_lambda = matches!(
+                    self.checked.tree[where_expression.expression].kind,
+                    ExpressionKind::Lambda { .. }
+                );
+                (expression, bindings, force_body_break, is_lambda)
             } else {
                 let expression = self.guarded_expression(
                     &equation.guarded_expression,
                     evidence_names,
                     &mut type_pretty,
                 )?;
-                (expression, None, false)
+                (expression, None, false, false)
             };
 
             let mut abstractions = vec![];
@@ -723,6 +750,8 @@ where
                 self.arena
                     .text(format!("{prefix}{name} ="))
                     .append(self.arena.hardline().append(expression).nest(2))
+            } else if is_lambda {
+                self.arena.text(format!("{prefix}{name} = ")).append(expression).group()
             } else {
                 self.arena
                     .text(format!("{prefix}{name} ="))

--- a/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.purs
+++ b/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+
+foreign import data Opaque :: Type
+
+derive instance Eq Opaque
+derive instance Ord Opaque

--- a/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types
+Opaque :: Type
+
+Derived
+derive Eq Opaque
+derive Ord Opaque
+
+Roles
+Opaque = []
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Opaque
+  --> 8:1..8:26
+  |
+8 | derive instance Eq Opaque
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: Opaque
+  --> 9:1..9:27
+  |
+9 | derive instance Ord Opaque
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Library.purs
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Library.purs
@@ -1,0 +1,3 @@
+module Library where
+
+data Imported a = Imported a

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.purs
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.purs
@@ -1,0 +1,15 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+import Library (Imported)
+
+foreign import data Opaque1 :: Type -> Type
+
+derive instance Eq1 Opaque1
+derive instance Ord1 Opaque1
+
+derive instance Eq a => Eq (Imported a)
+derive instance Eq1 Imported
+derive instance Ord a => Ord (Imported a)
+derive instance Ord1 Imported

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
@@ -20,43 +20,33 @@ Roles
 Opaque1 = [Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq (Opaque1 (t :: Type))
+error[CannotDeriveForType]: Cannot derive for type: Opaque1
   --> 9:1..9:28
   |
 9 | derive instance Eq1 Opaque1
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq (t :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord (Opaque1 (t1 :: Type))
+error[CannotDeriveForType]: Cannot derive for type: Opaque1
   --> 10:1..10:29
    |
 10 | derive instance Ord1 Opaque1
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t1 :: Type) is in scope
-  trivia: Eq (t1 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq (Imported (t2 :: Type))
+error[CannotDeriveForType]: Cannot derive for type: Imported (t :: Type)
+  --> 12:1..12:40
+   |
+12 | derive instance Eq a => Eq (Imported a)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+error[CannotDeriveForType]: Cannot derive for type: Imported
   --> 13:1..13:29
    |
 13 | derive instance Eq1 Imported
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq (t2 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq (Imported (t3 :: Type))
+error[CannotDeriveForType]: Cannot derive for type: Imported (t1 :: Type)
   --> 14:1..14:42
    |
 14 | derive instance Ord a => Ord (Imported a)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t3 :: Type) is in scope
-  trivia: Eq (t3 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq1 Imported
+error[CannotDeriveForType]: Cannot derive for type: Imported
   --> 15:1..15:30
    |
 15 | derive instance Ord1 Imported
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t4 :: Type) is in scope
-  trivia: Eq (t4 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord (Imported (t4 :: Type))
-  --> 15:1..15:30
-   |
-15 | derive instance Ord1 Imported
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t4 :: Type) is in scope
-  trivia: Eq (t4 :: Type) is in scope

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
@@ -1,0 +1,62 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types
+Opaque1 :: Type -> Type
+
+Derived
+derive Eq1 Opaque1
+derive Ord1 Opaque1
+derive forall (t :: Type). Eq (t :: Type) => Eq (Imported (t :: Type))
+derive Eq1 Imported
+derive forall (t :: Type). Ord (t :: Type) => Ord (Imported (t :: Type))
+derive Ord1 Imported
+
+Roles
+Opaque1 = [Nominal]
+
+Diagnostics
+error[NoInstanceFound]: No instance found for: Eq (Opaque1 (t :: Type))
+  --> 9:1..9:28
+  |
+9 | derive instance Eq1 Opaque1
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Eq (t :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Ord (Opaque1 (t1 :: Type))
+  --> 10:1..10:29
+   |
+10 | derive instance Ord1 Opaque1
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Ord (t1 :: Type) is in scope
+  trivia: Eq (t1 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Eq (Imported (t2 :: Type))
+  --> 13:1..13:29
+   |
+13 | derive instance Eq1 Imported
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Eq (t2 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Eq (Imported (t3 :: Type))
+  --> 14:1..14:42
+   |
+14 | derive instance Ord a => Ord (Imported a)
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Ord (t3 :: Type) is in scope
+  trivia: Eq (t3 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Eq1 Imported
+  --> 15:1..15:30
+   |
+15 | derive instance Ord1 Imported
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Ord (t4 :: Type) is in scope
+  trivia: Eq (t4 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Ord (Imported (t4 :: Type))
+  --> 15:1..15:30
+   |
+15 | derive instance Ord1 Imported
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: Ord (t4 :: Type) is in scope
+  trivia: Eq (t4 :: Type) is in scope

--- a/tests-integration/fixtures/checking/1785144660_derive_eq_ord_record_field/Main.purs
+++ b/tests-integration/fixtures/checking/1785144660_derive_eq_ord_record_field/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+
+data Box = Box { value :: Int }
+
+derive instance Eq Box
+derive instance Ord Box

--- a/tests-integration/fixtures/checking/1785144660_derive_eq_ord_record_field/Main.snap
+++ b/tests-integration/fixtures/checking/1785144660_derive_eq_ord_record_field/Main.snap
@@ -1,0 +1,17 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Box :: { value :: Int } -> Box
+
+Types
+Box :: Type
+
+Derived
+derive Eq Box
+derive Ord Box
+
+Roles
+Box = []

--- a/tests-integration/fixtures/checking/prelude/Data.Ord.purs
+++ b/tests-integration/fixtures/checking/prelude/Data.Ord.purs
@@ -1,7 +1,10 @@
 module Data.Ord where
 
-import Data.Eq (class Eq, class Eq1)
+import Data.Eq (class Eq, class Eq1, class EqRecord)
 import Data.Ordering (Ordering(..))
+import Data.Symbol (class IsSymbol)
+import Prim.Row as Row
+import Prim.RowList as RL
 
 class Eq a <= Ord a where
   compare :: a -> a -> Ordering
@@ -14,3 +17,22 @@ instance Ord Int where
 
 instance Ord Boolean where
   compare _ _ = EQ
+
+instance ordRec :: (RL.RowToList row list, OrdRecord list row) => Ord (Record row) where
+  compare _ _ = EQ
+
+class OrdRecord :: RL.RowList Type -> Row Type -> Constraint
+class EqRecord rowlist row <= OrdRecord rowlist row where
+  compareRecord :: rowlist -> Record row -> Record row -> Ordering
+
+instance OrdRecord RL.Nil row where
+  compareRecord _ _ _ = EQ
+
+instance
+  ( OrdRecord rowlistTail row
+  , Row.Cons key focus rowTail row
+  , IsSymbol key
+  , Ord focus
+  ) =>
+  OrdRecord (RL.Cons key focus rowlistTail) row where
+  compareRecord _ _ _ = EQ

--- a/tests-integration/fixtures/checking/prelude/Data.Ord.purs
+++ b/tests-integration/fixtures/checking/prelude/Data.Ord.purs
@@ -1,8 +1,7 @@
 module Data.Ord where
 
 import Data.Eq (class Eq, class Eq1)
-
-data Ordering = LT | EQ | GT
+import Data.Ordering (Ordering(..))
 
 class Eq a <= Ord a where
   compare :: a -> a -> Ordering

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
@@ -24,4 +24,5 @@ dictionary exampleAB ::
   { secondDict :: Second t1 } =>
   Example t t1
   where
+  example :: t -> t1 -> Boolean
   example = implementation @t1 @t {secondDict}

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
@@ -14,5 +14,7 @@ interface Example a where
   second :: a
 
 dictionary exampleToken :: Example Token where
+  first :: Token
   first = FirstToken
+  second :: Token
   second = SecondToken

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
@@ -15,4 +15,5 @@ foreign import compareImpl :: Int -> Int -> Int
 
 dictionary ordInt :: { eqDict :: Eq Int } => Ord Int where
   superclass eqDict = eqDict
+  compare :: Int -> Int -> Int
   compare = compareImpl

--- a/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
@@ -16,4 +16,5 @@ implementation = \{requiredDict} -> \_ -> \_ -> boolean
 foreign import boolean :: Boolean
 
 dictionary exampleInt :: Example Int where
+  apply :: forall (b :: Type). Required b => Int -> b -> Boolean
   apply = \{requiredDict} -> implementation @Int @b {requiredDict}

--- a/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
@@ -21,4 +21,5 @@ dictionary exampleInt ::
   { failDict1 :: Fail (Text "second deferred error") } =>
   Example Int
   where
+  example :: Boolean
   example = implementation {failDict} {requiredDict} {failDict1}

--- a/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
@@ -9,4 +9,5 @@ data Token
 
 dictionary childToken :: { parentDict :: Parent Token } => Child Token where
   superclass parentDict = parentDict
+  child :: Token
   child = Token

--- a/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
@@ -12,8 +12,7 @@ nested :: forall t t1. t -> t1 -> t
 nested = \first -> \second -> first
 
 caseBody :: Maybe Int -> Int
-caseBody =
-  \maybe ->
-    case maybe of
-      Nothing -> 0
-      (Just value) -> value
+caseBody = \maybe ->
+  case maybe of
+    Nothing -> 0
+    (Just value) -> value

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
@@ -29,27 +29,23 @@ update :: forall t t1 t2 t3 t4.
 update = \v87 v90 v92 -> v87 { first = v90, second = v92 }
 
 conditional :: forall t. Boolean -> t -> t -> t
-conditional =
-  \v98 v100 v102 ->
-    if v98 then v100 else v102
+conditional = \v98 v100 v102 ->
+  if v98 then v100 else v102
 
 caseScrutinee :: Boolean -> Int
-caseScrutinee =
-  \v108 ->
-    case v108 of
-      true -> 1
-      false -> 0
+caseScrutinee = \v108 ->
+  case v108 of
+    true -> 1
+    false -> 0
 
 caseScrutinees :: Boolean -> Int -> Int
-caseScrutinees =
-  \v127 v128 ->
-    case v127, v128 of
-      true, value -> value
-      false, _ -> 0
+caseScrutinees = \v127 v128 ->
+  case v127, v128 of
+    true, value -> value
+    false, _ -> 0
 
 caseAlternatives :: forall t t1. Boolean -> { value :: t | t1 } -> t
-caseAlternatives =
-  \v149 ->
-    case v149 of
-      true -> \v157 -> v157.value
-      false -> \v164 -> v164.value
+caseAlternatives = \v149 ->
+  case v149 of
+    true -> \v157 -> v157.value
+    false -> \v164 -> v164.value

--- a/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
@@ -49,12 +49,10 @@ test12 :: forall t t1. ({ bar :: t | t1 } -> t) -> Array ({ bar :: t | t1 } -> t
 test12 = \v166 -> [v166, \v168 -> v168.bar]
 
 test13 :: forall t t1 t2. t -> { prop :: t1 | t2 } -> t1
-test13 =
-  \v174 ->
-    case v174 of
-      _ -> \v182 -> v182.prop
+test13 = \v174 ->
+  case v174 of
+    _ -> \v182 -> v182.prop
 
 test14 :: forall t t1. Boolean -> { a :: t, b :: t | t1 } -> t
-test14 =
-  \v188 ->
-    if v188 then \v191 -> v191.a else \v194 -> v194.b
+test14 = \v188 ->
+  if v188 then \v191 -> v191.a else \v194 -> v194.b

--- a/tests-integration/fixtures/semantic/1785073620_derive_eq_unit_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785073620_derive_eq_unit_body/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Eq (class Eq)
+
+data Unit = Unit
+
+derive instance Eq Unit

--- a/tests-integration/fixtures/semantic/1785073620_derive_eq_unit_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785073620_derive_eq_unit_body/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Unit :: Type
+data Unit
+  | Unit :: Unit
+
+dictionary eqUnit :: Eq Unit where
+  eq :: Unit -> Unit -> Boolean
+  eq = \left right ->
+  case left, right of
+    Unit, Unit -> true

--- a/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Eq (class Eq)
+
+data Maybe a
+  = Nothing
+  | Just a
+
+derive instance Eq a => Eq (Maybe a)

--- a/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Type -> Type
+data Maybe @a
+  | Nothing :: Maybe a
+  | Just :: a -> Maybe a
+
+dictionary eqMaybe :: forall t. { eqDict :: Eq t } => Eq (Maybe t) where
+  eq :: Maybe t -> Maybe t -> Boolean
+  eq = \left right ->
+  case left, right of
+    Nothing, Nothing -> true
+    (Just left0), (Just right0) ->
+      if eq @t {eqDict} left0 right0 then true else false
+    _, _ -> false

--- a/tests-integration/fixtures/semantic/1785088080_derive_ord_unit_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785088080_derive_ord_unit_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+
+data Unit = Unit
+
+derive instance Eq Unit
+derive instance Ord Unit

--- a/tests-integration/fixtures/semantic/1785088080_derive_ord_unit_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785088080_derive_ord_unit_body/Main.snap
@@ -1,0 +1,21 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Unit :: Type
+data Unit
+  | Unit :: Unit
+
+dictionary eqUnit :: Eq Unit where
+  eq :: Unit -> Unit -> Boolean
+  eq = \left right ->
+  case left, right of
+    Unit, Unit -> true
+
+dictionary ordUnit :: Ord Unit where
+  superclass eqDict = eqUnit
+  compare :: Unit -> Unit -> Ordering
+  compare = \left right ->
+  case left, right of
+    Unit, Unit -> EQ

--- a/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+
+data Maybe a
+  = Nothing
+  | Just a
+
+derive instance Eq a => Eq (Maybe a)
+derive instance Ord a => Ord (Maybe a)

--- a/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
@@ -23,8 +23,8 @@ dictionary ordMaybe :: forall t. { ordDict :: Ord t } => Ord (Maybe t) where
   compare = \left right ->
   case left, right of
     Nothing, Nothing -> EQ
-    Nothing, (Just _) -> LT
-    (Just _), Nothing -> GT
+    Nothing, _ -> LT
+    _, Nothing -> GT
     (Just left0), (Just right0) ->
       case compare @t {ordDict} left0 right0 of
         EQ -> EQ

--- a/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Type -> Type
+data Maybe @a
+  | Nothing :: Maybe a
+  | Just :: a -> Maybe a
+
+dictionary eqMaybe :: forall t. { eqDict :: Eq t } => Eq (Maybe t) where
+  eq :: Maybe t -> Maybe t -> Boolean
+  eq = \left right ->
+  case left, right of
+    Nothing, Nothing -> true
+    (Just left0), (Just right0) ->
+      if eq @t {eqDict} left0 right0 then true else false
+    _, _ -> false
+
+dictionary ordMaybe :: forall t. { ordDict :: Ord t } => Ord (Maybe t) where
+  superclass eqDict = eqMaybe {ordDict.eqDict}
+  compare :: Maybe t -> Maybe t -> Ordering
+  compare = \left right ->
+  case left, right of
+    Nothing, Nothing -> EQ
+    Nothing, (Just _) -> LT
+    (Just _), Nothing -> GT
+    (Just left0), (Just right0) ->
+      case compare @t {ordDict} left0 right0 of
+        EQ -> EQ
+        ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+
+data Tuple a b = Tuple a b
+
+derive instance (Eq a, Eq b) => Eq (Tuple a b)
+derive instance (Ord a, Ord b) => Ord (Tuple a b)

--- a/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Tuple :: Type -> Type -> Type
+data Tuple @a @b
+  | Tuple :: a -> b -> Tuple a b
+
+dictionary eqTuple :: forall t t1. { eqDict :: Eq t } => { eqDict1 :: Eq t1 } => Eq (Tuple t t1)
+  where
+  eq :: Tuple t t1 -> Tuple t t1 -> Boolean
+  eq = \left right ->
+  case left, right of
+    (Tuple left0 left1), (Tuple right0 right1) ->
+      if eq @t {eqDict} left0 right0 then
+        if eq @t1 {eqDict1} left1 right1 then true else false
+      else
+        false
+
+dictionary ordTuple ::
+  forall t t1.
+  { ordDict :: Ord t } =>
+  { ordDict1 :: Ord t1 } =>
+  Ord (Tuple t t1)
+  where
+  superclass eqDict = eqTuple {ordDict.eqDict} {ordDict1.eqDict}
+  compare :: Tuple t t1 -> Tuple t t1 -> Ordering
+  compare = \left right ->
+  case left, right of
+    (Tuple left0 left1), (Tuple right0 right1) ->
+      case compare @t {ordDict} left0 right0 of
+        EQ ->
+          case compare @t1 {ordDict1} left1 right1 of
+            EQ -> EQ
+            ordering -> ordering
+        ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785133080_derive_eq_ord_constructor_ordering/Main.purs
+++ b/tests-integration/fixtures/semantic/1785133080_derive_eq_ord_constructor_ordering/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Data.Eq (class Eq)
+import Data.Ord (class Ord)
+
+data Void
+
+derive instance Eq Void
+derive instance Ord Void
+
+data Ordering = First | Second | Third
+
+derive instance Eq Ordering
+derive instance Ord Ordering

--- a/tests-integration/fixtures/semantic/1785133080_derive_eq_ord_constructor_ordering/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133080_derive_eq_ord_constructor_ordering/Main.snap
@@ -1,0 +1,46 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Void :: Type
+data Void
+
+data Ordering :: Type
+data Ordering
+  | First :: Ordering
+  | Second :: Ordering
+  | Third :: Ordering
+
+dictionary eqVoid :: Eq Void where
+  eq :: Void -> Void -> Boolean
+  eq = \left right ->
+  case left, right of
+    _, _ -> false
+
+dictionary ordVoid :: Ord Void where
+  superclass eqDict = eqVoid
+  compare :: Void -> Void -> Ordering
+  compare = \left right -> EQ
+
+dictionary eqOrdering :: Eq Ordering where
+  eq :: Ordering -> Ordering -> Boolean
+  eq = \left right ->
+  case left, right of
+    First, First -> true
+    Second, Second -> true
+    Third, Third -> true
+    _, _ -> false
+
+dictionary ordOrdering :: Ord Ordering where
+  superclass eqDict = eqOrdering
+  compare :: Ordering -> Ordering -> Ordering
+  compare = \left right ->
+  case left, right of
+    First, First -> EQ
+    First, _ -> LT
+    _, First -> GT
+    Second, Second -> EQ
+    Second, _ -> LT
+    _, Second -> GT
+    Third, Third -> EQ

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.purs
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+
+data Identity a = Identity a
+
+derive instance Eq a => Eq (Identity a)
+derive instance Eq1 Identity
+derive instance Ord a => Ord (Identity a)
+derive instance Ord1 Identity

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -14,6 +14,10 @@ dictionary eqIdentity :: forall t. { eqDict :: Eq t } => Eq (Identity t) where
     (Identity left0), (Identity right0) ->
       if eq @t {eqDict} left0 right0 then true else false
 
+dictionary eq1Identity :: Eq1 Identity where
+  eq1 :: forall (t :: Type). Eq t => Identity t -> Identity t -> Boolean
+  eq1 = \{eqDict} -> eq @(Identity t) {eqIdentity {eqDict}}
+
 dictionary ordIdentity :: forall t. { ordDict :: Ord t } => Ord (Identity t) where
   superclass eqDict = eqIdentity {ordDict.eqDict}
   compare :: Identity t -> Identity t -> Ordering
@@ -23,3 +27,8 @@ dictionary ordIdentity :: forall t. { ordDict :: Ord t } => Ord (Identity t) whe
       case compare @t {ordDict} left0 right0 of
         EQ -> EQ
         ordering -> ordering
+
+dictionary ord1Identity :: Ord1 Identity where
+  superclass eq1Dict = eq1Identity
+  compare1 :: forall (t :: Type). Ord t => Identity t -> Identity t -> Ordering
+  compare1 = \{ordDict} -> compare @(Identity t) {ordIdentity {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Identity :: Type -> Type
+data Identity @a
+  | Identity :: a -> Identity a
+
+dictionary eqIdentity :: forall t. { eqDict :: Eq t } => Eq (Identity t) where
+  eq :: Identity t -> Identity t -> Boolean
+  eq = \left right ->
+  case left, right of
+    (Identity left0), (Identity right0) ->
+      if eq @t {eqDict} left0 right0 then true else false
+
+dictionary ordIdentity :: forall t. { ordDict :: Ord t } => Ord (Identity t) where
+  superclass eqDict = eqIdentity {ordDict.eqDict}
+  compare :: Identity t -> Identity t -> Ordering
+  compare = \left right ->
+  case left, right of
+    (Identity left0), (Identity right0) ->
+      case compare @t {ordDict} left0 right0 of
+        EQ -> EQ
+        ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.purs
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+
+data Wrap f a = Wrap (f a)
+
+derive instance (Eq1 f, Eq a) => Eq (Wrap f a)
+derive instance Eq1 f => Eq1 (Wrap f)
+derive instance (Ord1 f, Ord a) => Ord (Wrap f a)
+derive instance Ord1 f => Ord1 (Wrap f)

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -6,3 +6,39 @@ expression: report
 data Wrap :: forall (k :: Type). (k -> Type) -> k -> Type
 data Wrap @f @a
   | Wrap :: f a -> Wrap f a
+
+dictionary eqWrap ::
+  forall t t1.
+  { eq1Dict :: Eq1 t } =>
+  { eqDict :: Eq t1 } =>
+  Eq (Wrap @Type t t1)
+  where
+  eq :: Wrap @Type t t1 -> Wrap @Type t t1 -> Boolean
+  eq = \left right ->
+  case left, right of
+    (Wrap left0), (Wrap right0) ->
+      if eq1 @t {eq1Dict} @t1 {eqDict} left0 right0 then true else false
+
+dictionary eq1Wrap :: forall t. { eq1Dict :: Eq1 t } => Eq1 (Wrap @Type t) where
+  eq1 :: forall (t1 :: Type). Eq t1 => Wrap @Type t t1 -> Wrap @Type t t1 -> Boolean
+  eq1 = \{eqDict} -> eq @(Wrap @Type t t1) {eqWrap {eq1Dict} {eqDict}}
+
+dictionary ordWrap ::
+  forall t t1.
+  { ord1Dict :: Ord1 t } =>
+  { ordDict :: Ord t1 } =>
+  Ord (Wrap @Type t t1)
+  where
+  superclass eqDict = eqWrap {ord1Dict.eq1Dict} {ordDict.eqDict}
+  compare :: Wrap @Type t t1 -> Wrap @Type t t1 -> Ordering
+  compare = \left right ->
+  case left, right of
+    (Wrap left0), (Wrap right0) ->
+      case compare1 @t {ord1Dict} @t1 {ordDict} left0 right0 of
+        EQ -> EQ
+        ordering -> ordering
+
+dictionary ord1Wrap :: forall t. { ord1Dict :: Ord1 t } => Ord1 (Wrap @Type t) where
+  superclass eq1Dict = eq1Wrap {ord1Dict.eq1Dict}
+  compare1 :: forall (t1 :: Type). Ord t1 => Wrap @Type t t1 -> Wrap @Type t t1 -> Ordering
+  compare1 = \{ordDict} -> compare @(Wrap @Type t t1) {ordWrap {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Wrap :: forall (k :: Type). (k -> Type) -> k -> Type
+data Wrap @f @a
+  | Wrap :: f a -> Wrap f a

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.purs
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+
+data List a
+  = Nil
+  | Cons a (List a)
+
+derive instance Eq a => Eq (List a)
+derive instance Eq1 List
+derive instance Ord a => Ord (List a)
+derive instance Ord1 List
+
+data Tree a
+  = Leaf a
+  | Branch (Tree a) (Tree a)
+
+derive instance Eq a => Eq (Tree a)
+derive instance Eq1 Tree
+derive instance Ord a => Ord (Tree a)
+derive instance Ord1 Tree

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
@@ -1,0 +1,92 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data List :: Type -> Type
+data List @a
+  | Nil :: List a
+  | Cons :: a -> List a -> List a
+
+data Tree :: Type -> Type
+data Tree @a
+  | Leaf :: a -> Tree a
+  | Branch :: Tree a -> Tree a -> Tree a
+
+dictionary eqList :: forall t. { eqDict :: Eq t } => Eq (List t) where
+  eq :: List t -> List t -> Boolean
+  eq = \left right ->
+  case left, right of
+    Nil, Nil -> true
+    (Cons left0 left1), (Cons right0 right1) ->
+      if eq @t {eqDict} left0 right0 then
+        if eq @(List t) {eqList {eqDict}} left1 right1 then true else false
+      else
+        false
+    _, _ -> false
+
+dictionary eq1List :: Eq1 List where
+  eq1 :: forall (t :: Type). Eq t => List t -> List t -> Boolean
+  eq1 = \{eqDict} -> eq @(List t) {eqList {eqDict}}
+
+dictionary ordList :: forall t. { ordDict :: Ord t } => Ord (List t) where
+  superclass eqDict = eqList {ordDict.eqDict}
+  compare :: List t -> List t -> Ordering
+  compare = \left right ->
+  case left, right of
+    Nil, Nil -> EQ
+    Nil, _ -> LT
+    _, Nil -> GT
+    (Cons left0 left1), (Cons right0 right1) ->
+      case compare @t {ordDict} left0 right0 of
+        EQ ->
+          case compare @(List t) {ordList {ordDict}} left1 right1 of
+            EQ -> EQ
+            ordering -> ordering
+        ordering -> ordering
+
+dictionary ord1List :: Ord1 List where
+  superclass eq1Dict = eq1List
+  compare1 :: forall (t :: Type). Ord t => List t -> List t -> Ordering
+  compare1 = \{ordDict} -> compare @(List t) {ordList {ordDict}}
+
+dictionary eqTree :: forall t. { eqDict :: Eq t } => Eq (Tree t) where
+  eq :: Tree t -> Tree t -> Boolean
+  eq = \left right ->
+  case left, right of
+    (Leaf left0), (Leaf right0) ->
+      if eq @t {eqDict} left0 right0 then true else false
+    (Branch left0 left1), (Branch right0 right1) ->
+      if eq @(Tree t) {eqTree {eqDict}} left0 right0 then
+        if eq @(Tree t) {eqTree {eqDict}} left1 right1 then true else false
+      else
+        false
+    _, _ -> false
+
+dictionary eq1Tree :: Eq1 Tree where
+  eq1 :: forall (t :: Type). Eq t => Tree t -> Tree t -> Boolean
+  eq1 = \{eqDict} -> eq @(Tree t) {eqTree {eqDict}}
+
+dictionary ordTree :: forall t. { ordDict :: Ord t } => Ord (Tree t) where
+  superclass eqDict = eqTree {ordDict.eqDict}
+  compare :: Tree t -> Tree t -> Ordering
+  compare = \left right ->
+  case left, right of
+    (Leaf left0), (Leaf right0) ->
+      case compare @t {ordDict} left0 right0 of
+        EQ -> EQ
+        ordering -> ordering
+    (Leaf _), _ -> LT
+    _, (Leaf _) -> GT
+    (Branch left0 left1), (Branch right0 right1) ->
+      case compare @(Tree t) {ordTree {ordDict}} left0 right0 of
+        EQ ->
+          case compare @(Tree t) {ordTree {ordDict}} left1 right1 of
+            EQ -> EQ
+            ordering -> ordering
+        ordering -> ordering
+
+dictionary ord1Tree :: Ord1 Tree where
+  superclass eq1Dict = eq1Tree
+  compare1 :: forall (t :: Type). Ord t => Tree t -> Tree t -> Ordering
+  compare1 = \{ordDict} -> compare @(Tree t) {ordTree {ordDict}}

--- a/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.purs
+++ b/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Eq (class Eq, class Eq1)
+import Data.Ord (class Ord, class Ord1)
+
+newtype Mu f = In (f (Mu f))
+
+derive instance Eq1 f => Eq (Mu f)
+derive instance Ord1 f => Ord (Mu f)

--- a/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+newtype Mu :: (Type -> Type) -> Type
+newtype Mu @f
+  | In :: f (Mu f) -> Mu f
+
+dictionary eqMu :: forall t. { eq1Dict :: Eq1 t } => Eq (Mu t) where
+  eq :: Mu t -> Mu t -> Boolean
+  eq = \left right ->
+  case left, right of
+    (In left0), (In right0) ->
+      if eq1 @t {eq1Dict} @(Mu t) {eqMu {eq1Dict}} left0 right0 then true else false
+
+dictionary ordMu :: forall t. { ord1Dict :: Ord1 t } => Ord (Mu t) where
+  superclass eqDict = eqMu {ord1Dict.eq1Dict}
+  compare :: Mu t -> Mu t -> Ordering
+  compare = \left right ->
+  case left, right of
+    (In left0), (In right0) ->
+      case compare1 @t {ord1Dict} @(Mu t) {ordMu {ord1Dict}} left0 right0 of
+        EQ -> EQ
+        ordering -> ordering


### PR DESCRIPTION
This implements the initial version of the semantic tree generated for deriving the Eq, Ord, Eq1, and Ord1 type classes.