### PR TITLE
[lsp] Harden rename failure handling

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -266,7 +266,10 @@ fn initialize(
                 definition_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
-                rename_provider: Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Right(RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: WorkDoneProgressOptions::default(),
+                })),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
@@ -476,6 +479,20 @@ fn rename(snapshot: StateSnapshot, p: RenameParams) -> Result<Option<WorkspaceEd
     let result = snapshot.with_analyzer_context(|context| {
         analyzer::rename::implementation(context, uri, position, new_name)
     });
+
+    result.on_non_fatal(None)
+}
+
+fn prepare_rename(
+    snapshot: StateSnapshot,
+    p: TextDocumentPositionParams,
+) -> Result<Option<PrepareRenameResponse>, LspError> {
+    let _span = tracing::info_span!("prepare_rename").entered();
+    let uri = p.text_document.uri;
+    let position = p.position;
+
+    let result =
+        snapshot.with_analyzer_context(|context| analyzer::rename::prepare(context, uri, position));
 
     result.on_non_fatal(None)
 }
@@ -693,6 +710,7 @@ pub async fn async_start(config: Arc<LspConfig>) {
             .request_snapshot::<request::Completion>(completion)
             .request_snapshot::<request::ResolveCompletionItem>(resolve_completion_item)
             .request_snapshot::<request::References>(references)
+            .request_snapshot::<request::PrepareRenameRequest>(prepare_rename)
             .request_snapshot::<request::Rename>(rename)
             .request_snapshot::<request::DocumentHighlightRequest>(document_highlight)
             .request_snapshot::<request::WorkspaceSymbolRequest>(workspace_symbols)

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -59,11 +59,18 @@ impl LspError {
         if let Some(QueryError::Cancelled) = self.as_query_error() {
             return "Request cancelled";
         }
+        if let LspError::AnalyzerError(AnalyzerError::RenameRejected(message)) = self {
+            return message;
+        }
         "Request failed"
     }
 
     pub fn emit_trace(&self) {
-        if let Some(QueryError::Cancelled) = self.as_query_error() {
+        let cancelled = matches!(self.as_query_error(), Some(QueryError::Cancelled));
+        let rename_rejected =
+            matches!(self, LspError::AnalyzerError(AnalyzerError::RenameRejected(_)));
+
+        if cancelled || rename_rejected {
             tracing::warn!("{self}")
         } else {
             tracing::error!("{self}")

--- a/compiler-core/lexing/src/lib.rs
+++ b/compiler-core/lexing/src/lib.rs
@@ -38,6 +38,7 @@ pub fn is_operator_name(source: &str) -> bool {
     !source.is_empty()
         && !source.starts_with("--")
         && source.chars().all(char::is_operator)
+        // Admit operator-like tokens explicitly: `..` is valid and `<=` lexes as LEFT_THICK_ARROW.
         && matches!(
             lexer::operator_kind(source),
             SyntaxKind::OPERATOR

--- a/compiler-core/syntax/src/ast.rs
+++ b/compiler-core/syntax/src/ast.rs
@@ -67,6 +67,16 @@ pub mod support {
         AstChildren::new(node)
     }
 
+    pub fn descendants<N: AstNode>(node: &SyntaxNode) -> impl Iterator<Item = N> + '_ {
+        node.preorder().filter_map(|event| {
+            let crate::WalkEvent::Enter(node) = event else {
+                return None;
+            };
+
+            N::cast(node)
+        })
+    }
+
     pub fn token(node: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
         node.children_with_tokens()
             .filter_map(|element| element.into_token())

--- a/compiler-lsp/analyzer/src/error.rs
+++ b/compiler-lsp/analyzer/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum AnalyzerError {
     #[error("Non-fatal error")]
     NonFatal,
+    #[error("Rename rejected: {0}")]
+    RenameRejected(String),
     #[error("QueryError: {0}")]
     QueryError(#[from] QueryError),
     #[error("UrlParseError: {0}")]

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -343,22 +343,25 @@ fn references_file_term(
             if let ExpressionKind::Constructor { resolution: Some((f_id, t_id)) } = expr_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(context, &content, &parsed, &stabilized, expr_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, expr_id) else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             } else if let ExpressionKind::OperatorName { resolution: Some((f_id, t_id)) } =
                 expr_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(context, &content, &parsed, &stabilized, expr_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, expr_id) else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             } else if let ExpressionKind::Variable { resolution: Some(resolution) } = expr_kind
                 && let TermVariableResolution::Reference(f_id, t_id) = resolution
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(context, &content, &parsed, &stabilized, expr_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, expr_id) else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             }
         }
@@ -367,16 +370,20 @@ fn references_file_term(
             if let BinderKind::Constructor { resolution: Some((f_id, t_id)), .. } = binder_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
-                let range = id_range(context, &content, &parsed, &stabilized, binder_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, binder_id)
+                else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             }
         }
 
         for (operator_id, f_id, t_id) in lowered.info.iter_term_operator() {
             if (f_id, t_id) == (file_id, term_id) {
-                let range = id_range(context, &content, &parsed, &stabilized, operator_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, operator_id)
+                else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             }
         }
@@ -408,23 +415,27 @@ fn references_file_type(
             if let TypeKind::Constructor { resolution: Some((f_id, t_id)) } = ty_kind
                 && (*f_id, *t_id) == (file_id, type_id)
             {
-                let range = id_range(context, &content, &parsed, &stabilized, ty_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, ty_id) else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             }
             if let TypeKind::Operator { resolution: Some((f_id, t_id)) } = ty_kind
                 && (*f_id, *t_id) == (file_id, type_id)
             {
-                let range = id_range(context, &content, &parsed, &stabilized, ty_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, ty_id) else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             }
         }
 
         for (operator_id, f_id, t_id) in lowered.info.iter_type_operator() {
             if (f_id, t_id) == (file_id, type_id) {
-                let range = id_range(context, &content, &parsed, &stabilized, operator_id)
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = id_range(context, &content, &parsed, &stabilized, operator_id)
+                else {
+                    continue;
+                };
                 locations.push(Location { uri: uri.clone(), range });
             }
         }

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -37,38 +37,43 @@ enum NameKind {
     Module,
 }
 
+impl NameKind {
+    fn description(self) -> &'static str {
+        match self {
+            NameKind::Lower => "lowercase identifier",
+            NameKind::Upper => "uppercase identifier",
+            NameKind::Operator => "operator",
+            NameKind::Module => "module",
+        }
+    }
+}
+
 pub fn implementation(
     context: &AnalyzerContext<impl crate::AnalyzerHost>,
     uri: Url,
     position: Position,
     new_name: String,
 ) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
-    let current_file = {
-        let uri = uri.as_str();
-        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
-    };
-
-    let content = context.queries().content(current_file);
-    let utf8_position =
-        position::protocol_position_to_utf8(&content, position, context.position_encoding())
-            .ok_or(AnalyzerError::NonFatal)?;
-
-    let target = if let Some(target) = qualifier_target(context, current_file, utf8_position)? {
-        target
-    } else {
-        let located = locate::locate(context.queries(), current_file, utf8_position)?;
-        rename_target(context, current_file, located)?
-    };
-
-    let Some((old_name, name_kind)) = target_name(context, target)? else {
+    let Some((target, old_name, name_kind)) = rename_target_at(context, uri.clone(), position)?
+    else {
         return Ok(None);
     };
-    if old_name == new_name || !valid_new_name(&new_name, name_kind) {
+
+    if old_name == new_name {
         return Ok(None);
     }
 
+    if !valid_new_name(&new_name, name_kind) {
+        return Err(AnalyzerError::RenameRejected(format!(
+            "'{new_name}' is not a valid {} name",
+            name_kind.description()
+        )));
+    }
+
     if !context.is_editable(target.file()) {
-        return Ok(None);
+        return Err(AnalyzerError::RenameRejected(
+            "The selected symbol is outside the workspace".to_string(),
+        ));
     }
 
     let mut edits = edit::RenameEdits::new(context);
@@ -90,14 +95,67 @@ pub fn implementation(
     edits.finish()
 }
 
+pub fn prepare(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: Url,
+    position: Position,
+) -> Result<Option<PrepareRenameResponse>, AnalyzerError> {
+    let Some((target, _, _)) = rename_target_at(context, uri, position)? else {
+        return Ok(None);
+    };
+
+    if !context.is_editable(target.file()) {
+        return Err(AnalyzerError::RenameRejected(
+            "The selected symbol is outside the workspace".to_string(),
+        ));
+    }
+
+    Ok(Some(PrepareRenameResponse::DefaultBehavior { default_behavior: true }))
+}
+
+fn rename_target_at(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: Url,
+    position: Position,
+) -> Result<Option<(RenameTarget, String, NameKind)>, AnalyzerError> {
+    let current_file = context.file_id(uri.as_str());
+    let Some(current_file) = current_file else {
+        return Ok(None);
+    };
+
+    let content = context.queries().content(current_file);
+    let utf8_position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding());
+    let Some(utf8_position) = utf8_position else {
+        return Ok(None);
+    };
+
+    let target = if let Some(target) = qualifier_target(context, current_file, utf8_position)? {
+        target
+    } else {
+        let located = locate::locate(context.queries(), current_file, utf8_position)?;
+        let Some(target) = rename_target(context, current_file, located)? else {
+            return Ok(None);
+        };
+        target
+    };
+
+    let Some((old_name, name_kind)) = target_name(context, target)? else {
+        return Ok(None);
+    };
+
+    Ok(Some((target, old_name, name_kind)))
+}
+
 fn qualifier_target(
     context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     position: position::Utf8Position,
 ) -> Result<Option<RenameTarget>, AnalyzerError> {
     let content = context.queries().content(current_file);
-    let offset =
-        position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
+    let Some(offset) = position::utf8_position_to_offset(&content, position) else {
+        return Ok(None);
+    };
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
 
@@ -115,7 +173,7 @@ fn qualifier_target(
         }
 
         let text = qualifier.text()?.text(&content);
-        Some(text.trim_end_matches('.').to_string())
+        qualifier_name(text).map(str::to_string)
     });
 
     let alias_name = token.parent_ancestors().find_map(|node| {
@@ -148,26 +206,31 @@ fn rename_target(
     context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     located: locate::Located,
-) -> Result<RenameTarget, AnalyzerError> {
-    let lowered = context.queries().lowered(current_file)?;
-
+) -> Result<Option<RenameTarget>, AnalyzerError> {
     let target = match located {
         locate::Located::ModuleName(module_name) => {
-            module_target(context, current_file, module_name)?
+            return module_target(context, current_file, module_name);
         }
-        locate::Located::ImportItem(import_id) => import_target(context, current_file, import_id)?,
+        locate::Located::ImportItem(import_id) => {
+            return import_target(context, current_file, import_id);
+        }
         locate::Located::Binder(binder_id) => {
-            let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+            let lowered = context.queries().lowered(current_file)?;
+            let Some(kind) = lowered.info.get_binder_kind(binder_id) else {
+                return Ok(None);
+            };
 
             let BinderKind::Constructor { resolution: Some((file_id, term_id)), .. } = kind else {
-                return Err(AnalyzerError::NonFatal);
+                return Ok(None);
             };
 
             RenameTarget::Term(*file_id, *term_id)
         }
         locate::Located::Expression(expression_id) => {
-            let kind =
-                lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
+            let lowered = context.queries().lowered(current_file)?;
+            let Some(kind) = lowered.info.get_expression_kind(expression_id) else {
+                return Ok(None);
+            };
 
             let resolution = match kind {
                 ExpressionKind::Constructor { resolution: Some(resolution) }
@@ -175,151 +238,190 @@ fn rename_target(
                 ExpressionKind::Variable {
                     resolution: Some(TermVariableResolution::Reference(file_id, term_id)),
                 } => (*file_id, *term_id),
-                _ => return Err(AnalyzerError::NonFatal),
+                _ => return Ok(None),
             };
 
             RenameTarget::Term(resolution.0, resolution.1)
         }
         locate::Located::Type(type_id) => {
-            let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
+            let lowered = context.queries().lowered(current_file)?;
+            let Some(kind) = lowered.info.get_type_kind(type_id) else {
+                return Ok(None);
+            };
 
             let resolution = match kind {
                 TypeKind::Constructor { resolution: Some(resolution) }
                 | TypeKind::Operator { resolution: Some(resolution) } => *resolution,
-                _ => return Err(AnalyzerError::NonFatal),
+                _ => return Ok(None),
             };
 
             RenameTarget::Type(resolution.0, resolution.1)
         }
         locate::Located::TermOperator(operator_id) => {
-            let (file_id, term_id) =
-                lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+            let lowered = context.queries().lowered(current_file)?;
+            let Some((file_id, term_id)) = lowered.info.get_term_operator(operator_id) else {
+                return Ok(None);
+            };
 
             RenameTarget::Term(file_id, term_id)
         }
         locate::Located::TypeOperator(operator_id) => {
-            let (file_id, type_id) =
-                lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+            let lowered = context.queries().lowered(current_file)?;
+            let Some((file_id, type_id)) = lowered.info.get_type_operator(operator_id) else {
+                return Ok(None);
+            };
 
             RenameTarget::Type(file_id, type_id)
         }
         locate::Located::TermItem(term_id) => RenameTarget::Term(current_file, term_id),
         locate::Located::TypeItem(type_id) => RenameTarget::Type(current_file, type_id),
-        _ => return Err(AnalyzerError::NonFatal),
+        _ => return Ok(None),
     };
 
-    Ok(target)
+    Ok(Some(target))
 }
 
 fn module_target(
     context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     module_name: AstPtr<cst::ModuleName>,
-) -> Result<RenameTarget, AnalyzerError> {
+) -> Result<Option<RenameTarget>, AnalyzerError> {
     let content = context.queries().content(current_file);
     let (parsed, _) = context.queries().parsed(current_file)?;
     let root = parsed.syntax_node();
-    let module_name = module_name.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
-    let parent = module_name.syntax().parent().ok_or(AnalyzerError::NonFatal)?;
+    let Some(module_name) = module_name.try_to_node(&root) else {
+        return Ok(None);
+    };
+    let Some(parent) = module_name.syntax().parent() else {
+        return Ok(None);
+    };
     let parent_kind = parent.kind();
 
     if cst::ModuleHeader::can_cast(parent_kind) {
-        return Ok(RenameTarget::Module(current_file));
+        return Ok(Some(RenameTarget::Module(current_file)));
     }
 
     if !cst::ImportStatement::can_cast(parent_kind) && !cst::ExportModule::can_cast(parent_kind) {
-        return Err(AnalyzerError::NonFatal);
+        return Ok(None);
     }
 
     let name = module_name.syntax().text(&content);
-    let file_id = context.queries().module_file(name).ok_or(AnalyzerError::NonFatal)?;
+    let Some(file_id) = context.queries().module_file(name) else {
+        return Ok(None);
+    };
 
-    Ok(RenameTarget::Module(file_id))
+    Ok(Some(RenameTarget::Module(file_id)))
 }
 
 fn import_target(
     context: &AnalyzerContext<impl crate::AnalyzerHost>,
     current_file: FileId,
     import_id: ImportItemId,
-) -> Result<RenameTarget, AnalyzerError> {
+) -> Result<Option<RenameTarget>, AnalyzerError> {
     let content = context.queries().content(current_file);
     let (parsed, _) = context.queries().parsed(current_file)?;
     let stabilized = context.queries().stabilized(current_file)?;
 
     let root = parsed.syntax_node();
-    let ptr = stabilized.ast_ptr(import_id).ok_or(AnalyzerError::NonFatal)?;
-    let node = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+    let Some(ptr) = stabilized.ast_ptr(import_id) else {
+        return Ok(None);
+    };
+    let Some(node) = ptr.try_to_node(&root) else {
+        return Ok(None);
+    };
 
-    let statement = node
-        .syntax()
-        .ancestors()
-        .find_map(cst::ImportStatement::cast)
-        .ok_or(AnalyzerError::NonFatal)?;
-    let module_name =
-        statement.module_name().ok_or(AnalyzerError::NonFatal)?.syntax().text(&content).to_string();
+    let statement = node.syntax().ancestors().find_map(cst::ImportStatement::cast);
+    let Some(statement) = statement else {
+        return Ok(None);
+    };
+    let Some(module_name) = statement.module_name() else {
+        return Ok(None);
+    };
+    let module_name = module_name.syntax().text(&content).to_string();
 
-    let imported_file =
-        context.queries().module_file(&module_name).ok_or(AnalyzerError::NonFatal)?;
+    let Some(imported_file) = context.queries().module_file(&module_name) else {
+        return Ok(None);
+    };
     let resolved = context.queries().resolved(imported_file)?;
 
     let target = match node {
         cst::ImportItem::ImportValue(item) => {
-            let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
+            let Some(name) = item.name_token() else {
+                return Ok(None);
+            };
+            let name = name.text(&content);
 
-            let (file_id, term_id) =
-                resolved.exports.lookup_term(name).ok_or(AnalyzerError::NonFatal)?;
+            let Some((file_id, term_id)) = resolved.exports.lookup_term(name) else {
+                return Ok(None);
+            };
 
             RenameTarget::Term(file_id, term_id)
         }
         cst::ImportItem::ImportClass(item) => {
-            let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
+            let Some(name) = item.name_token() else {
+                return Ok(None);
+            };
+            let name = name.text(&content);
 
-            let (file_id, type_id) = resolved
-                .exports
-                .lookup_class(name)
-                .or_else(|| resolved.exports.lookup_type(name))
-                .ok_or(AnalyzerError::NonFatal)?;
+            let resolution =
+                resolved.exports.lookup_class(name).or_else(|| resolved.exports.lookup_type(name));
+            let Some((file_id, type_id)) = resolution else {
+                return Ok(None);
+            };
 
             RenameTarget::Type(file_id, type_id)
         }
         cst::ImportItem::ImportType(item) => {
-            let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
+            let Some(name) = item.name_token() else {
+                return Ok(None);
+            };
+            let name = name.text(&content);
 
-            let (file_id, type_id) = resolved
-                .exports
-                .lookup_type(name)
-                .or_else(|| resolved.exports.lookup_class(name))
-                .ok_or(AnalyzerError::NonFatal)?;
+            let resolution =
+                resolved.exports.lookup_type(name).or_else(|| resolved.exports.lookup_class(name));
+            let Some((file_id, type_id)) = resolution else {
+                return Ok(None);
+            };
 
             RenameTarget::Type(file_id, type_id)
         }
         cst::ImportItem::ImportOperator(item) => {
-            let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
+            let Some(name) = item.name_token() else {
+                return Ok(None);
+            };
+            let name = name.text(&content);
 
-            let (file_id, term_id) = resolved
-                .exports
-                .lookup_term(trim_operator_name(name))
-                .ok_or(AnalyzerError::NonFatal)?;
+            let resolution = resolved.exports.lookup_term(trim_operator_name(name));
+            let Some((file_id, term_id)) = resolution else {
+                return Ok(None);
+            };
 
             RenameTarget::Term(file_id, term_id)
         }
         cst::ImportItem::ImportTypeOperator(item) => {
-            let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
+            let Some(name) = item.name_token() else {
+                return Ok(None);
+            };
+            let name = name.text(&content);
 
-            let (file_id, type_id) = resolved
-                .exports
-                .lookup_type(trim_operator_name(name))
-                .ok_or(AnalyzerError::NonFatal)?;
+            let resolution = resolved.exports.lookup_type(trim_operator_name(name));
+            let Some((file_id, type_id)) = resolution else {
+                return Ok(None);
+            };
 
             RenameTarget::Type(file_id, type_id)
         }
     };
 
-    Ok(target)
+    Ok(Some(target))
 }
 
 fn trim_operator_name(name: &str) -> &str {
     name.trim_start_matches('(').trim_end_matches(')')
+}
+
+pub(super) fn qualifier_name(name: &str) -> Option<&str> {
+    name.strip_suffix('.')
 }
 
 fn target_name(

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -6,15 +6,17 @@ use indexing::{
     ImplicitItems, ImportId, ImportItemId, TermItemId, TermItemKind, TypeItemId, TypeItemKind,
     TypeSelection,
 };
+use itertools::Itertools;
 use lsp_types::*;
 use stabilizing::AstId;
-use syntax::ast::AstNode;
-use syntax::{SyntaxNode, SyntaxNodePtr, SyntaxToken, TextRange, TokenAtOffset, WalkEvent, cst};
+use syntax::ast::{AstNode, support};
+use syntax::{SyntaxNode, SyntaxNodePtr, SyntaxToken, TextRange, TokenAtOffset, cst};
 
-use super::{NameKind, RenameTarget};
+use super::{NameKind, RenameTarget, qualifier_name};
 use crate::position::Utf8Range;
 use crate::{AnalyzerContext, AnalyzerError, AnalyzerHost, common, position};
 
+// A macro permits one invocation to contain IDs with different AstId<T> types.
 macro_rules! push_name_edits {
     ($self:expr, $file_id:expr, $new_name:expr, $range:expr; $($id:expr),+ $(,)?) => {
         $($self.push_name_edit($file_id, $id, $range, $new_name)?;)+
@@ -51,23 +53,20 @@ where
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
         let indexed = self.context.queries().indexed(file_id)?;
-        let old_name = indexed
-            .imports
-            .get(&import_id)
-            .and_then(|import| import.alias.as_deref())
-            .ok_or(AnalyzerError::NonFatal)?;
+        let old_name =
+            indexed.imports.get(&import_id).and_then(|import| import.alias.as_deref()).ok_or_else(
+                || {
+                    AnalyzerError::RenameRejected(
+                        "Rename could not resolve the target qualifier".to_string(),
+                    )
+                },
+            )?;
 
         let content = self.context.queries().content(file_id);
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
 
-        let statements = root.preorder().filter_map(|event| {
-            let WalkEvent::Enter(node) = event else {
-                return None;
-            };
-
-            cst::ImportStatement::cast(node)
-        });
+        let statements = support::descendants::<cst::ImportStatement>(&root);
 
         for statement in statements {
             let Some(module_name) = statement.import_alias().and_then(|alias| alias.module_name())
@@ -78,16 +77,11 @@ where
                 continue;
             }
 
-            self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name)?;
+            let _ = self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name);
         }
 
-        let qualified_names = root.preorder().filter_map(|event| {
-            let WalkEvent::Enter(node) = event else {
-                return None;
-            };
-
-            cst::QualifiedName::cast(node)
-        });
+        let qualified_names = support::descendants::<cst::QualifiedName>(&root);
+        let qualified_new_name = format!("{new_name}.");
 
         for qualified in qualified_names {
             let Some(qualifier) = qualified.qualifier() else {
@@ -96,21 +90,14 @@ where
             let Some(token) = qualifier.text() else {
                 continue;
             };
-            if token.text(&content).trim_end_matches('.') != old_name {
+            if qualifier_name(token.text(&content)) != Some(old_name) {
                 continue;
             }
 
-            let new_name = format!("{new_name}.");
-            self.push_text_range_edit(file_id, token.text_range(), &new_name)?;
+            let _ = self.push_text_range_edit(file_id, token.text_range(), &qualified_new_name);
         }
 
-        let exports = root.preorder().filter_map(|event| {
-            let WalkEvent::Enter(node) = event else {
-                return None;
-            };
-
-            cst::ExportModule::cast(node)
-        });
+        let exports = support::descendants::<cst::ExportModule>(&root);
 
         for export in exports {
             let Some(module_name) = export.module_name() else {
@@ -120,7 +107,7 @@ where
                 continue;
             }
 
-            self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name)?;
+            let _ = self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name);
         }
 
         Ok(())
@@ -132,13 +119,19 @@ where
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
         let (parsed, _) = self.context.queries().parsed(target_file)?;
-        let module_name = parsed
-            .cst()
-            .header()
-            .and_then(|header| header.name())
-            .ok_or(AnalyzerError::NonFatal)?;
+        let module_name =
+            parsed.cst().header().and_then(|header| header.name()).ok_or_else(|| {
+                AnalyzerError::RenameRejected(
+                    "Rename could not resolve the target module name".to_string(),
+                )
+            })?;
 
-        self.push_text_range_edit(target_file, module_name.syntax().text_range(), new_name)?;
+        self.push_text_range_edit(target_file, module_name.syntax().text_range(), new_name)
+            .ok_or_else(|| {
+                AnalyzerError::RenameRejected(
+                    "Rename could not edit the target module name".to_string(),
+                )
+            })?;
 
         for file_id in self.context.active_files() {
             if !self.context.is_editable(file_id) {
@@ -171,11 +164,17 @@ where
                 continue;
             }
 
-            let ptr = stabilized.ast_ptr(*import_id).ok_or(AnalyzerError::NonFatal)?;
-            let statement = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
-            let module_name = statement.module_name().ok_or(AnalyzerError::NonFatal)?;
+            let Some(ptr) = stabilized.ast_ptr(*import_id) else {
+                continue;
+            };
+            let Some(statement) = ptr.try_to_node(&root) else {
+                continue;
+            };
+            let Some(module_name) = statement.module_name() else {
+                continue;
+            };
 
-            self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name)?;
+            let _ = self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name);
         }
 
         Ok(())
@@ -197,24 +196,31 @@ where
         for export in &indexed.exports.modules {
             let exports_self =
                 file_id == target_file && current_module.as_ref() == Some(&export.name);
-            let exports_import = indexed.imports.values().any(|import| {
-                import.alias.is_none()
-                    && import.name.as_ref() == Some(&export.name)
-                    && self.context.queries().module_file(&export.name) == Some(target_file)
-            });
+            let exports_target_module =
+                self.context.queries().module_file(&export.name) == Some(target_file);
+            let exports_import = exports_target_module
+                && indexed.imports.values().any(|import| {
+                    import.alias.is_none() && import.name.as_ref() == Some(&export.name)
+                });
 
             if !exports_self && !exports_import {
                 continue;
             }
 
-            let ptr = stabilized.ast_ptr(export.id).ok_or(AnalyzerError::NonFatal)?;
-            let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
-            let cst::ExportItem::ExportModule(export) = item else {
-                return Err(AnalyzerError::NonFatal);
+            let Some(ptr) = stabilized.ast_ptr(export.id) else {
+                continue;
             };
-            let module_name = export.module_name().ok_or(AnalyzerError::NonFatal)?;
+            let Some(item) = ptr.try_to_node(&root) else {
+                continue;
+            };
+            let cst::ExportItem::ExportModule(export) = item else {
+                continue;
+            };
+            let Some(module_name) = export.module_name() else {
+                continue;
+            };
 
-            self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name)?;
+            let _ = self.push_text_range_edit(file_id, module_name.syntax().text_range(), new_name);
         }
 
         Ok(())
@@ -232,14 +238,19 @@ where
         new_name: &str,
     ) -> Result<(), AnalyzerError> {
         for location in locations {
-            let file_id =
-                self.context.file_id(location.uri.as_str()).ok_or(AnalyzerError::NonFatal)?;
+            let Some(file_id) = self.context.file_id(location.uri.as_str()) else {
+                continue;
+            };
             if !self.context.is_editable(file_id) {
                 continue;
             }
 
-            let range = self.reference_name_range(file_id, location.range, name_kind)?;
-            self.push_protocol_edit(file_id, range, new_name)?;
+            let Some(range) = self.reference_name_range(file_id, location.range, name_kind)? else {
+                continue;
+            };
+            if self.push_protocol_edit(file_id, range, new_name).is_none() {
+                continue;
+            }
         }
 
         Ok(())
@@ -250,36 +261,42 @@ where
         file_id: FileId,
         range: Range,
         name_kind: NameKind,
-    ) -> Result<Range, AnalyzerError> {
+    ) -> Result<Option<Range>, AnalyzerError> {
         let content = self.context.queries().content(file_id);
-        let position = position::protocol_position_to_utf8(
+        let Some(position) = position::protocol_position_to_utf8(
             &content,
             range.start,
             self.context.position_encoding(),
-        )
-        .ok_or(AnalyzerError::NonFatal)?;
-        let offset =
-            position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
+        ) else {
+            return Ok(None);
+        };
+        let Some(offset) = position::utf8_position_to_offset(&content, position) else {
+            return Ok(None);
+        };
 
         let (parsed, _) = self.context.queries().parsed(file_id)?;
         let root = parsed.syntax_node();
 
         let token = match root.token_at_offset(offset) {
-            TokenAtOffset::None => return Err(AnalyzerError::NonFatal),
+            TokenAtOffset::None => return Ok(None),
             TokenAtOffset::Single(token) => token,
             TokenAtOffset::Between(left, right) => {
-                if Self::qualified_name_token(&right, name_kind).is_some() { right } else { left }
+                if RenameEdits::<Host>::qualified_name_token(&right, name_kind).is_some() {
+                    right
+                } else {
+                    left
+                }
             }
         };
 
-        let token = Self::qualified_name_token(&token, name_kind).ok_or(AnalyzerError::NonFatal)?;
+        let Some(token) = RenameEdits::<Host>::qualified_name_token(&token, name_kind) else {
+            return Ok(None);
+        };
 
-        position::text_range_to_protocol(
-            &content,
-            token.text_range(),
-            self.context.position_encoding(),
-        )
-        .ok_or(AnalyzerError::NonFatal)
+        let range = token.text_range();
+        let range =
+            position::text_range_to_protocol(&content, range, self.context.position_encoding());
+        Ok(range)
     }
 
     fn qualified_name_token(token: &SyntaxToken, name_kind: NameKind) -> Option<SyntaxToken> {
@@ -575,12 +592,18 @@ where
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
 
-        let ptr = stabilized.ast_ptr(import_item_id).ok_or(AnalyzerError::NonFatal)?;
-        let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
-        let range =
-            position::import_item_name_range(&content, item).ok_or(AnalyzerError::NonFatal)?;
+        let Some(ptr) = stabilized.ast_ptr(import_item_id) else {
+            return Ok(());
+        };
+        let Some(item) = ptr.try_to_node(&root) else {
+            return Ok(());
+        };
+        let Some(range) = position::import_item_name_range(&content, item) else {
+            return Ok(());
+        };
 
-        self.push_utf8_edit(file_id, range, new_name)
+        let _ = self.push_utf8_edit(file_id, range, new_name);
+        Ok(())
     }
 
     fn push_export_item_edit(
@@ -594,12 +617,18 @@ where
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
 
-        let ptr = stabilized.ast_ptr(export_item_id).ok_or(AnalyzerError::NonFatal)?;
-        let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
-        let range =
-            position::export_item_name_range(&content, item).ok_or(AnalyzerError::NonFatal)?;
+        let Some(ptr) = stabilized.ast_ptr(export_item_id) else {
+            return Ok(());
+        };
+        let Some(item) = ptr.try_to_node(&root) else {
+            return Ok(());
+        };
+        let Some(range) = position::export_item_name_range(&content, item) else {
+            return Ok(());
+        };
 
-        self.push_utf8_edit(file_id, range, new_name)
+        let _ = self.push_utf8_edit(file_id, range, new_name);
+        Ok(())
     }
 
     fn push_import_constructor_edit(
@@ -613,13 +642,19 @@ where
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
 
-        let ptr = stabilized.ast_ptr(import_item_id).ok_or(AnalyzerError::NonFatal)?;
-        let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+        let Some(ptr) = stabilized.ast_ptr(import_item_id) else {
+            return Ok(());
+        };
+        let Some(item) = ptr.try_to_node(&root) else {
+            return Ok(());
+        };
         let cst::ImportItem::ImportType(item) = item else {
-            return Err(AnalyzerError::NonFatal);
+            return Ok(());
         };
 
-        let type_items = item.type_items().ok_or(AnalyzerError::NonFatal)?;
+        let Some(type_items) = item.type_items() else {
+            return Ok(());
+        };
         self.push_constructor_token_edit(file_id, type_items, old_name, new_name)
     }
 
@@ -634,13 +669,19 @@ where
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
 
-        let ptr = stabilized.ast_ptr(export_item_id).ok_or(AnalyzerError::NonFatal)?;
-        let item = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+        let Some(ptr) = stabilized.ast_ptr(export_item_id) else {
+            return Ok(());
+        };
+        let Some(item) = ptr.try_to_node(&root) else {
+            return Ok(());
+        };
         let cst::ExportItem::ExportType(item) = item else {
-            return Err(AnalyzerError::NonFatal);
+            return Ok(());
         };
 
-        let type_items = item.type_items().ok_or(AnalyzerError::NonFatal)?;
+        let Some(type_items) = item.type_items() else {
+            return Ok(());
+        };
         self.push_constructor_token_edit(file_id, type_items, old_name, new_name)
     }
 
@@ -658,10 +699,12 @@ where
 
         for token in items.name_tokens() {
             if token.text(&content) == old_name {
-                let range = position::text_range_to_utf8_range(&content, token.text_range())
-                    .ok_or(AnalyzerError::NonFatal)?;
+                let Some(range) = position::text_range_to_utf8_range(&content, token.text_range())
+                else {
+                    continue;
+                };
 
-                self.push_utf8_edit(file_id, range, new_name)?;
+                let _ = self.push_utf8_edit(file_id, range, new_name);
             }
         }
 
@@ -678,24 +721,17 @@ where
         file_id: FileId,
         range: TextRange,
         new_name: &str,
-    ) -> Result<(), AnalyzerError> {
+    ) -> Option<()> {
         let content = self.context.queries().content(file_id);
-        let range =
-            position::text_range_to_utf8_range(&content, range).ok_or(AnalyzerError::NonFatal)?;
+        let range = position::text_range_to_utf8_range(&content, range)?;
 
         self.push_utf8_edit(file_id, range, new_name)
     }
 
-    fn push_utf8_edit(
-        &mut self,
-        file_id: FileId,
-        range: Utf8Range,
-        new_name: &str,
-    ) -> Result<(), AnalyzerError> {
+    fn push_utf8_edit(&mut self, file_id: FileId, range: Utf8Range, new_name: &str) -> Option<()> {
         let content = self.context.queries().content(file_id);
         let range =
-            position::utf8_range_to_protocol(&content, range, self.context.position_encoding())
-                .ok_or(AnalyzerError::NonFatal)?;
+            position::utf8_range_to_protocol(&content, range, self.context.position_encoding())?;
         self.push_protocol_edit(file_id, range, new_name)
     }
 
@@ -718,54 +754,47 @@ where
         let root = parsed.syntax_node();
         let stabilized = self.context.queries().stabilized(file_id)?;
 
-        let ptr = stabilized.syntax_ptr(id).ok_or(AnalyzerError::NonFatal)?;
-        let range = range(&content, &root, &ptr).ok_or(AnalyzerError::NonFatal)?;
+        let rejected = || {
+            AnalyzerError::RenameRejected(
+                "Rename could not edit the target declaration".to_string(),
+            )
+        };
+        let ptr = stabilized.syntax_ptr(id).ok_or_else(rejected)?;
+        let range = range(&content, &root, &ptr).ok_or_else(rejected)?;
         let range =
             position::utf8_range_to_protocol(&content, range, self.context.position_encoding())
-                .ok_or(AnalyzerError::NonFatal)?;
-        self.push_protocol_edit(file_id, range, new_name)
+                .ok_or_else(rejected)?;
+        self.push_protocol_edit(file_id, range, new_name).ok_or_else(rejected)
     }
 
-    fn push_protocol_edit(
-        &mut self,
-        file_id: FileId,
-        range: Range,
-        new_name: &str,
-    ) -> Result<(), AnalyzerError> {
+    fn push_protocol_edit(&mut self, file_id: FileId, range: Range, new_name: &str) -> Option<()> {
         let new_name = self.new_name_text(file_id, range, new_name)?;
         self.edits.push((file_id, TextEdit { range, new_text: new_name }));
-        Ok(())
+        Some(())
     }
 
-    fn new_name_text(
-        &self,
-        file_id: FileId,
-        range: Range,
-        new_name: &str,
-    ) -> Result<String, AnalyzerError> {
+    fn new_name_text(&self, file_id: FileId, range: Range, new_name: &str) -> Option<String> {
         let content = self.context.queries().content(file_id);
         let start = position::protocol_position_to_utf8(
             &content,
             range.start,
             self.context.position_encoding(),
         )
-        .and_then(|position| position::utf8_position_to_offset(&content, position))
-        .ok_or(AnalyzerError::NonFatal)?;
+        .and_then(|position| position::utf8_position_to_offset(&content, position))?;
         let end = position::protocol_position_to_utf8(
             &content,
             range.end,
             self.context.position_encoding(),
         )
-        .and_then(|position| position::utf8_position_to_offset(&content, position))
-        .ok_or(AnalyzerError::NonFatal)?;
+        .and_then(|position| position::utf8_position_to_offset(&content, position))?;
 
         let range = TextRange::new(start, end);
         let text = &content[range];
 
         if text.starts_with('(') && text.ends_with(')') {
-            Ok(format!("({new_name})"))
+            Some(format!("({new_name})"))
         } else {
-            Ok(new_name.to_string())
+            Some(new_name.to_string())
         }
     }
 
@@ -779,7 +808,26 @@ where
                 edit.range.end.character,
             )
         });
