### PR TITLE
[checking] Generate delegated newtype instances

### DIFF
--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -4,6 +4,7 @@ use building_types::QueryResult;
 use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
+use crate::core::substitute::SubstituteName;
 use crate::core::{KindOrType, TypeId, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
@@ -25,6 +26,10 @@ pub(crate) fn generate_instance<Q>(
 where
     Q: ExternalQueries,
 {
+    if let DeriveStrategy::NewtypeDeriveConstraint { delegate_constraint } = result.strategy {
+        return generate_delegate_instance(state, context, result, delegate_constraint);
+    }
+
     let dispatch = derive_dispatch(context, result.class_file, result.class_id);
     match dispatch {
         DeriveDispatch::Eq | DeriveDispatch::Eq1 | DeriveDispatch::Ord | DeriveDispatch::Ord1 => {
@@ -32,6 +37,67 @@ where
         }
         _ => Ok(()),
     }
+}
+
+fn generate_delegate_instance<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    delegate_constraint: TypeId,
+) -> QueryResult<()>
+where
+    Q: ExternalQueries,
+{
+    let Some(instance) = toolkit::instance_info(
+        state,
+        context,
+        result.signature,
+        (result.class_file, result.class_id),
+    )?
+    else {
+        return Ok(());
+    };
+
+    let freshened = freshen_instance_rigids(state, context, &instance)?;
+    state.with_implicit(context, &freshened.substitution, |state| {
+        let mut evidences = Vec::with_capacity(freshened.constraints.len());
+        for (&constraint, &signature_constraint) in
+            std::iter::zip(&freshened.constraints, &instance.constraints)
+        {
+            let evidence = Evidence::Given(state.push_given(constraint));
+            evidences.push(tree::InstanceEvidence { constraint: signature_constraint, evidence });
+        }
+
+        let superclasses = emit_instance_superclass_constraints(
+            state,
+            context,
+            result.class_file,
+            result.class_id,
+            &freshened.arguments,
+        )?;
+
+        let delegate_constraint =
+            SubstituteName::many(state, context, &freshened.substitution, delegate_constraint)?;
+        let evidence = state.push_wanted(delegate_constraint);
+
+        let instance = tree::InstanceDeclaration {
+            class: (result.class_file, result.class_id),
+            rigid_parameters: Arc::from(freshened.rigids),
+            evidences: Arc::from(evidences),
+            superclasses: Arc::from(superclasses),
+            implementation: tree::InstanceImplementation::Delegate {
+                constraint: delegate_constraint,
+                evidence,
+            },
+        };
+        let declaration = tree::TermDeclaration {
+            type_id: result.signature,
+            kind: tree::TermDeclarationKind::Instance(instance),
+        };
+        state.checked.tree.insert_term(result.item_id, declaration);
+
+        Ok(())
+    })
 }
 
 fn generate_known_instance<Q>(

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -476,6 +476,13 @@ where
             instance,
             &mut outer_evidence_names,
         )?;
+
+        if let InstanceImplementation::Delegate { evidence, .. } = &instance.implementation {
+            let evidence = self.evidence_variable_name(&mut outer_evidence_names, *evidence)?;
+            let delegation = self.arena.text(format!(" = {evidence}"));
+            return Ok(signature.append(delegation));
+        }
+
         let mut fields = vec![];
 
         let superclass_names = self.instance_superclass_field_names(instance)?;
@@ -524,9 +531,10 @@ where
                     fields.push(signature.append(self.arena.hardline()).append(equations));
                 }
             }
-            InstanceImplementation::Delegate { evidence, .. } => {
-                let evidence = self.evidence_variable_name(&mut outer_evidence_names, *evidence)?;
-                fields.push(self.arena.text(format!("  delegate = {evidence}")));
+            InstanceImplementation::Delegate { .. } => {
+                unreachable!(
+                    "invariant violated: delegated instances return before rendering members"
+                )
             }
         }
 

--- a/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.purs
+++ b/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Show (class Show)
+
+newtype Identity a = Identity a
+
+derive newtype instance Show a => Show (Identity a)

--- a/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+newtype Identity :: Type -> Type
+newtype Identity @a
+  | Identity :: a -> Identity a
+
+dictionary showIdentity :: forall t. { showDict :: Show t } => Show (Identity t) = showDict

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.purs
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Show (class Show)
+
+newtype NonEmpty a = NonEmpty (Array a)
+
+derive newtype instance Show a => Show (NonEmpty a)

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+newtype NonEmpty :: Type -> Type
+newtype NonEmpty @a
+  | NonEmpty :: Array a -> NonEmpty a
+
+dictionary showNonEmpty ::
+  forall t.
+  { showDict :: Show t } =>
+  Show (NonEmpty t) = showArray {showDict}

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_concrete_representation/Main.purs
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_concrete_representation/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Show (class Show)
+
+newtype NonZero = NonZero Int
+
+derive newtype instance Show NonZero

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_concrete_representation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_concrete_representation/Main.snap
@@ -1,0 +1,10 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+newtype NonZero :: Type
+newtype NonZero
+  | NonZero :: Int -> NonZero
+
+dictionary showNonZero :: Show NonZero = showInt


### PR DESCRIPTION
## Motivation

Newtype-derived instances were validated during checking, but their checked semantic declarations were not generated. This left successful `derive newtype instance` declarations without the dictionary implementation needed by later compiler phases.

## Changes

- generate checked instance declarations that delegate to the representation type's resolved dictionary
- preserve freshened rigid parameters, explicit givens, superclass evidence, and the specialized delegate constraint
- render delegated dictionaries as dictionary aliases rather than synthetic class members
- cover direct given, concrete representation, and applied representation delegation

## Validation

- `just format`
- `just t semantic 1785249840_derive_newtype_delegate_implementation 1785250560_derive_newtype_delegate_concrete_representation 1785250560_derive_newtype_delegate_applied_representation`
- `cargo check -p checking --tests`
- `git diff --check`