### PR TITLE
[analyzer] Use host contexts for analyzer requests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,6 +48,26 @@ jobs:
       - name: Run integration tests
         run: cargo nextest run -p tests-integration
 
+  wasm:
+    name: Compilation (docs-lib)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        run: rustup update stable && rustup default stable && rustup target add wasm32-unknown-unknown
+
+      - name: Cache build artifacts
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          cache-bin: "false"
+          prefix-key: "v1-wasm"
+
+      - name: Check Wasm crates
+        run: cargo check -p analyzer -p docs-lib --target wasm32-unknown-unknown
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -5,14 +5,14 @@ pub mod extension;
 
 use std::borrow::BorrowMut;
 use std::ops::ControlFlow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 use std::{env, fs, mem, process};
 
-use analyzer::LanguageContext;
 use analyzer::completion::SuggestionsCache;
 use analyzer::position::PositionEncoding;
 use analyzer::symbols::WorkspaceSymbolsCache;
+use analyzer::{AnalyzerContext, AnalyzerHost};
 use async_lsp::client_monitor::ClientProcessMonitorLayer;
 use async_lsp::concurrency::ConcurrencyLayer;
 use async_lsp::panic::CatchUnwindLayer;
@@ -20,12 +20,12 @@ use async_lsp::router::Router;
 use async_lsp::server::LifecycleLayer;
 use async_lsp::{ClientSocket, ResponseError};
 use building::QueryEngine;
-use files::Files;
+use files::{FileId, Files};
 use itertools::Itertools;
 use lsp_types::notification::Notification;
 use lsp_types::request::Request;
 use lsp_types::*;
-use parking_lot::RwLock;
+use parking_lot::{RwLock, RwLockReadGuard};
 use prim_constants::MODULE_MAP;
 use tempfile::TempDir;
 use tokio::task;
@@ -141,17 +141,55 @@ struct StateSnapshot {
 }
 
 impl StateSnapshot {
-    fn with_language_context<T>(
+    fn with_analyzer_context<T>(
         &self,
-        f: impl FnOnce(&LanguageContext<QueryEngine, Files>) -> T,
+        f: impl FnOnce(&AnalyzerContext<LspAnalyzerHost<'_>>) -> T,
     ) -> T {
         let files = self.files.read();
-        let context = LanguageContext::<QueryEngine, Files>::new(
-            &self.engine,
-            &files,
-            self.position_encoding,
-        );
+        let host =
+            LspAnalyzerHost { queries: &self.engine, files, workspace_root: self.root.as_deref() };
+        let context = AnalyzerContext::new(&host, self.position_encoding);
         f(&context)
+    }
+}
+
+struct LspAnalyzerHost<'a> {
+    queries: &'a QueryEngine,
+    files: RwLockReadGuard<'a, Files>,
+    workspace_root: Option<&'a Path>,
+}
+
+impl AnalyzerHost for LspAnalyzerHost<'_> {
+    type Queries = QueryEngine;
+
+    fn queries(&self) -> &QueryEngine {
+        self.queries
+    }
+
+    fn file_id(&self, uri: &str) -> Option<FileId> {
+        self.files.id(uri)
+    }
+
+    fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError> {
+        let uri = self.files.path(file_id);
+        Url::parse(&uri).map(Some)
+    }
+
+    fn active_files(&self) -> impl Iterator<Item = FileId> {
+        self.files.iter_id()
+    }
+
+    fn is_editable(&self, file_id: FileId) -> bool {
+        let Some(workspace_root) = self.workspace_root else {
+            return true;
+        };
+        let Ok(Some(uri)) = self.file_uri(file_id) else {
+            return false;
+        };
+        let Ok(path) = uri.to_file_path() else {
+            return false;
+        };
+        path.starts_with(workspace_root)
     }
 }
 
@@ -299,7 +337,7 @@ fn load_files(state: &mut State, files: &[PathBuf]) -> Result<(), LspError> {
         let uri = url.to_string();
 
         let text = fs::read_to_string(file)?;
-        on_change(state, &uri, &text)?
+        on_change(state, &uri, &text)?;
     }
 
     tracing::info!("Loaded {} files.", files.len());
@@ -315,7 +353,7 @@ fn definition(
     let uri = p.text_document_position_params.text_document.uri;
     let position = p.text_document_position_params.position;
 
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::definition::implementation(context, uri, position)
     });
 
@@ -328,7 +366,7 @@ fn hover(snapshot: StateSnapshot, p: HoverParams) -> Result<Option<Hover>, LspEr
     let position = p.text_document_position_params.position;
 
     let result = snapshot
-        .with_language_context(|context| analyzer::hover::implementation(context, uri, position));
+        .with_analyzer_context(|context| analyzer::hover::implementation(context, uri, position));
 
     result.on_non_fatal(None)
 }
@@ -342,7 +380,7 @@ fn code_action(
     let range = p.range;
     let action_context = p.context;
 
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::code_action::implementation(context, uri, range, action_context)
     });
 
@@ -359,7 +397,7 @@ fn completion(
 
     let mut cache = snapshot.suggestions_cache.write();
 
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::completion::implementation(context, &mut cache, uri, position)
     });
 
@@ -383,7 +421,7 @@ fn references(
     let uri = p.text_document_position.text_document.uri;
     let position = p.text_document_position.position;
 
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::references::implementation(context, uri, position)
     });
 
@@ -396,8 +434,8 @@ fn rename(snapshot: StateSnapshot, p: RenameParams) -> Result<Option<WorkspaceEd
     let position = p.text_document_position.position;
     let new_name = p.new_name;
 
-    let result = snapshot.with_language_context(|context| {
-        analyzer::rename::implementation(context, snapshot.root.as_deref(), uri, position, new_name)
+    let result = snapshot.with_analyzer_context(|context| {
+        analyzer::rename::implementation(context, uri, position, new_name)
     });
 
     result.on_non_fatal(None)
@@ -410,7 +448,7 @@ fn document_highlight(
     let _span = tracing::info_span!("document_highlight").entered();
     let uri = p.text_document_position_params.text_document.uri;
     let position = p.text_document_position_params.position;
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::document_highlight::implementation(context, uri, position)
     });
 
@@ -425,7 +463,7 @@ fn workspace_symbols(
 
     let mut cache = snapshot.workspace_symbols_cache.write();
 
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::symbols::workspace(context, &mut cache, &p.query)
     });
 
@@ -439,7 +477,7 @@ fn document_symbols(
     let _span = tracing::info_span!("document_symbols").entered();
     let uri = p.text_document.uri;
     let result =
-        snapshot.with_language_context(|context| analyzer::symbols::document(context, uri));
+        snapshot.with_analyzer_context(|context| analyzer::symbols::document(context, uri));
 
     result.on_non_fatal(None)
 }
