### PR TITLE
[lsp] Handle rename rejections

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -266,7 +266,12 @@ fn initialize(
                 definition_provider: Some(OneOf::Left(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
-                rename_provider: Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Right(RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
+                })),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
@@ -476,6 +481,20 @@ fn rename(snapshot: StateSnapshot, p: RenameParams) -> Result<Option<WorkspaceEd
     let result = snapshot.with_analyzer_context(|context| {
         analyzer::rename::implementation(context, uri, position, new_name)
     });
+
+    result.on_non_fatal(None)
+}
+
+fn prepare_rename(
+    snapshot: StateSnapshot,
+    p: TextDocumentPositionParams,
+) -> Result<Option<PrepareRenameResponse>, LspError> {
+    let _span = tracing::info_span!("prepare_rename").entered();
+    let uri = p.text_document.uri;
+    let position = p.position;
+
+    let result =
+        snapshot.with_analyzer_context(|context| analyzer::rename::prepare(context, uri, position));
 
     result.on_non_fatal(None)
 }
@@ -693,6 +712,7 @@ pub async fn async_start(config: Arc<LspConfig>) {
             .request_snapshot::<request::Completion>(completion)
             .request_snapshot::<request::ResolveCompletionItem>(resolve_completion_item)
             .request_snapshot::<request::References>(references)
+            .request_snapshot::<request::PrepareRenameRequest>(prepare_rename)
             .request_snapshot::<request::Rename>(rename)
             .request_snapshot::<request::DocumentHighlightRequest>(document_highlight)
             .request_snapshot::<request::WorkspaceSymbolRequest>(workspace_symbols)

--- a/compiler-bin/src/lsp/error.rs
+++ b/compiler-bin/src/lsp/error.rs
@@ -52,6 +52,9 @@ impl LspError {
         if let Some(QueryError::Cancelled) = self.as_query_error() {
             return ErrorCode::REQUEST_CANCELLED;
         }
+        if matches!(self, LspError::AnalyzerError(AnalyzerError::RenameRejected(_))) {
+            return ErrorCode::INVALID_PARAMS;
+        }
         ErrorCode::REQUEST_FAILED
     }
 
@@ -59,11 +62,16 @@ impl LspError {
         if let Some(QueryError::Cancelled) = self.as_query_error() {
             return "Request cancelled";
         }
+        if let LspError::AnalyzerError(AnalyzerError::RenameRejected(message)) = self {
+            return message;
+        }
         "Request failed"
     }
 
     pub fn emit_trace(&self) {
         if let Some(QueryError::Cancelled) = self.as_query_error() {
+            tracing::warn!("{self}")
+        } else if matches!(self, LspError::AnalyzerError(AnalyzerError::RenameRejected(_))) {
             tracing::warn!("{self}")
         } else {
             tracing::error!("{self}")

--- a/compiler-lsp/analyzer/src/error.rs
+++ b/compiler-lsp/analyzer/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum AnalyzerError {
     #[error("Non-fatal error")]
     NonFatal,
+    #[error("Rename rejected: {0}")]
+    RenameRejected(String),
     #[error("QueryError: {0}")]
     QueryError(#[from] QueryError),
     #[error("UrlParseError: {0}")]

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -51,14 +51,15 @@ pub fn implementation(
     if old_name == new_name {
         return Ok(None);
     }
+
+    if !context.is_editable(target.file()) {
+        return Ok(None);
+    }
+
     if !valid_new_name(&new_name, name_kind) {
         let message =
             format!("Cannot rename `{old_name}` to `{new_name}` because the new name is invalid");
         return Err(AnalyzerError::RenameRejected(message));
-    }
-
-    if !context.is_editable(target.file()) {
-        return Ok(None);
     }
 
     let mut edits = edit::RenameEdits::new(context);

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -4,7 +4,7 @@ use indexing::{ImportId, ImportItemId, TermItemId, TermItemKind, TypeItemId, Typ
 use lowering::{BinderKind, ExpressionKind, TermVariableResolution, TypeKind};
 use lsp_types::*;
 use syntax::ast::{AstNode, AstPtr};
-use syntax::{TokenAtOffset, cst};
+use syntax::{SyntaxToken, TextRange, TextSize, TokenAtOffset, cst};
 
 use crate::{AnalyzerContext, AnalyzerError, locate, position, references};
 
@@ -43,28 +43,18 @@ pub fn implementation(
     position: Position,
     new_name: String,
 ) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
-    let current_file = {
-        let uri = uri.as_str();
-        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
-    };
-
-    let content = context.queries().content(current_file);
-    let utf8_position =
-        position::protocol_position_to_utf8(&content, position, context.position_encoding())
-            .ok_or(AnalyzerError::NonFatal)?;
-
-    let target = if let Some(target) = qualifier_target(context, current_file, utf8_position)? {
-        target
-    } else {
-        let located = locate::locate(context.queries(), current_file, utf8_position)?;
-        rename_target(context, current_file, located)?
-    };
+    let (_, _, target) = target_at_position(context, &uri, position)?;
 
     let Some((old_name, name_kind)) = target_name(context, target)? else {
         return Ok(None);
     };
-    if old_name == new_name || !valid_new_name(&new_name, name_kind) {
+    if old_name == new_name {
         return Ok(None);
+    }
+    if !valid_new_name(&new_name, name_kind) {
+        let message =
+            format!("Cannot rename `{old_name}` to `{new_name}` because the new name is invalid");
+        return Err(AnalyzerError::RenameRejected(message));
     }
 
     if !context.is_editable(target.file()) {
@@ -88,6 +78,88 @@ pub fn implementation(
     }
 
     edits.finish()
+}
+
+pub fn prepare(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: Url,
+    position: Position,
+) -> Result<Option<PrepareRenameResponse>, AnalyzerError> {
+    let (current_file, utf8_position, target) = target_at_position(context, &uri, position)?;
+    let Some((old_name, _)) = target_name(context, target)? else {
+        return Ok(None);
+    };
+    if !context.is_editable(target.file()) {
+        return Ok(None);
+    }
+
+    let range = rename_range(context, current_file, utf8_position, &old_name)?;
+
+    Ok(Some(PrepareRenameResponse::RangeWithPlaceholder { range, placeholder: old_name }))
+}
+
+fn target_at_position(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    uri: &Url,
+    position: Position,
+) -> Result<(FileId, position::Utf8Position, RenameTarget), AnalyzerError> {
+    let current_file = {
+        let uri = uri.as_str();
+        context.file_id(uri).ok_or(AnalyzerError::NonFatal)?
+    };
+
+    let content = context.queries().content(current_file);
+    let utf8_position =
+        position::protocol_position_to_utf8(&content, position, context.position_encoding())
+            .ok_or(AnalyzerError::NonFatal)?;
+
+    let target = if let Some(target) = qualifier_target(context, current_file, utf8_position)? {
+        target
+    } else {
+        let located = locate::locate(context.queries(), current_file, utf8_position)?;
+        rename_target(context, current_file, located)?
+    };
+
+    Ok((current_file, utf8_position, target))
+}
+
+fn rename_range(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    current_file: FileId,
+    position: position::Utf8Position,
+    old_name: &str,
+) -> Result<Range, AnalyzerError> {
+    let content = context.queries().content(current_file);
+    let offset =
+        position::utf8_position_to_offset(&content, position).ok_or(AnalyzerError::NonFatal)?;
+    let (parsed, _) = context.queries().parsed(current_file)?;
+    let root = parsed.syntax_node();
+
+    let name_range = |token: SyntaxToken| -> Option<TextRange> {
+        let token_text = token.text(&content);
+        if token_text == old_name {
+            return Some(token.text_range());
+        }
+        if token_text.strip_suffix('.') == Some(old_name) {
+            let range = token.text_range();
+            let end = range.end() - TextSize::from(1);
+            return Some(TextRange::new(range.start(), end));
+        }
+
+        token
+            .parent_ancestors()
+            .find_map(|node| (node.text(&content) == old_name).then(|| node.text_range()))
+    };
+
+    let range = match root.token_at_offset(offset) {
+        TokenAtOffset::None => None,
+        TokenAtOffset::Single(token) => name_range(token),
+        TokenAtOffset::Between(left, right) => name_range(right).or_else(|| name_range(left)),
+    };
+
+    let range = range.ok_or(AnalyzerError::NonFatal)?;
+    position::text_range_to_protocol(&content, range, context.position_encoding())
+        .ok_or(AnalyzerError::NonFatal)
 }
 
 fn qualifier_target(

--- a/tests-integration/fixtures/lsp/1785248820_prepare_rename/Main.purs
+++ b/tests-integration/fixtures/lsp/1785248820_prepare_rename/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+--     ?
+
+import Prim as P
+--             ?
+
+value = 42
+-- ?
+
+use = value
+--    ?
+
+typed :: P.Int
+--        ?
+typed = 42
+
+literal = 42
+--        ?

--- a/tests-integration/fixtures/lsp/1785248820_prepare_rename/Main.snap
+++ b/tests-integration/fixtures/lsp/1785248820_prepare_rename/Main.snap
@@ -1,0 +1,63 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+PrepareRename at Position { line: 0, character: 7 }
+
+```
+module Main where
+--     ?
+```
+
+0:7..0:11 Main
+
+
+PrepareRename at Position { line: 3, character: 15 }
+
+```
+import Prim as P
+--             ?
+```
+
+3:15..3:16 P
+
+
+PrepareRename at Position { line: 6, character: 3 }
+
+```
+value = 42
+-- ?
+```
+
+6:0..6:5 value
+
+
+PrepareRename at Position { line: 9, character: 6 }
+
+```
+use = value
+--    ?
+```
+
+9:6..9:11 value
+
+
+PrepareRename at Position { line: 12, character: 10 }
+
+```
+typed :: P.Int
+--        ?
+```
+
+12:9..12:10 P
+
+
+PrepareRename at Position { line: 16, character: 10 }
+
+```
+literal = 42
+--        ?
+```
+
+<empty>

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -13,8 +13,8 @@ use lsp_types::{
     CodeActionContext, CodeActionKind, CodeActionOrCommand, CodeActionResponse,
     CodeActionTriggerKind, CompletionItemKind, CompletionList, CompletionResponse,
     DocumentHighlight, DocumentSymbolResponse, GotoDefinitionResponse, HoverContents,
-    LanguageString, Location, MarkedString, Position, Range, SemanticTokens, SymbolInformation,
-    TextEdit, Url, WorkspaceEdit, WorkspaceSymbolResponse,
+    LanguageString, Location, MarkedString, Position, PrepareRenameResponse, Range, SemanticTokens,
+    SymbolInformation, TextEdit, Url, WorkspaceEdit, WorkspaceSymbolResponse,
 };
 use render::{TabledCompletionItem, TabledDetailedCompletionItem};
 use similar::TextDiff;
@@ -60,13 +60,14 @@ enum CursorKind {
     CompletionCached,
     References,
     Rename,
+    PrepareRename,
     DocumentHighlight,
     DocumentSymbols,
     CodeAction,
 }
 
 impl CursorKind {
-    const CHARACTERS: &[char] = &['@', '$', '^', '~', '%', '/', '!', '&', '.'];
+    const CHARACTERS: &[char] = &['@', '$', '^', '~', '%', '/', '?', '!', '&', '.'];
 
     fn parse(text: &str) -> Option<CursorKind> {
         match text {
@@ -76,6 +77,7 @@ impl CursorKind {
             "~" => Some(CursorKind::CompletionCached),
             "%" => Some(CursorKind::References),
             "/" => Some(CursorKind::Rename),
+            "?" => Some(CursorKind::PrepareRename),
             "&" => Some(CursorKind::DocumentHighlight),
             "!" => Some(CursorKind::DocumentSymbols),
             "." => Some(CursorKind::CodeAction),
@@ -292,6 +294,13 @@ fn render_location(location: Location) -> String {
         location.range.start.character,
         location.range.end.line,
         location.range.end.character,
+    )
+}
+
+fn render_range(range: Range) -> String {
+    format!(
+        "{}:{}..{}:{}",
+        range.start.line, range.start.character, range.end.line, range.end.character,
     )
 }
 
@@ -563,6 +572,20 @@ fn dispatch_cursor(
                 writeln!(result, "<empty>").unwrap();
             }
         }
+        CursorKind::PrepareRename => match analyzer::rename::prepare(&context, uri, position) {
+            Ok(Some(PrepareRenameResponse::Range(range))) => {
+                writeln!(result, "{}", render_range(range)).unwrap();
+            }
+            Ok(Some(PrepareRenameResponse::RangeWithPlaceholder { range, placeholder })) => {
+                writeln!(result, "{} {placeholder}", render_range(range)).unwrap();
+            }
+            Ok(Some(PrepareRenameResponse::DefaultBehavior { default_behavior })) => {
+                writeln!(result, "default behavior: {default_behavior}").unwrap();
+            }
+            Ok(None) | Err(_) => {
+                writeln!(result, "<empty>").unwrap();
+            }
+        },
         CursorKind::DocumentHighlight => {
             let render_highlight = |h: DocumentHighlight| -> String {
                 format!(


### PR DESCRIPTION
## Summary

Rename currently treats an invalid replacement name like any other non-fatal analyzer failure, so editors receive an empty response without an actionable explanation. This change introduces a rename-specific rejection error and preserves its message at the LSP boundary, allowing clients to tell users why the request was refused.

It also implements and advertises `textDocument/prepareRename`. Preparation shares target resolution with rename execution, returns the exact source range and placeholder for editable symbols, and quietly declines syntax that cannot be renamed.

## Validation

- `just format`
- `cargo check -p analyzer --tests`
- `cargo check -p purescript-alexandrite --tests`
- `cargo test -p analyzer rename::tests`
- `just t lsp 1785248820_prepare_rename`