-        self.edits.dedup_by(|left, right| left.0 == right.0 && left.1.range == right.1.range);
+        self.edits.dedup_by(|(left_file, left_edit), (right_file, right_edit)| {
+            left_file == right_file
+                && left_edit.range == right_edit.range
+                && left_edit.new_text == right_edit.new_text
+        });
+
+        let mut edit_windows = self.edits.iter().tuple_windows();
+        let conflicting_edits = edit_windows.any(|(left, right)| {
+            let (left_file, left_edit) = left;
+            let (right_file, right_edit) = right;
+
+            left_file == right_file
+                && (right_edit.range == left_edit.range
+                    || right_edit.range.start < left_edit.range.end)
+        });
+        if conflicting_edits {
+            return Err(AnalyzerError::RenameRejected(
+                "Rename produced conflicting text edits".to_string(),
+            ));
+        }
 
         if self.edits.is_empty() {
             return Ok(None);


### PR DESCRIPTION
## Summary

- keep unsupported rename targets in the normal `Result<Option<_>>` control flow instead of routing them through `AnalyzerError::NonFatal`
- skip stale per-occurrence rename metadata without aborting valid workspace edits, while rejecting incomplete target edits and overlapping edits explicitly
- advertise and handle `textDocument/prepareRename`, and return client-visible messages for invalid names and other semantic refusals
- canonicalize workspace paths before allowing edits and apply the associated rename review cleanups

## Validation

- `cargo check -p syntax --tests`
- `cargo check -p analyzer --tests`
- `cargo check -p purescript-alexandrite --tests`
- `just t lsp`
- `just format`
- exercised an invalid rename through Neovim with nvim-lspconfig and confirmed the server returned `RequestFailed` with the rejected name
