### PR TITLE
[meta] Fix Windows checks and failure reporting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,11 +39,14 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Build and Test
-        run: |
-          cargo build --workspace --verbose
-          cargo nextest run
-          cargo nextest run -p tests-integration
+      - name: Build workspace
+        run: cargo build --workspace --verbose
+
+      - name: Run workspace tests
+        run: cargo nextest run
+
+      - name: Run integration tests
+        run: cargo nextest run -p tests-integration
 
   coverage:
     name: Coverage

--- a/compiler-lsp/spago/tests/lockfile.rs
+++ b/compiler-lsp/spago/tests/lockfile.rs
@@ -27,6 +27,11 @@ fn normalize_source(source: PathBuf) -> Option<String> {
     Some(source.replace('\\', "/"))
 }
 
+fn normalize_path(path: &mut PathBuf) {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    *path = PathBuf::from(normalized);
+}
+
 #[test]
 fn test_parse_lockfile() {
     let lockfile = serde_json::from_str::<Lockfile>(SPAGO_LOCK);
@@ -116,7 +121,15 @@ fn test_lockfile_sources_by_package_include_package_roots() {
     )
     .unwrap();
 
-    let packages = lockfile.sources_by_package();
+    let mut packages = lockfile.sources_by_package();
+    for package in packages.values_mut() {
+        for root in &mut package.roots {
+            normalize_path(root);
+        }
+        for source in &mut package.sources {
+            normalize_path(source);
+        }
+    }
     insta::assert_debug_snapshot!(packages, @r#"
     {
         "git-package": PackageSources {


### PR DESCRIPTION
## Problem

The Windows compilation job contains a failing Spago lockfile snapshot, but still reports success. The snapshot compares native `PathBuf` debug output against forward-slash paths, and PowerShell continues to the passing integration command after the workspace test command fails.

## Changes

- Normalize package roots and source paths at the snapshot boundary so the test is platform-independent while production paths remain native.
- Run the workspace build, workspace tests, and integration tests as separate Actions steps so each command's exit status is reported independently.

## Verification

- `cargo nextest run -p spago`
- `cargo check -p spago --tests`
- `cargo fmt --check -- compiler-lsp/spago/tests/lockfile.rs`
- `git diff --check`