### PR TITLE
[release] Prepare verified v0.0.14 release

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -23,6 +23,8 @@ jobs:
   install:
     name: Install on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      GH_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "purescript-alexandrite"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "analyzer",
  "async-lsp",

--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ irm https://raw.githubusercontent.com/purefunctor/purescript-alexandrite/main/in
 
 The installers verify the release's GitHub build-provenance attestation when
 [GitHub CLI](https://cli.github.com/) is available. They display a warning and continue when it is not
-installed. Set `ALEXANDRITE_VERSION` to a release tag or `ALEXANDRITE_INSTALL_DIR` to an installation
-directory to override the defaults.
+installed. Releases through v0.0.13 predate attestations, so the installers warn and continue without
+verification for those versions. Set `ALEXANDRITE_VERSION` to a release tag or
+`ALEXANDRITE_INSTALL_DIR` to an installation directory to override the defaults.

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purescript-alexandrite"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 authors = ["Justin Garcia <git@purefunctor.me>"]
 license = "BSD-3-Clause"

--- a/install.ps1
+++ b/install.ps1
@@ -33,22 +33,26 @@ try {
     Write-Host "Downloading purescript-alexandrite $Version for $Target"
     Invoke-WebRequest -Uri $ArchiveUrl -OutFile $Archive
 
-    $GitHubAttestationsAvailable = if (Get-Command gh -ErrorAction SilentlyContinue) {
-        & gh attestation verify --help 2>$null | Out-Null
-        $LASTEXITCODE -eq 0
+    if ($Version -match '^v0\.0\.([0-9]|1[0-3])$') {
+        Write-Warning "$Version predates release attestations and cannot be verified."
     } else {
-        $false
-    }
-
-    if ($GitHubAttestationsAvailable) {
-        Write-Host "Verifying GitHub release attestation"
-        & gh attestation verify $Archive --repo $Repository | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "GitHub release attestation verification failed"
+        $GitHubAttestationsAvailable = if (Get-Command gh -ErrorAction SilentlyContinue) {
+            & gh attestation verify --help 2>$null | Out-Null
+            $LASTEXITCODE -eq 0
+        } else {
+            $false
         }
-    } else {
-        Write-Warning "A GitHub CLI with attestation support is not installed; release provenance was not verified."
-        Write-Warning "Install or update gh from https://cli.github.com/ to verify future installations."
+
+        if ($GitHubAttestationsAvailable) {
+            Write-Host "Verifying GitHub release attestation"
+            & gh attestation verify $Archive --repo $Repository | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "GitHub release attestation verification failed"
+            }
+        } else {
+            Write-Warning "A GitHub CLI with attestation support is not installed; release provenance was not verified."
+            Write-Warning "Install or update gh from https://cli.github.com/ to verify future installations."
+        }
     }
 
     Expand-Archive -LiteralPath $Archive -DestinationPath $TemporaryDirectory

--- a/install.sh
+++ b/install.sh
@@ -47,15 +47,22 @@ archive="$temporary_directory/$archive_name"
 printf 'Downloading %s %s for %s\n' "$binary" "$version" "$target"
 curl --proto '=https' --tlsv1.2 -LsSf --retry 3 --output "$archive" "$archive_url"
 
-if command -v gh >/dev/null 2>&1 && gh attestation verify --help >/dev/null 2>&1; then
-    printf 'Verifying GitHub release attestation\n'
-    gh attestation verify "$archive" --repo "$repository" >/dev/null || \
-        fail "GitHub release attestation verification failed"
-else
-    printf '%s\n' \
-        'warning: A GitHub CLI with attestation support is not installed; release provenance was not verified.' \
-        'warning: Install or update gh from https://cli.github.com/ to verify future installations.' >&2
-fi
+case "$version" in
+    v0.0.[0-9] | v0.0.1[0-3])
+        printf 'warning: %s predates release attestations and cannot be verified.\n' "$version" >&2
+        ;;
+    *)
+        if command -v gh >/dev/null 2>&1 && gh attestation verify --help >/dev/null 2>&1; then
+            printf 'Verifying GitHub release attestation\n'
+            gh attestation verify "$archive" --repo "$repository" >/dev/null || \
+                fail "GitHub release attestation verification failed"
+        else
+            printf '%s\n' \
+                'warning: A GitHub CLI with attestation support is not installed; release provenance was not verified.' \
+                'warning: Install or update gh from https://cli.github.com/ to verify future installations.' >&2
+        fi
+        ;;
+esac
 
 archive_directory="$binary-$target"
 archive_binary="$archive_directory/$binary"


### PR DESCRIPTION
## Purpose

v0.0.13 was tagged before the verified-installer workflow merged, so it and earlier releases have no GitHub build-provenance attestations. The installers currently try to verify those releases whenever `gh` is available and fail instead of installing them.

This PR treats releases through v0.0.13 as legacy: both installers emit an explicit warning and continue without verification. Newer releases retain strict verification when GitHub CLI supports attestations. The installer workflow now exposes its automatically generated job token to `gh`, allowing its attestation check to authenticate with the existing read-only permissions.

The second commit prepares v0.0.14 so the first release containing the attestation workflow can be published and tested end to end.

## Changes

- warn and skip provenance verification for v0.0.13 and earlier
- provide `${{ github.token }}` to GitHub CLI as `GH_TOKEN` in installer tests
- document the legacy-release behavior
- update `purescript-alexandrite` to 0.0.14 using `just prepare-release 0.0.14`

## Verification

- `sh -n install.sh`
- `shellcheck install.sh`
- installed v0.0.13 end to end and confirmed the legacy warning and binary version
- parsed both modified/current workflow YAML files
- `cargo check -p purescript-alexandrite --tests`
