### PR TITLE
[analyzer] Collect diagnostics through analyzer hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ version = "0.1.0"
 dependencies = [
  "building-types",
  "checking",
+ "diagnostics",
  "files",
  "indexing",
  "insta",
@@ -1844,7 +1845,6 @@ dependencies = [
  "building",
  "checking",
  "clap",
- "diagnostics",
  "documentation",
  "files",
  "globset",
@@ -1865,7 +1865,6 @@ dependencies = [
  "smol_str",
  "spago",
  "stabilizing",
- "syntax",
  "tempfile",
  "thiserror",
  "tokio",

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -29,7 +29,6 @@ async-lsp = { version = "0.2.2", features = ["tokio"] }
 building = { version = "0.1.0", path = "../compiler-core/building" }
 checking = { version = "0.1.0", path = "../compiler-core/checking" }
 clap = { version = "4.5.53", features = ["derive"] }
-diagnostics = { version = "0.1.0", path = "../compiler-core/diagnostics" }
 documentation = { version = "0.1.0", path = "../compiler-lsp/documentation" }
 files = { version = "0.1.0", path = "../compiler-core/files" }
 globset = "0.4.18"
@@ -49,7 +48,6 @@ serde_json = "1.0.150"
 smol_str = "0.3.6"
 spago = { version = "0.1.0", path = "../compiler-lsp/spago" }
 stabilizing = { version = "0.1.0", path = "../compiler-core/stabilizing" }
-syntax = { version = "0.1.0", path = "../compiler-core/syntax" }
 tempfile = "3.24.0"
 thiserror = "2.0.17"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/compiler-bin/src/lsp/event.rs
+++ b/compiler-bin/src/lsp/event.rs
@@ -1,10 +1,6 @@
-use analyzer::{common, position};
 use async_lsp::LanguageClient;
-use diagnostics::{DiagnosticsContext, ToDiagnostics};
 use files::FileId;
-use itertools::Itertools;
-use lsp_types::*;
-use syntax::TextSize;
+use lsp_types::{PublishDiagnosticsParams, Url};
 
 use crate::lsp::error::LspError;
 use crate::lsp::{State, StateSnapshot};
@@ -34,92 +30,12 @@ fn collect_diagnostics_core(
     mut snapshot: StateSnapshot,
     CollectDiagnostics(id): CollectDiagnostics,
 ) -> Result<(), LspError> {
-    let content = snapshot.engine.content(id);
-
-    let (parsed, _) = snapshot.engine.parsed(id)?;
-    let root = parsed.syntax_node();
-
-    let stabilized = snapshot.engine.stabilized(id)?;
-    let indexed = snapshot.engine.indexed(id)?;
-    let resolved = snapshot.engine.resolved(id)?;
-    let lowered = snapshot.engine.lowered(id)?;
-    let checked = snapshot.engine.checked(id)?;
-
-    let uri = snapshot.with_analyzer_context(|context| common::file_uri(context, id))?;
-
-    let context = DiagnosticsContext::new(
-        &snapshot.engine,
-        &content,
-        &root,
-        &stabilized,
-        &indexed,
-        &lowered,
-        &checked,
-    );
-
-    let mut all_diagnostics = vec![];
-
-    for error in &lowered.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    for error in &resolved.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    for error in &checked.errors {
-        all_diagnostics.extend(error.to_diagnostics(&context));
-    }
-
-    let to_position = |offset: u32| {
-        let position = position::offset_to_utf8_position(&content, TextSize::from(offset))?;
-        position::utf8_position_to_protocol(&content, position, snapshot.position_encoding)
-    };
-
-    let diagnostics = all_diagnostics
-        .iter()
-        .filter_map(|diagnostic| {
-            let start = to_position(diagnostic.span.start)?;
-            let end = to_position(diagnostic.span.end)?;
-            let range = Range { start, end };
-
-            let severity = match diagnostic.severity {
-                diagnostics::Severity::Error => DiagnosticSeverity::ERROR,
-                diagnostics::Severity::Warning => DiagnosticSeverity::WARNING,
-            };
-
-            let related_information = diagnostic.related.iter().filter_map(|related| {
-                let start = to_position(related.span.start)?;
-                let end = to_position(related.span.end)?;
-                Some(DiagnosticRelatedInformation {
-                    location: Location { uri: uri.clone(), range: Range { start, end } },
-                    message: related.message.clone(),
-                })
-            });
-
-            let related_information = related_information.collect_vec();
-
-            Some(Diagnostic {
-                range,
-                severity: Some(severity),
-                code: Some(NumberOrString::String(diagnostic.code.to_string())),
-                code_description: None,
-                source: Some(format!("analyzer/{}", diagnostic.source)),
-                message: diagnostic.message.clone(),
-                related_information: if related_information.is_empty() {
-                    None
-                } else {
-                    Some(related_information)
-                },
-                tags: None,
-                data: None,
-            })
-        })
-        .collect();
+    let collected = snapshot
+        .with_analyzer_context(|context| analyzer::diagnostics::implementation(context, id))?;
 
     snapshot.client.publish_diagnostics(PublishDiagnosticsParams {
-        uri,
-        diagnostics,
+        uri: collected.uri,
+        diagnostics: collected.diagnostics,
         version: None,
     })?;
 

--- a/compiler-lsp/analyzer/Cargo.toml
+++ b/compiler-lsp/analyzer/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 building-types = { version = "0.1.0", path = "../../compiler-core/building-types" }
 checking = { version = "0.1.0", path = "../../compiler-core/checking" }
+diagnostics = { version = "0.1.0", path = "../../compiler-core/diagnostics" }
 files = { version = "0.1.0", path = "../../compiler-core/files" }
 indexing = { version = "0.1.0", path = "../../compiler-core/indexing" }
 itertools = "0.14.0"

--- a/compiler-lsp/analyzer/src/diagnostics.rs
+++ b/compiler-lsp/analyzer/src/diagnostics.rs
@@ -1,0 +1,65 @@
+use building_types::QueryProxy;
+use diagnostics::{DiagnosticsContext, ToDiagnostics};
+use files::FileId;
+use lsp_types::{Diagnostic, Url};
+
+use crate::{AnalyzerContext, AnalyzerError, AnalyzerHost, common};
+
+pub struct CollectedDiagnostics {
+    pub uri: Url,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+pub fn implementation<Host>(
+    context: &AnalyzerContext<Host>,
+    file_id: FileId,
+) -> Result<CollectedDiagnostics, AnalyzerError>
+where
+    Host: AnalyzerHost,
+    Host::Queries: diagnostics::ExternalQueries,
+{
+    let queries = context.queries();
+    let content = queries.content(file_id);
+
+    let (parsed, _) = queries.parsed(file_id)?;
+    let root = parsed.syntax_node();
+
+    let stabilized = queries.stabilized(file_id)?;
+    let indexed = queries.indexed(file_id)?;
+    let resolved = queries.resolved(file_id)?;
+    let lowered = queries.lowered(file_id)?;
+    let checked = queries.checked(file_id)?;
+
+    let uri = common::file_uri(context, file_id)?;
+    let diagnostics_context = DiagnosticsContext::new(
+        queries,
+        &content,
+        &root,
+        &stabilized,
+        &indexed,
+        &lowered,
+        &checked,
+    );
+
+    let mut all_diagnostics = vec![];
+
+    for error in &lowered.errors {
+        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
+    }
+
+    for error in &resolved.errors {
+        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
+    }
+
+    for error in &checked.errors {
+        all_diagnostics.extend(error.to_diagnostics(&diagnostics_context));
+    }
+
+    let position_encoding = context.position_encoding().into();
+    let diagnostics = all_diagnostics.iter().filter_map(|diagnostic| {
+        diagnostics::to_lsp_diagnostic(diagnostic, &content, &uri, &position_encoding)
+    });
+
+    let diagnostics = diagnostics.collect();
+    Ok(CollectedDiagnostics { uri, diagnostics })
+}

--- a/compiler-lsp/analyzer/src/lib.rs
+++ b/compiler-lsp/analyzer/src/lib.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod completion;
 pub mod context;
 pub mod definition;
+pub mod diagnostics;
 pub mod document_highlight;
 pub mod error;
 pub mod extract;


### PR DESCRIPTION
## Intent

Make LSP diagnostic calculation available to every analyzer host instead of coupling it to the native server. This gives native and Wasm-backed hosts one implementation for running diagnostic queries and translating compiler diagnostics into negotiated LSP positions.

## Changes

- move diagnostic query execution and LSP rendering into `analyzer::diagnostics`
- keep the diagnostic-specific external-query requirement local to that handler
- preserve the existing query order and lowered/resolved/checked diagnostic ordering
- leave snapshot scheduling and `publishDiagnostics` transport in the native LSP adapter
- move the diagnostics dependency from the native binary to the analyzer crate

The analyzer operation remains inside `AnalyzerContext`, preserving the existing invariant that host file metadata cannot change while a result is computed.

## Verification

- `cargo check -p analyzer -p purescript-alexandrite --tests`
- `cargo nextest run -p analyzer`
- `cargo check -p analyzer -p docs-lib --target wasm32-unknown-unknown`
- `just format`