@@ -450,7 +488,7 @@ fn semantic_tokens(
 ) -> Result<Option<SemanticTokensResult>, LspError> {
     let _span = tracing::info_span!("semantic_tokens").entered();
     let uri = p.text_document.uri;
-    let result = snapshot.with_language_context(|context| {
+    let result = snapshot.with_analyzer_context(|context| {
         analyzer::semantic_tokens::implementation(context, uri)
             .map(|tokens| tokens.map(SemanticTokensResult::Tokens))
     });
@@ -463,7 +501,7 @@ fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), L
 
     for content_change in &p.content_changes {
         let text = content_change.text.as_str();
-        on_change(state, uri, text)?
+        on_change(state, uri, text)?;
     }
 
     state.invalidate_workspace_symbols();

--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -5,7 +5,7 @@ pub mod extension;
 
 use std::borrow::BorrowMut;
 use std::ops::ControlFlow;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
 use std::{env, fs, mem, process};
 
@@ -27,6 +27,7 @@ use lsp_types::request::Request;
 use lsp_types::*;
 use parking_lot::{RwLock, RwLockReadGuard};
 use prim_constants::MODULE_MAP;
+use rustc_hash::FxHashSet;
 use tempfile::TempDir;
 use tokio::task;
 use tower::ServiceBuilder;
@@ -65,7 +66,7 @@ pub struct State {
     pub client: ClientSocket,
 
     pub engine: QueryEngine,
-    pub files: Arc<RwLock<Files>>,
+    pub files: Arc<RwLock<LspFiles>>,
 
     pub workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     pub suggestions_cache: Arc<RwLock<SuggestionsCache>>,
@@ -80,6 +81,7 @@ impl State {
         let mut files = Files::default();
         configure_materialized_prim(&engine, &mut files);
 
+        let files = LspFiles::new(files);
         let files = Arc::new(RwLock::new(files));
 
         let workspace_symbols_cache = WorkspaceSymbolsCache::default();
@@ -113,7 +115,6 @@ impl State {
             files: Arc::clone(&self.files),
             workspace_symbols_cache: Arc::clone(&self.workspace_symbols_cache),
             suggestions_cache: Arc::clone(&self.suggestions_cache),
-            root: self.root.clone(),
             position_encoding: self.position_encoding,
         };
         task::spawn_blocking(move || f(snapshot))
@@ -133,10 +134,9 @@ impl State {
 struct StateSnapshot {
     client: ClientSocket,
     engine: QueryEngine,
-    files: Arc<RwLock<Files>>,
+    files: Arc<RwLock<LspFiles>>,
     workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     suggestions_cache: Arc<RwLock<SuggestionsCache>>,
-    root: Option<PathBuf>,
     position_encoding: PositionEncoding,
 }
 
@@ -146,17 +146,54 @@ impl StateSnapshot {
         f: impl FnOnce(&AnalyzerContext<LspAnalyzerHost<'_>>) -> T,
     ) -> T {
         let files = self.files.read();
-        let host =
-            LspAnalyzerHost { queries: &self.engine, files, workspace_root: self.root.as_deref() };
+        let host = LspAnalyzerHost { queries: &self.engine, files };
         let context = AnalyzerContext::new(&host, self.position_encoding);
         f(&context)
     }
 }
 
+pub struct LspFiles {
+    files: Files,
+    editable: FxHashSet<FileId>,
+}
+
+impl LspFiles {
+    fn new(files: Files) -> LspFiles {
+        LspFiles { files, editable: FxHashSet::default() }
+    }
+
+    fn id(&self, uri: &str) -> Option<FileId> {
+        self.files.id(uri)
+    }
+
+    fn path(&self, file_id: FileId) -> Arc<str> {
+        self.files.path(file_id)
+    }
+
+    fn iter_id(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.files.iter_id()
+    }
+
+    fn is_editable(&self, file_id: FileId) -> bool {
+        self.editable.contains(&file_id)
+    }
+
+    fn insert(&mut self, uri: &str, content: &str, editable: Option<bool>) -> FileId {
+        let file_id = self.files.insert(uri, content);
+        if let Some(editable) = editable {
+            if editable {
+                self.editable.insert(file_id);
+            } else {
+                self.editable.remove(&file_id);
+            }
+        }
+        file_id
+    }
+}
+
 struct LspAnalyzerHost<'a> {
     queries: &'a QueryEngine,
-    files: RwLockReadGuard<'a, Files>,
-    workspace_root: Option<&'a Path>,
+    files: RwLockReadGuard<'a, LspFiles>,
 }
 
 impl AnalyzerHost for LspAnalyzerHost<'_> {
@@ -180,16 +217,7 @@ impl AnalyzerHost for LspAnalyzerHost<'_> {
     }
 
     fn is_editable(&self, file_id: FileId) -> bool {
-        let Some(workspace_root) = self.workspace_root else {
-            return true;
-        };
-        let Ok(Some(uri)) = self.file_uri(file_id) else {
-            return false;
-        };
-        let Ok(path) = uri.to_file_path() else {
-            return false;
-        };
-        path.starts_with(workspace_root)
+        self.files.is_editable(file_id)
     }
 }
 
@@ -292,7 +320,7 @@ fn exit(_state: &mut State, (): ()) -> Result<(), LspError> {
 }
 
 fn initialized_manual(state: &mut State, command: &str) -> Result<(), LspError> {
-    let root = state.root.as_ref().ok_or(LspError::MissingRoot)?;
+    let root = state.root.clone().ok_or(LspError::MissingRoot)?;
 
     tracing::info!("Using '{}'", command);
 
@@ -305,8 +333,12 @@ fn initialized_manual(state: &mut State, command: &str) -> Result<(), LspError> 
     let output = command.output()?;
     let output = str::from_utf8(&output.stdout)?;
 
-    let walk::Walk { files, .. } = walk::walk(root, output.lines())?;
-    load_files(state, &files)?;
+    let walk::Walk { files, .. } = walk::walk(&root, output.lines())?;
+    let files = files.into_iter().map(|file| {
+        let editable = file.starts_with(&root);
+        (file, editable)
+    });
+    load_files(state, files)?;
 
     Ok(())
 }
@@ -317,18 +349,25 @@ fn initialized_spago(state: &mut State) -> Result<(), LspError> {
     tracing::info!("Using 'spago.lock'");
 
     let packages = spago::source_files_by_package(root).map_err(LspError::SpagoLock)?;
-    let files = packages.into_values().flat_map(|package| package.sources);
+    let files = packages.into_values().flat_map(|package| {
+        let editable = package.reference == spago::PackageReference::Workspace;
+        package.sources.into_iter().map(move |file| (file, editable))
+    });
 
     let files = files.sorted().collect_vec();
-    load_files(state, &files)?;
+    load_files(state, files)?;
 
     Ok(())
 }
 
-fn load_files(state: &mut State, files: &[PathBuf]) -> Result<(), LspError> {
+fn load_files(
+    state: &mut State,
+    files: impl IntoIterator<Item = (PathBuf, bool)>,
+) -> Result<(), LspError> {
+    let files = files.into_iter().collect_vec();
     tracing::info!("Loading {} files.", files.len());
 
-    for file in files {
+    for (file, editable) in &files {
         let url = url::Url::from_file_path(file).map_err(|_| {
             let file = PathBuf::clone(file);
             LspError::PathParseFail(file)
@@ -337,7 +376,7 @@ fn load_files(state: &mut State, files: &[PathBuf]) -> Result<(), LspError> {
         let uri = url.to_string();
 
         let text = fs::read_to_string(file)?;
-        on_change(state, &uri, &text)?;
+        on_change(state, &uri, &text, Some(*editable))?;
     }
 
     tracing::info!("Loaded {} files.", files.len());
@@ -501,7 +540,7 @@ fn did_change(state: &mut State, p: DidChangeTextDocumentParams) -> Result<(), L
 
     for content_change in &p.content_changes {
         let text = content_change.text.as_str();
-        on_change(state, uri, text)?;
+        on_change(state, uri, text, None)?;
     }
 
     state.invalidate_workspace_symbols();
@@ -518,7 +557,18 @@ fn did_open(state: &mut State, p: DidOpenTextDocumentParams) -> Result<(), LspEr
     let uri = p.text_document.uri.as_str();
     let text = p.text_document.text.as_str();
 
-    on_change(state, uri, text)?;
+    let editable = {
+        let files = state.files.read();
+        let previous_id = files.id(uri);
+        previous_id.map(|file_id| files.is_editable(file_id))
+    }
+    .unwrap_or_else(|| {
+        let Some(root) = state.root.as_ref() else {
+            return true;
+        };
+        p.text_document.uri.to_file_path().is_ok_and(|path| path.starts_with(root))
+    });
+    on_change(state, uri, text, Some(editable))?;
 
     state.invalidate_workspace_symbols();
     state.invalidate_suggestions_cache();
@@ -539,7 +589,12 @@ fn did_save(state: &mut State, p: DidSaveTextDocumentParams) -> Result<(), LspEr
     Ok(())
 }
 
-fn on_change(state: &mut State, uri: &str, content: &str) -> Result<(), LspError> {
+fn on_change(
+    state: &mut State,
+    uri: &str,
+    content: &str,
+    editable: Option<bool>,
+) -> Result<(), LspError> {
     let previous_id = state.files.read().id(uri);
     let previous_name = if let Some(id) = previous_id {
         let previous_content = state.engine.content(id);
@@ -555,7 +610,7 @@ fn on_change(state: &mut State, uri: &str, content: &str) -> Result<(), LspError
     state.engine.request_cancel();
 
     let mut files = state.files.write();
-    let id = files.insert(uri, content);
+    let id = files.insert(uri, content, editable);
 
     state.engine.set_content(id, content);
 

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -45,7 +45,7 @@ fn collect_diagnostics_core(
     let lowered = snapshot.engine.lowered(id)?;
     let checked = snapshot.engine.checked(id)?;
 
-    let uri = snapshot.with_language_context(|context| common::file_uri(context, id))?;
+    let uri = snapshot.with_analyzer_context(|context| common::file_uri(context, id))?;
 
     let context = DiagnosticsContext::new(
         &snapshot.engine,

--- a/compiler-lsp/analyzer/src/code_action.rs
+++ b/compiler-lsp/analyzer/src/code_action.rs
@@ -2,28 +2,30 @@ mod holes;
 
 use std::collections::HashMap;
 
+use building_types::QueryProxy;
 use files::FileId;
 use lowering::{ExpressionId, TypeId};
 use lsp_types::*;
 
-use crate::{AnalyzerError, LanguageContext, locate, position};
+use crate::{AnalyzerContext, AnalyzerError, locate, position};
 
 pub fn implementation(
-    language: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    language: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     range: Range,
     action_context: CodeActionContext,
 ) -> Result<Option<CodeActionResponse>, AnalyzerError> {
     let file = {
         let uri = uri.as_str();
-        language.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        language.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = language.engine.content(file);
-    let position = position::protocol_position_to_utf8(&content, range.start, language.encoding)
-        .ok_or(AnalyzerError::NonFatal)?;
+    let content = language.queries().content(file);
+    let position =
+        position::protocol_position_to_utf8(&content, range.start, language.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
 
-    let located = locate::locate(language.engine, file, position)?;
+    let located = locate::locate(language.queries(), file, position)?;
     let kinds = RequestedCodeActionKinds { only: action_context.only.as_deref() };
     let request = CodeActionRequest { language, uri: &uri, file, kinds, located };
 
@@ -34,8 +36,8 @@ pub fn implementation(
     Ok(has_actions.then_some(actions))
 }
 
-pub struct CodeActionRequest<'request, 'language, Queries, Catalog> {
-    pub language: &'request LanguageContext<'language, Queries, Catalog>,
+pub struct CodeActionRequest<'request, 'language, Host> {
+    pub language: &'request AnalyzerContext<'language, Host>,
     pub uri: &'request Url,
     pub file: FileId,
     pub kinds: RequestedCodeActionKinds<'request>,
@@ -72,31 +74,31 @@ pub fn workspace_edit(uri: &Url, edits: Vec<TextEdit>) -> WorkspaceEdit {
 }
 
 pub fn expression_range(
-    request: &CodeActionRequest<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    request: &CodeActionRequest<impl crate::AnalyzerHost>,
     expression_id: ExpressionId,
 ) -> Result<Range, AnalyzerError> {
-    let content = request.language.engine.content(request.file);
-    let (parsed, _) = request.language.engine.parsed(request.file)?;
-    let stabilized = request.language.engine.stabilized(request.file)?;
+    let content = request.language.queries().content(request.file);
+    let (parsed, _) = request.language.queries().parsed(request.file)?;
+    let stabilized = request.language.queries().stabilized(request.file)?;
 
     let range = locate::id_range(&content, &parsed, &stabilized, expression_id)
         .ok_or(AnalyzerError::NonFatal)?;
 
-    position::utf8_range_to_protocol(&content, range, request.language.encoding)
+    position::utf8_range_to_protocol(&content, range, request.language.position_encoding())
         .ok_or(AnalyzerError::NonFatal)
 }
 
 pub fn type_range(
-    request: &CodeActionRequest<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    request: &CodeActionRequest<impl crate::AnalyzerHost>,
     type_id: TypeId,
 ) -> Result<Range, AnalyzerError> {
-    let content = request.language.engine.content(request.file);
-    let (parsed, _) = request.language.engine.parsed(request.file)?;
-    let stabilized = request.language.engine.stabilized(request.file)?;
+    let content = request.language.queries().content(request.file);
+    let (parsed, _) = request.language.queries().parsed(request.file)?;
+    let stabilized = request.language.queries().stabilized(request.file)?;
 
     let range =
         locate::id_range(&content, &parsed, &stabilized, type_id).ok_or(AnalyzerError::NonFatal)?;
 
-    position::utf8_range_to_protocol(&content, range, request.language.encoding)
+    position::utf8_range_to_protocol(&content, range, request.language.position_encoding())
         .ok_or(AnalyzerError::NonFatal)
 }

--- a/compiler-lsp/analyzer/src/code_action/holes.rs
+++ b/compiler-lsp/analyzer/src/code_action/holes.rs
@@ -1,3 +1,4 @@
+use building_types::QueryProxy;
 use checking::holes::HoleBinding;
 use lsp_types::*;
 
@@ -5,14 +6,14 @@ use crate::code_action::{CodeActionRequest, expression_range, type_range, worksp
 use crate::{AnalyzerError, locate};
 
 pub fn collect(
-    request: &CodeActionRequest<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    request: &CodeActionRequest<impl crate::AnalyzerHost>,
     actions: &mut Vec<CodeActionOrCommand>,
 ) -> Result<(), AnalyzerError> {
     if !request.kinds.includes(&CodeActionKind::QUICKFIX) {
         return Ok(());
     }
 
-    let checked = request.language.engine.checked(request.file)?;
+    let checked = request.language.queries().checked(request.file)?;
     match &request.located {
         locate::Located::Expression(expression_id) => {
             let Some(hole) = checked.lookup_term_hole(*expression_id) else { return Ok(()) };
@@ -33,7 +34,7 @@ pub fn collect(
 }
 
 fn collect_binding_actions(
-    request: &CodeActionRequest<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    request: &CodeActionRequest<impl crate::AnalyzerHost>,
     range: Range,
     bindings: &[HoleBinding],
     actions: &mut Vec<CodeActionOrCommand>,

--- a/compiler-lsp/analyzer/src/common.rs
+++ b/compiler-lsp/analyzer/src/common.rs
@@ -1,18 +1,19 @@
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{TermItemId, TypeItemId};
 use lsp_types::*;
 use syntax::{SyntaxNode, SyntaxNodePtr};
 
 use crate::position::Utf8Range;
-use crate::{AnalyzerError, LanguageContext, locate, position};
+use crate::{AnalyzerContext, AnalyzerError, locate, position};
 
 pub fn file_term_location(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     file_id: FileId,
     term_id: TermItemId,
 ) -> Result<Location, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(file_id);
     let (parsed, _) = engine.parsed(file_id)?;
 
@@ -23,18 +24,18 @@ pub fn file_term_location(
     let pointers = indexed.term_item_ptr(&stabilized, term_id);
 
     let range = pointers_range(&content, root, pointers)?;
-    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
+    let range = position::utf8_range_to_protocol(&content, range, context.position_encoding())
         .ok_or(AnalyzerError::NonFatal)?;
     Ok(Location { uri, range })
 }
 
 pub fn file_type_location(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     file_id: FileId,
     type_id: TypeItemId,
 ) -> Result<Location, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(file_id);
     let (parsed, _) = engine.parsed(file_id)?;
 
@@ -45,17 +46,17 @@ pub fn file_type_location(
     let pointers = indexed.type_item_ptr(&stabilized, type_id);
 
     let range = pointers_range(&content, root, pointers)?;
-    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
+    let range = position::utf8_range_to_protocol(&content, range, context.position_encoding())
         .ok_or(AnalyzerError::NonFatal)?;
 
     Ok(Location { uri, range })
 }
 
 pub fn file_uri(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     file_id: FileId,
 ) -> Result<Url, AnalyzerError> {
-    context.files.file_uri(file_id)?.ok_or(AnalyzerError::NonFatal)
+    context.file_uri(file_id)?.ok_or(AnalyzerError::NonFatal)
 }
 
 pub fn pointers_range(

--- a/compiler-lsp/analyzer/src/completion.rs
+++ b/compiler-lsp/analyzer/src/completion.rs
@@ -8,6 +8,7 @@ pub mod resolve;
 
 use std::sync::Arc;
 
+use building_types::QueryProxy;
 use filter::{FuzzyMatch, NoFilter, StartsWith};
 use lsp_types::*;
 use prelude::{CompletionContext, CompletionSource, CursorSemantics, CursorText, Filter};
@@ -20,7 +21,7 @@ use sources::{
 };
 use syntax::{SyntaxKind, TokenAtOffset};
 
-use crate::{AnalyzerError, LanguageContext, position};
+use crate::{AnalyzerContext, AnalyzerError, position};
 
 #[derive(Clone, Default)]
 pub struct SuggestionsCacheEntry {
@@ -33,18 +34,18 @@ pub struct SuggestionsCacheEntry {
 pub type SuggestionsCache = Trie<String, Arc<SuggestionsCacheEntry>>;
 
 pub fn implementation(
-    language: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    language: &AnalyzerContext<impl crate::AnalyzerHost>,
     cache: &mut SuggestionsCache,
     uri: Url,
     position: Position,
 ) -> Result<Option<CompletionResponse>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        language.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        language.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let engine = language.engine;
-    let encoding = language.encoding;
+    let engine = language.queries();
+    let encoding = language.position_encoding();
     let prim_id = engine.prim_id();
     let content = engine.content(current_file);
     let position = position::protocol_position_to_utf8(&content, position, encoding)
@@ -98,7 +99,7 @@ pub fn implementation(
 }
 
 fn collect(
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     cache: &mut SuggestionsCache,
 ) -> Result<Vec<CompletionItem>, AnalyzerError> {
     let mut items = vec![];
@@ -219,7 +220,7 @@ fn collect(
 fn get_or_populate_suggestions<F: Filter>(
     cache: &mut SuggestionsCache,
     query: &str,
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     prefix: Option<&str>,
     filter: F,
 ) -> Result<Arc<SuggestionsCacheEntry>, AnalyzerError> {
@@ -273,7 +274,7 @@ fn filter_suggestions<F>(
     cached: &SuggestionsCacheEntry,
     prefix: Option<&str>,
     filter: &F,
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
 ) -> SuggestionsCacheEntry
 where
     F: Filter,
@@ -290,7 +291,7 @@ fn collect_entries<F>(
     items: &[CompletionItem],
     filter: &F,
     prefix: Option<&str>,
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
 ) -> Vec<CompletionItem>
 where
     F: Filter,

--- a/compiler-lsp/analyzer/src/completion/edit.rs
+++ b/compiler-lsp/analyzer/src/completion/edit.rs
@@ -1,5 +1,6 @@
 use std::iter;
 
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{ImportKind, IndexedModule, TermItemId, TermItemKind, TypeItemId, TypeItemKind};
 use itertools::Itertools;
@@ -12,7 +13,7 @@ use crate::completion::CompletionContext;
 use crate::{locate, position};
 
 fn import_item<F, G>(
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     module_name: &str,
     file_id: FileId,
     lookup_fn: F,
@@ -28,7 +29,7 @@ where
         .flatten()
         .find_map(|import| lookup_fn(import).map(|kind| (import, kind)));
 
-    let Ok(import_indexed) = context.language.engine.indexed(file_id) else {
+    let Ok(import_indexed) = context.language.queries().indexed(file_id) else {
         return (None, None);
     };
 
@@ -80,7 +81,11 @@ where
         let import_range = {
             let ptr = ptr.syntax_node_ptr();
             locate::syntax_range(context.content, &root, &ptr).and_then(|range| {
-                position::utf8_range_to_protocol(context.content, range, context.language.encoding)
+                position::utf8_range_to_protocol(
+                    context.content,
+                    range,
+                    context.language.position_encoding(),
+                )
             })
         };
 
@@ -94,7 +99,7 @@ where
 }
 
 pub(super) fn term_import_item(
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     module_name: &str,
     term_name: &str,
     file_id: FileId,
@@ -114,7 +119,7 @@ pub(super) fn term_import_item(
 }
 
 pub(super) fn type_import_item(
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     module_name: &str,
     type_name: &str,
     file_id: FileId,

--- a/compiler-lsp/analyzer/src/completion/prelude.rs
+++ b/compiler-lsp/analyzer/src/completion/prelude.rs
@@ -1,3 +1,4 @@
+use building_types::QueryProxy;
 use files::FileId;
 use lowering::{GraphNodeId, LoweredModule};
 use lsp_types::*;
@@ -11,10 +12,10 @@ use syntax::{
 };
 
 use crate::position::{PositionEncoding, Utf8Position};
-use crate::{AnalyzerError, LanguageContext, position};
+use crate::{AnalyzerContext, AnalyzerError, position};
 
-pub struct CompletionContext<'c, 'a, Queries, Catalog> {
-    pub language: &'c LanguageContext<'c, Queries, Catalog>,
+pub struct CompletionContext<'c, 'a, Host> {
+    pub language: &'c AnalyzerContext<'c, Host>,
     pub current_file: FileId,
     pub content: &'a str,
     pub stabilized: &'a StabilizedModule,
@@ -30,11 +31,7 @@ pub struct CompletionContext<'c, 'a, Queries, Catalog> {
     pub offset: TextSize,
 }
 
-impl<Queries, Catalog> CompletionContext<'_, '_, Queries, Catalog>
-where
-    Queries: crate::AnalyzerQueries,
-    Catalog: crate::FileCatalog,
-{
+impl<Host: crate::AnalyzerHost> CompletionContext<'_, '_, Host> {
     pub fn insert_import_range(&self) -> Option<Range> {
         let cst = self.parsed.cst();
 
@@ -51,8 +48,11 @@ where
         position.line += 1;
         position.column = 0;
 
-        let position =
-            position::utf8_position_to_protocol(self.content, position, self.language.encoding)?;
+        let position = position::utf8_position_to_protocol(
+            self.content,
+            position,
+            self.language.position_encoding(),
+        )?;
         Some(Range::new(position, position))
     }
 
@@ -86,7 +86,7 @@ where
     }
 
     pub fn scope_node(&self) -> Result<Option<GraphNodeId>, AnalyzerError> {
-        let lowered = self.language.engine.lowered(self.current_file)?;
+        let lowered = self.language.queries().lowered(self.current_file)?;
         let root = self.parsed.syntax_node();
 
         let scope_node = match root.token_at_offset(self.offset) {
@@ -160,7 +160,7 @@ pub trait CompletionSource {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError>;

--- a/compiler-lsp/analyzer/src/completion/sources.rs
+++ b/compiler-lsp/analyzer/src/completion/sources.rs
@@ -1,3 +1,4 @@
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{ImportKind, TermItemId, TypeItemId};
 use itertools::Itertools;
@@ -16,11 +17,11 @@ use super::prelude::{CompletionContext, CompletionSource, Filter};
 use super::resolve::CompletionResolveData;
 
 fn module_name(
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     file_id: FileId,
 ) -> Result<Option<String>, AnalyzerError> {
-    let content = context.language.engine.content(file_id);
-    let (parsed, _) = context.language.engine.parsed(file_id)?;
+    let content = context.language.queries().content(file_id);
+    let (parsed, _) = context.language.queries().parsed(file_id)?;
     Ok(parsed.module_name(&content).map(|name| name.to_string()))
 }
 
@@ -40,7 +41,7 @@ impl CompletionSource for QualifiedModules {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -77,13 +78,13 @@ impl CompletionSource for ScopeTerms {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
         let Some(scope_node) = context.scope_node()? else { return Ok(()) };
 
-        let lowered = context.language.engine.lowered(context.current_file)?;
+        let lowered = context.language.queries().lowered(context.current_file)?;
         let mut seen = FxHashSet::default();
 
         for (_, node) in lowered.graph.traverse(scope_node) {
@@ -166,13 +167,13 @@ impl CompletionSource for ScopeTypes {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
         let Some(scope_node) = context.scope_node()? else { return Ok(()) };
 
-        let lowered = context.language.engine.lowered(context.current_file)?;
+        let lowered = context.language.queries().lowered(context.current_file)?;
         let mut seen = FxHashSet::default();
 
         for (node_id, node) in lowered.graph.traverse(scope_node) {
@@ -240,7 +241,7 @@ impl CompletionSource for ScopeTypes {
 }
 
 fn implicit_binding_at_cursor(
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     type_id: &[lowering::TypeId],
 ) -> bool {
     let root = context.parsed.syntax_node();
@@ -262,7 +263,7 @@ impl CompletionSource for LocalTerms {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -294,7 +295,7 @@ impl CompletionSource for LocalTypes {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -342,7 +343,7 @@ impl CompletionSource for ImportedTerms {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -383,7 +384,7 @@ impl CompletionSource for ImportedTypes {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -443,7 +444,7 @@ impl CompletionSource for QualifiedTerms<'_> {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -487,7 +488,7 @@ impl CompletionSource for QualifiedTypes<'_> {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -559,7 +560,7 @@ trait SuggestionsHelper {
 
     fn candidate(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         name: &SmolStr,
         import_id: FileId,
         file_id: FileId,
@@ -576,7 +577,7 @@ impl SuggestionsHelper for SuggestedTerms {
 
     fn candidate(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         name: &SmolStr,
         import_id: FileId,
         file_id: FileId,
@@ -628,7 +629,7 @@ impl SuggestionsHelper for SuggestedTypes {
 
     fn candidate(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         name: &SmolStr,
         import_id: FileId,
         file_id: FileId,
@@ -671,7 +672,7 @@ impl SuggestionsHelper for SuggestedTypes {
 
 fn suggestions_candidates<T: SuggestionsHelper>(
     this: &T,
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     filter: impl Filter,
     items: &mut Vec<CompletionItem>,
 ) -> Result<(), AnalyzerError> {
@@ -682,14 +683,14 @@ fn suggestions_candidates<T: SuggestionsHelper>(
         .flatten()
         .any(|import| import.file == context.prim_id);
 
-    let file_ids = context.language.files.active_files().filter(move |&id| {
+    let file_ids = context.language.active_files().filter(move |&id| {
         let not_self = id != context.current_file;
         let not_prim = id != context.prim_id;
         not_self && (not_prim || has_prim)
     });
 
     for import_id in file_ids {
-        let resolved = context.language.engine.resolved(import_id)?;
+        let resolved = context.language.queries().resolved(import_id)?;
 
         let source = T::exports(&resolved)
             .filter(|(name, file_id, _)| filter.matches(name) && *file_id == import_id);
@@ -709,7 +710,7 @@ impl CompletionSource for SuggestedTerms {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -722,7 +723,7 @@ impl CompletionSource for SuggestedTypes {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -738,7 +739,7 @@ impl CompletionSource for PrimTerms {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -773,7 +774,7 @@ impl CompletionSource for PrimTypes {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -836,7 +837,7 @@ impl SuggestionsHelper for QualifiedTermsSuggestions<'_> {
 
     fn candidate(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         name: &SmolStr,
         import_id: FileId,
         file_id: FileId,
@@ -879,7 +880,7 @@ impl SuggestionsHelper for QualifiedTypesSuggestions<'_> {
 
     fn candidate(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         name: &SmolStr,
         import_id: FileId,
         file_id: FileId,
@@ -914,14 +915,14 @@ impl SuggestionsHelper for QualifiedTypesSuggestions<'_> {
 fn suggestions_candidates_qualified<T: SuggestionsHelper>(
     this: &T,
     prefix: &str,
-    context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &CompletionContext<impl crate::AnalyzerHost>,
     filter: impl Filter,
     items: &mut Vec<CompletionItem>,
 ) -> Result<(), AnalyzerError> {
     let has_prim =
         context.resolved.qualified.values().flatten().any(|import| import.file == context.prim_id);
 
-    let file_ids = context.language.files.active_files().filter(move |&id| {
+    let file_ids = context.language.active_files().filter(move |&id| {
         let not_self = id != context.current_file;
         let not_prim = id != context.prim_id;
         not_self && (not_prim || has_prim)
@@ -929,7 +930,7 @@ fn suggestions_candidates_qualified<T: SuggestionsHelper>(
 
     for import_id in file_ids {
         let module_name = module_name(context, import_id)?;
-        let resolved = context.language.engine.resolved(import_id)?;
+        let resolved = context.language.queries().resolved(import_id)?;
 
         if module_name.is_some_and(|module_name| {
             let filter = PerfectSegmentFuzzy(&module_name);
@@ -955,7 +956,7 @@ impl CompletionSource for QualifiedTermsSuggestions<'_> {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -968,7 +969,7 @@ impl CompletionSource for QualifiedTypesSuggestions<'_> {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
@@ -984,11 +985,11 @@ impl CompletionSource for WorkspaceModules {
 
     fn collect_into<F: Filter>(
         &self,
-        context: &CompletionContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
         filter: F,
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
-        for id in context.language.files.active_files() {
+        for id in context.language.active_files() {
             let Some(module_name) = module_name(context, id)? else {
                 continue;
             };

--- a/compiler-lsp/analyzer/src/context.rs
+++ b/compiler-lsp/analyzer/src/context.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use building_types::QueryProxy;
 use checking::core::pretty::PrettyQueries;
-use files::{FileId, Files};
+use files::FileId;
 use lsp_types::Url;
 
 use crate::position::PositionEncoding;
@@ -33,39 +33,47 @@ impl<Queries> AnalyzerQueries for Queries where
 {
 }
 
-pub trait FileCatalog {
+pub trait AnalyzerHost {
+    type Queries: AnalyzerQueries;
+
+    fn queries(&self) -> &Self::Queries;
     fn file_id(&self, uri: &str) -> Option<FileId>;
     fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError>;
-    fn active_files(&self) -> impl Iterator<Item = FileId>;
+    fn active_files(&self) -> impl Iterator<Item = FileId> + '_;
+    fn is_editable(&self, file_id: FileId) -> bool;
 }
 
-impl FileCatalog for Files {
-    fn file_id(&self, uri: &str) -> Option<FileId> {
-        self.id(uri)
-    }
-
-    fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError> {
-        let path = self.path(file_id);
-        Url::parse(&path).map(Some)
-    }
-
-    fn active_files(&self) -> impl Iterator<Item = FileId> {
-        self.iter_id()
-    }
+pub struct AnalyzerContext<'a, Host> {
+    host: &'a Host,
+    position_encoding: PositionEncoding,
 }
 
-pub struct LanguageContext<'a, Queries, Catalog> {
-    pub engine: &'a Queries,
-    pub files: &'a Catalog,
-    pub encoding: PositionEncoding,
-}
+impl<'a, Host: AnalyzerHost> AnalyzerContext<'a, Host> {
+    pub fn new(host: &'a Host, position_encoding: PositionEncoding) -> AnalyzerContext<'a, Host> {
+        AnalyzerContext { host, position_encoding }
+    }
 
-impl<'a, Queries, Catalog> LanguageContext<'a, Queries, Catalog> {
-    pub fn new(
-        engine: &'a Queries,
-        files: &'a Catalog,
-        encoding: PositionEncoding,
-    ) -> LanguageContext<'a, Queries, Catalog> {
-        LanguageContext { engine, files, encoding }
+    pub fn queries(&self) -> &Host::Queries {
+        self.host.queries()
+    }
+
+    pub fn file_id(&self, uri: &str) -> Option<FileId> {
+        self.host.file_id(uri)
+    }
+
+    pub fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError> {
+        self.host.file_uri(file_id)
+    }
+
+    pub fn active_files(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.host.active_files()
+    }
+
+    pub fn is_editable(&self, file_id: FileId) -> bool {
+        self.host.is_editable(file_id)
+    }
+
+    pub fn position_encoding(&self) -> PositionEncoding {
+        self.position_encoding
     }
 }

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -1,5 +1,6 @@
 use std::iter;
 
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{ImportItemId, TermItemId, TypeItemId};
 use lowering::{
@@ -13,23 +14,24 @@ use syntax::{SyntaxNode, SyntaxNodePtr, cst};
 
 use crate::extract::AnnotationSyntaxRange;
 use crate::position::Utf8Range;
-use crate::{AnalyzerError, LanguageContext, common, locate, position};
+use crate::{AnalyzerContext, AnalyzerError, common, locate, position};
 
 pub fn implementation(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     position: Position,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        context.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.engine.content(current_file);
-    let position = position::protocol_position_to_utf8(&content, position, context.encoding)
-        .ok_or(AnalyzerError::NonFatal)?;
+    let content = context.queries().content(current_file);
+    let position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
 
-    let located = locate::locate(context.engine, current_file, position)?;
+    let located = locate::locate(context.queries(), current_file, position)?;
 
     match located {
         locate::Located::ModuleName(module_name) => {
@@ -44,13 +46,13 @@ pub fn implementation(
         }
         locate::Located::Type(type_id) => definition_type(context, uri, current_file, type_id),
         locate::Located::TermOperator(operator_id) => {
-            let lowered = context.engine.lowered(current_file)?;
+            let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_term(context, f_id, t_id)
         }
         locate::Located::TypeOperator(operator_id) => {
-            let lowered = context.engine.lowered(current_file)?;
+            let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_type(context, f_id, t_id)
@@ -67,11 +69,11 @@ pub fn implementation(
 }
 
 fn definition_module_name(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
 
@@ -89,18 +91,18 @@ fn definition_module_name(
     let range = root.text_range();
 
     let uri = common::file_uri(context, module_id)?;
-    let range = position::text_range_to_protocol(&content, range, context.encoding)
+    let range = position::text_range_to_protocol(&content, range, context.position_encoding())
         .ok_or(AnalyzerError::NonFatal)?;
 
     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
 }
 
 fn definition_import(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
@@ -183,11 +185,11 @@ fn definition_import(
 }
 
 fn definition_binder(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     binder_id: BinderId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         BinderKind::Constructor { resolution, .. } => {
@@ -199,12 +201,12 @@ fn definition_binder(
 }
 
 fn definition_expression(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     current_file: FileId,
     expression_id: ExpressionId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
 
@@ -226,8 +228,12 @@ fn definition_expression(
                     let ptr = stabilized.syntax_ptr(*id).ok_or(AnalyzerError::NonFatal)?;
                     let range = locate::syntax_range(&content, &root, &ptr)
                         .ok_or(AnalyzerError::NonFatal)?;
-                    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
-                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(
+                        &content,
+                        range,
+                        context.position_encoding(),
+                    )
+                    .ok_or(AnalyzerError::NonFatal)?;
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
                 TermVariableResolution::Let(binding_id) => {
@@ -252,8 +258,12 @@ fn definition_expression(
                         .chain(equations)
                         .reduce(|start, end| Utf8Range { start: start.start, end: end.end })
                         .ok_or(AnalyzerError::NonFatal)?;
-                    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
-                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(
+                        &content,
+                        range,
+                        context.position_encoding(),
+                    )
+                    .ok_or(AnalyzerError::NonFatal)?;
 
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
@@ -262,8 +272,12 @@ fn definition_expression(
                     let ptr = stabilized.syntax_ptr(*id).ok_or(AnalyzerError::NonFatal)?;
                     let range = record_pun_name_range(&content, &root, &ptr)
                         .ok_or(AnalyzerError::NonFatal)?;
-                    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
-                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(
+                        &content,
+                        range,
+                        context.position_encoding(),
+                    )
+                    .ok_or(AnalyzerError::NonFatal)?;
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
                 TermVariableResolution::Reference(f_id, t_id) => {
@@ -295,12 +309,12 @@ fn record_pun_name_range(
 }
 
 fn definition_type(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     current_file: FileId,
     type_id: TypeId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
@@ -327,8 +341,12 @@ fn definition_type(
                         .syntax_node_ptr();
                     let range = locate::syntax_range(&content, &root, &ptr)
                         .ok_or(AnalyzerError::NonFatal)?;
-                    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
-                        .ok_or(AnalyzerError::NonFatal)?;
+                    let range = position::utf8_range_to_protocol(
+                        &content,
+                        range,
+                        context.position_encoding(),
+                    )
+                    .ok_or(AnalyzerError::NonFatal)?;
                     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))
                 }
                 TypeVariableResolution::Implicit(ImplicitTypeVariable { .. }) => Ok(None),
@@ -339,7 +357,7 @@ fn definition_type(
 }
 
 fn definition_file_term(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     file_id: FileId,
     term_id: TermItemId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
@@ -349,7 +367,7 @@ fn definition_file_term(
 }
 
 fn definition_file_type(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     file_id: FileId,
     type_id: TypeItemId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
@@ -359,11 +377,11 @@ fn definition_file_type(
 }
 
 fn definition_let_binding(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     file_id: FileId,
     let_id: LetBindingNameGroupId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(file_id);
     let (parsed, _) = engine.parsed(file_id)?;
     let stabilized = engine.stabilized(file_id)?;
@@ -379,7 +397,7 @@ fn definition_let_binding(
 
     let pointers = iter::chain(signature, equations);
     let range = common::pointers_range(&content, root, pointers)?;
-    let range = position::utf8_range_to_protocol(&content, range, context.encoding)
+    let range = position::utf8_range_to_protocol(&content, range, context.position_encoding())
         .ok_or(AnalyzerError::NonFatal)?;
 
     Ok(Some(GotoDefinitionResponse::Scalar(Location { uri, range })))

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -1,5 +1,6 @@
 use std::iter;
 
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{ImportItemId, ImportKind, TermItemId, TermItemKind, TypeItemId, TypeItemKind};
 use lowering::{
@@ -13,23 +14,24 @@ use syntax::ast::AstNode;
 use syntax::{SyntaxNode, SyntaxNodePtr, cst};
 
 use crate::position::{PositionEncoding, Utf8Range};
-use crate::{AnalyzerError, LanguageContext, locate, position};
+use crate::{AnalyzerContext, AnalyzerError, locate, position};
 
 pub fn implementation(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     position: Position,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        context.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.engine.content(current_file);
-    let position = position::protocol_position_to_utf8(&content, position, context.encoding)
-        .ok_or(AnalyzerError::NonFatal)?;
+    let content = context.queries().content(current_file);
+    let position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
 
-    let located = locate::locate(context.engine, current_file, position)?;
+    let located = locate::locate(context.queries(), current_file, position)?;
     match located {
         locate::Located::ImportItem(import_id) => {
             highlight_import(context, current_file, import_id)
@@ -68,7 +70,7 @@ enum HighlightTarget {
 }
 
 fn highlight_import(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
@@ -84,30 +86,30 @@ fn highlight_import(
     }
     .unwrap_or_default();
 
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
-    let stabilized = context.engine.stabilized(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
 
     let ptr = stabilized.ast_ptr(import_id).ok_or(AnalyzerError::NonFatal)?;
     let node = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
 
     highlights.extend(
         position::import_item_name_range(&content, node)
-            .and_then(|range| document_highlight(&content, context.encoding, range)),
+            .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
     );
 
     Ok(finish_highlights(highlights))
 }
 
 fn import_target(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<HighlightTarget, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
-    let stabilized = context.engine.stabilized(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
 
     let root = parsed.syntax_node();
     let ptr = stabilized.ast_ptr(import_id).ok_or(AnalyzerError::NonFatal)?;
@@ -125,8 +127,9 @@ fn import_target(
         .text(&content)
         .to_smolstr();
 
-    let imported_file = context.engine.module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
-    let imported_resolved = context.engine.resolved(imported_file)?;
+    let imported_file =
+        context.queries().module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
+    let imported_resolved = context.queries().resolved(imported_file)?;
 
     let term_target = |name: &str| {
         let name = name.trim_start_matches("(").trim_end_matches(")");
@@ -180,14 +183,14 @@ fn import_target(
 }
 
 fn highlight_binder(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     binder_id: BinderId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
-    let stabilized = context.engine.stabilized(current_file)?;
-    let lowered = context.engine.lowered(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
 
     let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
 
@@ -203,7 +206,7 @@ fn highlight_binder(
     highlights.extend(
         binder_name_range(&content, &root, &ptr)
             .or_else(|| locate::syntax_range(&content, &root, &ptr))
-            .and_then(|range| document_highlight(&content, context.encoding, range)),
+            .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
     );
 
     for (expr_id, expr_kind) in lowered.info.iter_expression() {
@@ -212,10 +215,9 @@ fn highlight_binder(
         } = expr_kind
             && *id == binder_id
         {
-            highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expr_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
-            );
+            highlights.extend(locate::id_range(&content, &parsed, &stabilized, expr_id).and_then(
+                |range| document_highlight(&content, context.position_encoding(), range),
+            ));
         }
     }
 
@@ -223,10 +225,9 @@ fn highlight_binder(
         if let TermVariableResolution::Binder(id) = resolution
             && id == binder_id
         {
-            highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, pun_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
-            );
+            highlights.extend(locate::id_range(&content, &parsed, &stabilized, pun_id).and_then(
+                |range| document_highlight(&content, context.position_encoding(), range),
+            ));
         }
     }
 
@@ -234,11 +235,11 @@ fn highlight_binder(
 }
 
 fn highlight_expression(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     expression_id: ExpressionId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
@@ -265,11 +266,11 @@ fn highlight_expression(
 }
 
 fn highlight_type(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     type_id: TypeId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
@@ -282,18 +283,18 @@ fn highlight_type(
 }
 
 fn highlight_file_term(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     file_id: FileId,
     term_id: TermItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
-    let stabilized = context.engine.stabilized(current_file)?;
-    let lowered = context.engine.lowered(current_file)?;
-    let indexed = context.engine.indexed(current_file)?;
-    let resolved = context.engine.resolved(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
+    let indexed = context.queries().indexed(current_file)?;
+    let resolved = context.queries().resolved(current_file)?;
 
     let mut highlights = vec![];
 
@@ -307,8 +308,9 @@ fn highlight_file_term(
             && (*f_id, *t_id) == (file_id, term_id)
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expression_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
+                locate::id_range(&content, &parsed, &stabilized, expression_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
             );
         }
     }
@@ -318,8 +320,9 @@ fn highlight_file_term(
             && (*f_id, *t_id) == (file_id, term_id)
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, binder_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
+                locate::id_range(&content, &parsed, &stabilized, binder_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
             );
         }
     }
@@ -327,8 +330,9 @@ fn highlight_file_term(
     for (operator_id, f_id, t_id) in lowered.info.iter_term_operator() {
         if (f_id, t_id) == (file_id, term_id) {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, operator_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
+                locate::id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
             );
         }
     }
@@ -337,10 +341,9 @@ fn highlight_file_term(
         if let TermVariableResolution::Reference(f_id, t_id) = resolution
             && (f_id, t_id) == (file_id, term_id)
         {
-            highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, pun_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
-            );
+            highlights.extend(locate::id_range(&content, &parsed, &stabilized, pun_id).and_then(
+                |range| document_highlight(&content, context.position_encoding(), range),
+            ));
         }
     }
 
@@ -358,7 +361,7 @@ fn highlight_file_term(
                     highlights.extend(stabilized.ast_ptr(*import_item_id).and_then(|ptr| {
                         let node = ptr.try_to_node(&root)?;
                         let range = position::import_item_name_range(&content, node)?;
-                        document_highlight(&content, context.encoding, range)
+                        document_highlight(&content, context.position_encoding(), range)
                     }));
                 }
             }
@@ -375,18 +378,18 @@ fn highlight_file_term(
 }
 
 fn highlight_file_type(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     file_id: FileId,
     type_id: TypeItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
-    let stabilized = context.engine.stabilized(current_file)?;
-    let lowered = context.engine.lowered(current_file)?;
-    let indexed = context.engine.indexed(current_file)?;
-    let resolved = context.engine.resolved(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
+    let indexed = context.queries().indexed(current_file)?;
+    let resolved = context.queries().resolved(current_file)?;
 
     let mut highlights = vec![];
 
@@ -395,18 +398,18 @@ fn highlight_file_type(
         | TypeKind::Operator { resolution: Some((f_id, t_id)) } = ty_kind
             && (*f_id, *t_id) == (file_id, type_id)
         {
-            highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, ty_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
-            );
+            highlights.extend(locate::id_range(&content, &parsed, &stabilized, ty_id).and_then(
+                |range| document_highlight(&content, context.position_encoding(), range),
+            ));
         }
     }
 
     for (operator_id, f_id, t_id) in lowered.info.iter_type_operator() {
         if (f_id, t_id) == (file_id, type_id) {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, operator_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
+                locate::id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
             );
         }
     }
@@ -422,7 +425,7 @@ fn highlight_file_type(
                     highlights.extend(stabilized.ast_ptr(*import_item_id).and_then(|ptr| {
                         let node = ptr.try_to_node(&root)?;
                         let range = position::import_item_name_range(&content, node)?;
-                        document_highlight(&content, context.encoding, range)
+                        document_highlight(&content, context.position_encoding(), range)
                     }));
                 }
             }
@@ -439,36 +442,36 @@ fn highlight_file_type(
 }
 
 fn highlight_term_operator(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     operator_id: TermOperatorId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let (file_id, term_id) =
         lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
     highlight_file_term(context, current_file, file_id, term_id)
 }
 
 fn highlight_type_operator(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     operator_id: TypeOperatorId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let (file_id, type_id) =
         lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
     highlight_file_type(context, current_file, file_id, type_id)
 }
 
 fn highlight_let(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     let_binding_id: LetBindingNameGroupId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
-    let stabilized = context.engine.stabilized(current_file)?;
-    let lowered = context.engine.lowered(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
 
     let root = parsed.syntax_node();
     let binding = lowered.info.get_let_binding_group(let_binding_id);
@@ -480,7 +483,7 @@ fn highlight_let(
         highlights.extend(
             let_signature_name_range(&content, &root, &ptr)
                 .or_else(|| locate::syntax_range(&content, &root, &ptr))
-                .and_then(|range| document_highlight(&content, context.encoding, range)),
+                .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
         );
     }
 
@@ -489,7 +492,7 @@ fn highlight_let(
         highlights.extend(
             let_equation_name_range(&content, &root, &ptr)
                 .or_else(|| locate::syntax_range(&content, &root, &ptr))
-                .and_then(|range| document_highlight(&content, context.encoding, range)),
+                .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
         );
     }
 
@@ -499,10 +502,9 @@ fn highlight_let(
         } = expr_kind
             && *id == let_binding_id
         {
-            highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expr_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
-            );
+            highlights.extend(locate::id_range(&content, &parsed, &stabilized, expr_id).and_then(
+                |range| document_highlight(&content, context.position_encoding(), range),
+            ));
         }
     }
 
@@ -510,10 +512,9 @@ fn highlight_let(
         if let TermVariableResolution::Let(id) = resolution
             && id == let_binding_id
         {
-            highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, pun_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
-            );
+            highlights.extend(locate::id_range(&content, &parsed, &stabilized, pun_id).and_then(
+                |range| document_highlight(&content, context.position_encoding(), range),
+            ));
         }
     }
 
@@ -521,20 +522,20 @@ fn highlight_let(
 }
 
 fn highlight_binder_pun(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
-    let stabilized = context.engine.stabilized(current_file)?;
-    let lowered = context.engine.lowered(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
 
     let mut highlights = vec![];
 
     highlights.extend(
         locate::id_range(&content, &parsed, &stabilized, pun_id)
-            .and_then(|range| document_highlight(&content, context.encoding, range)),
+            .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
     );
 
     for (expression_id, expression_kind) in lowered.info.iter_expression() {
@@ -544,8 +545,9 @@ fn highlight_binder_pun(
             && *candidate_id == pun_id
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expression_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
+                locate::id_range(&content, &parsed, &stabilized, expression_id).and_then(|range| {
+                    document_highlight(&content, context.position_encoding(), range)
+                }),
             );
         }
     }
@@ -555,8 +557,9 @@ fn highlight_binder_pun(
             && candidate_id == pun_id
         {
             highlights.extend(
-                locate::id_range(&content, &parsed, &stabilized, expression_pun_id)
-                    .and_then(|range| document_highlight(&content, context.encoding, range)),
+                locate::id_range(&content, &parsed, &stabilized, expression_pun_id).and_then(
+                    |range| document_highlight(&content, context.position_encoding(), range),
+                ),
             );
         }
     }
@@ -565,11 +568,11 @@ fn highlight_binder_pun(
 }
 
 fn highlight_expression_pun(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     match lowered.info.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)? {
         TermVariableResolution::Binder(binder_id) => {
             highlight_binder(context, current_file, binder_id)
@@ -587,11 +590,11 @@ fn highlight_expression_pun(
 }
 
 fn term_item_highlights(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     term_id: TermItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let indexed = context.engine.indexed(current_file)?;
+    let indexed = context.queries().indexed(current_file)?;
 
     let mut highlights = vec![];
 
@@ -641,11 +644,11 @@ fn term_item_highlights(
 }
 
 fn type_item_highlights(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     type_id: TypeItemId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
-    let indexed = context.engine.indexed(current_file)?;
+    let indexed = context.queries().indexed(current_file)?;
 
     let mut highlights = vec![];
 
@@ -726,7 +729,7 @@ fn let_equation_name_range(
 }
 
 fn push_name_highlight<T>(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     highlights: &mut Vec<DocumentHighlight>,
     id: Option<AstId<T>>,
@@ -735,15 +738,15 @@ fn push_name_highlight<T>(
 where
     T: AstNode,
 {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
-    let stabilized = context.engine.stabilized(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
 
     highlights.extend(id.and_then(|id| {
         let ptr = stabilized.syntax_ptr(id)?;
         let range = range(&content, &root, &ptr)?;
-        document_highlight(&content, context.encoding, range)
+        document_highlight(&content, context.position_encoding(), range)
     }));
 
     Ok(())

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -1,3 +1,4 @@
+use building_types::QueryProxy;
 use checking::core::pretty::{Pretty, PrettyConfig};
 use files::FileId;
 use indexing::{ImportItemId, TermItemId, TypeItemId};
@@ -9,24 +10,25 @@ use syntax::ast::{AstNode, AstPtr};
 use syntax::{TextRange, cst};
 
 use crate::extract::AnnotationSyntaxRange;
-use crate::{AnalyzerError, AnalyzerQueries, LanguageContext, extract, locate, position};
+use crate::{AnalyzerContext, AnalyzerError, AnalyzerQueries, extract, locate, position};
 
 const PRETTY_CONFIG: PrettyConfig = PrettyConfig::new().width(80);
 
 pub fn implementation(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     position: Position,
 ) -> Result<Option<Hover>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        context.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
-    let position = position::protocol_position_to_utf8(&content, position, context.encoding)
-        .ok_or(AnalyzerError::NonFatal)?;
+    let position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
 
     let located = locate::locate(engine, current_file, position)?;
 

--- a/compiler-lsp/analyzer/src/lib.rs
+++ b/compiler-lsp/analyzer/src/lib.rs
@@ -14,5 +14,5 @@ pub mod rename;
 pub mod semantic_tokens;
 pub mod symbols;
 
-pub use context::{AnalyzerQueries, FileCatalog, LanguageContext};
+pub use context::{AnalyzerContext, AnalyzerHost, AnalyzerQueries};
 pub use error::AnalyzerError;

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -1,3 +1,4 @@
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{ImportId, ImportItemId, ImportKind, TermItemId, TypeItemId};
 use lowering::{
@@ -13,23 +14,24 @@ use stabilizing::{AstId, StabilizedModule};
 use syntax::ast::{AstNode, AstPtr};
 use syntax::cst;
 
-use crate::{AnalyzerError, LanguageContext, common, locate, position};
+use crate::{AnalyzerContext, AnalyzerError, common, locate, position};
 
 pub fn implementation(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     position: Position,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        context.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.engine.content(current_file);
-    let position = position::protocol_position_to_utf8(&content, position, context.encoding)
-        .ok_or(AnalyzerError::NonFatal)?;
+    let content = context.queries().content(current_file);
+    let position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
 
-    let located = locate::locate(context.engine, current_file, position)?;
+    let located = locate::locate(context.queries(), current_file, position)?;
 
     match located {
         locate::Located::ModuleName(module_name) => {
@@ -44,13 +46,13 @@ pub fn implementation(
         }
         locate::Located::Type(type_id) => references_type(context, current_file, type_id),
         locate::Located::TermOperator(operator_id) => {
-            let lowered = context.engine.lowered(current_file)?;
+            let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_term(context, current_file, f_id, t_id)
         }
         locate::Located::TypeOperator(operator_id) => {
-            let lowered = context.engine.lowered(current_file)?;
+            let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
                 lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_type(context, current_file, f_id, t_id)
@@ -71,11 +73,11 @@ pub fn implementation(
 }
 
 fn references_module_name(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
 
@@ -98,7 +100,7 @@ fn references_module_name(
         let stabilized = engine.stabilized(candidate_id)?;
         let ptr = stabilized.syntax_ptr(import_id).ok_or(AnalyzerError::NonFatal)?;
         let range = locate::syntax_range(&content, &root, &ptr).ok_or(AnalyzerError::NonFatal)?;
-        let range = position::utf8_range_to_protocol(&content, range, context.encoding)
+        let range = position::utf8_range_to_protocol(&content, range, context.position_encoding())
             .ok_or(AnalyzerError::NonFatal)?;
 
         locations.push(Location { uri, range });
@@ -108,11 +110,11 @@ fn references_module_name(
 }
 
 fn references_import(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let content = engine.content(current_file);
     let (parsed, _) = engine.parsed(current_file)?;
     let stabilized = engine.stabilized(current_file)?;
@@ -195,17 +197,17 @@ fn references_import(
 }
 
 fn references_binder(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     binder_id: BinderId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let uri = common::file_uri(context, current_file)?;
 
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
 
-    let stabilized = context.engine.stabilized(current_file)?;
-    let lowered = context.engine.lowered(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
 
     let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
@@ -247,11 +249,11 @@ fn references_binder(
 }
 
 fn references_expression(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     expression_id: ExpressionId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         ExpressionKind::Constructor { resolution, .. } => {
@@ -284,11 +286,11 @@ fn references_expression(
 }
 
 fn references_type(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     type_id: TypeId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         TypeKind::Constructor { resolution, .. } => {
@@ -304,7 +306,7 @@ fn references_type(
 }
 
 fn id_range<T>(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     content: &str,
     parsed: &ParsedModule,
     stabilized: &StabilizedModule,
@@ -316,16 +318,16 @@ where
     let root = parsed.syntax_node();
     let ptr = stabilized.syntax_ptr(item_id)?;
     let range = locate::syntax_range(content, &root, &ptr)?;
-    position::utf8_range_to_protocol(content, range, context.encoding)
+    position::utf8_range_to_protocol(content, range, context.position_encoding())
 }
 
 fn references_file_term(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     file_id: FileId,
     term_id: TermItemId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let candidates = probe_term_references(context, current_file, file_id, term_id)?;
 
     let mut locations = vec![];
@@ -384,12 +386,12 @@ fn references_file_term(
 }
 
 fn references_file_type(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     file_id: FileId,
     type_id: TypeItemId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let candidates = probe_type_references(context, current_file, file_id, type_id)?;
 
     let mut locations = vec![];
@@ -432,7 +434,7 @@ fn references_file_type(
 }
 
 fn probe_term_references(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     file_id: FileId,
     term_id: TermItemId,
@@ -445,7 +447,7 @@ fn probe_term_references(
 }
 
 fn probe_type_references(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     file_id: FileId,
     type_id: TypeItemId,
@@ -460,19 +462,19 @@ fn probe_type_references(
 }
 
 fn probe_workspace_imports(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     source_file: FileId,
     check_import: impl Fn(&ResolvedImport) -> bool,
 ) -> Result<FxHashSet<FileId>, AnalyzerError> {
     let mut probe = FxHashSet::from_iter([current_file, source_file]);
 
-    for workspace_file_id in context.files.active_files() {
+    for workspace_file_id in context.active_files() {
         if workspace_file_id == current_file || workspace_file_id == source_file {
             continue;
         }
 
-        let resolved = context.engine.resolved(workspace_file_id)?;
+        let resolved = context.queries().resolved(workspace_file_id)?;
 
         let unqualified = resolved.unqualified.values().flatten();
         let qualified = resolved.qualified.values().flatten();
@@ -489,13 +491,13 @@ fn probe_workspace_imports(
 }
 
 fn probe_imports_for(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     module_id: FileId,
 ) -> Result<FxHashSet<(FileId, ImportId)>, AnalyzerError> {
     let mut probe = FxHashSet::default();
 
-    for workspace_file_id in context.files.active_files() {
-        let resolved = context.engine.resolved(workspace_file_id)?;
+    for workspace_file_id in context.active_files() {
+        let resolved = context.queries().resolved(workspace_file_id)?;
 
         let unqualified = resolved.unqualified.values().flatten();
         let qualified = resolved.qualified.values().flatten();
@@ -512,11 +514,11 @@ fn probe_imports_for(
 }
 
 fn references_let(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     let_id: LetBindingNameGroupId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let uri = common::file_uri(context, current_file)?;
 
     let content = engine.content(current_file);
@@ -556,11 +558,11 @@ fn references_let(
 }
 
 fn references_binder_pun(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let engine = context.engine;
+    let engine = context.queries();
     let uri = common::file_uri(context, current_file)?;
 
     let content = engine.content(current_file);
@@ -599,11 +601,11 @@ fn references_binder_pun(
 }
 
 fn references_expression_pun(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
     match lowered.info.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)? {
         TermVariableResolution::Binder(binder_id) => {
             references_binder(context, current_file, binder_id)

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{ImportId, ImportItemId, TermItemId, TermItemKind, TypeItemId, TypeItemKind};
 use lowering::{BinderKind, ExpressionKind, TermVariableResolution, TypeKind};
@@ -7,7 +6,7 @@ use lsp_types::*;
 use syntax::ast::{AstNode, AstPtr};
 use syntax::{TokenAtOffset, cst};
 
-use crate::{AnalyzerError, LanguageContext, locate, position, references};
+use crate::{AnalyzerContext, AnalyzerError, locate, position, references};
 
 mod edit;
 
@@ -39,25 +38,25 @@ enum NameKind {
 }
 
 pub fn implementation(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
-    workspace_root: Option<&Path>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     position: Position,
     new_name: String,
 ) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        context.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.engine.content(current_file);
-    let utf8_position = position::protocol_position_to_utf8(&content, position, context.encoding)
-        .ok_or(AnalyzerError::NonFatal)?;
+    let content = context.queries().content(current_file);
+    let utf8_position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
 
     let target = if let Some(target) = qualifier_target(context, current_file, utf8_position)? {
         target
     } else {
-        let located = locate::locate(context.engine, current_file, utf8_position)?;
+        let located = locate::locate(context.queries(), current_file, utf8_position)?;
         rename_target(context, current_file, located)?
     };
 
@@ -68,7 +67,7 @@ pub fn implementation(
         return Ok(None);
     }
 
-    if !editable_file(context, workspace_root, target.file()) {
+    if !context.is_editable(target.file()) {
         return Ok(None);
     }
 
@@ -78,13 +77,13 @@ pub fn implementation(
             edits.collect_qualifier(file_id, import_id, &new_name)?;
         }
         RenameTarget::Module(file_id) => {
-            edits.collect_module(workspace_root, file_id, &new_name)?;
+            edits.collect_module(file_id, &new_name)?;
         }
         RenameTarget::Term(_, _) | RenameTarget::Type(_, _) => {
             let locations = references::implementation(context, uri, position)?.unwrap_or_default();
-            edits.collect_references(workspace_root, locations, name_kind, &new_name)?;
+            edits.collect_references(locations, name_kind, &new_name)?;
             edits.collect_declaration(target, &new_name)?;
-            edits.collect_item_surfaces(workspace_root, target, &old_name, &new_name)?;
+            edits.collect_item_surfaces(target, &old_name, &new_name)?;
         }
     }
 
@@ -92,14 +91,14 @@ pub fn implementation(
 }
 
 fn qualifier_target(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     position: position::Utf8Position,
 ) -> Result<Option<RenameTarget>, AnalyzerError> {
-    let content = context.engine.content(current_file);
+    let content = context.queries().content(current_file);
     let offset =
         position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
 
     let token = match root.token_at_offset(offset) {
@@ -137,7 +136,7 @@ fn qualifier_target(
         return Ok(None);
     };
 
-    let indexed = context.engine.indexed(current_file)?;
+    let indexed = context.queries().indexed(current_file)?;
     let import_id = indexed.imports.iter().find_map(|(import_id, import)| {
         (import.alias.as_deref() == Some(name.as_str())).then_some(*import_id)
     });
@@ -146,11 +145,11 @@ fn qualifier_target(
 }
 
 fn rename_target(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     located: locate::Located,
 ) -> Result<RenameTarget, AnalyzerError> {
-    let lowered = context.engine.lowered(current_file)?;
+    let lowered = context.queries().lowered(current_file)?;
 
     let target = match located {
         locate::Located::ModuleName(module_name) => {
@@ -213,12 +212,12 @@ fn rename_target(
 }
 
 fn module_target(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
 ) -> Result<RenameTarget, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let module_name = module_name.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
     let parent = module_name.syntax().parent().ok_or(AnalyzerError::NonFatal)?;
@@ -233,19 +232,19 @@ fn module_target(
     }
 
     let name = module_name.syntax().text(&content);
-    let file_id = context.engine.module_file(name).ok_or(AnalyzerError::NonFatal)?;
+    let file_id = context.queries().module_file(name).ok_or(AnalyzerError::NonFatal)?;
 
     Ok(RenameTarget::Module(file_id))
 }
 
 fn import_target(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     import_id: ImportItemId,
 ) -> Result<RenameTarget, AnalyzerError> {
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
-    let stabilized = context.engine.stabilized(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
+    let stabilized = context.queries().stabilized(current_file)?;
 
     let root = parsed.syntax_node();
     let ptr = stabilized.ast_ptr(import_id).ok_or(AnalyzerError::NonFatal)?;
@@ -259,8 +258,9 @@ fn import_target(
     let module_name =
         statement.module_name().ok_or(AnalyzerError::NonFatal)?.syntax().text(&content).to_string();
 
-    let imported_file = context.engine.module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
-    let resolved = context.engine.resolved(imported_file)?;
+    let imported_file =
+        context.queries().module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
+    let resolved = context.queries().resolved(imported_file)?;
 
     let target = match node {
         cst::ImportItem::ImportValue(item) => {
@@ -323,12 +323,12 @@ fn trim_operator_name(name: &str) -> &str {
 }
 
 fn target_name(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     target: RenameTarget,
 ) -> Result<Option<(String, NameKind)>, AnalyzerError> {
     let result = match target {
         RenameTarget::Term(file_id, term_id) => {
-            let indexed = context.engine.indexed(file_id)?;
+            let indexed = context.queries().indexed(file_id)?;
             let item = &indexed.items[term_id];
 
             let Some(name) = item.name.as_ref() else {
@@ -345,7 +345,7 @@ fn target_name(
             Some((name.to_string(), kind))
         }
         RenameTarget::Type(file_id, type_id) => {
-            let indexed = context.engine.indexed(file_id)?;
+            let indexed = context.queries().indexed(file_id)?;
             let item = &indexed.items[type_id];
 
             let Some(name) = item.name.as_ref() else {
@@ -360,14 +360,14 @@ fn target_name(
             Some((name.to_string(), kind))
         }
         RenameTarget::Qualifier(file_id, import_id) => {
-            let indexed = context.engine.indexed(file_id)?;
+            let indexed = context.queries().indexed(file_id)?;
             let name = indexed.imports.get(&import_id).and_then(|import| import.alias.as_ref());
 
             name.map(|name| (name.to_string(), NameKind::Upper))
         }
         RenameTarget::Module(file_id) => {
-            let content = context.engine.content(file_id);
-            let (parsed, _) = context.engine.parsed(file_id)?;
+            let content = context.queries().content(file_id);
+            let (parsed, _) = context.queries().parsed(file_id)?;
 
             parsed.module_name(&content).map(|name| (name.to_string(), NameKind::Module))
         }
@@ -383,25 +383,6 @@ fn valid_new_name(new_name: &str, kind: NameKind) -> bool {
         NameKind::Operator => lexing::is_operator_name(new_name),
         NameKind::Module => new_name.split('.').all(lexing::is_upper_name),
     }
-}
-
-fn editable_file(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
-    workspace_root: Option<&Path>,
-    file_id: FileId,
-) -> bool {
-    let Some(workspace_root) = workspace_root else {
-        return true;
-    };
-
-    let Ok(Some(uri)) = context.files.file_uri(file_id) else {
-        return false;
-    };
-    let Ok(path) = uri.to_file_path() else {
-        return false;
-    };
-
-    path.starts_with(workspace_root)
 }
 
 #[cfg(test)]

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::path::Path;
 
+use building_types::QueryProxy;
 use files::FileId;
 use indexing::{
     ImplicitItems, ImportId, ImportItemId, TermItemId, TermItemKind, TypeItemId, TypeItemKind,
@@ -11,9 +11,9 @@ use stabilizing::AstId;
 use syntax::ast::AstNode;
 use syntax::{SyntaxNode, SyntaxNodePtr, SyntaxToken, TextRange, TokenAtOffset, WalkEvent, cst};
 
-use super::{NameKind, RenameTarget, editable_file};
+use super::{NameKind, RenameTarget};
 use crate::position::Utf8Range;
-use crate::{AnalyzerError, AnalyzerQueries, FileCatalog, LanguageContext, common, position};
+use crate::{AnalyzerContext, AnalyzerError, AnalyzerHost, common, position};
 
 macro_rules! push_name_edits {
     ($self:expr, $file_id:expr, $new_name:expr, $range:expr; $($id:expr),+ $(,)?) => {
@@ -21,31 +21,28 @@ macro_rules! push_name_edits {
     };
 }
 
-pub(super) struct RenameEdits<'edits, 'language, Queries, Catalog>
+pub(super) struct RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
-    context: &'edits LanguageContext<'language, Queries, Catalog>,
+    context: &'edits AnalyzerContext<'language, Host>,
     edits: Vec<(FileId, TextEdit)>,
 }
 
-impl<'edits, 'language, Queries, Catalog> RenameEdits<'edits, 'language, Queries, Catalog>
+impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
     pub(super) fn new(
-        context: &'edits LanguageContext<'language, Queries, Catalog>,
-    ) -> RenameEdits<'edits, 'language, Queries, Catalog> {
+        context: &'edits AnalyzerContext<'language, Host>,
+    ) -> RenameEdits<'edits, 'language, Host> {
         RenameEdits { context, edits: vec![] }
     }
 }
 
-impl<'edits, 'language, Queries, Catalog> RenameEdits<'edits, 'language, Queries, Catalog>
+impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
     pub(super) fn collect_qualifier(
         &mut self,
@@ -53,15 +50,15 @@ where
         import_id: ImportId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let indexed = self.context.engine.indexed(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
         let old_name = indexed
             .imports
             .get(&import_id)
             .and_then(|import| import.alias.as_deref())
             .ok_or(AnalyzerError::NonFatal)?;
 
-        let content = self.context.engine.content(file_id);
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
 
         let statements = root.preorder().filter_map(|event| {
@@ -131,11 +128,10 @@ where
 
     pub(super) fn collect_module(
         &mut self,
-        workspace_root: Option<&Path>,
         target_file: FileId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let (parsed, _) = self.context.engine.parsed(target_file)?;
+        let (parsed, _) = self.context.queries().parsed(target_file)?;
         let module_name = parsed
             .cst()
             .header()
@@ -144,8 +140,8 @@ where
 
         self.push_text_range_edit(target_file, module_name.syntax().text_range(), new_name)?;
 
-        for file_id in self.context.files.active_files() {
-            if !editable_file(self.context, workspace_root, file_id) {
+        for file_id in self.context.active_files() {
+            if !self.context.is_editable(file_id) {
                 continue;
             }
 
@@ -162,16 +158,16 @@ where
         target_file: FileId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let indexed = self.context.engine.indexed(file_id)?;
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
 
         for (import_id, import) in &indexed.imports {
             let Some(name) = import.name.as_deref() else {
                 continue;
             };
-            if self.context.engine.module_file(name) != Some(target_file) {
+            if self.context.queries().module_file(name) != Some(target_file) {
                 continue;
             }
 
@@ -191,11 +187,11 @@ where
         target_file: FileId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.engine.content(file_id);
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let indexed = self.context.engine.indexed(file_id)?;
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
         let current_module = parsed.module_name(&content);
 
         for export in &indexed.exports.modules {
@@ -204,7 +200,7 @@ where
             let exports_import = indexed.imports.values().any(|import| {
                 import.alias.is_none()
                     && import.name.as_ref() == Some(&export.name)
-                    && self.context.engine.module_file(&export.name) == Some(target_file)
+                    && self.context.queries().module_file(&export.name) == Some(target_file)
             });
 
             if !exports_self && !exports_import {
@@ -225,22 +221,20 @@ where
     }
 }
 
-impl<'edits, 'language, Queries, Catalog> RenameEdits<'edits, 'language, Queries, Catalog>
+impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
     pub(super) fn collect_references(
         &mut self,
-        workspace_root: Option<&Path>,
         locations: Vec<Location>,
         name_kind: NameKind,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
         for location in locations {
             let file_id =
-                self.context.files.file_id(location.uri.as_str()).ok_or(AnalyzerError::NonFatal)?;
-            if !editable_file(self.context, workspace_root, file_id) {
+                self.context.file_id(location.uri.as_str()).ok_or(AnalyzerError::NonFatal)?;
+            if !self.context.is_editable(file_id) {
                 continue;
             }
 
@@ -257,14 +251,17 @@ where
         range: Range,
         name_kind: NameKind,
     ) -> Result<Range, AnalyzerError> {
-        let content = self.context.engine.content(file_id);
-        let position =
-            position::protocol_position_to_utf8(&content, range.start, self.context.encoding)
-                .ok_or(AnalyzerError::NonFatal)?;
+        let content = self.context.queries().content(file_id);
+        let position = position::protocol_position_to_utf8(
+            &content,
+            range.start,
+            self.context.position_encoding(),
+        )
+        .ok_or(AnalyzerError::NonFatal)?;
         let offset =
             position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
 
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
 
         let token = match root.token_at_offset(offset) {
@@ -277,8 +274,12 @@ where
 
         let token = Self::qualified_name_token(&token, name_kind).ok_or(AnalyzerError::NonFatal)?;
 
-        position::text_range_to_protocol(&content, token.text_range(), self.context.encoding)
-            .ok_or(AnalyzerError::NonFatal)
+        position::text_range_to_protocol(
+            &content,
+            token.text_range(),
+            self.context.position_encoding(),
+        )
+        .ok_or(AnalyzerError::NonFatal)
     }
 
     fn qualified_name_token(token: &SyntaxToken, name_kind: NameKind) -> Option<SyntaxToken> {
@@ -293,10 +294,9 @@ where
     }
 }
 
-impl<'edits, 'language, Queries, Catalog> RenameEdits<'edits, 'language, Queries, Catalog>
+impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
     pub(super) fn collect_declaration(
         &mut self,
@@ -321,7 +321,7 @@ where
         term_id: TermItemId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let indexed = self.context.engine.indexed(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
 
         match &indexed.items[term_id].kind {
             TermItemKind::ClassMember { id } => {
@@ -360,7 +360,7 @@ where
         type_id: TypeItemId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let indexed = self.context.engine.indexed(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
 
         match indexed.items[type_id].kind {
             TypeItemKind::Data { signature, equation, role, .. } => {
@@ -387,20 +387,18 @@ where
     }
 }
 
-impl<'edits, 'language, Queries, Catalog> RenameEdits<'edits, 'language, Queries, Catalog>
+impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
     pub(super) fn collect_item_surfaces(
         &mut self,
-        workspace_root: Option<&Path>,
         target: RenameTarget,
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        for file_id in self.context.files.active_files() {
-            if !editable_file(self.context, workspace_root, file_id) {
+        for file_id in self.context.active_files() {
+            if !self.context.is_editable(file_id) {
                 continue;
             }
 
@@ -418,8 +416,8 @@ where
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let indexed = self.context.engine.indexed(file_id)?;
-        let resolved = self.context.engine.resolved(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
+        let resolved = self.context.queries().resolved(file_id)?;
 
         let unqualified = resolved.unqualified.values().flatten();
         let qualified = resolved.qualified.values().flatten();
@@ -480,7 +478,7 @@ where
     ) -> Result<(), AnalyzerError> {
         let (target_file, target_term) = target;
         let (old_name, new_name) = names;
-        let target_indexed = self.context.engine.indexed(target_file)?;
+        let target_indexed = self.context.queries().indexed(target_file)?;
         let Some(parent_type) = target_indexed.constructor_type(target_term) else {
             return Ok(());
         };
@@ -513,8 +511,8 @@ where
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let indexed = self.context.engine.indexed(file_id)?;
-        let resolved = self.context.engine.resolved(file_id)?;
+        let indexed = self.context.queries().indexed(file_id)?;
+        let resolved = self.context.queries().resolved(file_id)?;
 
         match target {
             RenameTarget::Term(target_file, target_term) => {
@@ -526,7 +524,7 @@ where
                     }
                 }
 
-                let target_indexed = self.context.engine.indexed(target_file)?;
+                let target_indexed = self.context.queries().indexed(target_file)?;
                 let Some(parent_type) = target_indexed.constructor_type(target_term) else {
                     return Ok(());
                 };
@@ -572,10 +570,10 @@ where
         import_item_id: ImportItemId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.engine.content(file_id);
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
 
         let ptr = stabilized.ast_ptr(import_item_id).ok_or(AnalyzerError::NonFatal)?;
         let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
@@ -591,10 +589,10 @@ where
         export_item_id: indexing::ExportItemId,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.engine.content(file_id);
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
 
         let ptr = stabilized.ast_ptr(export_item_id).ok_or(AnalyzerError::NonFatal)?;
         let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
@@ -611,9 +609,9 @@ where
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
 
         let ptr = stabilized.ast_ptr(import_item_id).ok_or(AnalyzerError::NonFatal)?;
         let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
@@ -632,9 +630,9 @@ where
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
 
         let ptr = stabilized.ast_ptr(export_item_id).ok_or(AnalyzerError::NonFatal)?;
         let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
@@ -653,7 +651,7 @@ where
         old_name: &str,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.engine.content(file_id);
+        let content = self.context.queries().content(file_id);
         let cst::TypeItems::TypeItemsList(items) = type_items else {
             return Ok(());
         };
@@ -671,10 +669,9 @@ where
     }
 }
 
-impl<'edits, 'language, Queries, Catalog> RenameEdits<'edits, 'language, Queries, Catalog>
+impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
-    Queries: AnalyzerQueries,
-    Catalog: FileCatalog,
+    Host: AnalyzerHost,
 {
     fn push_text_range_edit(
         &mut self,
@@ -682,7 +679,7 @@ where
         range: TextRange,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.engine.content(file_id);
+        let content = self.context.queries().content(file_id);
         let range =
             position::text_range_to_utf8_range(&content, range).ok_or(AnalyzerError::NonFatal)?;
 
@@ -695,9 +692,10 @@ where
         range: Utf8Range,
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
-        let content = self.context.engine.content(file_id);
-        let range = position::utf8_range_to_protocol(&content, range, self.context.encoding)
-            .ok_or(AnalyzerError::NonFatal)?;
+        let content = self.context.queries().content(file_id);
+        let range =
+            position::utf8_range_to_protocol(&content, range, self.context.position_encoding())
+                .ok_or(AnalyzerError::NonFatal)?;
         self.push_protocol_edit(file_id, range, new_name)
     }
 
@@ -715,15 +713,16 @@ where
             return Ok(());
         };
 
-        let content = self.context.engine.content(file_id);
-        let (parsed, _) = self.context.engine.parsed(file_id)?;
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
-        let stabilized = self.context.engine.stabilized(file_id)?;
+        let stabilized = self.context.queries().stabilized(file_id)?;
 
         let ptr = stabilized.syntax_ptr(id).ok_or(AnalyzerError::NonFatal)?;
         let range = range(&content, &root, &ptr).ok_or(AnalyzerError::NonFatal)?;
-        let range = position::utf8_range_to_protocol(&content, range, self.context.encoding)
-            .ok_or(AnalyzerError::NonFatal)?;
+        let range =
+            position::utf8_range_to_protocol(&content, range, self.context.position_encoding())
+                .ok_or(AnalyzerError::NonFatal)?;
         self.push_protocol_edit(file_id, range, new_name)
     }
 
@@ -744,14 +743,21 @@ where
         range: Range,
         new_name: &str,
     ) -> Result<String, AnalyzerError> {
-        let content = self.context.engine.content(file_id);
-        let start =
-            position::protocol_position_to_utf8(&content, range.start, self.context.encoding)
-                .and_then(|position| position::utf8_position_to_offset(&content, position))
-                .ok_or(AnalyzerError::NonFatal)?;
-        let end = position::protocol_position_to_utf8(&content, range.end, self.context.encoding)
-            .and_then(|position| position::utf8_position_to_offset(&content, position))
-            .ok_or(AnalyzerError::NonFatal)?;
+        let content = self.context.queries().content(file_id);
+        let start = position::protocol_position_to_utf8(
+            &content,
+            range.start,
+            self.context.position_encoding(),
+        )
+        .and_then(|position| position::utf8_position_to_offset(&content, position))
+        .ok_or(AnalyzerError::NonFatal)?;
+        let end = position::protocol_position_to_utf8(
+            &content,
+            range.end,
+            self.context.position_encoding(),
+        )
+        .and_then(|position| position::utf8_position_to_offset(&content, position))
+        .ok_or(AnalyzerError::NonFatal)?;
 
         let range = TextRange::new(start, end);
         let text = &content[range];

--- a/compiler-lsp/analyzer/src/semantic_tokens.rs
+++ b/compiler-lsp/analyzer/src/semantic_tokens.rs
@@ -1,8 +1,9 @@
+use building_types::QueryProxy;
 use line_index::LineIndex;
 use lsp_types::{SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens};
 use syntax::{SyntaxKind, SyntaxToken, TextRange, WalkEvent};
 
-use crate::{AnalyzerError, LanguageContext, position};
+use crate::{AnalyzerContext, AnalyzerError, position};
 
 pub const TOKEN_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::NAMESPACE,
@@ -57,16 +58,16 @@ impl TokenClassification {
 }
 
 pub fn implementation(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: lsp_types::Url,
 ) -> Result<Option<SemanticTokens>, AnalyzerError> {
     let current_file = {
         let uri = uri.as_str();
-        context.files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
-    let content = context.engine.content(current_file);
-    let (parsed, _) = context.engine.parsed(current_file)?;
+    let content = context.queries().content(current_file);
+    let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
     let line_index = LineIndex::new(&content);
     let mut data = vec![];
@@ -84,7 +85,7 @@ pub fn implementation(
             &content,
             token.text_range(),
             classification,
-            context.encoding,
+            context.position_encoding(),
         );
     }
 

--- a/compiler-lsp/analyzer/src/symbols.rs
+++ b/compiler-lsp/analyzer/src/symbols.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use building_types::QueryProxy;
 use indexing::{TermItemKind, TypeItemKind};
 use lsp_types::*;
 use radix_trie::Trie;
 
-use crate::{AnalyzerError, LanguageContext, common};
+use crate::{AnalyzerContext, AnalyzerError, common};
 
 fn term_symbol_kind(kind: &TermItemKind) -> SymbolKind {
     match kind {
@@ -31,15 +32,14 @@ fn type_symbol_kind(kind: &TypeItemKind) -> SymbolKind {
 }
 
 pub fn document(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
 ) -> Result<Option<DocumentSymbolResponse>, AnalyzerError> {
-    let engine = context.engine;
-    let files = context.files;
+    let engine = context.queries();
 
     let current_file = {
         let uri = uri.as_str();
-        files.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
     };
 
     let resolved = engine.resolved(current_file)?;
@@ -106,7 +106,7 @@ pub fn document(
 }
 
 pub fn workspace(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     cache: &mut WorkspaceSymbolsCache,
     query: &str,
 ) -> Result<Option<WorkspaceSymbolResponse>, AnalyzerError> {
@@ -149,14 +149,14 @@ fn filter_symbols(cached: &[SymbolInformation], query: &str) -> Vec<SymbolInform
 }
 
 fn build_symbol_list(
-    context: &LanguageContext<impl crate::AnalyzerQueries, impl crate::FileCatalog>,
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
     query: &str,
 ) -> Result<Vec<SymbolInformation>, AnalyzerError> {
     let mut symbols = vec![];
 
-    for file_id in context.files.active_files() {
-        let resolved = context.engine.resolved(file_id)?;
-        let indexed = context.engine.indexed(file_id)?;
+    for file_id in context.active_files() {
+        let resolved = context.queries().resolved(file_id)?;
+        let indexed = context.queries().indexed(file_id)?;
         let uri = common::file_uri(context, file_id)?;
 
         for (name, _, term_id) in resolved.locals.iter_terms() {

--- a/docs/src/wasm/src/engine.rs
+++ b/docs/src/wasm/src/engine.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use analyzer::FileCatalog;
+use analyzer::AnalyzerHost;
 use building_types::{ModuleNameId, ModuleNameInterner, QueryProxy, QueryResult};
 use documenting::DocumentedModule;
 use files::{FileId, Files};
@@ -353,7 +353,13 @@ impl QueryProxy for WasmQueryEngine {
     }
 }
 
-impl FileCatalog for WasmQueryEngine {
+impl AnalyzerHost for WasmQueryEngine {
+    type Queries = WasmQueryEngine;
+
+    fn queries(&self) -> &WasmQueryEngine {
+        self
+    }
+
     fn file_id(&self, uri: &str) -> Option<FileId> {
         let id = self.files.id(uri)?;
         self.input.content.contains_key(&id).then_some(id)
@@ -370,6 +376,10 @@ impl FileCatalog for WasmQueryEngine {
     fn active_files(&self) -> impl Iterator<Item = FileId> {
         let files = self.files.iter_id();
         files.filter(|id| self.input.content.contains_key(id))
+    }
+
+    fn is_editable(&self, file_id: FileId) -> bool {
+        self.user_id == Some(file_id)
     }
 }
 

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -1,8 +1,8 @@
 pub mod render;
 
 use std::fmt::Write;
-use std::path::Path;
 
+use analyzer::AnalyzerHost;
 use analyzer::completion::SuggestionsCache;
 use analyzer::position::PositionEncoding;
 use building::QueryEngine;
@@ -21,6 +21,36 @@ use similar::TextDiff;
 use syntax::{SyntaxKind, TokenAtOffset};
 use tabled::Table;
 use tabled::settings::{Padding, Style};
+
+struct IntegrationAnalyzerHost<'a> {
+    queries: &'a QueryEngine,
+    files: &'a Files,
+}
+
+impl AnalyzerHost for IntegrationAnalyzerHost<'_> {
+    type Queries = QueryEngine;
+
+    fn queries(&self) -> &QueryEngine {
+        self.queries
+    }
+
+    fn file_id(&self, uri: &str) -> Option<FileId> {
+        self.files.id(uri)
+    }
+
+    fn file_uri(&self, file_id: FileId) -> Result<Option<Url>, url::ParseError> {
+        let uri = self.files.path(file_id);
+        Url::parse(&uri).map(Some)
+    }
+
+    fn active_files(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.files.iter_id()
+    }
+
+    fn is_editable(&self, _file_id: FileId) -> bool {
+        true
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 enum CursorKind {
@@ -205,7 +235,8 @@ fn dispatch_semantic_tokens(
     content: &str,
 ) {
     let encoding = PositionEncoding::Utf16;
-    let context = analyzer::LanguageContext::new(engine, files, encoding);
+    let host = IntegrationAnalyzerHost { queries: engine, files };
+    let context = analyzer::AnalyzerContext::new(&host, encoding);
     let Ok(Some(SemanticTokens { data, .. })) =
         analyzer::semantic_tokens::implementation(&context, uri)
     else {
@@ -384,7 +415,8 @@ fn dispatch_cursor(
     uri: Url,
 ) {
     let encoding = PositionEncoding::Utf16;
-    let context = analyzer::LanguageContext::new(engine, files, encoding);
+    let host = IntegrationAnalyzerHost { queries: engine, files };
+    let context = analyzer::AnalyzerContext::new(&host, encoding);
 
     match cursor {
         CursorKind::GotoDefinition => {
@@ -521,16 +553,9 @@ fn dispatch_cursor(
                 writeln!(result, "<empty>").unwrap();
                 return;
             };
-            let context = analyzer::LanguageContext::new(engine, files, encoding);
-            let workspace_root =
-                uri.to_file_path().ok().and_then(|path| path.parent().map(Path::to_path_buf));
-            let response = analyzer::rename::implementation(
-                &context,
-                workspace_root.as_deref(),
-                uri,
-                position,
-                new_name,
-            );
+            let host = IntegrationAnalyzerHost { queries: engine, files };
+            let context = analyzer::AnalyzerContext::new(&host, encoding);
+            let response = analyzer::rename::implementation(&context, uri, position, new_name);
             if let Ok(Some(edit)) = response {
                 let edit = render_rename_edit(edit, files, encoding);
                 writeln!(result, "{edit}").unwrap();
@@ -606,7 +631,8 @@ fn dispatch_workspace_symbols(
     query: &str,
 ) {
     let encoding = PositionEncoding::Utf16;
-    let context = analyzer::LanguageContext::new(engine, files, encoding);
+    let host = IntegrationAnalyzerHost { queries: engine, files };
+    let context = analyzer::AnalyzerContext::new(&host, encoding);
 
     match analyzer::symbols::workspace(&context, cache, query) {
         Ok(Some(WorkspaceSymbolResponse::Flat(symbols))) => {


### PR DESCRIPTION
## Intent

Keep the analyzer portable across native, integration-test, and browser/Wasm hosts as its required capabilities grow. Rename editability exposed that `QueryEngine + Files` was no longer a complete host model: editability is host policy, and converting an LSP URI into an operating-system path inside the analyzer broke the Wasm build.

## Analyzer host boundary

- Replace `LanguageContext<Queries, Catalog>` and `FileCatalog` with an analyzer-owned `AnalyzerContext<Host>` and `AnalyzerHost`.
- Give each host one associated query implementation plus URI lookup, active-file visibility, and editability capabilities.
- Keep context fields private and expose the host through analyzer-facing accessors.
- Reduce completion, code-action, rename, definition, reference, highlight, symbol, and semantic-token helpers from separate query/catalog generics to one host generic.
- Keep request inputs and mutable completion/workspace-symbol caches outside the stable context.

The three hosts now state their policy explicitly:

- `compiler-bin` constructs a request-scoped host over its query snapshot and locked LSP file state.
- integration fixtures use a host where every fixture file is editable.
- `WasmQueryEngine` implements the host directly, exposes only live virtual inputs, and marks only the user module editable.

No platform path API remains in the analyzer or Wasm host.

## Native editability metadata

- Add `LspFiles` as the native source of truth for file identity and editability.
- Encapsulate underlying `Files` operations behind `LspFiles` methods.
- Store file contents and editability under one lock and update both in one critical section.
- Mark Spago workspace packages editable while keeping Prim, registry, Git, and local dependency sources read-only.
- Preserve an existing file's policy when the editor opens it, so opening a dependency does not promote it to editable.
- Use workspace-root containment only as a native fallback for newly opened files and manual source discovery.

## Verification

Passed:

- `cargo check -p analyzer --tests`
- `cargo check -p purescript-alexandrite --tests`
- `cargo check -p tests-integration --tests`
- `cargo check -p docs-lib --target wasm32-unknown-unknown`
- `cargo nextest run -p analyzer` (37/37)
- `just t lsp` (no pending snapshots)
- `just format`
- `git diff --check`