### PR TITLE
[checking] Print fully qualified names in checking reports

### DIFF
--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -29,7 +29,11 @@ pub(crate) fn breakable_continuation<'arena>(
 }
 
 pub trait PrettyQueries:
-    QueryProxy<Indexed = Arc<indexing::IndexedModule>, Lowered = Arc<lowering::LoweredModule>>
+    QueryProxy<
+        Parsed = parsing::FullParsedModule,
+        Indexed = Arc<indexing::IndexedModule>,
+        Lowered = Arc<lowering::LoweredModule>,
+    >
 {
     fn lookup_type(&self, id: TypeId) -> Type;
 
@@ -138,11 +142,17 @@ pub struct PrettyConfig {
     width: usize,
     show_rigid_kinds: bool,
     show_forall_kinds: bool,
+    fully_qualified_names: bool,
 }
 
 impl PrettyConfig {
     pub const fn new() -> PrettyConfig {
-        PrettyConfig { width: DEFAULT_WIDTH, show_rigid_kinds: true, show_forall_kinds: true }
+        PrettyConfig {
+            width: DEFAULT_WIDTH,
+            show_rigid_kinds: true,
+            show_forall_kinds: true,
+            fully_qualified_names: false,
+        }
     }
 
     #[must_use]
@@ -160,6 +170,12 @@ impl PrettyConfig {
     #[must_use]
     pub const fn without_forall_kinds(mut self) -> PrettyConfig {
         self.show_forall_kinds = false;
+        self
+    }
+
+    #[must_use]
+    pub const fn fully_qualified_names(mut self) -> PrettyConfig {
+        self.fully_qualified_names = true;
         self
     }
 }
@@ -268,6 +284,7 @@ where
             &mut self.names,
             self.config.show_rigid_kinds,
             self.config.show_forall_kinds,
+            self.config.fully_qualified_names,
         );
 
         let document = if let Some(name) = signature {
@@ -303,6 +320,7 @@ where
     pretty_names: &'names mut PrettyNames,
     show_rigid_kinds: bool,
     show_forall_kinds: bool,
+    fully_qualified_names: bool,
 }
 
 impl<'arena, 'context, 'names, Q> Printer<'arena, 'context, 'names, Q>
@@ -316,8 +334,17 @@ where
         pretty_names: &'names mut PrettyNames,
         show_rigid_kinds: bool,
         show_forall_kinds: bool,
+        fully_qualified_names: bool,
     ) -> Printer<'arena, 'context, 'names, Q> {
-        Printer { arena, queries, names, pretty_names, show_rigid_kinds, show_forall_kinds }
+        Printer {
+            arena,
+            queries,
+            names,
+            pretty_names,
+            show_rigid_kinds,
+            show_forall_kinds,
+            fully_qualified_names,
+        }
     }
 
     fn lookup_type(&self, id: TypeId) -> Type {
@@ -343,6 +370,30 @@ where
     ) -> Option<String> {
         let indexed = self.queries.indexed(file_id).ok()?;
         indexed.items[type_id].name.as_ref().map(|name| name.to_string())
+    }
+
+    fn lookup_module_name(&self, file_id: files::FileId) -> Option<SmolStr> {
+        let content = self.queries.content(file_id);
+        let (parsed, _) = self.queries.parsed(file_id).ok()?;
+        parsed.module_name(&content)
+    }
+
+    fn display_type_name(
+        &self,
+        file_id: files::FileId,
+        type_id: indexing::TypeItemId,
+    ) -> Option<String> {
+        let name = self.lookup_type_name(file_id, type_id)?;
+
+        if !self.fully_qualified_names {
+            return Some(name);
+        }
+
+        let Some(module_name) = self.lookup_module_name(file_id) else {
+            return Some(name);
+        };
+
+        Some(format!("{module_name}.{name}"))
     }
 
     fn is_record_constructor(&self, id: TypeId) -> bool {
@@ -394,7 +445,7 @@ where
 
             Type::Constructor(file_id, type_id) => {
                 let name = self
-                    .lookup_type_name(file_id, type_id)
+                    .display_type_name(file_id, type_id)
                     .unwrap_or_else(|| "<InvalidName>".to_string());
                 self.arena.text(name)
             }

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -78,16 +78,23 @@ impl EvidenceNames {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PrettyConfig {
     width: usize,
+    fully_qualified_names: bool,
 }
 
 impl PrettyConfig {
     pub const fn new() -> PrettyConfig {
-        PrettyConfig { width: DEFAULT_WIDTH }
+        PrettyConfig { width: DEFAULT_WIDTH, fully_qualified_names: false }
     }
 
     #[must_use]
     pub const fn width(mut self, width: usize) -> PrettyConfig {
         self.width = width;
+        self
+    }
+
+    #[must_use]
+    pub const fn fully_qualified_names(mut self) -> PrettyConfig {
+        self.fully_qualified_names = true;
         self
     }
 }
@@ -155,6 +162,7 @@ where
     checked: &'context CheckedModule,
     type_pretty: TypePretty<'context, Q>,
     signature_type_pretty: TypePretty<'context, Q>,
+    fully_qualified_names: bool,
 }
 
 impl<'arena, 'context, 'module, Q> Printer<'arena, 'context, 'module, Q>
@@ -170,7 +178,10 @@ where
         checked: &'context CheckedModule,
         config: PrettyConfig,
     ) -> Printer<'arena, 'context, 'module, Q> {
-        let type_config = TypePrettyConfig::new().without_rigid_kinds().width(config.width);
+        let mut type_config = TypePrettyConfig::new().without_rigid_kinds().width(config.width);
+        if config.fully_qualified_names {
+            type_config = type_config.fully_qualified_names();
+        }
         let signature_type_config = type_config.without_forall_kinds();
         let type_pretty = TypePretty::with_config(queries, checked, type_config);
         let signature_type_pretty =
@@ -184,7 +195,26 @@ where
             checked,
             type_pretty,
             signature_type_pretty,
+            fully_qualified_names: config.fully_qualified_names,
         }
+    }
+
+    fn display_local_type_name(&self, name: &str) -> String {
+        if !self.fully_qualified_names {
+            return name.to_string();
+        }
+
+        let content = self.queries.content(self.file_id);
+
+        let Ok((parsed, _)) = self.queries.parsed(self.file_id) else {
+            return name.to_string();
+        };
+
+        let Some(module_name) = parsed.module_name(&content) else {
+            return name.to_string();
+        };
+
+        format!("{module_name}.{name}")
     }
 
     fn module(&mut self) -> QueryResult<Doc<'arena>> {
@@ -314,7 +344,8 @@ where
                 unreachable!("invariant violated: data declaration contains a value declaration");
             };
 
-            let mut result = self.arena.text(name.to_string());
+            let result_name = self.display_local_type_name(name);
+            let mut result = self.arena.text(result_name);
             for (parameter, _) in &parameter_names {
                 result = result.append(self.arena.text(format!(" {parameter}")));
             }

--- a/tests-integration/fixtures/checking/1771860360_foreign_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771860360_foreign_check/Main.snap
@@ -6,9 +6,11 @@ expression: report
 Terms
 
 Types
-M :: Type -> Type
-P :: forall (k :: Type). (k :: Type) -> Type
-T :: forall (t :: Type) (k :: (t :: Type)). P @(t :: Type) (k :: (t :: Type)) -> Type
+M :: Prim.Type -> Prim.Type
+P :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+T ::
+  forall (t :: Prim.Type) (k :: (t :: Prim.Type)).
+    Main.P @(t :: Prim.Type) (k :: (t :: Prim.Type)) -> Prim.Type
 
 Roles
 M = [Nominal]

--- a/tests-integration/fixtures/checking/1771864260_newtype_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771864260_newtype_check/Main.snap
@@ -1,15 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 Tagged ::
-  forall (k :: Type) (@t :: (k :: Type)) (@a :: Type).
-    (a :: Type) -> Tagged @(k :: Type) (t :: (k :: Type)) (a :: Type)
+  forall (k :: Prim.Type) (@t :: (k :: Prim.Type)) (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Tagged @(k :: Prim.Type) (t :: (k :: Prim.Type)) (a :: Prim.Type)
 
 Types
-Tagged :: forall (k :: Type). (k :: Type) -> Type -> Type
+Tagged :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type -> Prim.Type
 
 Roles
 Tagged = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1771864320_newtype_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1771864320_newtype_infer/Main.snap
@@ -5,11 +5,11 @@ expression: report
 ---
 Terms
 Tagged ::
-  forall (t :: Type) (@t1 :: (t :: Type)) (@a :: Type).
-    (a :: Type) -> Tagged @(t :: Type) (t1 :: (t :: Type)) (a :: Type)
+  forall (t :: Prim.Type) (@t1 :: (t :: Prim.Type)) (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Tagged @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (a :: Prim.Type)
 
 Types
-Tagged :: forall (t :: Type). (t :: Type) -> Type -> Type
+Tagged :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type -> Prim.Type
 
 Roles
 Tagged = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1771864380_data_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771864380_data_check/Main.snap
@@ -1,13 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1771864440_data_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1771864440_data_infer/Main.snap
@@ -4,10 +4,12 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
+Proxy ::
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Proxy :: forall (t :: Type). (t :: Type) -> Type
+Proxy :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1771869960_synonym_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771869960_synonym_check/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-NonZeroInt :: Type
-Identity :: Type -> Type
-FourtyTwo :: Int
+NonZeroInt :: Prim.Type
+Identity :: Prim.Type -> Prim.Type
+FourtyTwo :: Prim.Int
 
 Synonyms
-type NonZeroInt = Int
-type Identity a = (a :: Type)
+type NonZeroInt = Prim.Int
+type Identity a = (a :: Prim.Type)
 type FourtyTwo = 42

--- a/tests-integration/fixtures/checking/1771918140_synonym_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1771918140_synonym_infer/Main.snap
@@ -6,11 +6,11 @@ expression: report
 Terms
 
 Types
-NonZeroInt :: Type
-Identity :: forall (t :: Type). (t :: Type) -> (t :: Type)
-FourtyTwo :: Int
+NonZeroInt :: Prim.Type
+Identity :: forall (t :: Prim.Type). (t :: Prim.Type) -> (t :: Prim.Type)
+FourtyTwo :: Prim.Int
 
 Synonyms
-type NonZeroInt = Int
-type Identity a = (a :: (t :: Type))
+type NonZeroInt = Prim.Int
+type Identity a = (a :: (t :: Prim.Type))
 type FourtyTwo = 42

--- a/tests-integration/fixtures/checking/1771923300_class_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771923300_class_check/Main.snap
@@ -1,14 +1,18 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1771923360_class_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1771923360_class_infer/Main.snap
@@ -1,14 +1,18 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1771923420_class_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1771923420_class_superclass/Main.snap
@@ -4,15 +4,23 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-compare :: forall (@a :: Type). Ord (a :: Type) => (a :: Type) -> (a :: Type) -> Int
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+compare ::
+  forall (@a :: Prim.Type).
+    Main.Ord (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Int
 
 Types
-Eq :: Type -> Constraint
-Ord :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
+Ord :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-class forall (a :: Type). Eq (a :: Type) <= Ord (a :: Type)
-  compare :: forall (@a :: Type). Ord (a :: Type) => (a :: Type) -> (a :: Type) -> Int
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) <= Main.Ord (a :: Prim.Type)
+  compare ::
+  forall (@a :: Prim.Type).
+    Main.Ord (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Int

--- a/tests-integration/fixtures/checking/1771923480_class_polykind_check/Main.snap
+++ b/tests-integration/fixtures/checking/1771923480_class_polykind_check/Main.snap
@@ -5,16 +5,18 @@ expression: report
 ---
 Terms
 reflectKind ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    HasKind @(k :: Type) (a :: (k :: Type)) =>
-    (forall (p :: (k :: Type) -> Type). (p :: (k :: Type) -> Type) (a :: (k :: Type)) -> String)
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.HasKind @(k :: Prim.Type) (a :: (k :: Prim.Type)) =>
+    (forall (p :: (k :: Prim.Type) -> Prim.Type).
+      (p :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type)) -> Prim.String)
 
 Types
-HasKind :: forall (k :: Type). (k :: Type) -> Constraint
+HasKind :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (k :: Type) (a :: (k :: Type)). HasKind @(k :: Type) (a :: (k :: Type))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)). Main.HasKind @(k :: Prim.Type) (a :: (k :: Prim.Type))
   reflectKind ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    HasKind @(k :: Type) (a :: (k :: Type)) =>
-    (forall (p :: (k :: Type) -> Type). (p :: (k :: Type) -> Type) (a :: (k :: Type)) -> String)
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.HasKind @(k :: Prim.Type) (a :: (k :: Prim.Type)) =>
+    (forall (p :: (k :: Prim.Type) -> Prim.Type).
+      (p :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type)) -> Prim.String)

--- a/tests-integration/fixtures/checking/1771923540_class_polykind_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1771923540_class_polykind_infer/Main.snap
@@ -5,16 +5,18 @@ expression: report
 ---
 Terms
 reflectKind' ::
-  forall (t :: Type) (@a :: (t :: Type)).
-    HasKind' @(t :: Type) (a :: (t :: Type)) =>
-    (forall (p :: (t :: Type) -> Type). (p :: (t :: Type) -> Type) (a :: (t :: Type)) -> String)
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.HasKind' @(t :: Prim.Type) (a :: (t :: Prim.Type)) =>
+    (forall (p :: (t :: Prim.Type) -> Prim.Type).
+      (p :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) -> Prim.String)
 
 Types
-HasKind' :: forall (t :: Type). (t :: Type) -> Constraint
+HasKind' :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (a :: (t :: Type)). HasKind' @(t :: Type) (a :: (t :: Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.HasKind' @(t :: Prim.Type) (a :: (t :: Prim.Type))
   reflectKind' ::
-  forall (t :: Type) (@a :: (t :: Type)).
-    HasKind' @(t :: Type) (a :: (t :: Type)) =>
-    (forall (p :: (t :: Type) -> Type). (p :: (t :: Type) -> Type) (a :: (t :: Type)) -> String)
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.HasKind' @(t :: Prim.Type) (a :: (t :: Prim.Type)) =>
+    (forall (p :: (t :: Prim.Type) -> Prim.Type).
+      (p :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) -> Prim.String)

--- a/tests-integration/fixtures/checking/1771935300_operator_alias_kind/Main.snap
+++ b/tests-integration/fixtures/checking/1771935300_operator_alias_kind/Main.snap
@@ -6,8 +6,12 @@ expression: report
 Terms
 
 Types
-Add :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
-+ :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
+Add ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
++ ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
 
 Synonyms
-type Add a b = (a :: (t :: Type))
+type Add a b = (a :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1771935360_operator_alias_invalid_kind/Main.snap
+++ b/tests-integration/fixtures/checking/1771935360_operator_alias_invalid_kind/Main.snap
@@ -6,8 +6,8 @@ expression: report
 Terms
 
 Types
-Identity :: forall (t :: Type). (t :: Type) -> (t :: Type)
-+ :: forall (t :: Type). (t :: Type) -> (t :: Type)
+Identity :: forall (t :: Prim.Type). (t :: Prim.Type) -> (t :: Prim.Type)
++ :: forall (t :: Prim.Type). (t :: Prim.Type) -> (t :: Prim.Type)
 
 Synonyms
-type Identity a = (a :: (t :: Type))
+type Identity a = (a :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772011200_type_operator_chain_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1772011200_type_operator_chain_infer/Main.snap
@@ -6,20 +6,24 @@ expression: report
 Terms
 
 Types
-Add :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
-+ :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
+Add ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
++ ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
 Chain ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> (t :: Prim.Type)
 ChainParen ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> (t :: Prim.Type)
 
 Synonyms
-type Add a b = (a :: (t :: Type))
-type Chain a b c = Add @(t :: Type) @(t1 :: Type)
-  (Add @(t :: Type) @(t2 :: Type) (a :: (t :: Type)) (b :: (t2 :: Type)))
-  (c :: (t1 :: Type))
-type ChainParen a b c = Add @(t :: Type) @(t1 :: Type)
-  (Add @(t :: Type) @(t2 :: Type) (a :: (t :: Type)) (b :: (t2 :: Type)))
-  (c :: (t1 :: Type))
+type Add a b = (a :: (t :: Prim.Type))
+type Chain a b c = Main.Add @(t :: Prim.Type) @(t1 :: Prim.Type)
+  (Main.Add @(t :: Prim.Type) @(t2 :: Prim.Type) (a :: (t :: Prim.Type)) (b :: (t2 :: Prim.Type)))
+  (c :: (t1 :: Prim.Type))
+type ChainParen a b c = Main.Add @(t :: Prim.Type) @(t1 :: Prim.Type)
+  (Main.Add @(t :: Prim.Type) @(t2 :: Prim.Type) (a :: (t :: Prim.Type)) (b :: (t2 :: Prim.Type)))
+  (c :: (t1 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772011260_type_operator_chain_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772011260_type_operator_chain_check/Main.snap
@@ -6,12 +6,12 @@ expression: report
 Terms
 
 Types
-Add :: Type -> Type -> Type
-+ :: Type -> Type -> Type
-Chain :: Type -> Type -> Type -> Type
-ChainParen :: Type -> Type -> Type -> Type
+Add :: Prim.Type -> Prim.Type -> Prim.Type
++ :: Prim.Type -> Prim.Type -> Prim.Type
+Chain :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Type
+ChainParen :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Type
 
 Synonyms
-type Add a b = (a :: Type)
-type Chain a b c = Add (Add (a :: Type) (b :: Type)) (c :: Type)
-type ChainParen a b c = Add (Add (a :: Type) (b :: Type)) (c :: Type)
+type Add a b = (a :: Prim.Type)
+type Chain a b c = Main.Add (Main.Add (a :: Prim.Type) (b :: Prim.Type)) (c :: Prim.Type)
+type ChainParen a b c = Main.Add (Main.Add (a :: Prim.Type) (b :: Prim.Type)) (c :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772011320_type_operator_chain_polykind/Main.snap
+++ b/tests-integration/fixtures/checking/1772011320_type_operator_chain_polykind/Main.snap
@@ -6,12 +6,20 @@ expression: report
 Terms
 
 Types
-Add :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type)
-+ :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type)
-Chain :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type) -> (k :: Type)
-ChainParen :: forall (k :: Type). (k :: Type) -> (k :: Type) -> (k :: Type) -> (k :: Type)
+Add :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> (k :: Prim.Type)
++ :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> (k :: Prim.Type)
+Chain ::
+  forall (k :: Prim.Type).
+    (k :: Prim.Type) -> (k :: Prim.Type) -> (k :: Prim.Type) -> (k :: Prim.Type)
+ChainParen ::
+  forall (k :: Prim.Type).
+    (k :: Prim.Type) -> (k :: Prim.Type) -> (k :: Prim.Type) -> (k :: Prim.Type)
 
 Synonyms
-type Add a b = (a :: (k :: Type))
-type Chain a b c = Add @(k :: Type) (Add @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))) (c :: (k :: Type))
-type ChainParen a b c = Add @(k :: Type) (Add @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))) (c :: (k :: Type))
+type Add a b = (a :: (k :: Prim.Type))
+type Chain a b c = Main.Add @(k :: Prim.Type)
+  (Main.Add @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)))
+  (c :: (k :: Prim.Type))
+type ChainParen a b c = Main.Add @(k :: Prim.Type)
+  (Main.Add @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)))
+  (c :: (k :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772011380_type_operator_chain_precedence/Main.snap
+++ b/tests-integration/fixtures/checking/1772011380_type_operator_chain_precedence/Main.snap
@@ -6,23 +6,31 @@ expression: report
 Terms
 
 Types
-Add :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
-:+: :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
-Mul :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
-:*: :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> (t :: Type)
+Add ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
+:+: ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
+Mul ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
+:*: ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type)
 Chain ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> (t :: Prim.Type)
 ChainParen ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> (t :: Prim.Type)
 
 Synonyms
-type Add a b = (a :: (t :: Type))
-type Mul a b = (a :: (t :: Type))
-type Chain a b c = Add @(t :: Type) @(t1 :: Type)
-  (a :: (t :: Type))
-  (Mul @(t1 :: Type) @(t2 :: Type) (b :: (t1 :: Type)) (c :: (t2 :: Type)))
-type ChainParen a b c = Mul @(t :: Type) @(t1 :: Type)
-  (Add @(t :: Type) @(t2 :: Type) (a :: (t :: Type)) (b :: (t2 :: Type)))
-  (c :: (t1 :: Type))
+type Add a b = (a :: (t :: Prim.Type))
+type Mul a b = (a :: (t :: Prim.Type))
+type Chain a b c = Main.Add @(t :: Prim.Type) @(t1 :: Prim.Type)
+  (a :: (t :: Prim.Type))
+  (Main.Mul @(t1 :: Prim.Type) @(t2 :: Prim.Type) (b :: (t1 :: Prim.Type)) (c :: (t2 :: Prim.Type)))
+type ChainParen a b c = Main.Mul @(t :: Prim.Type) @(t1 :: Prim.Type)
+  (Main.Add @(t :: Prim.Type) @(t2 :: Prim.Type) (a :: (t :: Prim.Type)) (b :: (t2 :: Prim.Type)))
+  (c :: (t1 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772011440_type_operator_chain_kind_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772011440_type_operator_chain_kind_error/Main.snap
@@ -1,18 +1,18 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-Add :: Type -> Type -> Type
-+ :: Type -> Type -> Type
-Bad :: Type
+Add :: Prim.Type -> Prim.Type -> Prim.Type
++ :: Prim.Type -> Prim.Type -> Prim.Type
+Bad :: Prim.Type
 
 Synonyms
-type Add a b = (a :: Type)
-type Bad = Add Int "hello"
+type Add a b = (a :: Prim.Type)
+type Bad = Main.Add Prim.Int "hello"
 
 Diagnostics
 error[CannotUnify]: Cannot unify 'Symbol' with 'Type'

--- a/tests-integration/fixtures/checking/1772011500_operator_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772011500_operator_check/Main.snap
@@ -1,12 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-<: :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-const :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-+ :: Int -> Int -> Int
-add :: Int -> Int -> Int
+<: ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+const ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
++ :: Prim.Int -> Prim.Int -> Prim.Int
+add :: Prim.Int -> Prim.Int -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772011560_role_inference_phantom/Main.snap
+++ b/tests-integration/fixtures/checking/1772011560_role_inference_phantom/Main.snap
@@ -4,10 +4,12 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
+Proxy ::
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Proxy :: forall (t :: Type). (t :: Type) -> Type
+Proxy :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772011620_role_inference_representational/Main.snap
+++ b/tests-integration/fixtures/checking/1772011620_role_inference_representational/Main.snap
@@ -1,14 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772011680_role_inference_nominal_parametric/Main.snap
+++ b/tests-integration/fixtures/checking/1772011680_role_inference_nominal_parametric/Main.snap
@@ -5,12 +5,12 @@ expression: report
 ---
 Terms
 F ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    F @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.F @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-F :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+F :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 
 Roles
 F = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772011740_role_declaration_strengthen/Main.snap
+++ b/tests-integration/fixtures/checking/1772011740_role_declaration_strengthen/Main.snap
@@ -1,14 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Nominal]

--- a/tests-integration/fixtures/checking/1772011800_role_declaration_loosen_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772011800_role_declaration_loosen_error/Main.snap
@@ -5,12 +5,12 @@ expression: report
 ---
 Terms
 F ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    F @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.F @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-F :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+F :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 
 Roles
 F = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772011860_role_declaration_foreign/Main.snap
+++ b/tests-integration/fixtures/checking/1772011860_role_declaration_foreign/Main.snap
@@ -1,12 +1,12 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-Effect :: Type -> Type
+Effect :: Prim.Type -> Prim.Type
 
 Roles
 Effect = [Representational]

--- a/tests-integration/fixtures/checking/1772011920_foreign_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772011920_foreign_check/Main.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772011980_value_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772011980_value_check/Main.snap
@@ -1,9 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-const :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
+const ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772045820_exhaustive_case_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1772045820_exhaustive_case_infer/Main.snap
@@ -4,12 +4,12 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test :: forall (t :: Type). Partial => Maybe (t :: Type) -> Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test :: forall (t :: Prim.Type). Prim.Partial => Main.Maybe (t :: Prim.Type) -> Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772045880_exhaustive_case_redundant/Main.snap
+++ b/tests-integration/fixtures/checking/1772045880_exhaustive_case_redundant/Main.snap
@@ -4,12 +4,12 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test :: forall (t :: Type). Maybe (t :: Type) -> Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test :: forall (t :: Prim.Type). Main.Maybe (t :: Prim.Type) -> Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772045940_exhaustive_equation_signature/Main.snap
+++ b/tests-integration/fixtures/checking/1772045940_exhaustive_equation_signature/Main.snap
@@ -1,15 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test :: Maybe Int -> Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test :: Main.Maybe Prim.Int -> Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772046000_exhaustive_guards_otherwise/Main.snap
+++ b/tests-integration/fixtures/checking/1772046000_exhaustive_guards_otherwise/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test1 :: forall (t :: Type). Partial => Maybe (t :: Type) -> Int
-test2 :: forall (t :: Type). Partial => Maybe (t :: Type) -> Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test1 :: forall (t :: Prim.Type). Prim.Partial => Main.Maybe (t :: Prim.Type) -> Prim.Int
+test2 :: forall (t :: Prim.Type). Prim.Partial => Main.Maybe (t :: Prim.Type) -> Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772046060_exhaustive_let_pattern/Main.snap
+++ b/tests-integration/fixtures/checking/1772046060_exhaustive_let_pattern/Main.snap
@@ -1,15 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test :: Partial => Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test :: Prim.Partial => Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772046120_exhaustive_operator_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772046120_exhaustive_operator_constructor/Main.snap
@@ -4,13 +4,17 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Cons :: forall (@a :: Type). (a :: Type) -> List (a :: Type) -> List (a :: Type)
-Nil :: forall (@a :: Type). List (a :: Type)
-: :: forall (@a :: Type). (a :: Type) -> List (a :: Type) -> List (a :: Type)
-head :: forall (a :: Type). List (a :: Type) -> (a :: Type)
+Cons ::
+  forall (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.List (a :: Prim.Type) -> Main.List (a :: Prim.Type)
+Nil :: forall (@a :: Prim.Type). Main.List (a :: Prim.Type)
+: ::
+  forall (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.List (a :: Prim.Type) -> Main.List (a :: Prim.Type)
+head :: forall (a :: Prim.Type). Main.List (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-List :: Type -> Type
+List :: Prim.Type -> Prim.Type
 
 Roles
 List = [Representational]

--- a/tests-integration/fixtures/checking/1772088540_synonym_partial_defer/Main.snap
+++ b/tests-integration/fixtures/checking/1772088540_synonym_partial_defer/Main.snap
@@ -4,20 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
-ReaderT :: Type -> (Type -> Type) -> Type -> Type
+Identity :: Prim.Type -> Prim.Type
+ReaderT :: Prim.Type -> (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
 Apply ::
-  forall (k1 :: Type) (k2 :: Type). ((k1 :: Type) -> (k2 :: Type)) -> (k1 :: Type) -> (k2 :: Type)
-Good :: Type
+  forall (k1 :: Prim.Type) (k2 :: Prim.Type).
+    ((k1 :: Prim.Type) -> (k2 :: Prim.Type)) -> (k1 :: Prim.Type) -> (k2 :: Prim.Type)
+Good :: Prim.Type
 Bad :: ?[partial synonym application]
 
 Synonyms
-type ReaderT r m a = (r :: Type) -> (m :: Type -> Type) (a :: Type)
-type Apply f a = (f :: (k1 :: Type) -> (k2 :: Type)) (a :: (k1 :: Type))
-type Good = Apply @Type @Type (Apply @(Type -> Type) @(Type -> Type) (ReaderT Int) Identity) String
+type ReaderT r m a = (r :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+type Apply f a = (f :: (k1 :: Prim.Type) -> (k2 :: Prim.Type)) (a :: (k1 :: Prim.Type))
+type Good = Main.Apply @Prim.Type @Prim.Type
+  (Main.Apply @(Prim.Type -> Prim.Type) @(Prim.Type -> Prim.Type)
+    (Main.ReaderT Prim.Int)
+    Main.Identity)
+  Prim.String
 type Bad = ?[partial synonym application]
 
 Roles

--- a/tests-integration/fixtures/checking/1772108280_value_recursive_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772108280_value_recursive_check/Main.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-id :: forall (a :: Type). (a :: Type) -> (a :: Type)
+id :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772108340_value_recursive_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1772108340_value_recursive_infer/Main.snap
@@ -4,6 +4,6 @@ assertion_line: 50
 expression: report
 ---
 Terms
-id :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type)
+id :: forall (t :: Prim.Type) (t1 :: Prim.Type). (t :: Prim.Type) -> (t1 :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772108400_value_mutual_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772108400_value_mutual_check/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 50
 expression: report
 ---
 Terms
-f :: forall (a :: Type). (a :: Type) -> (a :: Type)
-g :: forall (a :: Type). (a :: Type) -> (a :: Type)
+f :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+g :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772108460_value_mutual_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1772108460_value_mutual_infer/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 50
 expression: report
 ---
 Terms
-f :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type)
-g :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type)
+f :: forall (t :: Prim.Type) (t1 :: Prim.Type). (t :: Prim.Type) -> (t1 :: Prim.Type)
+g :: forall (t :: Prim.Type) (t1 :: Prim.Type). (t :: Prim.Type) -> (t1 :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772108520_data_mutual_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772108520_data_mutual_check/Main.snap
@@ -5,15 +5,17 @@ expression: report
 ---
 Terms
 F ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    G @(k :: Type) (a :: (k :: Type)) -> F @(k :: Type) (a :: (k :: Type))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.G @(k :: Prim.Type) (a :: (k :: Prim.Type)) ->
+    Main.F @(k :: Prim.Type) (a :: (k :: Prim.Type))
 G ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    F @(k :: Type) (a :: (k :: Type)) -> G @(k :: Type) (a :: (k :: Type))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.F @(k :: Prim.Type) (a :: (k :: Prim.Type)) ->
+    Main.G @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Types
-F :: forall (k :: Type). (k :: Type) -> Type
-G :: forall (k :: Type). (k :: Type) -> Type
+F :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+G :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 F = [Representational]

--- a/tests-integration/fixtures/checking/1772108580_data_mutual_infer/Main.snap
+++ b/tests-integration/fixtures/checking/1772108580_data_mutual_infer/Main.snap
@@ -5,13 +5,15 @@ expression: report
 ---
 Terms
 F ::
-  forall (t :: Type) (@a :: (t :: Type)). G (a :: (t :: Type)) -> F @(t :: Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.G (a :: (t :: Prim.Type)) -> Main.F @(t :: Prim.Type) (a :: (t :: Prim.Type))
 G ::
-  forall (t :: Type) (@a :: (t :: Type)). F (a :: (t :: Type)) -> G @(t :: Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.F (a :: (t :: Prim.Type)) -> Main.G @(t :: Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-F :: forall (t :: Type). (t :: Type) -> Type
-G :: forall (t :: Type). (t :: Type) -> Type
+F :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
+G :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
 
 Roles
 F = [Representational]

--- a/tests-integration/fixtures/checking/1772140680_instance_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772140680_instance_check/Main.snap
@@ -6,13 +6,14 @@ expression: report
 Terms
 
 Types
-Eq :: Type -> Constraint
-TypeEq :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
+TypeEq :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). TypeEq @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEq @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
 
 Instances
-instance forall (t :: Type). Eq (t :: Type) => Eq (Array (t :: Type))
-instance forall (t :: Type) (t1 :: (t :: Type)). TypeEq @(t :: Type) (t1 :: (t :: Type)) (t1 :: (t :: Type))
+instance forall (t :: Prim.Type). Main.Eq (t :: Prim.Type) => Main.Eq (Prim.Array (t :: Prim.Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.TypeEq @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t1 :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301720_instance_constraint_solving/Main.snap
+++ b/tests-integration/fixtures/checking/1772301720_instance_constraint_solving/Main.snap
@@ -4,18 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-test :: Boolean
-test2 :: Boolean
-test3 :: forall (t :: Type). Eq (t :: Type) => (t :: Type) -> (t :: Type) -> Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+test :: Prim.Boolean
+test2 :: Prim.Boolean
+test3 ::
+  forall (t :: Prim.Type).
+    Main.Eq (t :: Prim.Type) => (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
 
 Instances
-instance Eq Int
-instance forall (t :: Type). Eq (t :: Type) => Eq (Array (t :: Type))
+instance Main.Eq Prim.Int
+instance forall (t :: Prim.Type). Main.Eq (t :: Prim.Type) => Main.Eq (Prim.Array (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301780_instance_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/checking/1772301780_instance_functional_dependency/Main.snap
@@ -5,19 +5,22 @@ expression: report
 ---
 Terms
 convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-test :: String
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+test :: Prim.String
 
 Types
-Convert :: Type -> Type -> Constraint
-TypeEq :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
+TypeEq :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Convert (a :: Prim.Type) (b :: Prim.Type)
   convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). TypeEq @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEq @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
 
 Instances
-instance Convert Int String
-instance forall (t :: Type) (t1 :: (t :: Type)). TypeEq @(t :: Type) (t1 :: (t :: Type)) (t1 :: (t :: Type))
+instance Main.Convert Prim.Int Prim.String
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.TypeEq @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t1 :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301840_instance_given_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1772301840_instance_given_constraint/Main.snap
@@ -4,16 +4,20 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-test :: Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+test :: Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
 
 Instances
-instance Eq Int
-instance forall (t :: Type). Eq (t :: Type) => Eq (Array (t :: Type))
+instance Main.Eq Prim.Int
+instance forall (t :: Prim.Type). Main.Eq (t :: Prim.Type) => Main.Eq (Prim.Array (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301900_instance_constraint_generalization/Main.snap
+++ b/tests-integration/fixtures/checking/1772301900_instance_constraint_generalization/Main.snap
@@ -4,17 +4,27 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-compare :: forall (@a :: Type). Ord (a :: Type) => (a :: Type) -> (a :: Type) -> Int
-test1 :: forall (t :: Type). Eq (t :: Type) => (t :: Type) -> Boolean
-test2 :: forall (t :: Type). Ord (t :: Type) => Eq (t :: Type) => (t :: Type) -> Int
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+compare ::
+  forall (@a :: Prim.Type).
+    Main.Ord (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Int
+test1 :: forall (t :: Prim.Type). Main.Eq (t :: Prim.Type) => (t :: Prim.Type) -> Prim.Boolean
+test2 ::
+  forall (t :: Prim.Type).
+    Main.Ord (t :: Prim.Type) => Main.Eq (t :: Prim.Type) => (t :: Prim.Type) -> Prim.Int
 
 Types
-Eq :: Type -> Constraint
-Ord :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
+Ord :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-class forall (a :: Type). Ord (a :: Type)
-  compare :: forall (@a :: Type). Ord (a :: Type) => (a :: Type) -> (a :: Type) -> Int
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+class forall (a :: Prim.Type). Main.Ord (a :: Prim.Type)
+  compare ::
+  forall (@a :: Prim.Type).
+    Main.Ord (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Int

--- a/tests-integration/fixtures/checking/1772301960_instance_superclass_elaboration/Main.snap
+++ b/tests-integration/fixtures/checking/1772301960_instance_superclass_elaboration/Main.snap
@@ -4,16 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-compare :: forall (@a :: Type). Ord (a :: Type) => (a :: Type) -> (a :: Type) -> Int
-test :: forall (t :: Type). Ord (t :: Type) => (t :: Type) -> Int
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+compare ::
+  forall (@a :: Prim.Type).
+    Main.Ord (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Int
+test :: forall (t :: Prim.Type). Main.Ord (t :: Prim.Type) => (t :: Prim.Type) -> Prim.Int
 
 Types
-Eq :: Type -> Constraint
-Ord :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
+Ord :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-class forall (a :: Type). Eq (a :: Type) <= Ord (a :: Type)
-  compare :: forall (@a :: Type). Ord (a :: Type) => (a :: Type) -> (a :: Type) -> Int
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) <= Main.Ord (a :: Prim.Type)
+  compare ::
+  forall (@a :: Prim.Type).
+    Main.Ord (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Int

--- a/tests-integration/fixtures/checking/1772304600_given_constraint_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772304600_given_constraint_check/Main.snap
@@ -4,12 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-test :: forall (a :: Type). Eq (a :: Type) => (a :: Type) -> Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+test :: forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1772304660_given_constraint_let_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772304660_given_constraint_let_check/Main.snap
@@ -1,15 +1,19 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-test :: Int
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+test :: Prim.Int
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1772304720_given_constraint_operator_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772304720_given_constraint_operator_check/Main.snap
@@ -1,15 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-== :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+== ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1772440020_prim_int/Main.snap
+++ b/tests-integration/fixtures/checking/1772440020_prim_int/Main.snap
@@ -4,30 +4,47 @@ assertion_line: 50
 expression: report
 ---
 Terms
-deriveSum :: forall (sum :: Int). Add 1 2 (sum :: Int) => Proxy @Int (sum :: Int)
-deriveRight :: forall (right :: Int). Add 1 (right :: Int) 3 => Proxy @Int (right :: Int)
-deriveLeft :: forall (left :: Int). Add (left :: Int) 2 3 => Proxy @Int (left :: Int)
+deriveSum ::
+  forall (sum :: Prim.Int).
+    Prim.Int.Add 1 2 (sum :: Prim.Int) => Type.Proxy.Proxy @Prim.Int (sum :: Prim.Int)
+deriveRight ::
+  forall (right :: Prim.Int).
+    Prim.Int.Add 1 (right :: Prim.Int) 3 => Type.Proxy.Proxy @Prim.Int (right :: Prim.Int)
+deriveLeft ::
+  forall (left :: Prim.Int).
+    Prim.Int.Add (left :: Prim.Int) 2 3 => Type.Proxy.Proxy @Prim.Int (left :: Prim.Int)
 stuckAdd ::
-  forall (left :: Int) (sum :: Int).
-    Add (left :: Int) 1 (sum :: Int) => Proxy @Int (left :: Int) -> Proxy @Int (sum :: Int)
-deriveMul :: forall (product :: Int). Mul 3 4 (product :: Int) => Proxy @Int (product :: Int)
+  forall (left :: Prim.Int) (sum :: Prim.Int).
+    Prim.Int.Add (left :: Prim.Int) 1 (sum :: Prim.Int) =>
+    Type.Proxy.Proxy @Prim.Int (left :: Prim.Int) -> Type.Proxy.Proxy @Prim.Int (sum :: Prim.Int)
+deriveMul ::
+  forall (product :: Prim.Int).
+    Prim.Int.Mul 3 4 (product :: Prim.Int) => Type.Proxy.Proxy @Prim.Int (product :: Prim.Int)
 compareLT ::
-  forall (ord :: Ordering). Compare 1 2 (ord :: Ordering) => Proxy @Ordering (ord :: Ordering)
+  forall (ord :: Prim.Ordering.Ordering).
+    Prim.Int.Compare 1 2 (ord :: Prim.Ordering.Ordering) =>
+    Type.Proxy.Proxy @Prim.Ordering.Ordering (ord :: Prim.Ordering.Ordering)
 compareEQ ::
-  forall (ord :: Ordering). Compare 5 5 (ord :: Ordering) => Proxy @Ordering (ord :: Ordering)
+  forall (ord :: Prim.Ordering.Ordering).
+    Prim.Int.Compare 5 5 (ord :: Prim.Ordering.Ordering) =>
+    Type.Proxy.Proxy @Prim.Ordering.Ordering (ord :: Prim.Ordering.Ordering)
 compareGT ::
-  forall (ord :: Ordering). Compare 10 3 (ord :: Ordering) => Proxy @Ordering (ord :: Ordering)
-deriveString :: forall (s :: Symbol). ToString 42 (s :: Symbol) => Proxy @Symbol (s :: Symbol)
+  forall (ord :: Prim.Ordering.Ordering).
+    Prim.Int.Compare 10 3 (ord :: Prim.Ordering.Ordering) =>
+    Type.Proxy.Proxy @Prim.Ordering.Ordering (ord :: Prim.Ordering.Ordering)
+deriveString ::
+  forall (s :: Prim.Symbol).
+    Prim.Int.ToString 42 (s :: Prim.Symbol) => Type.Proxy.Proxy @Prim.Symbol (s :: Prim.Symbol)
 forceSolve ::
-  { compareEQ :: Proxy @Ordering EQ
-  , compareGT :: Proxy @Ordering GT
-  , compareLT :: Proxy @Ordering LT
-  , deriveLeft :: Proxy @Int 1
-  , deriveMul :: Proxy @Int 12
-  , deriveRight :: Proxy @Int 2
-  , deriveString :: Proxy @Symbol "42"
-  , deriveSum :: Proxy @Int 3
-  , keepStuck :: Proxy @Int 1
+  { compareEQ :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.EQ
+  , compareGT :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.GT
+  , compareLT :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.LT
+  , deriveLeft :: Type.Proxy.Proxy @Prim.Int 1
+  , deriveMul :: Type.Proxy.Proxy @Prim.Int 12
+  , deriveRight :: Type.Proxy.Proxy @Prim.Int 2
+  , deriveString :: Type.Proxy.Proxy @Prim.Symbol "42"
+  , deriveSum :: Type.Proxy.Proxy @Prim.Int 3
+  , keepStuck :: Type.Proxy.Proxy @Prim.Int 1
   }
 
 Types

--- a/tests-integration/fixtures/checking/1772440080_prim_int_compare_transitive/Main.snap
+++ b/tests-integration/fixtures/checking/1772440080_prim_int_compare_transitive/Main.snap
@@ -5,33 +5,40 @@ expression: report
 ---
 Terms
 assertLesser ::
-  forall (l :: Int) (r :: Int).
-    Compare (l :: Int) (r :: Int) LT => Proxy @(Row Int) ( left :: (l :: Int), right :: (r :: Int) )
+  forall (l :: Prim.Int) (r :: Prim.Int).
+    Prim.Int.Compare (l :: Prim.Int) (r :: Prim.Int) Prim.Ordering.LT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (l :: Prim.Int), right :: (r :: Prim.Int) )
 assertGreater ::
-  forall (l :: Int) (r :: Int).
-    Compare (l :: Int) (r :: Int) GT => Proxy @(Row Int) ( left :: (l :: Int), right :: (r :: Int) )
+  forall (l :: Prim.Int) (r :: Prim.Int).
+    Prim.Int.Compare (l :: Prim.Int) (r :: Prim.Int) Prim.Ordering.GT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (l :: Prim.Int), right :: (r :: Prim.Int) )
 assertEqual ::
-  forall (l :: Int) (r :: Int).
-    Compare (l :: Int) (r :: Int) EQ => Proxy @(Row Int) ( left :: (l :: Int), right :: (r :: Int) )
+  forall (l :: Prim.Int) (r :: Prim.Int).
+    Prim.Int.Compare (l :: Prim.Int) (r :: Prim.Int) Prim.Ordering.EQ =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (l :: Prim.Int), right :: (r :: Prim.Int) )
 transLt ::
-  forall (m :: Int) (n :: Int) (p :: Int).
-    Compare (m :: Int) (n :: Int) LT =>
-    Compare (n :: Int) (p :: Int) LT =>
-    Proxy @Int (n :: Int) -> Proxy @(Row Int) ( left :: (m :: Int), right :: (p :: Int) )
+  forall (m :: Prim.Int) (n :: Prim.Int) (p :: Prim.Int).
+    Prim.Int.Compare (m :: Prim.Int) (n :: Prim.Int) Prim.Ordering.LT =>
+    Prim.Int.Compare (n :: Prim.Int) (p :: Prim.Int) Prim.Ordering.LT =>
+    Type.Proxy.Proxy @Prim.Int (n :: Prim.Int) ->
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (m :: Prim.Int), right :: (p :: Prim.Int) )
 transLtEq ::
-  forall (m :: Int) (n :: Int) (p :: Int).
-    Compare (m :: Int) (n :: Int) LT =>
-    Compare (n :: Int) (p :: Int) EQ =>
-    Proxy @Int (n :: Int) -> Proxy @(Row Int) ( left :: (m :: Int), right :: (p :: Int) )
+  forall (m :: Prim.Int) (n :: Prim.Int) (p :: Prim.Int).
+    Prim.Int.Compare (m :: Prim.Int) (n :: Prim.Int) Prim.Ordering.LT =>
+    Prim.Int.Compare (n :: Prim.Int) (p :: Prim.Int) Prim.Ordering.EQ =>
+    Type.Proxy.Proxy @Prim.Int (n :: Prim.Int) ->
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (m :: Prim.Int), right :: (p :: Prim.Int) )
 transEqGt ::
-  forall (m :: Int) (n :: Int) (p :: Int).
-    Compare (m :: Int) (n :: Int) EQ =>
-    Compare (n :: Int) (p :: Int) GT =>
-    Proxy @Int (n :: Int) -> Proxy @(Row Int) ( left :: (m :: Int), right :: (p :: Int) )
+  forall (m :: Prim.Int) (n :: Prim.Int) (p :: Prim.Int).
+    Prim.Int.Compare (m :: Prim.Int) (n :: Prim.Int) Prim.Ordering.EQ =>
+    Prim.Int.Compare (n :: Prim.Int) (p :: Prim.Int) Prim.Ordering.GT =>
+    Type.Proxy.Proxy @Prim.Int (n :: Prim.Int) ->
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (m :: Prim.Int), right :: (p :: Prim.Int) )
 transSymmEq ::
-  forall (m :: Int) (n :: Int) (p :: Int).
-    Compare (n :: Int) (m :: Int) EQ =>
-    Compare (n :: Int) (p :: Int) EQ =>
-    Proxy @Int (n :: Int) -> Proxy @(Row Int) ( left :: (m :: Int), right :: (p :: Int) )
+  forall (m :: Prim.Int) (n :: Prim.Int) (p :: Prim.Int).
+    Prim.Int.Compare (n :: Prim.Int) (m :: Prim.Int) Prim.Ordering.EQ =>
+    Prim.Int.Compare (n :: Prim.Int) (p :: Prim.Int) Prim.Ordering.EQ =>
+    Type.Proxy.Proxy @Prim.Int (n :: Prim.Int) ->
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (m :: Prim.Int), right :: (p :: Prim.Int) )
 
 Types

--- a/tests-integration/fixtures/checking/1772440140_prim_symbol/Main.snap
+++ b/tests-integration/fixtures/checking/1772440140_prim_symbol/Main.snap
@@ -5,39 +5,50 @@ expression: report
 ---
 Terms
 deriveAppended ::
-  forall (appended :: Symbol).
-    Append "Hello" "World" (appended :: Symbol) => Proxy @Symbol (appended :: Symbol)
+  forall (appended :: Prim.Symbol).
+    Prim.Symbol.Append "Hello" "World" (appended :: Prim.Symbol) =>
+    Type.Proxy.Proxy @Prim.Symbol (appended :: Prim.Symbol)
 deriveLeft ::
-  forall (left :: Symbol).
-    Append (left :: Symbol) "World" "HelloWorld" => Proxy @Symbol (left :: Symbol)
+  forall (left :: Prim.Symbol).
+    Prim.Symbol.Append (left :: Prim.Symbol) "World" "HelloWorld" =>
+    Type.Proxy.Proxy @Prim.Symbol (left :: Prim.Symbol)
 deriveRight ::
-  forall (right :: Symbol).
-    Append "Hello" (right :: Symbol) "HelloWorld" => Proxy @Symbol (right :: Symbol)
+  forall (right :: Prim.Symbol).
+    Prim.Symbol.Append "Hello" (right :: Prim.Symbol) "HelloWorld" =>
+    Type.Proxy.Proxy @Prim.Symbol (right :: Prim.Symbol)
 compareLT ::
-  forall (ord :: Ordering). Compare "a" "b" (ord :: Ordering) => Proxy @Ordering (ord :: Ordering)
+  forall (ord :: Prim.Ordering.Ordering).
+    Prim.Symbol.Compare "a" "b" (ord :: Prim.Ordering.Ordering) =>
+    Type.Proxy.Proxy @Prim.Ordering.Ordering (ord :: Prim.Ordering.Ordering)
 compareEQ ::
-  forall (ord :: Ordering).
-    Compare "hello" "hello" (ord :: Ordering) => Proxy @Ordering (ord :: Ordering)
+  forall (ord :: Prim.Ordering.Ordering).
+    Prim.Symbol.Compare "hello" "hello" (ord :: Prim.Ordering.Ordering) =>
+    Type.Proxy.Proxy @Prim.Ordering.Ordering (ord :: Prim.Ordering.Ordering)
 compareGT ::
-  forall (ord :: Ordering). Compare "z" "a" (ord :: Ordering) => Proxy @Ordering (ord :: Ordering)
+  forall (ord :: Prim.Ordering.Ordering).
+    Prim.Symbol.Compare "z" "a" (ord :: Prim.Ordering.Ordering) =>
+    Type.Proxy.Proxy @Prim.Ordering.Ordering (ord :: Prim.Ordering.Ordering)
 deriveCons ::
-  forall (symbol :: Symbol). Cons "H" "ello" (symbol :: Symbol) => Proxy @Symbol (symbol :: Symbol)
+  forall (symbol :: Prim.Symbol).
+    Prim.Symbol.Cons "H" "ello" (symbol :: Prim.Symbol) =>
+    Type.Proxy.Proxy @Prim.Symbol (symbol :: Prim.Symbol)
 deriveHeadTail ::
-  forall (head :: Symbol) (tail :: Symbol).
-    Cons (head :: Symbol) (tail :: Symbol) "World" => Proxy @Symbol (head :: Symbol)
-symbolValue :: String
-symbolValue' :: String
+  forall (head :: Prim.Symbol) (tail :: Prim.Symbol).
+    Prim.Symbol.Cons (head :: Prim.Symbol) (tail :: Prim.Symbol) "World" =>
+    Type.Proxy.Proxy @Prim.Symbol (head :: Prim.Symbol)
+symbolValue :: Prim.String
+symbolValue' :: Prim.String
 forceSolve ::
-  { compareEQ :: Proxy @Ordering EQ
-  , compareGT :: Proxy @Ordering GT
-  , compareLT :: Proxy @Ordering LT
-  , deriveAppended :: Proxy @Symbol "HelloWorld"
-  , deriveCons :: Proxy @Symbol "Hello"
-  , deriveHeadTail :: Proxy @Symbol "W"
-  , deriveLeft :: Proxy @Symbol "Hello"
-  , deriveRight :: Proxy @Symbol "World"
-  , symbolValue :: String
-  , symbolValue' :: String
+  { compareEQ :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.EQ
+  , compareGT :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.GT
+  , compareLT :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.LT
+  , deriveAppended :: Type.Proxy.Proxy @Prim.Symbol "HelloWorld"
+  , deriveCons :: Type.Proxy.Proxy @Prim.Symbol "Hello"
+  , deriveHeadTail :: Type.Proxy.Proxy @Prim.Symbol "W"
+  , deriveLeft :: Type.Proxy.Proxy @Prim.Symbol "Hello"
+  , deriveRight :: Type.Proxy.Proxy @Prim.Symbol "World"
+  , symbolValue :: Prim.String
+  , symbolValue' :: Prim.String
   }
 
 Types

--- a/tests-integration/fixtures/checking/1772440200_prim_solver_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772440200_prim_solver_apart/Main.snap
@@ -1,18 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-invalidAdd :: Add 2 3 10 => Proxy @Int 10
-invalidCompare :: Compare 5 1 LT => Proxy @Ordering LT
-invalidAppend :: Append "hello" "world" "xyz" => Proxy @Symbol "xyz"
-invalidCons :: Cons "hello" "world" "helloworld" => Proxy @Symbol "world"
+invalidAdd :: Prim.Int.Add 2 3 10 => Type.Proxy.Proxy @Prim.Int 10
+invalidCompare ::
+  Prim.Int.Compare 5 1 Prim.Ordering.LT => Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.LT
+invalidAppend :: Prim.Symbol.Append "hello" "world" "xyz" => Type.Proxy.Proxy @Prim.Symbol "xyz"
+invalidCons ::
+  Prim.Symbol.Cons "hello" "world" "helloworld" => Type.Proxy.Proxy @Prim.Symbol "world"
 forceSolve ::
-  { invalidAdd :: Proxy @Int 10
-  , invalidAppend :: Proxy @Symbol "xyz"
-  , invalidCompare :: Proxy @Ordering LT
-  , invalidCons :: Proxy @Symbol "world"
+  { invalidAdd :: Type.Proxy.Proxy @Prim.Int 10
+  , invalidAppend :: Type.Proxy.Proxy @Prim.Symbol "xyz"
+  , invalidCompare :: Type.Proxy.Proxy @Prim.Ordering.Ordering Prim.Ordering.LT
+  , invalidCons :: Type.Proxy.Proxy @Prim.Symbol "world"
   }
 
 Types

--- a/tests-integration/fixtures/checking/1772440260_prim_row_list/Main.snap
+++ b/tests-integration/fixtures/checking/1772440260_prim_row_list/Main.snap
@@ -5,35 +5,59 @@ expression: report
 ---
 Terms
 rowToListSimple ::
-  forall (list :: RowList Type).
-    RowToList @Type ( a :: Int ) (list :: RowList Type) =>
-    Proxy @(RowList Type) (list :: RowList Type)
+  forall (list :: Prim.RowList.RowList Prim.Type).
+    Prim.RowList.RowToList @Prim.Type ( a :: Prim.Int ) (list :: Prim.RowList.RowList Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type) (list :: Prim.RowList.RowList Prim.Type)
 rowToListMultiple ::
-  forall (list :: RowList Type).
-    RowToList @Type ( a :: Int, b :: String ) (list :: RowList Type) =>
-    Proxy @(RowList Type) (list :: RowList Type)
+  forall (list :: Prim.RowList.RowList Prim.Type).
+    Prim.RowList.RowToList @Prim.Type
+      ( a :: Prim.Int, b :: Prim.String )
+      (list :: Prim.RowList.RowList Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type) (list :: Prim.RowList.RowList Prim.Type)
 rowToListEmpty ::
-  forall (t :: Type) (list :: RowList (t :: Type)).
-    RowToList @(t :: Type) () (list :: RowList (t :: Type)) =>
-    Proxy @(RowList (t :: Type)) (list :: RowList (t :: Type))
+  forall (t :: Prim.Type) (list :: Prim.RowList.RowList (t :: Prim.Type)).
+    Prim.RowList.RowToList @(t :: Prim.Type) () (list :: Prim.RowList.RowList (t :: Prim.Type)) =>
+    Type.Proxy.Proxy @(Prim.RowList.RowList (t :: Prim.Type))
+      (list :: Prim.RowList.RowList (t :: Prim.Type))
 rowToListThree ::
-  forall (list :: RowList Type).
-    RowToList @Type ( a :: Int, b :: String, c :: Boolean ) (list :: RowList Type) =>
-    Proxy @(RowList Type) (list :: RowList Type)
+  forall (list :: Prim.RowList.RowList Prim.Type).
+    Prim.RowList.RowToList @Prim.Type
+      ( a :: Prim.Int, b :: Prim.String, c :: Prim.Boolean )
+      (list :: Prim.RowList.RowList Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type) (list :: Prim.RowList.RowList Prim.Type)
 stuckOpenRow ::
-  forall (tail :: Row Type) (list :: RowList Type).
-    RowToList @Type ( a :: Int | (tail :: Row Type) ) (list :: RowList Type) =>
-    Proxy @(Row Type) (tail :: Row Type) -> Proxy @(RowList Type) (list :: RowList Type)
+  forall (tail :: Prim.Row Prim.Type) (list :: Prim.RowList.RowList Prim.Type).
+    Prim.RowList.RowToList @Prim.Type
+      ( a :: Prim.Int | (tail :: Prim.Row Prim.Type) )
+      (list :: Prim.RowList.RowList Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (tail :: Prim.Row Prim.Type) ->
+    Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type) (list :: Prim.RowList.RowList Prim.Type)
 forceSolve ::
-  forall (t :: Type).
-    { nowSolved :: Proxy @(RowList Type) (Cons @Type "a" Int (Nil @Type))
-    , rowToListEmpty :: Proxy @(RowList (t :: Type)) (Nil @(t :: Type))
+  forall (t :: Prim.Type).
+    { nowSolved ::
+        Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type)
+          (Prim.RowList.Cons @Prim.Type "a" Prim.Int (Prim.RowList.Nil @Prim.Type))
+    , rowToListEmpty ::
+        Type.Proxy.Proxy @(Prim.RowList.RowList (t :: Prim.Type))
+          (Prim.RowList.Nil @(t :: Prim.Type))
     , rowToListMultiple ::
-        Proxy @(RowList Type) (Cons @Type "a" Int (Cons @Type "b" String (Nil @Type)))
-    , rowToListSimple :: Proxy @(RowList Type) (Cons @Type "a" Int (Nil @Type))
+        Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type)
+          (Prim.RowList.Cons @Prim.Type
+            "a"
+            Prim.Int
+            (Prim.RowList.Cons @Prim.Type "b" Prim.String (Prim.RowList.Nil @Prim.Type)))
+    , rowToListSimple ::
+        Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type)
+          (Prim.RowList.Cons @Prim.Type "a" Prim.Int (Prim.RowList.Nil @Prim.Type))
     , rowToListThree ::
-        Proxy @(RowList Type)
-          (Cons @Type "a" Int (Cons @Type "b" String (Cons @Type "c" Boolean (Nil @Type))))
+        Type.Proxy.Proxy @(Prim.RowList.RowList Prim.Type)
+          (Prim.RowList.Cons @Prim.Type
+            "a"
+            Prim.Int
+            (Prim.RowList.Cons @Prim.Type
+              "b"
+              Prim.String
+              (Prim.RowList.Cons @Prim.Type "c" Prim.Boolean (Prim.RowList.Nil @Prim.Type))))
     }
 
 Types

--- a/tests-integration/fixtures/checking/1772440320_prim_row/Main.snap
+++ b/tests-integration/fixtures/checking/1772440320_prim_row/Main.snap
@@ -5,83 +5,107 @@ expression: report
 ---
 Terms
 deriveUnion ::
-  forall (u :: Row Type).
-    Union @Type ( a :: Int ) ( b :: String ) (u :: Row Type) => Proxy @(Row Type) (u :: Row Type)
+  forall (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type ( a :: Prim.Int ) ( b :: Prim.String ) (u :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 deriveUnionLeft ::
-  forall (l :: Row Type).
-    Union @Type (l :: Row Type) ( b :: String ) ( a :: Int, b :: String ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 deriveUnionRight ::
-  forall (r :: Row Type).
-    Union @Type ( a :: Int ) (r :: Row Type) ( a :: Int, b :: String ) =>
-    Proxy @(Row Type) (r :: Row Type)
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int )
+      (r :: Prim.Row Prim.Type)
+      ( a :: Prim.Int, b :: Prim.String ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type)
 unionEmptyLeft ::
-  forall (u :: Row Type).
-    Union @Type () ( a :: Int ) (u :: Row Type) => Proxy @(Row Type) (u :: Row Type)
+  forall (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type () ( a :: Prim.Int ) (u :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 unionEmptyRight ::
-  forall (u :: Row Type).
-    Union @Type ( a :: Int ) () (u :: Row Type) => Proxy @(Row Type) (u :: Row Type)
+  forall (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type ( a :: Prim.Int ) () (u :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 unionBothEmpty ::
-  forall (t :: Type) (u :: Row (t :: Type)).
-    Union @(t :: Type) () () (u :: Row (t :: Type)) =>
-    Proxy @(Row (t :: Type)) (u :: Row (t :: Type))
+  forall (t :: Prim.Type) (u :: Prim.Row (t :: Prim.Type)).
+    Prim.Row.Union @(t :: Prim.Type) () () (u :: Prim.Row (t :: Prim.Type)) =>
+    Type.Proxy.Proxy @(Prim.Row (t :: Prim.Type)) (u :: Prim.Row (t :: Prim.Type))
 unionMultiple ::
-  forall (u :: Row Type).
-    Union @Type ( a :: Int, b :: String ) ( c :: Boolean ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int, b :: Prim.String )
+      ( c :: Prim.Boolean )
+      (u :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 deriveCons ::
-  forall (row :: Row Type).
-    Cons @Type "name" String () (row :: Row Type) => Proxy @(Row Type) (row :: Row Type)
+  forall (row :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type "name" Prim.String () (row :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
 deriveTail ::
-  forall (tail :: Row Type).
-    Cons @Type "name" String (tail :: Row Type) ( age :: Int, name :: String ) =>
-    Proxy @(Row Type) (tail :: Row Type)
+  forall (tail :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "name"
+      Prim.String
+      (tail :: Prim.Row Prim.Type)
+      ( age :: Prim.Int, name :: Prim.String ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (tail :: Prim.Row Prim.Type)
 deriveType ::
-  forall (t :: Type). Cons @Type "name" (t :: Type) () ( name :: String ) => Proxy @Type (t :: Type)
+  forall (t :: Prim.Type).
+    Prim.Row.Cons @Prim.Type "name" (t :: Prim.Type) () ( name :: Prim.String ) =>
+    Type.Proxy.Proxy @Prim.Type (t :: Prim.Type)
 nestedCons ::
-  forall (row :: Row Type).
-    Cons @Type "a" Int ( b :: String ) (row :: Row Type) => Proxy @(Row Type) (row :: Row Type)
+  forall (row :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type "a" Prim.Int ( b :: Prim.String ) (row :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
 lacksSimple ::
-  forall (t :: Type) (r :: (t :: Type)).
-    Lacks @Type "missing" ( a :: Int, b :: String ) =>
-    Proxy @(t :: Type) (r :: (t :: Type)) -> Proxy @(t :: Type) (r :: (t :: Type))
+  forall (t :: Prim.Type) (r :: (t :: Prim.Type)).
+    Prim.Row.Lacks @Prim.Type "missing" ( a :: Prim.Int, b :: Prim.String ) =>
+    Type.Proxy.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type)) ->
+    Type.Proxy.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type))
 lacksEmpty ::
-  forall (t :: Type) (t1 :: Type) (r :: (t :: Type)).
-    Lacks @(t1 :: Type) "anything" () =>
-    Proxy @(t :: Type) (r :: (t :: Type)) -> Proxy @(t :: Type) (r :: (t :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (r :: (t :: Prim.Type)).
+    Prim.Row.Lacks @(t1 :: Prim.Type) "anything" () =>
+    Type.Proxy.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type)) ->
+    Type.Proxy.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type))
 nubNoDuplicates ::
-  forall (nubbed :: Row Type).
-    Nub @Type ( a :: Int, b :: String ) (nubbed :: Row Type) =>
-    Proxy @(Row Type) (nubbed :: Row Type)
+  forall (nubbed :: Prim.Row Prim.Type).
+    Prim.Row.Nub @Prim.Type ( a :: Prim.Int, b :: Prim.String ) (nubbed :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (nubbed :: Prim.Row Prim.Type)
 nubEmpty ::
-  forall (t :: Type) (nubbed :: Row (t :: Type)).
-    Nub @(t :: Type) () (nubbed :: Row (t :: Type)) =>
-    Proxy @(Row (t :: Type)) (nubbed :: Row (t :: Type))
+  forall (t :: Prim.Type) (nubbed :: Prim.Row (t :: Prim.Type)).
+    Prim.Row.Nub @(t :: Prim.Type) () (nubbed :: Prim.Row (t :: Prim.Type)) =>
+    Type.Proxy.Proxy @(Prim.Row (t :: Prim.Type)) (nubbed :: Prim.Row (t :: Prim.Type))
 solveUnion ::
-  forall (t :: Type).
-    { deriveUnion :: Proxy @(Row Type) ( a :: Int, b :: String )
-    , deriveUnionLeft :: Proxy @(Row Type) ( a :: Int )
-    , deriveUnionRight :: Proxy @(Row Type) ( b :: String )
-    , unionBothEmpty :: Proxy @(Row (t :: Type)) ()
-    , unionEmptyLeft :: Proxy @(Row Type) ( a :: Int )
-    , unionEmptyRight :: Proxy @(Row Type) ( a :: Int )
-    , unionMultiple :: Proxy @(Row Type) ( a :: Int, b :: String, c :: Boolean )
+  forall (t :: Prim.Type).
+    { deriveUnion :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int, b :: Prim.String )
+    , deriveUnionLeft :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int )
+    , deriveUnionRight :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( b :: Prim.String )
+    , unionBothEmpty :: Type.Proxy.Proxy @(Prim.Row (t :: Prim.Type)) ()
+    , unionEmptyLeft :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int )
+    , unionEmptyRight :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int )
+    , unionMultiple ::
+        Type.Proxy.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.Int, b :: Prim.String, c :: Prim.Boolean )
     }
 solveCons ::
-  { deriveCons :: Proxy @(Row Type) ( name :: String )
-  , deriveTail :: Proxy @(Row Type) ( age :: Int )
-  , deriveType :: Proxy @Type String
-  , nestedCons :: Proxy @(Row Type) ( a :: Int, b :: String )
+  { deriveCons :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( name :: Prim.String )
+  , deriveTail :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( age :: Prim.Int )
+  , deriveType :: Type.Proxy.Proxy @Prim.Type Prim.String
+  , nestedCons :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int, b :: Prim.String )
   }
 solveLacks ::
-  forall (t :: Type) (t1 :: (t :: Type)) (t2 :: Type) (t3 :: (t2 :: Type)).
-    { lacksEmpty :: Proxy @(t :: Type) (t1 :: (t :: Type))
-    , lacksSimple :: Proxy @(t2 :: Type) (t3 :: (t2 :: Type))
+  forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t2 :: Prim.Type) (t3 :: (t2 :: Prim.Type)).
+    { lacksEmpty :: Type.Proxy.Proxy @(t :: Prim.Type) (t1 :: (t :: Prim.Type))
+    , lacksSimple :: Type.Proxy.Proxy @(t2 :: Prim.Type) (t3 :: (t2 :: Prim.Type))
     }
 solveNub ::
-  forall (t :: Type).
-    { nubEmpty :: Proxy @(Row (t :: Type)) ()
-    , nubNoDuplicates :: Proxy @(Row Type) ( a :: Int, b :: String )
+  forall (t :: Prim.Type).
+    { nubEmpty :: Type.Proxy.Proxy @(Prim.Row (t :: Prim.Type)) ()
+    , nubNoDuplicates :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int, b :: Prim.String )
     }
 
 Types

--- a/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772440380_prim_row_apart/Main.snap
@@ -5,20 +5,28 @@ expression: report
 ---
 Terms
 unionTypeMismatch ::
-  forall (l :: Row Type).
-    Union @Type (l :: Row Type) ( b :: String ) ( a :: Int, b :: Int ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.Int ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 consMissingLabel ::
-  forall (t :: Row Type).
-    Cons @Type "missing" Int (t :: Row Type) ( a :: Int, b :: String ) =>
-    Proxy @(Row Type) (t :: Row Type)
+  forall (t :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "missing"
+      Prim.Int
+      (t :: Prim.Row Prim.Type)
+      ( a :: Prim.Int, b :: Prim.String ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (t :: Prim.Row Prim.Type)
 lacksPresent ::
-  Lacks @Type "b" ( a :: Int, b :: String ) => Proxy @(Row Type) ( a :: Int, b :: String )
+  Prim.Row.Lacks @Prim.Type "b" ( a :: Prim.Int, b :: Prim.String ) =>
+  Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int, b :: Prim.String )
 forceSolve ::
-  forall (t :: Row Type).
-    { consMissingLabel :: Proxy @(Row Type) (t :: Row Type)
-    , lacksPresent :: Proxy @(Row Type) ( a :: Int, b :: String )
-    , unionTypeMismatch :: Proxy @(Row Type) ( a :: Int )
+  forall (t :: Prim.Row Prim.Type).
+    { consMissingLabel :: Type.Proxy.Proxy @(Prim.Row Prim.Type) (t :: Prim.Row Prim.Type)
+    , lacksPresent :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int, b :: Prim.String )
+    , unionTypeMismatch :: Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int )
     }
 
 Types

--- a/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
+++ b/tests-integration/fixtures/checking/1772440440_prim_row_open/Main.snap
@@ -5,54 +5,95 @@ expression: report
 ---
 Terms
 openLeft ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int | (r :: Row Type) ) ( b :: String ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int | (r :: Prim.Row Prim.Type) )
+      ( b :: Prim.String )
+      (u :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 openRight ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int ) ( b :: String | (r :: Row Type) ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int )
+      ( b :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (u :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 backwardLeft ::
-  forall (l :: Row Type) (r :: Row Type).
-    Union @Type (l :: Row Type) ( b :: String ) ( a :: Int, b :: String | (r :: Row Type) ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 backwardRight ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int ) (r :: Row Type) ( a :: Int, b :: String | (u :: Row Type) ) =>
-    Proxy @(Row Type) (r :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int )
+      (r :: Prim.Row Prim.Type)
+      ( a :: Prim.Int, b :: Prim.String | (u :: Prim.Row Prim.Type) ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type)
 consOpen ::
-  forall (r :: Row Type) (row :: Row Type).
-    Cons @Type "x" Int ( a :: String | (r :: Row Type) ) (row :: Row Type) =>
-    Proxy @(Row Type) (row :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (row :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "x"
+      Prim.Int
+      ( a :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (row :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
 decomposeOpen ::
-  forall (t :: Type) (tail :: Row Type) (r :: Row Type).
-    Cons @Type "x" (t :: Type) (tail :: Row Type) ( a :: String, x :: Int | (r :: Row Type) ) =>
-    Proxy @Type (t :: Type)
+  forall (t :: Prim.Type) (tail :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "x"
+      (t :: Prim.Type)
+      (tail :: Prim.Row Prim.Type)
+      ( a :: Prim.String, x :: Prim.Int | (r :: Prim.Row Prim.Type) ) =>
+    Type.Proxy.Proxy @Prim.Type (t :: Prim.Type)
 extractTail ::
-  forall (tail :: Row Type) (r :: Row Type).
-    Cons @Type "x" Int (tail :: Row Type) ( a :: String, x :: Int | (r :: Row Type) ) =>
-    Proxy @(Row Type) (tail :: Row Type)
+  forall (tail :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "x"
+      Prim.Int
+      (tail :: Prim.Row Prim.Type)
+      ( a :: Prim.String, x :: Prim.Int | (r :: Prim.Row Prim.Type) ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (tail :: Prim.Row Prim.Type)
 lacksOpen ::
-  forall (r :: Row Type).
-    Lacks @Type "missing" ( a :: Int, b :: String | (r :: Row Type) ) =>
-    Proxy @(Row Type) (r :: Row Type) -> Int
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type
+      "missing"
+      ( a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type) -> Prim.Int
 lacksPresent ::
-  forall (r :: Row Type).
-    Lacks @Type "a" ( a :: Int | (r :: Row Type) ) => Proxy @(Row Type) (r :: Row Type) -> Int
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type "a" ( a :: Prim.Int | (r :: Prim.Row Prim.Type) ) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type) -> Prim.Int
 forceSolve ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Row Type) (t4 :: Row Type)
-    (t5 :: Row Type) (t6 :: Row Type) (t7 :: Row Type).
-    Union @Type (t :: Row Type) ( b :: String ) ( a :: Int, b :: String | (t1 :: Row Type) ) =>
-    Union @Type (t2 :: Row Type) ( b :: String ) (t3 :: Row Type) =>
-    { backwardLeft :: Proxy @(Row Type) (t :: Row Type)
-    , backwardRight :: Proxy @(Row Type) ( b :: String | (t4 :: Row Type) )
-    , consOpen :: Proxy @(Row Type) ( a :: String, x :: Int | (t5 :: Row Type) )
-    , decomposeOpen :: Proxy @Type Int
-    , extractTail :: Proxy @(Row Type) ( a :: String | (t6 :: Row Type) )
-    , lacksOpen :: Int
-    , lacksPresent :: Int
-    , openLeft :: Proxy @(Row Type) ( a :: Int | (t3 :: Row Type) )
-    , openRight :: Proxy @(Row Type) ( a :: Int, b :: String | (t7 :: Row Type) )
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type)
+    (t3 :: Prim.Row Prim.Type) (t4 :: Prim.Row Prim.Type) (t5 :: Prim.Row Prim.Type)
+    (t6 :: Prim.Row Prim.Type) (t7 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String | (t1 :: Prim.Row Prim.Type) ) =>
+    Prim.Row.Union @Prim.Type
+      (t2 :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      (t3 :: Prim.Row Prim.Type) =>
+    { backwardLeft :: Type.Proxy.Proxy @(Prim.Row Prim.Type) (t :: Prim.Row Prim.Type)
+    , backwardRight ::
+        Type.Proxy.Proxy @(Prim.Row Prim.Type) ( b :: Prim.String | (t4 :: Prim.Row Prim.Type) )
+    , consOpen ::
+        Type.Proxy.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.String, x :: Prim.Int | (t5 :: Prim.Row Prim.Type) )
+    , decomposeOpen :: Type.Proxy.Proxy @Prim.Type Prim.Int
+    , extractTail ::
+        Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.String | (t6 :: Prim.Row Prim.Type) )
+    , lacksOpen :: Prim.Int
+    , lacksPresent :: Prim.Int
+    , openLeft ::
+        Type.Proxy.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int | (t3 :: Prim.Row Prim.Type) )
+    , openRight ::
+        Type.Proxy.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.Int, b :: Prim.String | (t7 :: Prim.Row Prim.Type) )
     }
 
 Types

--- a/tests-integration/fixtures/checking/1772440500_prim_row_generalization/Main.snap
+++ b/tests-integration/fixtures/checking/1772440500_prim_row_generalization/Main.snap
@@ -4,47 +4,93 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 merge ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Nub @Type (r3 :: Row Type) (r4 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r4 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type)
+    (r4 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Prim.Row.Nub @Prim.Type (r3 :: Prim.Row Prim.Type) (r4 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r4 :: Prim.Row Prim.Type) }
 a ::
-  forall (t :: Row Type) (t1 :: Row Type).
-    Nub @Type ( a :: Int | (t :: Row Type) ) (t1 :: Row Type) =>
-    {| (t :: Row Type) } -> {| (t1 :: Row Type) }
-b :: { a :: Int, b :: Int }
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type).
+    Prim.Row.Nub @Prim.Type
+      ( a :: Prim.Int | (t :: Prim.Row Prim.Type) )
+      (t1 :: Prim.Row Prim.Type) =>
+    {| (t :: Prim.Row Prim.Type) } -> {| (t1 :: Prim.Row Prim.Type) }
+b :: { a :: Prim.Int, b :: Prim.Int }
 fromUnion ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) => {| (r3 :: Row Type) } -> Int
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    {| (r3 :: Prim.Row Prim.Type) } -> Prim.Int
 test ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type).
-    Union @Type (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) => {| (t2 :: Row Type) } -> Int
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      (t1 :: Prim.Row Prim.Type)
+      (t2 :: Prim.Row Prim.Type) =>
+    {| (t2 :: Prim.Row Prim.Type) } -> Prim.Int
 chainedUnion ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type) (r5 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Union @Type (r3 :: Row Type) (r4 :: Row Type) (r5 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r5 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type)
+    (r4 :: Prim.Row Prim.Type) (r5 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Prim.Row.Union @Prim.Type
+      (r3 :: Prim.Row Prim.Type)
+      (r4 :: Prim.Row Prim.Type)
+      (r5 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } -> {| (r5 :: Prim.Row Prim.Type) }
 testChained ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type).
-    Union @Type (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) => { x :: Int | (t2 :: Row Type) }
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      (t1 :: Prim.Row Prim.Type)
+      (t2 :: Prim.Row Prim.Type) =>
+    { x :: Prim.Int | (t2 :: Prim.Row Prim.Type) }
 multiMerge ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type) (r5 :: Row Type)
-    (r6 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Nub @Type (r3 :: Row Type) (r4 :: Row Type) =>
-    Union @Type (r4 :: Row Type) (r5 :: Row Type) (r6 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r5 :: Row Type) } -> {| (r6 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type)
+    (r4 :: Prim.Row Prim.Type) (r5 :: Prim.Row Prim.Type) (r6 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Prim.Row.Nub @Prim.Type (r3 :: Prim.Row Prim.Type) (r4 :: Prim.Row Prim.Type) =>
+    Prim.Row.Union @Prim.Type
+      (r4 :: Prim.Row Prim.Type)
+      (r5 :: Prim.Row Prim.Type)
+      (r6 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r5 :: Prim.Row Prim.Type) } ->
+    {| (r6 :: Prim.Row Prim.Type) }
 testMulti1 ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Row Type).
-    Union @Type (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) =>
-    Nub @Type ( a :: Int | (t3 :: Row Type) ) (t :: Row Type) =>
-    {| (t1 :: Row Type) } -> {| (t2 :: Row Type) }
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type)
+    (t3 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      (t1 :: Prim.Row Prim.Type)
+      (t2 :: Prim.Row Prim.Type) =>
+    Prim.Row.Nub @Prim.Type
+      ( a :: Prim.Int | (t3 :: Prim.Row Prim.Type) )
+      (t :: Prim.Row Prim.Type) =>
+    {| (t1 :: Prim.Row Prim.Type) } -> {| (t2 :: Prim.Row Prim.Type) }
 testMulti2 ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type).
-    Nub @Type ( a :: Int | (t :: Row Type) ) (t1 :: Row Type) =>
-    Union @Type (t1 :: Row Type) ( b :: Int ) (t2 :: Row Type) =>
-    {| (t2 :: Row Type) }
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type).
+    Prim.Row.Nub @Prim.Type
+      ( a :: Prim.Int | (t :: Prim.Row Prim.Type) )
+      (t1 :: Prim.Row Prim.Type) =>
+    Prim.Row.Union @Prim.Type
+      (t1 :: Prim.Row Prim.Type)
+      ( b :: Prim.Int )
+      (t2 :: Prim.Row Prim.Type) =>
+    {| (t2 :: Prim.Row Prim.Type) }
 
 Types

--- a/tests-integration/fixtures/checking/1772440560_prim_row_nub_left_bias/Main.snap
+++ b/tests-integration/fixtures/checking/1772440560_prim_row_nub_left_bias/Main.snap
@@ -1,15 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 merge ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Nub @Type (r3 :: Row Type) (r4 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r4 :: Row Type) }
-test :: { a :: Int, b :: String }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type)
+    (r4 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Prim.Row.Nub @Prim.Type (r3 :: Prim.Row Prim.Type) (r4 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r4 :: Prim.Row Prim.Type) }
+test :: { a :: Prim.Int, b :: Prim.String }
 
 Types

--- a/tests-integration/fixtures/checking/1772440620_prim_row_record/Main.snap
+++ b/tests-integration/fixtures/checking/1772440620_prim_row_record/Main.snap
@@ -4,23 +4,31 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 union ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r3 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r3 :: Prim.Row Prim.Type) }
 addField ::
-  forall (r :: Row Type).
-    { a :: Int | (r :: Row Type) } -> { a :: Int, b :: String | (r :: Row Type) }
-test :: { a :: Int, b :: String, c :: Boolean }
+  forall (r :: Prim.Row Prim.Type).
+    { a :: Prim.Int | (r :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) }
+test :: { a :: Prim.Int, b :: Prim.String, c :: Prim.Boolean }
 insertX ::
-  forall (r :: Row Type).
-    Lacks @Type "x" (r :: Row Type) => {| (r :: Row Type) } -> { x :: Int | (r :: Row Type) }
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type "x" (r :: Prim.Row Prim.Type) =>
+    {| (r :: Prim.Row Prim.Type) } -> { x :: Prim.Int | (r :: Prim.Row Prim.Type) }
 insertOpen ::
-  forall (r :: Row Type).
-    Lacks @Type "x" (r :: Row Type) =>
-    { a :: Int | (r :: Row Type) } -> { a :: Int, x :: Int | (r :: Row Type) }
-test2 :: { a :: Int, b :: String, x :: Int }
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type "x" (r :: Prim.Row Prim.Type) =>
+    { a :: Prim.Int | (r :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int, x :: Prim.Int | (r :: Prim.Row Prim.Type) }
+test2 :: { a :: Prim.Int, b :: Prim.String, x :: Prim.Int }
 
 Types
 

--- a/tests-integration/fixtures/checking/1772442480_compiler_solved_superclass_given/Main.snap
+++ b/tests-integration/fixtures/checking/1772442480_compiler_solved_superclass_given/Main.snap
@@ -4,18 +4,39 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 merge ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r3 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r3 :: Prim.Row Prim.Type) }
 merge2 ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Merge @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r3 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Main.Merge @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r3 :: Prim.Row Prim.Type) }
 
 Types
-Merge :: forall (t :: Type). Row (t :: Type) -> Row (t :: Type) -> Row (t :: Type) -> Constraint
+Merge ::
+  forall (t :: Prim.Type).
+    Prim.Row (t :: Prim.Type) ->
+    Prim.Row (t :: Prim.Type) ->
+    Prim.Row (t :: Prim.Type) ->
+    Prim.Constraint
 
 Classes
-class forall (t :: Type) (r1 :: Row (t :: Type)) (r2 :: Row (t :: Type)) (r3 :: Row (t :: Type)). Union @(t :: Type) (r1 :: Row (t :: Type)) (r2 :: Row (t :: Type)) (r3 :: Row (t :: Type)) <= Merge @(t :: Type) (r1 :: Row (t :: Type)) (r2 :: Row (t :: Type)) (r3 :: Row (t :: Type))
+class forall (t :: Prim.Type) (r1 :: Prim.Row (t :: Prim.Type)) (r2 :: Prim.Row (t :: Prim.Type)) (r3 :: Prim.Row (t :: Prim.Type)). Prim.Row.Union @(t :: Prim.Type)
+  (r1 :: Prim.Row (t :: Prim.Type))
+  (r2 :: Prim.Row (t :: Prim.Type))
+  (r3 :: Prim.Row (t :: Prim.Type)) <= Main.Merge @(t :: Prim.Type)
+  (r1 :: Prim.Row (t :: Prim.Type))
+  (r2 :: Prim.Row (t :: Prim.Type))
+  (r3 :: Prim.Row (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772442540_compiler_solved_superclass_minimisation/Main.snap
+++ b/tests-integration/fixtures/checking/1772442540_compiler_solved_superclass_minimisation/Main.snap
@@ -4,22 +4,51 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 useMerge ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Merge @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Proxy @(Row Type) (r3 :: Row Type) -> {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> Int
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Main.Merge @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type) ->
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    Prim.Int
 useUnion ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Proxy @(Row Type) (r3 :: Row Type) -> {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> Int
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type) ->
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    Prim.Int
 testMin ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type).
-    Merge @Type (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) =>
-    Proxy @(Row Type) (t2 :: Row Type) -> {| (t :: Row Type) } -> {| (t1 :: Row Type) } -> Int
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type).
+    Main.Merge @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      (t1 :: Prim.Row Prim.Type)
+      (t2 :: Prim.Row Prim.Type) =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type) ->
+    {| (t :: Prim.Row Prim.Type) } ->
+    {| (t1 :: Prim.Row Prim.Type) } ->
+    Prim.Int
 
 Types
-Merge :: forall (t :: Type). Row (t :: Type) -> Row (t :: Type) -> Row (t :: Type) -> Constraint
+Merge ::
+  forall (t :: Prim.Type).
+    Prim.Row (t :: Prim.Type) ->
+    Prim.Row (t :: Prim.Type) ->
+    Prim.Row (t :: Prim.Type) ->
+    Prim.Constraint
 
 Classes
-class forall (t :: Type) (r1 :: Row (t :: Type)) (r2 :: Row (t :: Type)) (r3 :: Row (t :: Type)). Union @(t :: Type) (r1 :: Row (t :: Type)) (r2 :: Row (t :: Type)) (r3 :: Row (t :: Type)) <= Merge @(t :: Type) (r1 :: Row (t :: Type)) (r2 :: Row (t :: Type)) (r3 :: Row (t :: Type))
+class forall (t :: Prim.Type) (r1 :: Prim.Row (t :: Prim.Type)) (r2 :: Prim.Row (t :: Prim.Type)) (r3 :: Prim.Row (t :: Prim.Type)). Prim.Row.Union @(t :: Prim.Type)
+  (r1 :: Prim.Row (t :: Prim.Type))
+  (r2 :: Prim.Row (t :: Prim.Type))
+  (r3 :: Prim.Row (t :: Prim.Type)) <= Main.Merge @(t :: Prim.Type)
+  (r1 :: Prim.Row (t :: Prim.Type))
+  (r2 :: Prim.Row (t :: Prim.Type))
+  (r3 :: Prim.Row (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772442600_prim_reflectable/Main.snap
+++ b/tests-integration/fixtures/checking/1772442600_prim_reflectable/Main.snap
@@ -1,22 +1,22 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-testSymbol :: String
-testSymbol' :: String
-testInt :: Int
-testInt' :: Int
-testTrue :: Boolean
-testTrue' :: Boolean
-testFalse :: Boolean
-testFalse' :: Boolean
-testLT :: Ordering
-testLT' :: Ordering
-testEQ :: Ordering
-testEQ' :: Ordering
-testGT :: Ordering
-testGT' :: Ordering
+testSymbol :: Prim.String
+testSymbol' :: Prim.String
+testInt :: Prim.Int
+testInt' :: Prim.Int
+testTrue :: Prim.Boolean
+testTrue' :: Prim.Boolean
+testFalse :: Prim.Boolean
+testFalse' :: Prim.Boolean
+testLT :: Data.Ordering.Ordering
+testLT' :: Data.Ordering.Ordering
+testEQ :: Data.Ordering.Ordering
+testEQ' :: Data.Ordering.Ordering
+testGT :: Data.Ordering.Ordering
+testGT' :: Data.Ordering.Ordering
 
 Types

--- a/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
+++ b/tests-integration/fixtures/checking/1772442660_prim_type_error_warn/Main.snap
@@ -4,40 +4,70 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 warnBasic ::
-  forall (a :: Type). Warn (Text "This function is deprecated") => (a :: Type) -> (a :: Type)
-useWarnBasic :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn (Prim.TypeError.Text "This function is deprecated") =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnBasic :: Prim.Int
 warnBeside ::
-  forall (a :: Type). Warn (Beside (Text "Left ") (Text "Right")) => (a :: Type) -> (a :: Type)
-useWarnBeside :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Beside (Prim.TypeError.Text "Left ") (Prim.TypeError.Text "Right")) =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnBeside :: Prim.Int
 warnAbove ::
-  forall (a :: Type). Warn (Above (Text "Line 1") (Text "Line 2")) => (a :: Type) -> (a :: Type)
-useWarnAbove :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Above (Prim.TypeError.Text "Line 1") (Prim.TypeError.Text "Line 2")) =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnAbove :: Prim.Int
 warnQuote ::
-  forall (t :: Type) (a :: (t :: Type)).
-    Warn (Beside (Text "Got type: ") (Quote @(t :: Type) (a :: (t :: Type)))) =>
-    Proxy @(t :: Type) (a :: (t :: Type)) -> Proxy @(t :: Type) (a :: (t :: Type))
-useWarnQuote :: Proxy @Type Int
+  forall (t :: Prim.Type) (a :: (t :: Prim.Type)).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Beside
+        (Prim.TypeError.Text "Got type: ")
+        (Prim.TypeError.Quote @(t :: Prim.Type) (a :: (t :: Prim.Type)))) =>
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
+useWarnQuote :: Main.Proxy @Prim.Type Prim.Int
 warnQuoteLabel ::
-  forall (a :: Type).
-    Warn (Beside (Text "Label: ") (QuoteLabel "myField")) => (a :: Type) -> (a :: Type)
-useWarnQuoteLabel :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Beside
+        (Prim.TypeError.Text "Label: ")
+        (Prim.TypeError.QuoteLabel "myField")) =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnQuoteLabel :: Prim.Int
 warnQuoteLabelSpaces ::
-  forall (a :: Type).
-    Warn (Beside (Text "Label: ") (QuoteLabel "h e l l o")) => (a :: Type) -> (a :: Type)
-useWarnQuoteLabelSpaces :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Beside
+        (Prim.TypeError.Text "Label: ")
+        (Prim.TypeError.QuoteLabel "h e l l o")) =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnQuoteLabelSpaces :: Prim.Int
 warnQuoteLabelQuote ::
-  forall (a :: Type).
-    Warn (Beside (Text "Label: ") (QuoteLabel "hel\"lo")) => (a :: Type) -> (a :: Type)
-useWarnQuoteLabelQuote :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Beside
+        (Prim.TypeError.Text "Label: ")
+        (Prim.TypeError.QuoteLabel "hel\"lo")) =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnQuoteLabelQuote :: Prim.Int
 warnQuoteLabelRaw ::
-  forall (a :: Type).
-    Warn (Beside (Text "Label: ") (QuoteLabel """raw\nstring""")) => (a :: Type) -> (a :: Type)
-useWarnQuoteLabelRaw :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Warn
+      (Prim.TypeError.Beside
+        (Prim.TypeError.Text "Label: ")
+        (Prim.TypeError.QuoteLabel """raw\nstring""")) =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useWarnQuoteLabelRaw :: Prim.Int
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1772442720_prim_type_error_fail/Main.snap
@@ -4,18 +4,28 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 failBasic ::
-  forall (a :: Type). Fail (Text "This operation is not allowed") => (a :: Type) -> (a :: Type)
-useFailBasic :: Int
+  forall (a :: Prim.Type).
+    Prim.TypeError.Fail (Prim.TypeError.Text "This operation is not allowed") =>
+    (a :: Prim.Type) -> (a :: Prim.Type)
+useFailBasic :: Prim.Int
 failComplex ::
-  forall (t :: Type) (a :: (t :: Type)).
-    Fail (Above (Text "Error:") (Beside (Text "Type ") (Quote @(t :: Type) (a :: (t :: Type))))) =>
-    Proxy @(t :: Type) (a :: (t :: Type)) -> Proxy @(t :: Type) (a :: (t :: Type))
-useFailComplex :: Proxy @Type String
+  forall (t :: Prim.Type) (a :: (t :: Prim.Type)).
+    Prim.TypeError.Fail
+      (Prim.TypeError.Above
+        (Prim.TypeError.Text "Error:")
+        (Prim.TypeError.Beside
+          (Prim.TypeError.Text "Type ")
+          (Prim.TypeError.Quote @(t :: Prim.Type) (a :: (t :: Prim.Type))))) =>
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
+useFailComplex :: Main.Proxy @Prim.Type Prim.String
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772475240_prim_coercible_given_symmetry/Main.snap
+++ b/tests-integration/fixtures/checking/1772475240_prim_coercible_given_symmetry/Main.snap
@@ -5,10 +5,12 @@ expression: report
 ---
 Terms
 test ::
-  forall (a :: Type) (b :: Type).
-    Coercible @Type (b :: Type) (a :: Type) => (a :: Type) -> (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Prim.Coerce.Coercible @Prim.Type (b :: Prim.Type) (a :: Prim.Type) =>
+    (a :: Prim.Type) -> (b :: Prim.Type)
 test' ::
-  forall (a :: Type) (b :: Type).
-    Coercible @Type (b :: Type) (a :: Type) => (a :: Type) -> (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Prim.Coerce.Coercible @Prim.Type (b :: Prim.Type) (a :: Prim.Type) =>
+    (a :: Prim.Type) -> (b :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772475300_prim_coercible_reflexivity/Main.snap
+++ b/tests-integration/fixtures/checking/1772475300_prim_coercible_reflexivity/Main.snap
@@ -1,11 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-testInt :: Int -> Int
-testString :: String -> String
-testPoly :: forall (a :: Type). (a :: Type) -> (a :: Type)
+testInt :: Prim.Int -> Prim.Int
+testString :: Prim.String -> Prim.String
+testPoly :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772475360_prim_coercible_newtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772475360_prim_coercible_newtype/Main.snap
@@ -4,16 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-wrapAge :: Int -> Age
-unwrapAge :: Age -> Int
-Wrapper :: forall (@a :: Type). (a :: Type) -> Wrapper (a :: Type)
-wrapValue :: forall (a :: Type). (a :: Type) -> Wrapper (a :: Type)
-unwrapValue :: forall (a :: Type). Wrapper (a :: Type) -> (a :: Type)
+Age :: Prim.Int -> Main.Age
+wrapAge :: Prim.Int -> Main.Age
+unwrapAge :: Main.Age -> Prim.Int
+Wrapper :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
+wrapValue :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
+unwrapValue :: forall (a :: Prim.Type). Main.Wrapper (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-Age :: Type
-Wrapper :: Type -> Type
+Age :: Prim.Type
+Wrapper :: Prim.Type -> Prim.Type
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772475420_prim_coercible_roles/Main.snap
+++ b/tests-integration/fixtures/checking/1772475420_prim_coercible_roles/Main.snap
@@ -4,20 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
-coerceProxy :: Proxy @Type Int -> Proxy @Type String
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-coerceMaybe :: Maybe Age -> Maybe Int
-coerceMaybeReverse :: Maybe Int -> Maybe Age
-coerceRecord :: { age :: Age, name :: String } -> { age :: Int, name :: String }
-coerceFunction :: (Int -> Age) -> Int -> Int
+Age :: Prim.Int -> Main.Age
+Proxy ::
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
+coerceProxy :: Main.Proxy @Prim.Type Prim.Int -> Main.Proxy @Prim.Type Prim.String
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+coerceMaybe :: Main.Maybe Main.Age -> Main.Maybe Prim.Int
+coerceMaybeReverse :: Main.Maybe Prim.Int -> Main.Maybe Main.Age
+coerceRecord :: { age :: Main.Age, name :: Prim.String } -> { age :: Prim.Int, name :: Prim.String }
+coerceFunction :: (Prim.Int -> Main.Age) -> Prim.Int -> Prim.Int
 
 Types
-Age :: Type
-Proxy :: forall (t :: Type). (t :: Type) -> Type
-Maybe :: Type -> Type
+Age :: Prim.Type
+Proxy :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772475480_prim_coercible_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1772475480_prim_coercible_apart/Main.snap
@@ -4,15 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
-coerceDifferent :: Maybe Int -> Either Int String
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+coerceDifferent :: Main.Maybe Prim.Int -> Main.Either Prim.Int Prim.String
 
 Types
-Maybe :: Type -> Type
-Either :: Type -> Type -> Type
+Maybe :: Prim.Type -> Prim.Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772475540_prim_coercible_hidden_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772475540_prim_coercible_hidden_constructor/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-coerceHidden :: Int -> HiddenAge
+coerceHidden :: Prim.Int -> Lib.HiddenAge
 
 Types
 

--- a/tests-integration/fixtures/checking/1772475600_prim_coercible_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772475600_prim_coercible_higher_kinded/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-coerceContainer :: Container Maybe -> Container MaybeAlias
-coerceContainerReverse :: Container MaybeAlias -> Container Maybe
+coerceContainer :: Lib.Container Lib.Maybe -> Lib.Container Lib.MaybeAlias
+coerceContainerReverse :: Lib.Container Lib.MaybeAlias -> Lib.Container Lib.Maybe
 
 Types

--- a/tests-integration/fixtures/checking/1772475660_prim_coercible_transitivity/Main.snap
+++ b/tests-integration/fixtures/checking/1772475660_prim_coercible_transitivity/Main.snap
@@ -1,17 +1,17 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-Years :: Age -> Years
-coerceTransitive :: Int -> Years
-unwrapTransitive :: Years -> Int
+Age :: Prim.Int -> Main.Age
+Years :: Main.Age -> Main.Years
+coerceTransitive :: Prim.Int -> Main.Years
+unwrapTransitive :: Main.Years -> Prim.Int
 
 Types
-Age :: Type
-Years :: Type
+Age :: Prim.Type
+Years :: Prim.Type
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772475720_instance_member_functor/Main.snap
+++ b/tests-integration/fixtures/checking/1772475720_instance_member_functor/Main.snap
@@ -5,30 +5,30 @@ expression: report
 ---
 Terms
 map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
-Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
 
 Types
-Functor :: (Type -> Type) -> Constraint
-Box :: Type -> Type
+Functor :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Box :: Prim.Type -> Prim.Type
 
 Classes
-class forall (f :: Type -> Type). Functor (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Functor (f :: Prim.Type -> Prim.Type)
   map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 
 Instances
-instance Functor Box
+instance Main.Functor Main.Box
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1772475780_instance_member_signature_head_variable/Main.snap
+++ b/tests-integration/fixtures/checking/1772475780_instance_member_signature_head_variable/Main.snap
@@ -4,19 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
-Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
+show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
 
 Types
-Show :: Type -> Constraint
-Box :: Type -> Type
+Show :: Prim.Type -> Prim.Constraint
+Box :: Prim.Type -> Prim.Type
 
 Classes
-class forall (a :: Type). Show (a :: Type)
-  show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
+  show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Instances
-instance forall (t :: Type). Show (t :: Type) => Show (Box (t :: Type))
+instance forall (t :: Prim.Type). Main.Show (t :: Prim.Type) => Main.Show (Main.Box (t :: Prim.Type))
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
@@ -4,19 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
-Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
+show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
 
 Types
-Show :: Type -> Constraint
-Box :: Type -> Type
+Show :: Prim.Type -> Prim.Constraint
+Box :: Prim.Type -> Prim.Type
 
 Classes
-class forall (a :: Type). Show (a :: Type)
-  show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
+  show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Instances
-instance forall (t :: Type). Show (Box (t :: Type))
+instance forall (t :: Prim.Type). Main.Show (Main.Box (t :: Prim.Type))
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1772475900_instance_member_signature_mismatch/Main.snap
+++ b/tests-integration/fixtures/checking/1772475900_instance_member_signature_mismatch/Main.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Types
-Show :: Type -> Constraint
+Show :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Show (a :: Type)
-  show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
+  show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Instances
-instance Show Int
+instance Main.Show Prim.Int
 
 Diagnostics
 error[CannotUnify]: Cannot unify 'Int' with 'String'

--- a/tests-integration/fixtures/checking/1772475960_instance_member_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772475960_instance_member_higher_kinded/Main.snap
@@ -5,34 +5,41 @@ expression: report
 ---
 Terms
 map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 Wrap ::
-  forall (k :: Type) (@e :: Type) (@w :: (k :: Type) -> Type) (@a :: (k :: Type)).
-    (w :: (k :: Type) -> Type) (a :: (k :: Type)) ->
-    Wrap @(k :: Type) (e :: Type) (w :: (k :: Type) -> Type) (a :: (k :: Type))
+  forall (k :: Prim.Type) (@e :: Prim.Type) (@w :: (k :: Prim.Type) -> Prim.Type)
+    (@a :: (k :: Prim.Type)).
+    (w :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type)) ->
+    Main.Wrap @(k :: Prim.Type)
+      (e :: Prim.Type)
+      (w :: (k :: Prim.Type) -> Prim.Type)
+      (a :: (k :: Prim.Type))
 
 Types
-Functor :: (Type -> Type) -> Constraint
-Wrap :: forall (k :: Type). Type -> ((k :: Type) -> Type) -> (k :: Type) -> Type
+Functor :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Wrap ::
+  forall (k :: Prim.Type).
+    Prim.Type -> ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
 
 Classes
-class forall (f :: Type -> Type). Functor (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Functor (f :: Prim.Type -> Prim.Type)
   map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 
 Instances
-instance forall (t :: Type -> Type) (t1 :: Type).
-  Functor (t :: Type -> Type) => Functor (Wrap @Type (t1 :: Type) (t :: Type -> Type))
+instance forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Main.Functor (t :: Prim.Type -> Prim.Type) =>
+  Main.Functor (Main.Wrap @Prim.Type (t1 :: Prim.Type) (t :: Prim.Type -> Prim.Type))
 
 Roles
 Wrap = [Phantom, Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772476020_instance_member_too_many_binders/Main.snap
+++ b/tests-integration/fixtures/checking/1772476020_instance_member_too_many_binders/Main.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Types
-Show :: Type -> Constraint
+Show :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Show (a :: Type)
-  show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
+  show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Instances
-instance Show Int
+instance Main.Show Prim.Int
 
 Diagnostics
 error[TooManyBinders]: Too many binders: expected 1, got 2

--- a/tests-integration/fixtures/checking/1772564520_derive_pipeline_smoke/Main.snap
+++ b/tests-integration/fixtures/checking/1772564520_derive_pipeline_smoke/Main.snap
@@ -1,17 +1,17 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Box :: Box
-test :: Boolean
+Box :: Main.Box
+test :: Prim.Boolean
 
 Types
-Box :: Type
+Box :: Prim.Type
 
 Derived
-derive Eq Box
+derive Data.Eq.Eq Main.Box
 
 Roles
 Box = []

--- a/tests-integration/fixtures/checking/1772564580_derive_ord_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772564580_derive_ord_simple/Main.snap
@@ -1,28 +1,28 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-MkBox :: Int -> Box
-MkPair :: Int -> Boolean -> Pair
-MkNoOrd :: NoOrd
-MkContainsNoOrd :: NoOrd -> ContainsNoOrd
+MkBox :: Prim.Int -> Main.Box
+MkPair :: Prim.Int -> Prim.Boolean -> Main.Pair
+MkNoOrd :: Main.NoOrd
+MkContainsNoOrd :: Main.NoOrd -> Main.ContainsNoOrd
 
 Types
-Box :: Type
-Pair :: Type
-NoOrd :: Type
-ContainsNoOrd :: Type
+Box :: Prim.Type
+Pair :: Prim.Type
+NoOrd :: Prim.Type
+ContainsNoOrd :: Prim.Type
 
 Derived
-derive Eq Box
-derive Ord Box
-derive Eq Pair
-derive Ord Pair
-derive Eq NoOrd
-derive Eq ContainsNoOrd
-derive Ord ContainsNoOrd
+derive Data.Eq.Eq Main.Box
+derive Data.Ord.Ord Main.Box
+derive Data.Eq.Eq Main.Pair
+derive Data.Ord.Ord Main.Pair
+derive Data.Eq.Eq Main.NoOrd
+derive Data.Eq.Eq Main.ContainsNoOrd
+derive Data.Ord.Ord Main.ContainsNoOrd
 
 Roles
 Box = []

--- a/tests-integration/fixtures/checking/1772564640_derive_ord_1_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772564640_derive_ord_1_higher_kinded/Main.snap
@@ -5,29 +5,35 @@ expression: report
 ---
 Terms
 MkWrap ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    Wrap @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Wrap @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 MkWrapNoOrd1 ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    WrapNoOrd1 @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.WrapNoOrd1 @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Wrap :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
-WrapNoOrd1 :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+Wrap :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
+WrapNoOrd1 ::
+  forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Eq1 (t :: Type -> Type) => Eq (t1 :: Type) => Eq (Wrap @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Ord1 (t :: Type -> Type) => Ord (t1 :: Type) => Ord (Wrap @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Eq1 (t :: Type -> Type) =>
-  Eq (t1 :: Type) =>
-  Eq (WrapNoOrd1 @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type) (t1 :: Type -> Type).
-  Ord (t :: Type) => Ord (WrapNoOrd1 @Type (t1 :: Type -> Type) (t :: Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (t1 :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (t1 :: Prim.Type) =>
+  Data.Ord.Ord (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (t1 :: Prim.Type) =>
+  Data.Eq.Eq (Main.WrapNoOrd1 @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord (t :: Prim.Type) =>
+  Data.Ord.Ord (Main.WrapNoOrd1 @Prim.Type (t1 :: Prim.Type -> Prim.Type) (t :: Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772564700_derive_eq_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772564700_derive_eq_simple/Main.snap
@@ -4,18 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
-MkNoEq :: NoEq
-MkContainsNoEq :: NoEq -> ContainsNoEq
+Proxy ::
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
+MkNoEq :: Main.NoEq
+MkContainsNoEq :: Main.NoEq -> Main.ContainsNoEq
 
 Types
-Proxy :: forall (t :: Type). (t :: Type) -> Type
-NoEq :: Type
-ContainsNoEq :: Type
+Proxy :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
+NoEq :: Prim.Type
+ContainsNoEq :: Prim.Type
 
 Derived
-derive forall (t :: Type) (t1 :: (t :: Type)). Eq (Proxy @(t :: Type) (t1 :: (t :: Type)))
-derive Eq ContainsNoEq
+derive forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Data.Eq.Eq (Main.Proxy @(t :: Prim.Type) (t1 :: (t :: Prim.Type)))
+derive Data.Eq.Eq Main.ContainsNoEq
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772564760_derive_eq_parameterized/Main.snap
+++ b/tests-integration/fixtures/checking/1772564760_derive_eq_parameterized/Main.snap
@@ -4,14 +4,14 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Eq (t :: Type) => Eq (Maybe (t :: Type))
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Maybe (t :: Prim.Type))
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772564820_derive_eq_missing_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1772564820_derive_eq_missing_instance/Main.snap
@@ -1,18 +1,18 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-MkNoEq :: NoEq
-MkBox :: NoEq -> Box
+MkNoEq :: Main.NoEq
+MkBox :: Main.NoEq -> Main.Box
 
 Types
-NoEq :: Type
-Box :: Type
+NoEq :: Prim.Type
+Box :: Prim.Type
 
 Derived
-derive Eq Box
+derive Data.Eq.Eq Main.Box
 
 Roles
 NoEq = []

--- a/tests-integration/fixtures/checking/1772564880_derive_eq_1/Main.snap
+++ b/tests-integration/fixtures/checking/1772564880_derive_eq_1/Main.snap
@@ -4,63 +4,80 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Id :: forall (@a :: Type). (a :: Type) -> Id (a :: Type)
-Pair :: forall (@a :: Type). (a :: Type) -> (a :: Type) -> Pair (a :: Type)
-Mixed :: forall (@a :: Type). Int -> (a :: Type) -> Boolean -> Mixed (a :: Type)
-Rec :: forall (@a :: Type). { count :: Int, value :: (a :: Type) } -> Rec (a :: Type)
+Id :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Id (a :: Prim.Type)
+Pair :: forall (@a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type) -> Main.Pair (a :: Prim.Type)
+Mixed ::
+  forall (@a :: Prim.Type).
+    Prim.Int -> (a :: Prim.Type) -> Prim.Boolean -> Main.Mixed (a :: Prim.Type)
+Rec ::
+  forall (@a :: Prim.Type).
+    { count :: Prim.Int, value :: (a :: Prim.Type) } -> Main.Rec (a :: Prim.Type)
 Wrap ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    Wrap @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Wrap @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 Compose ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> (t :: Type))
-    (@a :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) ((g :: (t1 :: Type) -> (t :: Type)) (a :: (t1 :: Type))) ->
-    Compose @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> (t :: Type))
-      (a :: (t1 :: Type))
-Left' :: forall (@a :: Type). (a :: Type) -> Either' (a :: Type)
-Right' :: forall (@a :: Type). (a :: Type) -> Either' (a :: Type)
-NoEq :: forall (@a :: Type). (a :: Type) -> NoEq (a :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (@a :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type)
+      ((g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (a :: (t1 :: Prim.Type))) ->
+    Main.Compose @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> (t :: Prim.Type))
+      (a :: (t1 :: Prim.Type))
+Left' :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Either' (a :: Prim.Type)
+Right' :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Either' (a :: Prim.Type)
+NoEq :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.NoEq (a :: Prim.Type)
 
 Types
-Id :: Type -> Type
-Pair :: Type -> Type
-Mixed :: Type -> Type
-Rec :: Type -> Type
-Wrap :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+Id :: Prim.Type -> Prim.Type
+Pair :: Prim.Type -> Prim.Type
+Mixed :: Prim.Type -> Prim.Type
+Rec :: Prim.Type -> Prim.Type
+Wrap :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 Compose ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> (t :: Type)) -> (t1 :: Type) -> Type
-Either' :: Type -> Type
-NoEq :: Type -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> (t :: Prim.Type)) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
+Either' :: Prim.Type -> Prim.Type
+NoEq :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Eq (t :: Type) => Eq (Id (t :: Type))
-derive Eq1 Id
-derive forall (t :: Type). Eq (t :: Type) => Eq (Pair (t :: Type))
-derive Eq1 Pair
-derive forall (t :: Type). Eq (t :: Type) => Eq (Mixed (t :: Type))
-derive Eq1 Mixed
-derive forall (t :: Type). Eq (t :: Type) => Eq (Rec (t :: Type))
-derive Eq1 Rec
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Eq1 (t :: Type -> Type) => Eq (t1 :: Type) => Eq (Wrap @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type). Eq1 (t :: Type -> Type) => Eq1 (Wrap @Type (t :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type) (t2 :: (t1 :: Type) -> Type) (t3 :: (t1 :: Type)).
-  Eq1 (t :: Type -> Type) =>
-  Eq ((t2 :: (t1 :: Type) -> Type) (t3 :: (t1 :: Type))) =>
-  Eq
-    (Compose @Type @(t1 :: Type)
-      (t :: Type -> Type)
-      (t2 :: (t1 :: Type) -> Type)
-      (t3 :: (t1 :: Type)))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Eq1 (t :: Type -> Type) => Eq1 (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type). Eq (t :: Type) => Eq (Either' (t :: Type))
-derive Eq1 Either'
-derive Eq1 NoEq
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Id (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.Id
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Pair (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.Pair
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Mixed (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.Mixed
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Rec (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.Rec
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (t1 :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1 (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type) -> Prim.Type)
+  (t3 :: (t1 :: Prim.Type)).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq ((t2 :: (t1 :: Prim.Type) -> Prim.Type) (t3 :: (t1 :: Prim.Type))) =>
+  Data.Eq.Eq
+    (Main.Compose @Prim.Type @(t1 :: Prim.Type)
+      (t :: Prim.Type -> Prim.Type)
+      (t2 :: (t1 :: Prim.Type) -> Prim.Type)
+      (t3 :: (t1 :: Prim.Type)))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Either' (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.Either'
+derive Data.Eq.Eq1 Main.NoEq
 
 Roles
 Id = [Representational]

--- a/tests-integration/fixtures/checking/1772564940_derive_ord_1/Main.snap
+++ b/tests-integration/fixtures/checking/1772564940_derive_ord_1/Main.snap
@@ -4,63 +4,85 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Id :: forall (@a :: Type). (a :: Type) -> Id (a :: Type)
+Id :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Id (a :: Prim.Type)
 Wrap ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    Wrap @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Wrap @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 Compose ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> (t :: Type))
-    (@a :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) ((g :: (t1 :: Type) -> (t :: Type)) (a :: (t1 :: Type))) ->
-    Compose @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> (t :: Type))
-      (a :: (t1 :: Type))
-NoOrd :: forall (@a :: Type). (a :: Type) -> NoOrd (a :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (@a :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type)
+      ((g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (a :: (t1 :: Prim.Type))) ->
+    Main.Compose @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> (t :: Prim.Type))
+      (a :: (t1 :: Prim.Type))
+NoOrd :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.NoOrd (a :: Prim.Type)
 
 Types
-Id :: Type -> Type
-Wrap :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+Id :: Prim.Type -> Prim.Type
+Wrap :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 Compose ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> (t :: Type)) -> (t1 :: Type) -> Type
-NoOrd :: Type -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> (t :: Prim.Type)) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
+NoOrd :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Eq (t :: Type) => Eq (Id (t :: Type))
-derive Eq1 Id
-derive forall (t :: Type). Ord (t :: Type) => Ord (Id (t :: Type))
-derive Ord1 Id
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Eq1 (t :: Type -> Type) => Eq (t1 :: Type) => Eq (Wrap @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type). Eq1 (t :: Type -> Type) => Eq1 (Wrap @Type (t :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Ord1 (t :: Type -> Type) => Ord (t1 :: Type) => Ord (Wrap @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type). Ord1 (t :: Type -> Type) => Ord1 (Wrap @Type (t :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type) (t2 :: (t1 :: Type) -> Type) (t3 :: (t1 :: Type)).
-  Eq1 (t :: Type -> Type) =>
-  Eq ((t2 :: (t1 :: Type) -> Type) (t3 :: (t1 :: Type))) =>
-  Eq
-    (Compose @Type @(t1 :: Type)
-      (t :: Type -> Type)
-      (t2 :: (t1 :: Type) -> Type)
-      (t3 :: (t1 :: Type)))
-derive forall (t :: Type -> Type) (t1 :: Type) (t2 :: (t1 :: Type) -> Type) (t3 :: (t1 :: Type)).
-  Ord1 (t :: Type -> Type) =>
-  Ord ((t2 :: (t1 :: Type) -> Type) (t3 :: (t1 :: Type))) =>
-  Ord
-    (Compose @Type @(t1 :: Type)
-      (t :: Type -> Type)
-      (t2 :: (t1 :: Type) -> Type)
-      (t3 :: (t1 :: Type)))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Eq1 (t :: Type -> Type) => Eq1 (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Ord1 (t :: Type -> Type) => Ord1 (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type). Eq (t :: Type) => Eq (NoOrd (t :: Type))
-derive Eq1 NoOrd
-derive Ord1 NoOrd
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Id (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.Id
+derive forall (t :: Prim.Type). Data.Ord.Ord (t :: Prim.Type) => Data.Ord.Ord (Main.Id (t :: Prim.Type))
+derive Data.Ord.Ord1 Main.Id
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (t1 :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1 (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (t1 :: Prim.Type) =>
+  Data.Ord.Ord (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord1 (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type) -> Prim.Type)
+  (t3 :: (t1 :: Prim.Type)).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq ((t2 :: (t1 :: Prim.Type) -> Prim.Type) (t3 :: (t1 :: Prim.Type))) =>
+  Data.Eq.Eq
+    (Main.Compose @Prim.Type @(t1 :: Prim.Type)
+      (t :: Prim.Type -> Prim.Type)
+      (t2 :: (t1 :: Prim.Type) -> Prim.Type)
+      (t3 :: (t1 :: Prim.Type)))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type) -> Prim.Type)
+  (t3 :: (t1 :: Prim.Type)).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord ((t2 :: (t1 :: Prim.Type) -> Prim.Type) (t3 :: (t1 :: Prim.Type))) =>
+  Data.Ord.Ord
+    (Main.Compose @Prim.Type @(t1 :: Prim.Type)
+      (t :: Prim.Type -> Prim.Type)
+      (t2 :: (t1 :: Prim.Type) -> Prim.Type)
+      (t3 :: (t1 :: Prim.Type)))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord1
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.NoOrd (t :: Prim.Type))
+derive Data.Eq.Eq1 Main.NoOrd
+derive Data.Ord.Ord1 Main.NoOrd
 
 Roles
 Id = [Representational]

--- a/tests-integration/fixtures/checking/1772565000_derive_functor_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565000_derive_functor_simple/Main.snap
@@ -4,22 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
 Const ::
-  forall (t :: Type) (@e :: Type) (@a :: (t :: Type)).
-    (e :: Type) -> Const @(t :: Type) (e :: Type) (a :: (t :: Type))
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+  forall (t :: Prim.Type) (@e :: Prim.Type) (@a :: (t :: Prim.Type)).
+    (e :: Prim.Type) -> Main.Const @(t :: Prim.Type) (e :: Prim.Type) (a :: (t :: Prim.Type))
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
-Const :: forall (t :: Type). Type -> (t :: Type) -> Type
-Maybe :: Type -> Type
+Identity :: Prim.Type -> Prim.Type
+Const :: forall (t :: Prim.Type). Prim.Type -> (t :: Prim.Type) -> Prim.Type
+Maybe :: Prim.Type -> Prim.Type
 
 Derived
-derive Functor Identity
-derive forall (t :: Type). Functor (Const @Type (t :: Type))
-derive Functor Maybe
+derive Data.Functor.Functor Main.Identity
+derive forall (t :: Prim.Type). Data.Functor.Functor (Main.Const @Prim.Type (t :: Prim.Type))
+derive Data.Functor.Functor Main.Maybe
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772565060_derive_functor_contravariant_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565060_derive_functor_contravariant_error/Main.snap
@@ -4,22 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Predicate :: forall (@a :: Type). ((a :: Type) -> Boolean) -> Predicate (a :: Type)
+Predicate ::
+  forall (@a :: Prim.Type). ((a :: Prim.Type) -> Prim.Boolean) -> Main.Predicate (a :: Prim.Type)
 Reader ::
-  forall (@r :: Type) (@a :: Type). ((r :: Type) -> (a :: Type)) -> Reader (r :: Type) (a :: Type)
+  forall (@r :: Prim.Type) (@a :: Prim.Type).
+    ((r :: Prim.Type) -> (a :: Prim.Type)) -> Main.Reader (r :: Prim.Type) (a :: Prim.Type)
 Cont ::
-  forall (@r :: Type) (@a :: Type).
-    (((a :: Type) -> (r :: Type)) -> (r :: Type)) -> Cont (r :: Type) (a :: Type)
+  forall (@r :: Prim.Type) (@a :: Prim.Type).
+    (((a :: Prim.Type) -> (r :: Prim.Type)) -> (r :: Prim.Type)) ->
+    Main.Cont (r :: Prim.Type) (a :: Prim.Type)
 
 Types
-Predicate :: Type -> Type
-Reader :: Type -> Type -> Type
-Cont :: Type -> Type -> Type
+Predicate :: Prim.Type -> Prim.Type
+Reader :: Prim.Type -> Prim.Type -> Prim.Type
+Cont :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Functor Predicate
-derive forall (t :: Type). Functor (Reader (t :: Type))
-derive forall (t :: Type). Functor (Cont (t :: Type))
+derive Data.Functor.Functor Main.Predicate
+derive forall (t :: Prim.Type). Data.Functor.Functor (Main.Reader (t :: Prim.Type))
+derive forall (t :: Prim.Type). Data.Functor.Functor (Main.Cont (t :: Prim.Type))
 
 Roles
 Predicate = [Representational]

--- a/tests-integration/fixtures/checking/1772565120_derive_functor_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772565120_derive_functor_insufficient_params/Main.snap
@@ -1,19 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Pair :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Pair (a :: Type) (b :: Type)
-Unit :: Unit
+Pair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Pair (a :: Prim.Type) (b :: Prim.Type)
+Unit :: Main.Unit
 
 Types
-Pair :: Type -> Type -> Type
-Unit :: Type
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+Unit :: Prim.Type
 
 Derived
-derive Functor (Pair Int String)
-derive Functor Unit
+derive Data.Functor.Functor (Main.Pair Prim.Int Prim.String)
+derive Data.Functor.Functor Main.Unit
 
 Roles
 Pair = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772565180_derive_bifunctor_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565180_derive_bifunctor_simple/Main.snap
@@ -4,23 +4,36 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
-Pair :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Pair (a :: Type) (b :: Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Pair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Pair (a :: Prim.Type) (b :: Prim.Type)
 Const2 ::
-  forall (t :: Type) (t1 :: Type) (@e :: Type) (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (e :: Type) ->
-    Const2 @(t :: Type) @(t1 :: Type) (e :: Type) (a :: (t :: Type)) (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@e :: Prim.Type) (@a :: (t :: Prim.Type))
+    (@b :: (t1 :: Prim.Type)).
+    (e :: Prim.Type) ->
+    Main.Const2 @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (e :: Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 
 Types
-Either :: Type -> Type -> Type
-Pair :: Type -> Type -> Type
-Const2 :: forall (t :: Type) (t1 :: Type). Type -> (t :: Type) -> (t1 :: Type) -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+Const2 ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Type -> (t :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Type
 
 Derived
-derive Bifunctor Either
-derive Bifunctor Pair
-derive forall (t :: Type). Bifunctor (Const2 @Type @Type (t :: Type))
+derive Data.Bifunctor.Bifunctor Main.Either
+derive Data.Bifunctor.Bifunctor Main.Pair
+derive forall (t :: Prim.Type).
+  Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type (t :: Prim.Type))
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
+++ b/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
@@ -5,24 +5,31 @@ expression: report
 ---
 Terms
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> Type)
-    (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    (g :: (t1 :: Type) -> Type) (b :: (t1 :: Type)) ->
-    WrapBoth @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    (g :: (t1 :: Prim.Type) -> Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Main.WrapBoth @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 
 Types
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> Type) -> (t :: Type) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Bifunctor (WrapBoth @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Bifunctor.Bifunctor
+    (Main.WrapBoth @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1772565300_derive_bifunctor_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772565300_derive_bifunctor_insufficient_params/Main.snap
@@ -1,18 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 Triple ::
-  forall (@a :: Type) (@b :: Type) (@c :: Type).
-    (a :: Type) -> (b :: Type) -> (c :: Type) -> Triple (a :: Type) (b :: Type) (c :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type) (@c :: Prim.Type).
+    (a :: Prim.Type) ->
+    (b :: Prim.Type) ->
+    (c :: Prim.Type) ->
+    Main.Triple (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
 
 Types
-Triple :: Type -> Type -> Type -> Type
+Triple :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Bifunctor (Triple Int String)
+derive Data.Bifunctor.Bifunctor (Main.Triple Prim.Int Prim.String)
 
 Roles
 Triple = [Representational, Representational, Representational]

--- a/tests-integration/fixtures/checking/1772565360_derive_traversable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565360_derive_traversable_simple/Main.snap
@@ -4,28 +4,28 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 Const ::
-  forall (t :: Type) (@e :: Type) (@a :: (t :: Type)).
-    (e :: Type) -> Const @(t :: Type) (e :: Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@e :: Prim.Type) (@a :: (t :: Prim.Type)).
+    (e :: Prim.Type) -> Main.Const @(t :: Prim.Type) (e :: Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Identity :: Type -> Type
-Maybe :: Type -> Type
-Const :: forall (t :: Type). Type -> (t :: Type) -> Type
+Identity :: Prim.Type -> Prim.Type
+Maybe :: Prim.Type -> Prim.Type
+Const :: forall (t :: Prim.Type). Prim.Type -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive Functor Identity
-derive Foldable Identity
-derive Traversable Identity
-derive Functor Maybe
-derive Foldable Maybe
-derive Traversable Maybe
-derive forall (t :: Type). Functor (Const @Type (t :: Type))
-derive forall (t :: Type). Foldable (Const @Type (t :: Type))
-derive forall (t :: Type). Traversable (Const @Type (t :: Type))
+derive Data.Functor.Functor Main.Identity
+derive Data.Foldable.Foldable Main.Identity
+derive Data.Traversable.Traversable Main.Identity
+derive Data.Functor.Functor Main.Maybe
+derive Data.Foldable.Foldable Main.Maybe
+derive Data.Traversable.Traversable Main.Maybe
+derive forall (t :: Prim.Type). Data.Functor.Functor (Main.Const @Prim.Type (t :: Prim.Type))
+derive forall (t :: Prim.Type). Data.Foldable.Foldable (Main.Const @Prim.Type (t :: Prim.Type))
+derive forall (t :: Prim.Type). Data.Traversable.Traversable (Main.Const @Prim.Type (t :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772565420_derive_traversable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772565420_derive_traversable_higher_kinded/Main.snap
@@ -5,32 +5,45 @@ expression: report
 ---
 Terms
 Compose ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> (t :: Type))
-    (@a :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) ((g :: (t1 :: Type) -> (t :: Type)) (a :: (t1 :: Type))) ->
-    Compose @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> (t :: Type))
-      (a :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (@a :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type)
+      ((g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (a :: (t1 :: Prim.Type))) ->
+    Main.Compose @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> (t :: Prim.Type))
+      (a :: (t1 :: Prim.Type))
 
 Types
 Compose ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> (t :: Type)) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> (t :: Prim.Type)) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Functor (t :: Type -> Type) =>
-  Functor (t1 :: Type -> Type) =>
-  Functor (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Foldable (t :: Type -> Type) =>
-  Foldable (t1 :: Type -> Type) =>
-  Foldable (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Traversable (t :: Type -> Type) =>
-  Traversable (t1 :: Type -> Type) =>
-  Traversable (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (t :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (t :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Traversable.Traversable (t :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 Compose = [Representational, Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772565480_derive_traversable_missing_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1772565480_derive_traversable_missing_superclass/Main.snap
@@ -5,24 +5,31 @@ expression: report
 ---
 Terms
 Compose ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> (t :: Type))
-    (@a :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) ((g :: (t1 :: Type) -> (t :: Type)) (a :: (t1 :: Type))) ->
-    Compose @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> (t :: Type))
-      (a :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (@a :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type)
+      ((g :: (t1 :: Prim.Type) -> (t :: Prim.Type)) (a :: (t1 :: Prim.Type))) ->
+    Main.Compose @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> (t :: Prim.Type))
+      (a :: (t1 :: Prim.Type))
 
 Types
 Compose ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> (t :: Type)) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> (t :: Prim.Type)) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Traversable (t :: Type -> Type) =>
-  Traversable (t1 :: Type -> Type) =>
-  Traversable (Compose @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Traversable.Traversable (t :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable
+    (Main.Compose @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 Compose = [Representational, Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772565540_derive_newtype_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565540_derive_newtype_simple/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Wrapper :: Int -> Wrapper
+Wrapper :: Prim.Int -> Main.Wrapper
 
 Types
-Wrapper :: Type
+Wrapper :: Prim.Type
 
 Derived
-derive Show Wrapper
+derive Data.Show.Show Main.Wrapper
 
 Roles
 Wrapper = []

--- a/tests-integration/fixtures/checking/1772565600_derive_newtype_parameterized/Main.snap
+++ b/tests-integration/fixtures/checking/1772565600_derive_newtype_parameterized/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
+Identity :: Prim.Type -> Prim.Type
 
 Derived
-derive Show (Identity Int)
+derive Data.Show.Show (Main.Identity Prim.Int)
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772565660_derive_newtype_not_newtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772565660_derive_newtype_not_newtype/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Foo :: Int -> Foo
+Foo :: Prim.Int -> Main.Foo
 
 Types
-Foo :: Type
+Foo :: Prim.Type
 
 Derived
-derive Show Foo
+derive Data.Show.Show Main.Foo
 
 Roles
 Foo = []

--- a/tests-integration/fixtures/checking/1772565720_derive_profunctor_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565720_derive_profunctor_simple/Main.snap
@@ -4,22 +4,29 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Fn :: forall (@a :: Type) (@b :: Type). ((a :: Type) -> (b :: Type)) -> Fn (a :: Type) (b :: Type)
+Fn ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> Main.Fn (a :: Prim.Type) (b :: Prim.Type)
 ConstR ::
-  forall (t :: Type) (@r :: Type) (@a :: Type) (@b :: (t :: Type)).
-    ((a :: Type) -> (r :: Type)) -> ConstR @(t :: Type) (r :: Type) (a :: Type) (b :: (t :: Type))
-GoLeft :: forall (@a :: Type) (@b :: Type). ((a :: Type) -> Int) -> Choice (a :: Type) (b :: Type)
-GoRight :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Choice (a :: Type) (b :: Type)
+  forall (t :: Prim.Type) (@r :: Prim.Type) (@a :: Prim.Type) (@b :: (t :: Prim.Type)).
+    ((a :: Prim.Type) -> (r :: Prim.Type)) ->
+    Main.ConstR @(t :: Prim.Type) (r :: Prim.Type) (a :: Prim.Type) (b :: (t :: Prim.Type))
+GoLeft ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    ((a :: Prim.Type) -> Prim.Int) -> Main.Choice (a :: Prim.Type) (b :: Prim.Type)
+GoRight ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Choice (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Fn :: Type -> Type -> Type
-ConstR :: forall (t :: Type). Type -> Type -> (t :: Type) -> Type
-Choice :: Type -> Type -> Type
+Fn :: Prim.Type -> Prim.Type -> Prim.Type
+ConstR :: forall (t :: Prim.Type). Prim.Type -> Prim.Type -> (t :: Prim.Type) -> Prim.Type
+Choice :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Profunctor Fn
-derive forall (t :: Type). Profunctor (ConstR @Type (t :: Type))
-derive Profunctor Choice
+derive Data.Profunctor.Profunctor Main.Fn
+derive forall (t :: Prim.Type). Data.Profunctor.Profunctor (Main.ConstR @Prim.Type (t :: Prim.Type))
+derive Data.Profunctor.Profunctor Main.Choice
 
 Roles
 Fn = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772565780_derive_profunctor_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565780_derive_profunctor_error/Main.snap
@@ -5,18 +5,19 @@ expression: report
 ---
 Terms
 WrongFirst ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> WrongFirst (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.WrongFirst (a :: Prim.Type) (b :: Prim.Type)
 WrongSecond ::
-  forall (@a :: Type) (@b :: Type).
-    ((b :: Type) -> (a :: Type)) -> WrongSecond (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    ((b :: Prim.Type) -> (a :: Prim.Type)) -> Main.WrongSecond (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-WrongFirst :: Type -> Type -> Type
-WrongSecond :: Type -> Type -> Type
+WrongFirst :: Prim.Type -> Prim.Type -> Prim.Type
+WrongSecond :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Profunctor WrongFirst
-derive Profunctor WrongSecond
+derive Data.Profunctor.Profunctor Main.WrongFirst
+derive Data.Profunctor.Profunctor Main.WrongSecond
 
 Roles
 WrongFirst = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772565840_derive_contravariant_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565840_derive_contravariant_simple/Main.snap
@@ -4,19 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Predicate :: forall (@a :: Type). ((a :: Type) -> Boolean) -> Predicate (a :: Type)
-Comparison :: forall (@a :: Type). ((a :: Type) -> (a :: Type) -> Boolean) -> Comparison (a :: Type)
-Op :: forall (@a :: Type) (@b :: Type). ((b :: Type) -> (a :: Type)) -> Op (a :: Type) (b :: Type)
+Predicate ::
+  forall (@a :: Prim.Type). ((a :: Prim.Type) -> Prim.Boolean) -> Main.Predicate (a :: Prim.Type)
+Comparison ::
+  forall (@a :: Prim.Type).
+    ((a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean) -> Main.Comparison (a :: Prim.Type)
+Op ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    ((b :: Prim.Type) -> (a :: Prim.Type)) -> Main.Op (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Predicate :: Type -> Type
-Comparison :: Type -> Type
-Op :: Type -> Type -> Type
+Predicate :: Prim.Type -> Prim.Type
+Comparison :: Prim.Type -> Prim.Type
+Op :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Contravariant Predicate
-derive Contravariant Comparison
-derive forall (t :: Type). Contravariant (Op (t :: Type))
+derive Data.Functor.Contravariant.Contravariant Main.Predicate
+derive Data.Functor.Contravariant.Contravariant Main.Comparison
+derive forall (t :: Prim.Type). Data.Functor.Contravariant.Contravariant (Main.Op (t :: Prim.Type))
 
 Roles
 Predicate = [Representational]

--- a/tests-integration/fixtures/checking/1772565900_derive_contravariant_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565900_derive_contravariant_error/Main.snap
@@ -4,16 +4,17 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
-Producer :: forall (@a :: Type). (Int -> (a :: Type)) -> Producer (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
+Producer ::
+  forall (@a :: Prim.Type). (Prim.Int -> (a :: Prim.Type)) -> Main.Producer (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
-Producer :: Type -> Type
+Identity :: Prim.Type -> Prim.Type
+Producer :: Prim.Type -> Prim.Type
 
 Derived
-derive Contravariant Identity
-derive Contravariant Producer
+derive Data.Functor.Contravariant.Contravariant Main.Identity
+derive Data.Functor.Contravariant.Contravariant Main.Producer
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772565960_derive_foldable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565960_derive_foldable_simple/Main.snap
@@ -4,22 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 Const ::
-  forall (t :: Type) (@e :: Type) (@a :: (t :: Type)).
-    (e :: Type) -> Const @(t :: Type) (e :: Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@e :: Prim.Type) (@a :: (t :: Prim.Type)).
+    (e :: Prim.Type) -> Main.Const @(t :: Prim.Type) (e :: Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Identity :: Type -> Type
-Maybe :: Type -> Type
-Const :: forall (t :: Type). Type -> (t :: Type) -> Type
+Identity :: Prim.Type -> Prim.Type
+Maybe :: Prim.Type -> Prim.Type
+Const :: forall (t :: Prim.Type). Prim.Type -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive Foldable Identity
-derive Foldable Maybe
-derive forall (t :: Type). Foldable (Const @Type (t :: Type))
+derive Data.Foldable.Foldable Main.Identity
+derive Data.Foldable.Foldable Main.Maybe
+derive forall (t :: Prim.Type). Data.Foldable.Foldable (Main.Const @Prim.Type (t :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772566020_derive_foldable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566020_derive_foldable_higher_kinded/Main.snap
@@ -5,22 +5,27 @@ expression: report
 ---
 Terms
 Wrap ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    Wrap @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Wrap @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 WrapNoFoldable ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    WrapNoFoldable @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.WrapNoFoldable @(t :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
 
 Types
-Wrap :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
-WrapNoFoldable :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+Wrap :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
+WrapNoFoldable ::
+  forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t :: Type -> Type).
-  Foldable (t :: Type -> Type) => Foldable (Wrap @Type (t :: Type -> Type))
-derive forall (t :: Type -> Type). Foldable (WrapNoFoldable @Type (t :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (t :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (Main.WrapNoFoldable @Prim.Type (t :: Prim.Type -> Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772566080_derive_bitraversable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772566080_derive_bitraversable_simple/Main.snap
@@ -4,21 +4,27 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
-Pair :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Pair (a :: Type) (b :: Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Pair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Pair (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Either :: Type -> Type -> Type
-Pair :: Type -> Type -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Bifunctor Either
-derive Bifoldable Either
-derive Bitraversable Either
-derive Bifunctor Pair
-derive Bifoldable Pair
-derive Bitraversable Pair
+derive Data.Bifunctor.Bifunctor Main.Either
+derive Data.Bifoldable.Bifoldable Main.Either
+derive Data.Bitraversable.Bitraversable Main.Either
+derive Data.Bifunctor.Bifunctor Main.Pair
+derive Data.Bifoldable.Bifoldable Main.Pair
+derive Data.Bitraversable.Bitraversable Main.Pair
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772566140_derive_bitraversable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566140_derive_bitraversable_higher_kinded/Main.snap
@@ -5,34 +5,47 @@ expression: report
 ---
 Terms
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> Type)
-    (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    (g :: (t1 :: Type) -> Type) (b :: (t1 :: Type)) ->
-    WrapBoth @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    (g :: (t1 :: Prim.Type) -> Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Main.WrapBoth @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 
 Types
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> Type) -> (t :: Type) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Functor (t :: Type -> Type) =>
-  Functor (t1 :: Type -> Type) =>
-  Bifunctor (WrapBoth @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Foldable (t :: Type -> Type) =>
-  Foldable (t1 :: Type -> Type) =>
-  Bifoldable (WrapBoth @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Traversable (t :: Type -> Type) =>
-  Traversable (t1 :: Type -> Type) =>
-  Bitraversable (WrapBoth @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (t :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Bifunctor.Bifunctor
+    (Main.WrapBoth @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (t :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Bifoldable.Bifoldable
+    (Main.WrapBoth @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Traversable.Traversable (t :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Bitraversable.Bitraversable
+    (Main.WrapBoth @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1772566200_derive_bifoldable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772566200_derive_bifoldable_simple/Main.snap
@@ -4,23 +4,36 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
-Pair :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Pair (a :: Type) (b :: Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Pair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Pair (a :: Prim.Type) (b :: Prim.Type)
 Const2 ::
-  forall (t :: Type) (t1 :: Type) (@e :: Type) (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (e :: Type) ->
-    Const2 @(t :: Type) @(t1 :: Type) (e :: Type) (a :: (t :: Type)) (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@e :: Prim.Type) (@a :: (t :: Prim.Type))
+    (@b :: (t1 :: Prim.Type)).
+    (e :: Prim.Type) ->
+    Main.Const2 @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (e :: Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 
 Types
-Either :: Type -> Type -> Type
-Pair :: Type -> Type -> Type
-Const2 :: forall (t :: Type) (t1 :: Type). Type -> (t :: Type) -> (t1 :: Type) -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+Const2 ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Type -> (t :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Type
 
 Derived
-derive Bifoldable Either
-derive Bifoldable Pair
-derive forall (t :: Type). Bifoldable (Const2 @Type @Type (t :: Type))
+derive Data.Bifoldable.Bifoldable Main.Either
+derive Data.Bifoldable.Bifoldable Main.Pair
+derive forall (t :: Prim.Type).
+  Data.Bifoldable.Bifoldable (Main.Const2 @Prim.Type @Prim.Type (t :: Prim.Type))
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772566260_derive_bifoldable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566260_derive_bifoldable_higher_kinded/Main.snap
@@ -5,41 +5,55 @@ expression: report
 ---
 Terms
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> Type)
-    (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    (g :: (t1 :: Type) -> Type) (b :: (t1 :: Type)) ->
-    WrapBoth @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    (g :: (t1 :: Prim.Type) -> Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Main.WrapBoth @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 WrapBothNoConstraint ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> Type)
-    (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    (g :: (t1 :: Type) -> Type) (b :: (t1 :: Type)) ->
-    WrapBothNoConstraint @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    (g :: (t1 :: Prim.Type) -> Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Main.WrapBothNoConstraint @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 
 Types
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> Type) -> (t :: Type) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 WrapBothNoConstraint ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> Type) -> (t :: Type) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Foldable (t :: Type -> Type) =>
-  Foldable (t1 :: Type -> Type) =>
-  Bifoldable (WrapBoth @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Bifoldable (WrapBothNoConstraint @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (t :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Bifoldable.Bifoldable
+    (Main.WrapBoth @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Bifoldable.Bifoldable
+    (Main.WrapBothNoConstraint @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1772566320_derive_newtype_class_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772566320_derive_newtype_class_simple/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-UserId :: Int -> UserId
+UserId :: Prim.Int -> Main.UserId
 
 Types
-UserId :: Type
+UserId :: Prim.Type
 
 Derived
-derive Newtype @Type UserId Int
+derive Data.Newtype.Newtype @Prim.Type Main.UserId Prim.Int
 
 Roles
 UserId = []

--- a/tests-integration/fixtures/checking/1772566380_derive_newtype_class_parameterized/Main.snap
+++ b/tests-integration/fixtures/checking/1772566380_derive_newtype_class_parameterized/Main.snap
@@ -4,13 +4,14 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Wrapper :: forall (@a :: Type). (a :: Type) -> Wrapper (a :: Type)
+Wrapper :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
 
 Types
-Wrapper :: Type -> Type
+Wrapper :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Newtype @Type (Wrapper (t :: Type)) (t :: Type)
+derive forall (t :: Prim.Type).
+  Data.Newtype.Newtype @Prim.Type (Main.Wrapper (t :: Prim.Type)) (t :: Prim.Type)
 
 Roles
 Wrapper = [Representational]

--- a/tests-integration/fixtures/checking/1772566440_derive_newtype_class_not_newtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772566440_derive_newtype_class_not_newtype/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-NotANewtype :: Int -> NotANewtype
+NotANewtype :: Prim.Int -> Main.NotANewtype
 
 Types
-NotANewtype :: Type
+NotANewtype :: Prim.Type
 
 Derived
-derive forall (t :: Type). Newtype @Type NotANewtype (t :: Type)
+derive forall (t :: Prim.Type). Data.Newtype.Newtype @Prim.Type Main.NotANewtype (t :: Prim.Type)
 
 Roles
 NotANewtype = []

--- a/tests-integration/fixtures/checking/1772566500_derive_generic_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772566500_derive_generic_simple/Main.snap
@@ -4,65 +4,107 @@ assertion_line: 50
 expression: report
 ---
 Terms
-MyUnit :: MyUnit
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
+MyUnit :: Main.MyUnit
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-Wrapper :: forall (@a :: Type). (a :: Type) -> Wrapper (a :: Type)
-Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
-getVoid :: forall (rep :: Type). Generic Void (rep :: Type) => Proxy @Type (rep :: Type)
-getMyUnit :: forall (rep :: Type). Generic MyUnit (rep :: Type) => Proxy @Type (rep :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+Wrapper :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
+Proxy ::
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
+getVoid ::
+  forall (rep :: Prim.Type).
+    Data.Generic.Rep.Generic Main.Void (rep :: Prim.Type) =>
+    Main.Proxy @Prim.Type (rep :: Prim.Type)
+getMyUnit ::
+  forall (rep :: Prim.Type).
+    Data.Generic.Rep.Generic Main.MyUnit (rep :: Prim.Type) =>
+    Main.Proxy @Prim.Type (rep :: Prim.Type)
 getIdentity ::
-  forall (a :: Type) (rep :: Type).
-    Generic (Identity (a :: Type)) (rep :: Type) => Proxy @Type (rep :: Type)
+  forall (a :: Prim.Type) (rep :: Prim.Type).
+    Data.Generic.Rep.Generic (Main.Identity (a :: Prim.Type)) (rep :: Prim.Type) =>
+    Main.Proxy @Prim.Type (rep :: Prim.Type)
 getEither ::
-  forall (a :: Type) (b :: Type) (rep :: Type).
-    Generic (Either (a :: Type) (b :: Type)) (rep :: Type) => Proxy @Type (rep :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type) (rep :: Prim.Type).
+    Data.Generic.Rep.Generic (Main.Either (a :: Prim.Type) (b :: Prim.Type)) (rep :: Prim.Type) =>
+    Main.Proxy @Prim.Type (rep :: Prim.Type)
 getTuple ::
-  forall (a :: Type) (b :: Type) (rep :: Type).
-    Generic (Tuple (a :: Type) (b :: Type)) (rep :: Type) => Proxy @Type (rep :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type) (rep :: Prim.Type).
+    Data.Generic.Rep.Generic (Main.Tuple (a :: Prim.Type) (b :: Prim.Type)) (rep :: Prim.Type) =>
+    Main.Proxy @Prim.Type (rep :: Prim.Type)
 getWrapper ::
-  forall (a :: Type) (rep :: Type).
-    Generic (Wrapper (a :: Type)) (rep :: Type) => Proxy @Type (rep :: Type)
+  forall (a :: Prim.Type) (rep :: Prim.Type).
+    Data.Generic.Rep.Generic (Main.Wrapper (a :: Prim.Type)) (rep :: Prim.Type) =>
+    Main.Proxy @Prim.Type (rep :: Prim.Type)
 forceSolve ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type) (t3 :: Type) (t4 :: Type) (t5 :: Type).
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type)
+    (t5 :: Prim.Type).
     { getEither ::
-        Proxy @Type
-          (Sum
-            (Constructor "Left" (Argument (t :: Type)))
-            (Constructor "Right" (Argument (t1 :: Type))))
-    , getIdentity :: Proxy @Type (Constructor "Identity" (Argument (t2 :: Type)))
-    , getMyUnit :: Proxy @Type (Constructor "MyUnit" NoArguments)
+        Main.Proxy @Prim.Type
+          (Data.Generic.Rep.Sum
+            (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument (t :: Prim.Type)))
+            (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument (t1 :: Prim.Type))))
+    , getIdentity ::
+        Main.Proxy @Prim.Type
+          (Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument (t2 :: Prim.Type)))
+    , getMyUnit ::
+        Main.Proxy @Prim.Type (Data.Generic.Rep.Constructor "MyUnit" Data.Generic.Rep.NoArguments)
     , getTuple ::
-        Proxy @Type (Constructor "Tuple" (Product (Argument (t3 :: Type)) (Argument (t4 :: Type))))
-    , getVoid :: Proxy @Type NoConstructors
-    , getWrapper :: Proxy @Type (Constructor "Wrapper" (Argument (t5 :: Type)))
+        Main.Proxy @Prim.Type
+          (Data.Generic.Rep.Constructor
+            "Tuple"
+            (Data.Generic.Rep.Product
+              (Data.Generic.Rep.Argument (t3 :: Prim.Type))
+              (Data.Generic.Rep.Argument (t4 :: Prim.Type))))
+    , getVoid :: Main.Proxy @Prim.Type Data.Generic.Rep.NoConstructors
+    , getWrapper ::
+        Main.Proxy @Prim.Type
+          (Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument (t5 :: Prim.Type)))
     }
 
 Types
-Void :: Type
-MyUnit :: Type
-Identity :: Type -> Type
-Either :: Type -> Type -> Type
-Tuple :: Type -> Type -> Type
-Wrapper :: Type -> Type
-Proxy :: forall (t :: Type). (t :: Type) -> Type
+Void :: Prim.Type
+MyUnit :: Prim.Type
+Identity :: Prim.Type -> Prim.Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
+Wrapper :: Prim.Type -> Prim.Type
+Proxy :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive Generic Void NoConstructors
-derive Generic MyUnit (Constructor "MyUnit" NoArguments)
-derive forall (t :: Type). Generic (Identity (t :: Type)) (Constructor "Identity" (Argument (t :: Type)))
-derive forall (t :: Type) (t1 :: Type).
-  Generic
-    (Either (t :: Type) (t1 :: Type))
-    (Sum (Constructor "Left" (Argument (t :: Type))) (Constructor "Right" (Argument (t1 :: Type))))
-derive forall (t :: Type) (t1 :: Type).
-  Generic
-    (Tuple (t :: Type) (t1 :: Type))
-    (Constructor "Tuple" (Product (Argument (t :: Type)) (Argument (t1 :: Type))))
-derive forall (t :: Type). Generic (Wrapper (t :: Type)) (Constructor "Wrapper" (Argument (t :: Type)))
+derive Data.Generic.Rep.Generic Main.Void Data.Generic.Rep.NoConstructors
+derive Data.Generic.Rep.Generic
+  Main.MyUnit
+  (Data.Generic.Rep.Constructor "MyUnit" Data.Generic.Rep.NoArguments)
+derive forall (t :: Prim.Type).
+  Data.Generic.Rep.Generic
+    (Main.Identity (t :: Prim.Type))
+    (Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument (t :: Prim.Type)))
+derive forall (t :: Prim.Type) (t1 :: Prim.Type).
+  Data.Generic.Rep.Generic
+    (Main.Either (t :: Prim.Type) (t1 :: Prim.Type))
+    (Data.Generic.Rep.Sum
+      (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument (t :: Prim.Type)))
+      (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument (t1 :: Prim.Type))))
+derive forall (t :: Prim.Type) (t1 :: Prim.Type).
+  Data.Generic.Rep.Generic
+    (Main.Tuple (t :: Prim.Type) (t1 :: Prim.Type))
+    (Data.Generic.Rep.Constructor
+      "Tuple"
+      (Data.Generic.Rep.Product
+        (Data.Generic.Rep.Argument (t :: Prim.Type))
+        (Data.Generic.Rep.Argument (t1 :: Prim.Type))))
+derive forall (t :: Prim.Type).
+  Data.Generic.Rep.Generic
+    (Main.Wrapper (t :: Prim.Type))
+    (Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument (t :: Prim.Type)))
 
 Roles
 Void = []

--- a/tests-integration/fixtures/checking/1772566560_row_open_union/Main.snap
+++ b/tests-integration/fixtures/checking/1772566560_row_open_union/Main.snap
@@ -4,36 +4,59 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 openLeft ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int | (r :: Row Type) ) ( b :: String ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int | (r :: Prim.Row Prim.Type) )
+      ( b :: Prim.String )
+      (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 openRight ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int ) ( b :: String | (r :: Row Type) ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int )
+      ( b :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 backwardLeft ::
-  forall (l :: Row Type) (r :: Row Type).
-    Union @Type (l :: Row Type) ( b :: String ) ( a :: Int, b :: String | (r :: Row Type) ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 backwardRight ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int ) (r :: Row Type) ( a :: Int, b :: String | (u :: Row Type) ) =>
-    Proxy @(Row Type) (r :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int )
+      (r :: Prim.Row Prim.Type)
+      ( a :: Prim.Int, b :: Prim.String | (u :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type)
 forceSolve ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Row Type) (t4 :: Row Type)
-    (t5 :: Row Type).
-    Union @Type (t :: Row Type) ( b :: String ) ( a :: Int, b :: String | (t1 :: Row Type) ) =>
-    Union @Type (t2 :: Row Type) ( b :: String ) (t3 :: Row Type) =>
-    { backwardLeft :: Proxy @(Row Type) (t :: Row Type)
-    , backwardRight :: Proxy @(Row Type) ( b :: String | (t4 :: Row Type) )
-    , openLeft :: Proxy @(Row Type) ( a :: Int | (t3 :: Row Type) )
-    , openRight :: Proxy @(Row Type) ( a :: Int, b :: String | (t5 :: Row Type) )
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type)
+    (t3 :: Prim.Row Prim.Type) (t4 :: Prim.Row Prim.Type) (t5 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String | (t1 :: Prim.Row Prim.Type) ) =>
+    Prim.Row.Union @Prim.Type
+      (t2 :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      (t3 :: Prim.Row Prim.Type) =>
+    { backwardLeft :: Main.Proxy @(Prim.Row Prim.Type) (t :: Prim.Row Prim.Type)
+    , backwardRight ::
+        Main.Proxy @(Prim.Row Prim.Type) ( b :: Prim.String | (t4 :: Prim.Row Prim.Type) )
+    , openLeft :: Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int | (t3 :: Prim.Row Prim.Type) )
+    , openRight ::
+        Main.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.Int, b :: Prim.String | (t5 :: Prim.Row Prim.Type) )
     }
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772566620_row_open_cons/Main.snap
+++ b/tests-integration/fixtures/checking/1772566620_row_open_cons/Main.snap
@@ -4,28 +4,45 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 consOpen ::
-  forall (r :: Row Type) (row :: Row Type).
-    Cons @Type "x" Int ( a :: String | (r :: Row Type) ) (row :: Row Type) =>
-    Proxy @(Row Type) (row :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (row :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "x"
+      Prim.Int
+      ( a :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (row :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type)
 decomposeOpen ::
-  forall (t :: Type) (tail :: Row Type) (r :: Row Type).
-    Cons @Type "x" (t :: Type) (tail :: Row Type) ( a :: String, x :: Int | (r :: Row Type) ) =>
-    Proxy @Type (t :: Type)
+  forall (t :: Prim.Type) (tail :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "x"
+      (t :: Prim.Type)
+      (tail :: Prim.Row Prim.Type)
+      ( a :: Prim.String, x :: Prim.Int | (r :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @Prim.Type (t :: Prim.Type)
 extractTail ::
-  forall (tail :: Row Type) (r :: Row Type).
-    Cons @Type "x" Int (tail :: Row Type) ( a :: String, x :: Int | (r :: Row Type) ) =>
-    Proxy @(Row Type) (tail :: Row Type)
+  forall (tail :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      "x"
+      Prim.Int
+      (tail :: Prim.Row Prim.Type)
+      ( a :: Prim.String, x :: Prim.Int | (r :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (tail :: Prim.Row Prim.Type)
 forceSolve ::
-  forall (t :: Row Type) (t1 :: Row Type).
-    { consOpen :: Proxy @(Row Type) ( a :: String, x :: Int | (t :: Row Type) )
-    , decomposeOpen :: Proxy @Type Int
-    , extractTail :: Proxy @(Row Type) ( a :: String | (t1 :: Row Type) )
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { consOpen ::
+        Main.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.String, x :: Prim.Int | (t :: Prim.Row Prim.Type) )
+    , decomposeOpen :: Main.Proxy @Prim.Type Prim.Int
+    , extractTail ::
+        Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.String | (t1 :: Prim.Row Prim.Type) )
     }
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772566680_row_open_lacks/Main.snap
+++ b/tests-integration/fixtures/checking/1772566680_row_open_lacks/Main.snap
@@ -4,19 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 lacksOpen ::
-  forall (r :: Row Type).
-    Lacks @Type "missing" ( a :: Int, b :: String | (r :: Row Type) ) =>
-    Proxy @(Row Type) (r :: Row Type) -> Int
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type
+      "missing"
+      ( a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type) -> Prim.Int
 lacksPresent ::
-  forall (r :: Row Type).
-    Lacks @Type "a" ( a :: Int | (r :: Row Type) ) => Proxy @(Row Type) (r :: Row Type) -> Int
-empty :: forall (t :: Type). Proxy @(Row (t :: Type)) ()
-forceSolve :: { lacksOpen :: Int, lacksPresent :: Int }
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type "a" ( a :: Prim.Int | (r :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (r :: Prim.Row Prim.Type) -> Prim.Int
+empty :: forall (t :: Prim.Type). Main.Proxy @(Prim.Row (t :: Prim.Type)) ()
+forceSolve :: { lacksOpen :: Prim.Int, lacksPresent :: Prim.Int }
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772566740_row_open_record/Main.snap
+++ b/tests-integration/fixtures/checking/1772566740_row_open_record/Main.snap
@@ -4,23 +4,31 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 union ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r3 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r3 :: Prim.Row Prim.Type) }
 addField ::
-  forall (r :: Row Type).
-    { a :: Int | (r :: Row Type) } -> { a :: Int, b :: String | (r :: Row Type) }
-test :: { a :: Int, b :: String, c :: Boolean }
+  forall (r :: Prim.Row Prim.Type).
+    { a :: Prim.Int | (r :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) }
+test :: { a :: Prim.Int, b :: Prim.String, c :: Prim.Boolean }
 insertX ::
-  forall (r :: Row Type).
-    Lacks @Type "x" (r :: Row Type) => {| (r :: Row Type) } -> { x :: Int | (r :: Row Type) }
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type "x" (r :: Prim.Row Prim.Type) =>
+    {| (r :: Prim.Row Prim.Type) } -> { x :: Prim.Int | (r :: Prim.Row Prim.Type) }
 insertOpen ::
-  forall (r :: Row Type).
-    Lacks @Type "x" (r :: Row Type) =>
-    { a :: Int | (r :: Row Type) } -> { a :: Int, x :: Int | (r :: Row Type) }
-test2 :: { a :: Int, b :: String, x :: Int }
+  forall (r :: Prim.Row Prim.Type).
+    Prim.Row.Lacks @Prim.Type "x" (r :: Prim.Row Prim.Type) =>
+    { a :: Prim.Int | (r :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int, x :: Prim.Int | (r :: Prim.Row Prim.Type) }
+test2 :: { a :: Prim.Int, b :: Prim.String, x :: Prim.Int }
 
 Types
 

--- a/tests-integration/fixtures/checking/1772566800_derive_eq_mutual_visibility_same_module/Main.snap
+++ b/tests-integration/fixtures/checking/1772566800_derive_eq_mutual_visibility_same_module/Main.snap
@@ -1,21 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Hours :: DurationComponent
-Minutes :: DurationComponent
-Seconds :: DurationComponent
-Duration :: DurationComponent -> Int -> Duration
+Hours :: Main.DurationComponent
+Minutes :: Main.DurationComponent
+Seconds :: Main.DurationComponent
+Duration :: Main.DurationComponent -> Prim.Int -> Main.Duration
 
 Types
-DurationComponent :: Type
-Duration :: Type
+DurationComponent :: Prim.Type
+Duration :: Prim.Type
 
 Derived
-derive Eq Duration
-derive Eq DurationComponent
+derive Data.Eq.Eq Main.Duration
+derive Data.Eq.Eq Main.DurationComponent
 
 Roles
 DurationComponent = []

--- a/tests-integration/fixtures/checking/1772566860_derive_newtype_class_coercible/Main.snap
+++ b/tests-integration/fixtures/checking/1772566860_derive_newtype_class_coercible/Main.snap
@@ -4,20 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-UserId :: Int -> UserId
-wrapUserId :: Int -> UserId
-unwrapUserId :: UserId -> Int
-Wrapper :: forall (@a :: Type). (a :: Type) -> Wrapper (a :: Type)
-wrapWrapper :: forall (a :: Type). (a :: Type) -> Wrapper (a :: Type)
-unwrapWrapper :: forall (a :: Type). Wrapper (a :: Type) -> (a :: Type)
+UserId :: Prim.Int -> Main.UserId
+wrapUserId :: Prim.Int -> Main.UserId
+unwrapUserId :: Main.UserId -> Prim.Int
+Wrapper :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
+wrapWrapper :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
+unwrapWrapper :: forall (a :: Prim.Type). Main.Wrapper (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-UserId :: Type
-Wrapper :: Type -> Type
+UserId :: Prim.Type
+Wrapper :: Prim.Type -> Prim.Type
 
 Derived
-derive Newtype @Type UserId Int
-derive forall (t :: Type). Newtype @Type (Wrapper (t :: Type)) (t :: Type)
+derive Data.Newtype.Newtype @Prim.Type Main.UserId Prim.Int
+derive forall (t :: Prim.Type).
+  Data.Newtype.Newtype @Prim.Type (Main.Wrapper (t :: Prim.Type)) (t :: Prim.Type)
 
 Roles
 UserId = []

--- a/tests-integration/fixtures/checking/1772566920_derive_newtype_with_given/Main.snap
+++ b/tests-integration/fixtures/checking/1772566920_derive_newtype_with_given/Main.snap
@@ -4,13 +4,14 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
+Identity :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Show (t :: Type) => Show (Identity (t :: Type))
+derive forall (t :: Prim.Type).
+  Data.Show.Show (t :: Prim.Type) => Data.Show.Show (Main.Identity (t :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772566980_derive_newtype_missing_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1772566980_derive_newtype_missing_instance/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
+Identity :: Prim.Type -> Prim.Type
 
 Derived
-derive Show (Identity String)
+derive Data.Show.Show (Main.Identity Prim.String)
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772567040_derive_newtype_missing_given/Main.snap
+++ b/tests-integration/fixtures/checking/1772567040_derive_newtype_missing_given/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
 
 Types
-Identity :: Type -> Type
+Identity :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Show (Identity (t :: Type))
+derive forall (t :: Prim.Type). Data.Show.Show (Main.Identity (t :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772567100_derive_newtype_multi_param/Main.snap
+++ b/tests-integration/fixtures/checking/1772567100_derive_newtype_multi_param/Main.snap
@@ -5,14 +5,14 @@ expression: report
 ---
 Terms
 Pair ::
-  forall (t :: Type) (@a :: Type) (@b :: (t :: Type)).
-    (a :: Type) -> Pair @(t :: Type) (a :: Type) (b :: (t :: Type))
+  forall (t :: Prim.Type) (@a :: Prim.Type) (@b :: (t :: Prim.Type)).
+    (a :: Prim.Type) -> Main.Pair @(t :: Prim.Type) (a :: Prim.Type) (b :: (t :: Prim.Type))
 
 Types
-Pair :: forall (t :: Type). Type -> (t :: Type) -> Type
+Pair :: forall (t :: Prim.Type). Prim.Type -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive Show (Pair @Type Int String)
+derive Data.Show.Show (Main.Pair @Prim.Type Prim.Int Prim.String)
 
 Roles
 Pair = [Representational, Phantom]

--- a/tests-integration/fixtures/checking/1772567160_derive_newtype_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567160_derive_newtype_higher_kinded/Main.snap
@@ -1,25 +1,29 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-empty :: forall (@f :: Type -> Type). Empty (f :: Type -> Type) => (f :: Type -> Type) Int
-Wrapper :: forall (@a :: Type). Array (a :: Type) -> Wrapper (a :: Type)
+empty ::
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Empty (f :: Prim.Type -> Prim.Type) => (f :: Prim.Type -> Prim.Type) Prim.Int
+Wrapper :: forall (@a :: Prim.Type). Prim.Array (a :: Prim.Type) -> Main.Wrapper (a :: Prim.Type)
 
 Types
-Empty :: (Type -> Type) -> Constraint
-Wrapper :: Type -> Type
+Empty :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Wrapper :: Prim.Type -> Prim.Type
 
 Classes
-class forall (f :: Type -> Type). Empty (f :: Type -> Type)
-  empty :: forall (@f :: Type -> Type). Empty (f :: Type -> Type) => (f :: Type -> Type) Int
+class forall (f :: Prim.Type -> Prim.Type). Main.Empty (f :: Prim.Type -> Prim.Type)
+  empty ::
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Empty (f :: Prim.Type -> Prim.Type) => (f :: Prim.Type -> Prim.Type) Prim.Int
 
 Instances
-instance Empty Array
+instance Main.Empty Prim.Array
 
 Derived
-derive Empty Wrapper
+derive Main.Empty Main.Wrapper
 
 Roles
 Wrapper = [Representational]

--- a/tests-integration/fixtures/checking/1772567220_derive_newtype_function/Main.snap
+++ b/tests-integration/fixtures/checking/1772567220_derive_newtype_function/Main.snap
@@ -1,18 +1,19 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 Builder ::
-  forall (@a :: Type) (@b :: Type). ((a :: Type) -> (b :: Type)) -> Builder (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> Main.Builder (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Builder :: Type -> Type -> Type
+Builder :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive Semigroupoid @Type Builder
-derive Category @Type Builder
+derive Data.Semigroupoid.Semigroupoid @Prim.Type Main.Builder
+derive Control.Category.Category @Prim.Type Main.Builder
 
 Roles
 Builder = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772567280_derive_newtype_synonym_inner/Main.snap
+++ b/tests-integration/fixtures/checking/1772567280_derive_newtype_synonym_inner/Main.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Test :: State -> Test
+Test :: Main.State -> Main.Test
 
 Types
-State :: Type
-Test :: Type
+State :: Prim.Type
+Test :: Prim.Type
 
 Instances
-instance Eq State
+instance Data.Eq.Eq Main.State
 
 Derived
-derive Eq Test
+derive Data.Eq.Eq Main.Test
 
 Roles
 State = []

--- a/tests-integration/fixtures/checking/1772567340_derive_eq_1_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567340_derive_eq_1_higher_kinded/Main.snap
@@ -5,23 +5,27 @@ expression: report
 ---
 Terms
 MkWrap ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    Wrap @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Wrap @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 MkWrapNoEq1 ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    WrapNoEq1 @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.WrapNoEq1 @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Wrap :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
-WrapNoEq1 :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+Wrap :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
+WrapNoEq1 ::
+  forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Eq1 (t :: Type -> Type) => Eq (t1 :: Type) => Eq (Wrap @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type) (t1 :: Type -> Type).
-  Eq (t :: Type) => Eq (WrapNoEq1 @Type (t1 :: Type -> Type) (t :: Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (t1 :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq (t :: Prim.Type) =>
+  Data.Eq.Eq (Main.WrapNoEq1 @Prim.Type (t1 :: Prim.Type -> Prim.Type) (t :: Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
@@ -4,15 +4,20 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Either :: Type -> Type -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive forall (t :: Type). Eq (t :: Type) => Eq (Either Int (t :: Type))
-derive forall (t :: Type). Eq (Either Int (t :: Type))
+derive forall (t :: Prim.Type).
+  Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Either Prim.Int (t :: Prim.Type))
+derive forall (t :: Prim.Type). Data.Eq.Eq (Main.Either Prim.Int (t :: Prim.Type))
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772567460_derive_eq_ord_nested_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567460_derive_eq_ord_nested_higher_kinded/Main.snap
@@ -5,36 +5,54 @@ expression: report
 ---
 Terms
 T ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@g :: Type -> (t :: Type)).
-    (f :: (t :: Type) -> Type) ((g :: Type -> (t :: Type)) Int) ->
-    T @(t :: Type) (f :: (t :: Type) -> Type) (g :: Type -> (t :: Type))
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-U :: forall (@f :: Type -> Type). (f :: Type -> Type) (Maybe Int) -> U (f :: Type -> Type)
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: Prim.Type -> (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) ((g :: Prim.Type -> (t :: Prim.Type)) Prim.Int) ->
+    Main.T @(t :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: Prim.Type -> (t :: Prim.Type))
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+U ::
+  forall (@f :: Prim.Type -> Prim.Type).
+    (f :: Prim.Type -> Prim.Type) (Main.Maybe Prim.Int) -> Main.U (f :: Prim.Type -> Prim.Type)
 V ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@g :: Int -> (t :: Type)).
-    (f :: (t :: Type) -> Type) ((g :: Int -> (t :: Type)) 42) ->
-    V @(t :: Type) (f :: (t :: Type) -> Type) (g :: Int -> (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: Prim.Int -> (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) ((g :: Prim.Int -> (t :: Prim.Type)) 42) ->
+    Main.V @(t :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: Prim.Int -> (t :: Prim.Type))
 
 Types
-T :: forall (t :: Type). ((t :: Type) -> Type) -> (Type -> (t :: Type)) -> Type
-Maybe :: Type -> Type
-U :: (Type -> Type) -> Type
-V :: forall (t :: Type). ((t :: Type) -> Type) -> (Int -> (t :: Type)) -> Type
+T ::
+  forall (t :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) -> (Prim.Type -> (t :: Prim.Type)) -> Prim.Type
+Maybe :: Prim.Type -> Prim.Type
+U :: (Prim.Type -> Prim.Type) -> Prim.Type
+V ::
+  forall (t :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) -> (Prim.Int -> (t :: Prim.Type)) -> Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Eq1 (t :: Type -> Type) => Eq (T @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Ord1 (t :: Type -> Type) => Ord (T @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type). Eq (t :: Type) => Eq (Maybe (t :: Type))
-derive forall (t :: Type). Ord (t :: Type) => Ord (Maybe (t :: Type))
-derive forall (t :: Type -> Type). Eq1 (t :: Type -> Type) => Eq (U (t :: Type -> Type))
-derive forall (t :: Type -> Type). Ord1 (t :: Type -> Type) => Ord (U (t :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Int -> Type).
-  Eq1 (t :: Type -> Type) => Eq (V @Type (t :: Type -> Type) (t1 :: Int -> Type))
-derive forall (t :: Type -> Type) (t1 :: Int -> Type).
-  Ord1 (t :: Type -> Type) => Ord (V @Type (t :: Type -> Type) (t1 :: Int -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (Main.T @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (Main.T @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Maybe (t :: Prim.Type))
+derive forall (t :: Prim.Type). Data.Ord.Ord (t :: Prim.Type) => Data.Ord.Ord (Main.Maybe (t :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) => Data.Eq.Eq (Main.U (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) => Data.Ord.Ord (Main.U (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (Main.V @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (Main.V @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type))
 
 Roles
 T = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
@@ -5,21 +5,27 @@ expression: report
 ---
 Terms
 Wrap ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    Wrap @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Wrap @(t :: Prim.Type) (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))
 WrapNoFunctor ::
-  forall (t :: Type) (@f :: (t :: Type) -> Type) (@a :: (t :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    WrapNoFunctor @(t :: Type) (f :: (t :: Type) -> Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.WrapNoFunctor @(t :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
 
 Types
-Wrap :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
-WrapNoFunctor :: forall (t :: Type). ((t :: Type) -> Type) -> (t :: Type) -> Type
+Wrap :: forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
+WrapNoFunctor ::
+  forall (t :: Prim.Type). ((t :: Prim.Type) -> Prim.Type) -> (t :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t :: Type -> Type). Functor (t :: Type -> Type) => Functor (Wrap @Type (t :: Type -> Type))
-derive forall (t :: Type -> Type). Functor (WrapNoFunctor @Type (t :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (t :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (Main.Wrap @Prim.Type (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (Main.WrapNoFunctor @Prim.Type (t :: Prim.Type -> Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
@@ -5,41 +5,55 @@ expression: report
 ---
 Terms
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> Type)
-    (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    (g :: (t1 :: Type) -> Type) (b :: (t1 :: Type)) ->
-    WrapBoth @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    (g :: (t1 :: Prim.Type) -> Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Main.WrapBoth @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 WrapBothNoConstraint ::
-  forall (t :: Type) (t1 :: Type) (@f :: (t :: Type) -> Type) (@g :: (t1 :: Type) -> Type)
-    (@a :: (t :: Type)) (@b :: (t1 :: Type)).
-    (f :: (t :: Type) -> Type) (a :: (t :: Type)) ->
-    (g :: (t1 :: Type) -> Type) (b :: (t1 :: Type)) ->
-    WrapBothNoConstraint @(t :: Type) @(t1 :: Type)
-      (f :: (t :: Type) -> Type)
-      (g :: (t1 :: Type) -> Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (@f :: (t :: Prim.Type) -> Prim.Type)
+    (@g :: (t1 :: Prim.Type) -> Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t1 :: Prim.Type)).
+    (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+    (g :: (t1 :: Prim.Type) -> Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Main.WrapBothNoConstraint @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (f :: (t :: Prim.Type) -> Prim.Type)
+      (g :: (t1 :: Prim.Type) -> Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
 
 Types
 WrapBoth ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> Type) -> (t :: Type) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 WrapBothNoConstraint ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> Type) -> ((t1 :: Type) -> Type) -> (t :: Type) -> (t1 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) ->
+    ((t1 :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t1 :: Prim.Type) ->
+    Prim.Type
 
 Derived
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Functor (t :: Type -> Type) =>
-  Functor (t1 :: Type -> Type) =>
-  Bifunctor (WrapBoth @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type -> Type).
-  Bifunctor (WrapBothNoConstraint @Type @Type (t :: Type -> Type) (t1 :: Type -> Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (t :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (t1 :: Prim.Type -> Prim.Type) =>
+  Data.Bifunctor.Bifunctor
+    (Main.WrapBoth @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Data.Bifunctor.Bifunctor
+    (Main.WrapBothNoConstraint @Prim.Type @Prim.Type
+      (t :: Prim.Type -> Prim.Type)
+      (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1772567640_givens_retained/Main.snap
+++ b/tests-integration/fixtures/checking/1772567640_givens_retained/Main.snap
@@ -4,12 +4,15 @@ assertion_line: 50
 expression: report
 ---
 Terms
-consume :: forall (@a :: Type). Given (a :: Type) => (a :: Type) -> (a :: Type)
-testGiven :: forall (a :: Type). Given (a :: Type) => (a :: Type) -> (a :: Type)
+consume ::
+  forall (@a :: Prim.Type). Main.Given (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
+testGiven ::
+  forall (a :: Prim.Type). Main.Given (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-Given :: Type -> Constraint
+Given :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Given (a :: Type)
-  consume :: forall (@a :: Type). Given (a :: Type) => (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Given (a :: Prim.Type)
+  consume ::
+  forall (@a :: Prim.Type). Main.Given (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772567700_givens_scoped/Main.snap
+++ b/tests-integration/fixtures/checking/1772567700_givens_scoped/Main.snap
@@ -4,15 +4,18 @@ assertion_line: 50
 expression: report
 ---
 Terms
-consume :: forall (@a :: Type). Given (a :: Type) => (a :: Type) -> (a :: Type)
-testGiven :: forall (a :: Type). Given (a :: Type) => (a :: Type) -> (a :: Type)
+consume ::
+  forall (@a :: Prim.Type). Main.Given (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
+testGiven ::
+  forall (a :: Prim.Type). Main.Given (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-Given :: Type -> Constraint
+Given :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Given (a :: Type)
-  consume :: forall (@a :: Type). Given (a :: Type) => (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Given (a :: Prim.Type)
+  consume ::
+  forall (@a :: Prim.Type). Main.Given (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Diagnostics
 error[NoInstanceFound]: No instance found for: Given Int

--- a/tests-integration/fixtures/checking/1772567760_let_constraint_scoping/Main.snap
+++ b/tests-integration/fixtures/checking/1772567760_let_constraint_scoping/Main.snap
@@ -4,15 +4,15 @@ assertion_line: 50
 expression: report
 ---
 Terms
-method :: forall (@a :: Type). MyClass (a :: Type) => (a :: Type) -> Int
-test :: forall (a :: Type). MyClass (a :: Type) => (a :: Type) -> Int
+method :: forall (@a :: Prim.Type). Main.MyClass (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+test :: forall (a :: Prim.Type). Main.MyClass (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Types
-MyClass :: Type -> Constraint
+MyClass :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). MyClass (a :: Type)
-  method :: forall (@a :: Type). MyClass (a :: Type) => (a :: Type) -> Int
+class forall (a :: Prim.Type). Main.MyClass (a :: Prim.Type)
+  method :: forall (@a :: Prim.Type). Main.MyClass (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Instances
-instance MyClass Int
+instance Main.MyClass Prim.Int

--- a/tests-integration/fixtures/checking/1772633520_type_operator_synonym_expansion/Main.snap
+++ b/tests-integration/fixtures/checking/1772633520_type_operator_synonym_expansion/Main.snap
@@ -4,21 +4,26 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
 
 Types
-Maybe :: Type -> Type
-NaturalTransformation :: forall (k :: Type). ((k :: Type) -> Type) -> ((k :: Type) -> Type) -> Type
-~> :: forall (k :: Type). ((k :: Type) -> Type) -> ((k :: Type) -> Type) -> Type
-Test1 :: Type
-Test2 :: Type
+Maybe :: Prim.Type -> Prim.Type
+NaturalTransformation ::
+  forall (k :: Prim.Type).
+    ((k :: Prim.Type) -> Prim.Type) -> ((k :: Prim.Type) -> Prim.Type) -> Prim.Type
+~> ::
+  forall (k :: Prim.Type).
+    ((k :: Prim.Type) -> Prim.Type) -> ((k :: Prim.Type) -> Prim.Type) -> Prim.Type
+Test1 :: Prim.Type
+Test2 :: Prim.Type
 
 Synonyms
-type NaturalTransformation f g = forall (a :: (k :: Type)).
-  (f :: (k :: Type) -> Type) (a :: (k :: Type)) -> (g :: (k :: Type) -> Type) (a :: (k :: Type))
-type Test1 = NaturalTransformation @Type Array Maybe
-type Test2 = NaturalTransformation @Type Array Maybe
+type NaturalTransformation f g = forall (a :: (k :: Prim.Type)).
+  (f :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type)) ->
+  (g :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type))
+type Test1 = Main.NaturalTransformation @Prim.Type Prim.Array Main.Maybe
+type Test2 = Main.NaturalTransformation @Prim.Type Prim.Array Main.Maybe
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772649720_synonym_kind_application/Main.snap
+++ b/tests-integration/fixtures/checking/1772649720_synonym_kind_application/Main.snap
@@ -1,18 +1,18 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-RowBox :: Row Type -> Type
-Apply :: forall (k :: Type). ((k :: Type) -> Type) -> (k :: Type) -> Type
-RowDesugared :: Type
+RowBox :: Prim.Row Prim.Type -> Prim.Type
+Apply :: forall (k :: Prim.Type). ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
+RowDesugared :: Prim.Type
 
 Synonyms
-type Apply f a = (f :: (k :: Type) -> Type) (a :: (k :: Type))
-type RowDesugared = Apply @(Row Type) RowBox ()
+type Apply f a = (f :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type))
+type RowDesugared = Main.Apply @(Prim.Row Prim.Type) Main.RowBox ()
 
 Roles
 RowBox = [Phantom]

--- a/tests-integration/fixtures/checking/1772649780_synonym_operator_alias/Main.snap
+++ b/tests-integration/fixtures/checking/1772649780_synonym_operator_alias/Main.snap
@@ -1,17 +1,17 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-Apply :: forall (k :: Type). ((k :: Type) -> Type) -> (k :: Type) -> Type
-$ :: forall (k :: Type). ((k :: Type) -> Type) -> (k :: Type) -> Type
-Test1 :: Type
-Test2 :: Type
+Apply :: forall (k :: Prim.Type). ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
+$ :: forall (k :: Prim.Type). ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
+Test1 :: Prim.Type
+Test2 :: Prim.Type
 
 Synonyms
-type Apply f = (f :: (k :: Type) -> Type)
-type Test1 = Apply @Type Array Int
-type Test2 = Apply @Type Array Int
+type Apply f = (f :: (k :: Prim.Type) -> Prim.Type)
+type Test1 = Main.Apply @Prim.Type Prim.Array Prim.Int
+type Test2 = Main.Apply @Prim.Type Prim.Array Prim.Int

--- a/tests-integration/fixtures/checking/1772716080_const_equation_forms/Main.snap
+++ b/tests-integration/fixtures/checking/1772716080_const_equation_forms/Main.snap
@@ -4,8 +4,11 @@ assertion_line: 50
 expression: report
 ---
 Terms
-const :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-const2 :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-const3 :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
+const ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+const2 ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+const3 ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772716140_const_forms_synonym_arrow/Main.snap
+++ b/tests-integration/fixtures/checking/1772716140_const_forms_synonym_arrow/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-const0 :: forall (a :: Type) (b :: Type). Const (a :: Type) (b :: Type)
-const1 :: forall (a :: Type) (b :: Type). Const (a :: Type) (b :: Type)
-const2 :: forall (a :: Type) (b :: Type). Const (a :: Type) (b :: Type)
-const3 :: forall (a :: Type) (b :: Type). Const (a :: Type) (b :: Type)
+const0 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.Const (a :: Prim.Type) (b :: Prim.Type)
+const1 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.Const (a :: Prim.Type) (b :: Prim.Type)
+const2 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.Const (a :: Prim.Type) (b :: Prim.Type)
+const3 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.Const (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Const :: Type -> Type -> Type
+Const :: Prim.Type -> Prim.Type -> Prim.Type
 
 Synonyms
-type Const a b = (a :: Type) -> (b :: Type) -> (a :: Type)
+type Const a b = (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772716200_const_forms_synonym_forall/Main.snap
+++ b/tests-integration/fixtures/checking/1772716200_const_forms_synonym_forall/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-poly0 :: ConstPoly
-poly1 :: ConstPoly
-poly2 :: ConstPoly
-poly3 :: ConstPoly
+poly0 :: Main.ConstPoly
+poly1 :: Main.ConstPoly
+poly2 :: Main.ConstPoly
+poly3 :: Main.ConstPoly
 
 Types
-ConstPoly :: Type
+ConstPoly :: Prim.Type
 
 Synonyms
-type ConstPoly = forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
+type ConstPoly = forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772716260_const_forms_fn_alias/Main.snap
+++ b/tests-integration/fixtures/checking/1772716260_const_forms_fn_alias/Main.snap
@@ -4,17 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-fn0 :: forall (a :: Type) (b :: Type). ConstFn (a :: Type) (b :: Type)
-fn1 :: forall (a :: Type) (b :: Type). ConstFn (a :: Type) (b :: Type)
-fn2 :: forall (a :: Type) (b :: Type). ConstFn (a :: Type) (b :: Type)
-fn3 :: forall (a :: Type) (b :: Type). ConstFn (a :: Type) (b :: Type)
-fn4 :: forall (b :: Type) (a :: Type). (a :: Type) -> Fn (b :: Type) (a :: Type)
-fn5 :: forall (b :: Type) (a :: Type). (a :: Type) -> Fn (b :: Type) (a :: Type)
+fn0 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.ConstFn (a :: Prim.Type) (b :: Prim.Type)
+fn1 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.ConstFn (a :: Prim.Type) (b :: Prim.Type)
+fn2 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.ConstFn (a :: Prim.Type) (b :: Prim.Type)
+fn3 :: forall (a :: Prim.Type) (b :: Prim.Type). Main.ConstFn (a :: Prim.Type) (b :: Prim.Type)
+fn4 ::
+  forall (b :: Prim.Type) (a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Fn (b :: Prim.Type) (a :: Prim.Type)
+fn5 ::
+  forall (b :: Prim.Type) (a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Fn (b :: Prim.Type) (a :: Prim.Type)
 
 Types
-Fn :: Type -> Type -> Type
-ConstFn :: Type -> Type -> Type
+Fn :: Prim.Type -> Prim.Type -> Prim.Type
+ConstFn :: Prim.Type -> Prim.Type -> Prim.Type
 
 Synonyms
-type Fn b a = (b :: Type) -> (a :: Type)
-type ConstFn a b = (a :: Type) -> Fn (b :: Type) (a :: Type)
+type Fn b a = (b :: Prim.Type) -> (a :: Prim.Type)
+type ConstFn a b = (a :: Prim.Type) -> Main.Fn (b :: Prim.Type) (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772723460_signature_synonym_data_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772723460_signature_synonym_data_equation/Main.snap
@@ -1,17 +1,17 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
 
 Types
-UnaryKind :: Type
-Box :: UnaryKind
+UnaryKind :: Prim.Type
+Box :: Main.UnaryKind
 
 Synonyms
-type UnaryKind = Type -> Type
+type UnaryKind = Prim.Type -> Prim.Type
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1772723520_signature_synonym_class_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772723520_signature_synonym_class_equation/Main.snap
@@ -1,18 +1,22 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-eqLike :: forall (@a :: Type). EqLike (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+eqLike ::
+  forall (@a :: Prim.Type).
+    Main.EqLike (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
 
 Types
-ClassHead :: Type
-EqLike :: ClassHead
+ClassHead :: Prim.Type
+EqLike :: Main.ClassHead
 
 Synonyms
-type ClassHead = Type -> Constraint
+type ClassHead = Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). EqLike (a :: Type)
-  eqLike :: forall (@a :: Type). EqLike (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.EqLike (a :: Prim.Type)
+  eqLike ::
+  forall (@a :: Prim.Type).
+    Main.EqLike (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1772723580_signature_synonym_type_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772723580_signature_synonym_type_equation/Main.snap
@@ -1,14 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-BinaryKind :: Type
-ConstT :: BinaryKind
+BinaryKind :: Prim.Type
+ConstT :: Main.BinaryKind
 
 Synonyms
-type BinaryKind = Type -> Type -> Type
-type ConstT a b = (a :: Type)
+type BinaryKind = Prim.Type -> Prim.Type -> Prim.Type
+type ConstT a b = (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772723640_synonym_oversaturation_equations/Main.snap
+++ b/tests-integration/fixtures/checking/1772723640_synonym_oversaturation_equations/Main.snap
@@ -5,17 +5,18 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-test1 :: Identity @(Type -> Type) Array Int
-test2 :: Identity @(Type -> Type -> Type) Tuple Int String
-forceSolve :: { test1 :: Array Int, test2 :: Tuple Int String }
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+test1 :: Main.Identity @(Prim.Type -> Prim.Type) Prim.Array Prim.Int
+test2 :: Main.Identity @(Prim.Type -> Prim.Type -> Prim.Type) Main.Tuple Prim.Int Prim.String
+forceSolve :: { test1 :: Prim.Array Prim.Int, test2 :: Main.Tuple Prim.Int Prim.String }
 
 Types
-Identity :: forall (k :: Type). (k :: Type) -> (k :: Type)
-Tuple :: Type -> Type -> Type
+Identity :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type)
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 
 Synonyms
-type Identity a = (a :: (k :: Type))
+type Identity a = (a :: (k :: Prim.Type))
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772743200_class_member_prenex/Main.snap
+++ b/tests-integration/fixtures/checking/1772743200_class_member_prenex/Main.snap
@@ -5,20 +5,24 @@ expression: report
 ---
 Terms
 const ::
-  forall (@f :: Type -> Type).
-    Const (f :: Type -> Type) =>
-    (forall (a :: Type).
-      (f :: Type -> Type) (a :: Type) ->
-      (forall (b :: Type). (f :: Type -> Type) (b :: Type) -> (f :: Type -> Type) (a :: Type)))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Const (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type).
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (forall (b :: Prim.Type).
+        (f :: Prim.Type -> Prim.Type) (b :: Prim.Type) ->
+        (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)))
 
 Types
-Const :: (Type -> Type) -> Constraint
+Const :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (f :: Type -> Type). Const (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Const (f :: Prim.Type -> Prim.Type)
   const ::
-  forall (@f :: Type -> Type).
-    Const (f :: Type -> Type) =>
-    (forall (a :: Type).
-      (f :: Type -> Type) (a :: Type) ->
-      (forall (b :: Type). (f :: Type -> Type) (b :: Type) -> (f :: Type -> Type) (a :: Type)))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Const (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type).
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (forall (b :: Prim.Type).
+        (f :: Prim.Type -> Prim.Type) (b :: Prim.Type) ->
+        (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)))

--- a/tests-integration/fixtures/checking/1772814960_synonym_oversaturation_kind/Main.snap
+++ b/tests-integration/fixtures/checking/1772814960_synonym_oversaturation_kind/Main.snap
@@ -4,22 +4,26 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-test0 :: Test0 @Int 42
-test1 :: Test1 @Type @Int Int 42
-test2 :: Test2 @Type @Type @Int Int String 42
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+test0 :: Main.Test0 @Prim.Int 42
+test1 :: Main.Test1 @Prim.Type @Prim.Int Prim.Int 42
+test2 :: Main.Test2 @Prim.Type @Prim.Type @Prim.Int Prim.Int Prim.String 42
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-Test0 :: forall (t :: Type). (t :: Type) -> Type
-Test1 :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Test0 :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
+Test1 ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type). (t :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Type
 Test2 ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type). (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> Type
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> Prim.Type
 
 Synonyms
-type Test0 = Proxy @(t :: Type)
-type Test1 a = Proxy @(t :: Type)
-type Test2 a b = Proxy @(t :: Type)
+type Test0 = Main.Proxy @(t :: Prim.Type)
+type Test1 a = Main.Proxy @(t :: Prim.Type)
+type Test2 a b = Main.Proxy @(t :: Prim.Type)
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772815740_derive_generic_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772815740_derive_generic_insufficient_params/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Box :: Int -> Box
+Box :: Prim.Int -> Main.Box
 
 Types
-Box :: Type
+Box :: Prim.Type
 
 Derived
-derive Generic Box
+derive Data.Generic.Rep.Generic Main.Box
 
 Roles
 Box = []

--- a/tests-integration/fixtures/checking/1772815800_derive_generic_not_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772815800_derive_generic_not_constructor/Main.snap
@@ -8,7 +8,7 @@ Terms
 Types
 
 Derived
-derive forall (t :: Type). Generic (Int -> Int) (t :: Type)
+derive forall (t :: Prim.Type). Data.Generic.Rep.Generic (Prim.Int -> Prim.Int) (t :: Prim.Type)
 
 Diagnostics
 error[CannotDeriveForType]: Cannot derive for type: Int -> Int

--- a/tests-integration/fixtures/checking/1772815860_derive_generic_missing_rep/Main.snap
+++ b/tests-integration/fixtures/checking/1772815860_derive_generic_missing_rep/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Box :: Int -> Box
+Box :: Prim.Int -> Main.Box
 
 Types
-Box :: Type
+Box :: Prim.Type
 
 Derived
-derive forall (t :: Type). Generic Box (t :: Type)
+derive forall (t :: Prim.Type). Data.Generic.Rep.Generic Main.Box (t :: Prim.Type)
 
 Roles
 Box = []

--- a/tests-integration/fixtures/checking/1772817840_do_discard/Main.snap
+++ b/tests-integration/fixtures/checking/1772817840_do_discard/Main.snap
@@ -4,21 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Unit :: Unit
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+Unit :: Main.Unit
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 bind ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
 discard ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
-unit :: Unit
-test :: Effect Unit
-test' :: Effect Unit
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
+unit :: Main.Unit
+test :: Main.Effect Main.Unit
+test' :: Main.Effect Main.Unit
 
 Types
-Effect :: Type -> Type
-Unit :: Type
+Effect :: Prim.Type -> Prim.Type
+Unit :: Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772817900_do_bind/Main.snap
+++ b/tests-integration/fixtures/checking/1772817900_do_bind/Main.snap
@@ -5,20 +5,25 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 bind ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
 discard ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
-test :: Effect (Tuple Int Int)
-test' :: Effect (Tuple Int Int)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
+test :: Main.Effect (Main.Tuple Prim.Int Prim.Int)
+test' :: Main.Effect (Main.Tuple Prim.Int Prim.Int)
 
 Types
-Effect :: Type -> Type
-Tuple :: Type -> Type -> Type
+Effect :: Prim.Type -> Prim.Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772817960_ado_discard/Main.snap
+++ b/tests-integration/fixtures/checking/1772817960_ado_discard/Main.snap
@@ -4,21 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Unit :: Unit
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+Unit :: Main.Unit
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
 apply ::
-  forall (a :: Type) (b :: Type).
-    Effect ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
-unit :: Unit
-test :: Effect Unit
-test' :: Effect Unit
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
+unit :: Main.Unit
+test :: Main.Effect Main.Unit
+test' :: Main.Effect Main.Unit
 
 Types
-Effect :: Type -> Type
-Unit :: Type
+Effect :: Prim.Type -> Prim.Type
+Unit :: Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818020_ado_bind/Main.snap
+++ b/tests-integration/fixtures/checking/1772818020_ado_bind/Main.snap
@@ -5,20 +5,25 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
 apply ::
-  forall (a :: Type) (b :: Type).
-    Effect ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
-test :: Effect (Tuple Int Int)
-test' :: Effect (Tuple Int Int)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
+test :: Main.Effect (Main.Tuple Prim.Int Prim.Int)
+test' :: Main.Effect (Main.Tuple Prim.Int Prim.Int)
 
 Types
-Effect :: Type -> Type
-Tuple :: Type -> Type -> Type
+Effect :: Prim.Type -> Prim.Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818080_do_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1772818080_do_polymorphic/Main.snap
@@ -5,23 +5,30 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
 bind ::
-  forall (m :: Type -> Type) (a :: Type) (b :: Type).
-    (m :: Type -> Type) (a :: Type) ->
-    ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-    (m :: Type -> Type) (b :: Type)
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)) ->
+    (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)
 discard ::
-  forall (m :: Type -> Type) (a :: Type) (b :: Type).
-    (m :: Type -> Type) (a :: Type) ->
-    ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-    (m :: Type -> Type) (b :: Type)
-pure :: forall (m :: Type -> Type) (a :: Type). (a :: Type) -> (m :: Type -> Type) (a :: Type)
-test :: forall (m :: Type -> Type). (m :: Type -> Type) (Tuple Int String)
-test' :: forall (t :: Type -> Type). (t :: Type -> Type) (Tuple Int String)
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)) ->
+    (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)
+pure ::
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    (a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+test ::
+  forall (m :: Prim.Type -> Prim.Type).
+    (m :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
+test' ::
+  forall (t :: Prim.Type -> Prim.Type).
+    (t :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
 
 Types
-Tuple :: Type -> Type -> Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772818140_ado_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1772818140_ado_polymorphic/Main.snap
@@ -5,23 +5,30 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
 map ::
-  forall (f :: Type -> Type) (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
+  forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (f :: Prim.Type -> Prim.Type) (b :: Prim.Type)
 apply ::
-  forall (f :: Type -> Type) (a :: Type) (b :: Type).
-    (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type)
-pure :: forall (f :: Type -> Type) (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type)
-test :: forall (f :: Type -> Type). (f :: Type -> Type) (Tuple Int String)
-test' :: forall (t :: Type -> Type). (t :: Type -> Type) (Tuple Int String)
+  forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    (f :: Prim.Type -> Prim.Type) ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (f :: Prim.Type -> Prim.Type) (b :: Prim.Type)
+pure ::
+  forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    (a :: Prim.Type) -> (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+test ::
+  forall (f :: Prim.Type -> Prim.Type).
+    (f :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
+test' ::
+  forall (t :: Prim.Type -> Prim.Type).
+    (t :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
 
 Types
-Tuple :: Type -> Type -> Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772818200_do_empty_block/Main.snap
+++ b/tests-integration/fixtures/checking/1772818200_do_empty_block/Main.snap
@@ -4,17 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 bind ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
 discard ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
 test :: ?[empty do block]
 
 Types
-Effect :: Type -> Type
+Effect :: Prim.Type -> Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818260_ado_empty_block/Main.snap
+++ b/tests-integration/fixtures/checking/1772818260_ado_empty_block/Main.snap
@@ -4,18 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
 apply ::
-  forall (a :: Type) (b :: Type).
-    Effect ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
 test1 :: ?[empty ado block]
-test2 :: Effect Int
+test2 :: Main.Effect Prim.Int
 
 Types
-Effect :: Type -> Type
+Effect :: Prim.Type -> Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818320_do_ado_constrained/Main.snap
+++ b/tests-integration/fixtures/checking/1772818320_do_ado_constrained/Main.snap
@@ -5,100 +5,111 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
 map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 apply ::
-  forall (@f :: Type -> Type).
-    Apply (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Apply (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      (f :: Prim.Type -> Prim.Type) ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 pure ::
-  forall (@f :: Type -> Type).
-    Applicative (f :: Type -> Type) =>
-    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Applicative (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type). (a :: Prim.Type) -> (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
 discard ::
-  forall (@m :: Type -> Type).
-    Discard (m :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      (m :: Type -> Type) (a :: Type) ->
-      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-      (m :: Type -> Type) (b :: Type))
+  forall (@m :: Prim.Type -> Prim.Type).
+    Main.Discard (m :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)) ->
+      (m :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 bind ::
-  forall (@m :: Type -> Type).
-    Bind (m :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      (m :: Type -> Type) (a :: Type) ->
-      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-      (m :: Type -> Type) (b :: Type))
+  forall (@m :: Prim.Type -> Prim.Type).
+    Main.Bind (m :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)) ->
+      (m :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 testDo ::
-  forall (m :: Type -> Type). Monad (m :: Type -> Type) => (m :: Type -> Type) (Tuple Int String)
+  forall (m :: Prim.Type -> Prim.Type).
+    Main.Monad (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
 testDo' ::
-  forall (t :: Type -> Type). Bind (t :: Type -> Type) => (t :: Type -> Type) (Tuple Int String)
+  forall (t :: Prim.Type -> Prim.Type).
+    Main.Bind (t :: Prim.Type -> Prim.Type) =>
+    (t :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
 testAdo ::
-  forall (f :: Type -> Type).
-    Applicative (f :: Type -> Type) => (f :: Type -> Type) (Tuple Int String)
+  forall (f :: Prim.Type -> Prim.Type).
+    Main.Applicative (f :: Prim.Type -> Prim.Type) =>
+    (f :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
 testAdo' ::
-  forall (t :: Type -> Type).
-    Applicative (t :: Type -> Type) => (t :: Type -> Type) (Tuple Int String)
-testDoDiscard :: forall (m :: Type -> Type). Monad (m :: Type -> Type) => (m :: Type -> Type) Int
-testDoDiscard' :: forall (t :: Type -> Type). Discard (t :: Type -> Type) => (t :: Type -> Type) Int
+  forall (t :: Prim.Type -> Prim.Type).
+    Main.Applicative (t :: Prim.Type -> Prim.Type) =>
+    (t :: Prim.Type -> Prim.Type) (Main.Tuple Prim.Int Prim.String)
+testDoDiscard ::
+  forall (m :: Prim.Type -> Prim.Type).
+    Main.Monad (m :: Prim.Type -> Prim.Type) => (m :: Prim.Type -> Prim.Type) Prim.Int
+testDoDiscard' ::
+  forall (t :: Prim.Type -> Prim.Type).
+    Main.Discard (t :: Prim.Type -> Prim.Type) => (t :: Prim.Type -> Prim.Type) Prim.Int
 
 Types
-Tuple :: Type -> Type -> Type
-Functor :: (Type -> Type) -> Constraint
-Apply :: (Type -> Type) -> Constraint
-Applicative :: (Type -> Type) -> Constraint
-Discard :: (Type -> Type) -> Constraint
-Bind :: (Type -> Type) -> Constraint
-Monad :: (Type -> Type) -> Constraint
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
+Functor :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Apply :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Applicative :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Discard :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Bind :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Monad :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (f :: Type -> Type). Functor (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Functor (f :: Prim.Type -> Prim.Type)
   map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
-class forall (f :: Type -> Type). Functor (f :: Type -> Type) <= Apply (f :: Type -> Type)
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
+class forall (f :: Prim.Type -> Prim.Type). Main.Functor (f :: Prim.Type -> Prim.Type) <= Main.Apply (f :: Prim.Type -> Prim.Type)
   apply ::
-  forall (@f :: Type -> Type).
-    Apply (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      (f :: Type -> Type) ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
-class forall (f :: Type -> Type). Apply (f :: Type -> Type) <= Applicative (f :: Type -> Type)
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Apply (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      (f :: Prim.Type -> Prim.Type) ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
+class forall (f :: Prim.Type -> Prim.Type). Main.Apply (f :: Prim.Type -> Prim.Type) <= Main.Applicative (f :: Prim.Type -> Prim.Type)
   pure ::
-  forall (@f :: Type -> Type).
-    Applicative (f :: Type -> Type) =>
-    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
-class forall (m :: Type -> Type). Applicative (m :: Type -> Type) <= Discard (m :: Type -> Type)
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Applicative (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type). (a :: Prim.Type) -> (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+class forall (m :: Prim.Type -> Prim.Type). Main.Applicative (m :: Prim.Type -> Prim.Type) <= Main.Discard (m :: Prim.Type -> Prim.Type)
   discard ::
-  forall (@m :: Type -> Type).
-    Discard (m :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      (m :: Type -> Type) (a :: Type) ->
-      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-      (m :: Type -> Type) (b :: Type))
-class forall (m :: Type -> Type). Applicative (m :: Type -> Type) <= Bind (m :: Type -> Type)
+  forall (@m :: Prim.Type -> Prim.Type).
+    Main.Discard (m :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)) ->
+      (m :: Prim.Type -> Prim.Type) (b :: Prim.Type))
+class forall (m :: Prim.Type -> Prim.Type). Main.Applicative (m :: Prim.Type -> Prim.Type) <= Main.Bind (m :: Prim.Type -> Prim.Type)
   bind ::
-  forall (@m :: Type -> Type).
-    Bind (m :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      (m :: Type -> Type) (a :: Type) ->
-      ((a :: Type) -> (m :: Type -> Type) (b :: Type)) ->
-      (m :: Type -> Type) (b :: Type))
-class forall (m :: Type -> Type). Bind (m :: Type -> Type) <= Monad (m :: Type -> Type)
+  forall (@m :: Prim.Type -> Prim.Type).
+    Main.Bind (m :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (b :: Prim.Type)) ->
+      (m :: Prim.Type -> Prim.Type) (b :: Prim.Type))
+class forall (m :: Prim.Type -> Prim.Type). Main.Bind (m :: Prim.Type -> Prim.Type) <= Main.Monad (m :: Prim.Type -> Prim.Type)
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772818380_do_let_premature_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818380_do_let_premature_solve/Main.snap
@@ -4,29 +4,39 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unit :: Unit
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+unit :: Main.Unit
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 bind ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
-discard :: forall (a :: Type). Effect (a :: Type) -> Effect Unit -> Effect Unit
-add :: forall (@a :: Type). Semiring (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-addImpl :: Int -> Int -> Int
-+ :: forall (@a :: Type). Semiring (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-thing1 :: Effect String
-test :: Effect Unit
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
+discard ::
+  forall (a :: Prim.Type).
+    Main.Effect (a :: Prim.Type) -> Main.Effect Main.Unit -> Main.Effect Main.Unit
+add ::
+  forall (@a :: Prim.Type).
+    Main.Semiring (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+addImpl :: Prim.Int -> Prim.Int -> Prim.Int
++ ::
+  forall (@a :: Prim.Type).
+    Main.Semiring (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+thing1 :: Main.Effect Prim.String
+test :: Main.Effect Main.Unit
 
 Types
-Effect :: Type -> Type
-Unit :: Type
-Semiring :: Type -> Constraint
+Effect :: Prim.Type -> Prim.Type
+Unit :: Prim.Type
+Semiring :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semiring (a :: Type)
-  add :: forall (@a :: Type). Semiring (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Semiring (a :: Prim.Type)
+  add ::
+  forall (@a :: Prim.Type).
+    Main.Semiring (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance Semiring Int
+instance Main.Semiring Prim.Int
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818440_do_let_annotation_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818440_do_let_annotation_solve/Main.snap
@@ -4,18 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unit :: Unit
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+unit :: Main.Unit
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 bind ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
-discard :: forall (a :: Type). Effect (a :: Type) -> Effect Unit -> Effect Unit
-thing1 :: Effect String
-test :: Effect Unit
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
+discard ::
+  forall (a :: Prim.Type).
+    Main.Effect (a :: Prim.Type) -> Main.Effect Main.Unit -> Main.Effect Main.Unit
+thing1 :: Main.Effect Prim.String
+test :: Main.Effect Main.Unit
 
 Types
-Effect :: Type -> Type
-Unit :: Type
+Effect :: Prim.Type -> Prim.Type
+Unit :: Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818500_ado_let_premature_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818500_ado_let_premature_solve/Main.snap
@@ -4,31 +4,41 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unit :: Unit
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+unit :: Main.Unit
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
 apply ::
-  forall (a :: Type) (b :: Type).
-    Effect ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
-add :: forall (@a :: Type). Semiring (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-addImpl :: Int -> Int -> Int
-+ :: forall (@a :: Type). Semiring (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-thing1 :: Effect String
-test :: Effect Unit
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
+add ::
+  forall (@a :: Prim.Type).
+    Main.Semiring (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+addImpl :: Prim.Int -> Prim.Int -> Prim.Int
++ ::
+  forall (@a :: Prim.Type).
+    Main.Semiring (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+thing1 :: Main.Effect Prim.String
+test :: Main.Effect Main.Unit
 
 Types
-Effect :: Type -> Type
-Unit :: Type
-Semiring :: Type -> Constraint
+Effect :: Prim.Type -> Prim.Type
+Unit :: Prim.Type
+Semiring :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semiring (a :: Type)
-  add :: forall (@a :: Type). Semiring (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Semiring (a :: Prim.Type)
+  add ::
+  forall (@a :: Prim.Type).
+    Main.Semiring (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance Semiring Int
+instance Main.Semiring Prim.Int
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818560_ado_let_annotation_solve/Main.snap
+++ b/tests-integration/fixtures/checking/1772818560_ado_let_annotation_solve/Main.snap
@@ -4,20 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unit :: Unit
-pure :: forall (a :: Type). (a :: Type) -> Effect (a :: Type)
+unit :: Main.Unit
+pure :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.Effect (a :: Prim.Type)
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
 apply ::
-  forall (a :: Type) (b :: Type).
-    Effect ((a :: Type) -> (b :: Type)) -> Effect (a :: Type) -> Effect (b :: Type)
-thing1 :: Effect String
-test :: Effect Unit
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Main.Effect (a :: Prim.Type) ->
+    Main.Effect (b :: Prim.Type)
+thing1 :: Main.Effect Prim.String
+test :: Main.Effect Main.Unit
 
 Types
-Effect :: Type -> Type
-Unit :: Type
+Effect :: Prim.Type -> Prim.Type
+Unit :: Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1772818620_do_bind_only/Main.snap
+++ b/tests-integration/fixtures/checking/1772818620_do_bind_only/Main.snap
@@ -4,9 +4,11 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: Effect Int
+test :: Effect.Effect Prim.Int
 test' ::
-  forall (t :: Type -> Type).
-    Bind (t :: Type -> Type) => Applicative (t :: Type -> Type) => (t :: Type -> Type) Int
+  forall (t :: Prim.Type -> Prim.Type).
+    Control.Bind.Bind (t :: Prim.Type -> Prim.Type) =>
+    Control.Applicative.Applicative (t :: Prim.Type -> Prim.Type) =>
+    (t :: Prim.Type -> Prim.Type) Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772818680_do_final_bind/Main.snap
+++ b/tests-integration/fixtures/checking/1772818680_do_final_bind/Main.snap
@@ -4,8 +4,11 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: Effect Int
-test' :: forall (t :: Type -> Type). Applicative (t :: Type -> Type) => (t :: Type -> Type) Int
+test :: Effect.Effect Prim.Int
+test' ::
+  forall (t :: Prim.Type -> Prim.Type).
+    Control.Applicative.Applicative (t :: Prim.Type -> Prim.Type) =>
+    (t :: Prim.Type -> Prim.Type) Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1772818740_do_final_let/Main.snap
+++ b/tests-integration/fixtures/checking/1772818740_do_final_let/Main.snap
@@ -4,8 +4,8 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: Effect Int
-test' :: forall (t :: Type). (t :: Type)
+test :: Effect.Effect Prim.Int
+test' :: forall (t :: Prim.Type). (t :: Prim.Type)
 
 Types
 

--- a/tests-integration/fixtures/checking/1772818800_exhaustive_multiple/Main.snap
+++ b/tests-integration/fixtures/checking/1772818800_exhaustive_multiple/Main.snap
@@ -4,20 +4,26 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-complete :: forall (t :: Type) (t1 :: Type). Maybe (t :: Type) -> Maybe (t1 :: Type) -> Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+complete ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Main.Maybe (t :: Prim.Type) -> Main.Maybe (t1 :: Prim.Type) -> Prim.Int
 incomplete1 ::
-  forall (t :: Type) (t1 :: Type). Partial => Maybe (t :: Type) -> Maybe (t1 :: Type) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial => Main.Maybe (t :: Prim.Type) -> Main.Maybe (t1 :: Prim.Type) -> Prim.Int
 incomplete2 ::
-  forall (t :: Type) (t1 :: Type). Partial => Maybe (t :: Type) -> Maybe (t1 :: Type) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial => Main.Maybe (t :: Prim.Type) -> Main.Maybe (t1 :: Prim.Type) -> Prim.Int
 incomplete3 ::
-  forall (t :: Type) (t1 :: Type). Partial => Maybe (t :: Type) -> Maybe (t1 :: Type) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial => Main.Maybe (t :: Prim.Type) -> Main.Maybe (t1 :: Prim.Type) -> Prim.Int
 incomplete4 ::
-  forall (t :: Type) (t1 :: Type). Partial => Maybe (t :: Type) -> Maybe (t1 :: Type) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial => Main.Maybe (t :: Prim.Type) -> Main.Maybe (t1 :: Prim.Type) -> Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772818860_exhaustive_tuple/Main.snap
+++ b/tests-integration/fixtures/checking/1772818860_exhaustive_tuple/Main.snap
@@ -5,22 +5,33 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-complete :: forall (t :: Type) (t1 :: Type). Tuple (Maybe (t :: Type)) (Maybe (t1 :: Type)) -> Int
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+complete ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Main.Tuple (Main.Maybe (t :: Prim.Type)) (Main.Maybe (t1 :: Prim.Type)) -> Prim.Int
 incomplete1 ::
-  forall (t :: Type) (t1 :: Type). Partial => Tuple (Maybe (t :: Type)) (Maybe (t1 :: Type)) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial =>
+    Main.Tuple (Main.Maybe (t :: Prim.Type)) (Main.Maybe (t1 :: Prim.Type)) -> Prim.Int
 incomplete2 ::
-  forall (t :: Type) (t1 :: Type). Partial => Tuple (Maybe (t :: Type)) (Maybe (t1 :: Type)) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial =>
+    Main.Tuple (Main.Maybe (t :: Prim.Type)) (Main.Maybe (t1 :: Prim.Type)) -> Prim.Int
 incomplete3 ::
-  forall (t :: Type) (t1 :: Type). Partial => Tuple (Maybe (t :: Type)) (Maybe (t1 :: Type)) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial =>
+    Main.Tuple (Main.Maybe (t :: Prim.Type)) (Main.Maybe (t1 :: Prim.Type)) -> Prim.Int
 incomplete4 ::
-  forall (t :: Type) (t1 :: Type). Partial => Tuple (Maybe (t :: Type)) (Maybe (t1 :: Type)) -> Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Partial =>
+    Main.Tuple (Main.Maybe (t :: Prim.Type)) (Main.Maybe (t1 :: Prim.Type)) -> Prim.Int
 
 Types
-Tuple :: Type -> Type -> Type
-Maybe :: Type -> Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772818920_exhaustive_equation_redundant/Main.snap
+++ b/tests-integration/fixtures/checking/1772818920_exhaustive_equation_redundant/Main.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Unit :: Unit
-unit :: Unit -> Int
-Yes :: YesNo
-No :: YesNo
-yes :: YesNo -> Int
-no :: YesNo -> Int
-yesNo :: YesNo -> Int
+Unit :: Main.Unit
+unit :: Main.Unit -> Prim.Int
+Yes :: Main.YesNo
+No :: Main.YesNo
+yes :: Main.YesNo -> Prim.Int
+no :: Main.YesNo -> Prim.Int
+yesNo :: Main.YesNo -> Prim.Int
 
 Types
-Unit :: Type
-YesNo :: Type
+Unit :: Prim.Type
+YesNo :: Prim.Type
 
 Roles
 Unit = []

--- a/tests-integration/fixtures/checking/1772818980_exhaustive_equation_guarded/Main.snap
+++ b/tests-integration/fixtures/checking/1772818980_exhaustive_equation_guarded/Main.snap
@@ -1,11 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-testGuarded :: Boolean -> Int
-testGuardedBoth :: Boolean -> Int
+testGuarded :: Prim.Boolean -> Prim.Int
+testGuardedBoth :: Prim.Boolean -> Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1772819040_exhaustive_let_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772819040_exhaustive_let_equation/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test :: Int
-test2 :: Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test :: Prim.Int
+test2 :: Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772819100_exhaustive_instance_equation/Main.snap
+++ b/tests-integration/fixtures/checking/1772819100_exhaustive_instance_equation/Main.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-c :: forall (@a :: Type). C (a :: Type) => (a :: Type) -> Int
+c :: forall (@a :: Prim.Type). Main.C (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Types
-C :: Type -> Constraint
+C :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). C (a :: Type)
-  c :: forall (@a :: Type). C (a :: Type) => (a :: Type) -> Int
+class forall (a :: Prim.Type). Main.C (a :: Prim.Type)
+  c :: forall (@a :: Prim.Type). Main.C (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Instances
-instance C Boolean
+instance Main.C Prim.Boolean
 
 Diagnostics
 warning[MissingPatterns]: Pattern match is not exhaustive. Missing: false

--- a/tests-integration/fixtures/checking/1772819160_exhaustive_guards_otherwise_true/Main.snap
+++ b/tests-integration/fixtures/checking/1772819160_exhaustive_guards_otherwise_true/Main.snap
@@ -1,13 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-lessThan :: Int -> Int -> Boolean
-test :: Int -> Int
-test' :: Int -> Int
-test2 :: Int -> Int
-test2' :: Int -> Int
+lessThan :: Prim.Int -> Prim.Int -> Prim.Boolean
+test :: Prim.Int -> Prim.Int
+test' :: Prim.Int -> Prim.Int
+test2 :: Prim.Int -> Prim.Int
+test2' :: Prim.Int -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772822940_givens_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1772822940_givens_matching/Main.snap
@@ -4,12 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
-test :: forall (a :: Type). Eq (a :: Type) => (a :: Type) -> Boolean
+eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean
+test :: forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Boolean
 
 Types
-Eq :: Type -> Constraint
+Eq :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Eq (a :: Type)
-  eq :: forall (@a :: Type). Eq (a :: Type) => (a :: Type) -> (a :: Type) -> Boolean
+class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
+  eq ::
+  forall (@a :: Prim.Type).
+    Main.Eq (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> Prim.Boolean

--- a/tests-integration/fixtures/checking/1772823000_givens_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/checking/1772823000_givens_functional_dependency/Main.snap
@@ -5,22 +5,27 @@ expression: report
 ---
 Terms
 convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-useGiven :: forall (x :: Type). Convert Int (x :: Type) => (x :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+useGiven :: forall (x :: Prim.Type). Main.Convert Prim.Int (x :: Prim.Type) => (x :: Prim.Type)
 relate ::
-  forall (@a :: Type) (@b :: Type) (@c :: Type).
-    Relate (a :: Type) (b :: Type) (c :: Type) => (a :: Type) -> (b :: Type) -> (c :: Type)
-useRelate :: forall (y :: Type). Relate Int String (y :: Type) => (y :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type) (@c :: Prim.Type).
+    Main.Relate (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) =>
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (c :: Prim.Type)
+useRelate ::
+  forall (y :: Prim.Type). Main.Relate Prim.Int Prim.String (y :: Prim.Type) => (y :: Prim.Type)
 
 Types
-Convert :: Type -> Type -> Constraint
-Relate :: Type -> Type -> Type -> Constraint
+Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
+Relate :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Convert (a :: Prim.Type) (b :: Prim.Type)
   convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-class forall (a :: Type) (b :: Type) (c :: Type). Relate (a :: Type) (b :: Type) (c :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+class forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type). Main.Relate (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
   relate ::
-  forall (@a :: Type) (@b :: Type) (@c :: Type).
-    Relate (a :: Type) (b :: Type) (c :: Type) => (a :: Type) -> (b :: Type) -> (c :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type) (@c :: Prim.Type).
+    Main.Relate (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) =>
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (c :: Prim.Type)

--- a/tests-integration/fixtures/checking/1772823060_givens_superclass_where_binding/Main.snap
+++ b/tests-integration/fixtures/checking/1772823060_givens_superclass_where_binding/Main.snap
@@ -5,14 +5,16 @@ expression: report
 ---
 Terms
 test ::
-  forall (m :: Type -> Type) (a :: Type).
-    MonadRec (m :: Type -> Type) => (a :: Type) -> (m :: Type -> Type) (a :: Type)
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    Control.Monad.Rec.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    (a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (a :: Prim.Type)
 test2 ::
-  forall (m :: Type -> Type) (a :: Type).
-    MonadRec (m :: Type -> Type) =>
-    (m :: Type -> Type) (a :: Type) -> (m :: Type -> Type) (a :: Type)
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    Control.Monad.Rec.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (a :: Prim.Type)
 test3 ::
-  forall (m :: Type -> Type).
-    MonadRec (m :: Type -> Type) => (m :: Type -> Type) Int -> (m :: Type -> Type) Int
+  forall (m :: Prim.Type -> Prim.Type).
+    Control.Monad.Rec.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) Prim.Int -> (m :: Prim.Type -> Prim.Type) Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772823120_instance_record_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1772823120_instance_record_matching/Main.snap
@@ -4,23 +4,31 @@ assertion_line: 50
 expression: report
 ---
 Terms
-make :: forall (@a :: Type) (@b :: Type). Make (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-testMake :: { a :: Int, b :: String } -> { a :: Int, b :: String }
+make ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Make (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+testMake :: { a :: Prim.Int, b :: Prim.String } -> { a :: Prim.Int, b :: Prim.String }
 convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-testConvert :: { x :: Int } -> { converted :: { x :: Int } }
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+testConvert :: { x :: Prim.Int } -> { converted :: { x :: Prim.Int } }
 
 Types
-Make :: Type -> Type -> Constraint
-Convert :: Type -> Type -> Constraint
+Make :: Prim.Type -> Prim.Type -> Prim.Constraint
+Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type) (b :: Type). Make (a :: Type) (b :: Type)
-  make :: forall (@a :: Type) (@b :: Type). Make (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Make (a :: Prim.Type) (b :: Prim.Type)
+  make ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Make (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Convert (a :: Prim.Type) (b :: Prim.Type)
   convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Instances
-instance forall (t :: Row Type). Make {| (t :: Row Type) } {| (t :: Row Type) }
-instance forall (t :: Row Type). Convert {| (t :: Row Type) } { converted :: {| (t :: Row Type) } }
+instance forall (t :: Prim.Row Prim.Type).
+  Main.Make {| (t :: Prim.Row Prim.Type) } {| (t :: Prim.Row Prim.Type) }
+instance forall (t :: Prim.Row Prim.Type).
+  Main.Convert {| (t :: Prim.Row Prim.Type) } { converted :: {| (t :: Prim.Row Prim.Type) } }

--- a/tests-integration/fixtures/checking/1772823180_instance_record_open_row/Main.snap
+++ b/tests-integration/fixtures/checking/1772823180_instance_record_open_row/Main.snap
@@ -5,24 +5,35 @@ expression: report
 ---
 Terms
 clone ::
-  forall (@a :: Type) (@b :: Type). Clone (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-testClonePerson :: { age :: Int, name :: String } -> { age :: Int, name :: String }
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Clone (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+testClonePerson ::
+  { age :: Prim.Int, name :: Prim.String } -> { age :: Prim.Int, name :: Prim.String }
 testCloneEmpty :: {} -> {}
-testCloneSingle :: { x :: Int } -> { x :: Int }
-nest :: forall (@a :: Type) (@b :: Type). Nest (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-testNest :: { a :: String } -> { inner :: { a :: String }, outer :: Int }
+testCloneSingle :: { x :: Prim.Int } -> { x :: Prim.Int }
+nest ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Nest (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+testNest :: { a :: Prim.String } -> { inner :: { a :: Prim.String }, outer :: Prim.Int }
 
 Types
-Clone :: Type -> Type -> Constraint
-Nest :: Type -> Type -> Constraint
+Clone :: Prim.Type -> Prim.Type -> Prim.Constraint
+Nest :: Prim.Type -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type) (b :: Type). Clone (a :: Type) (b :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Clone (a :: Prim.Type) (b :: Prim.Type)
   clone ::
-  forall (@a :: Type) (@b :: Type). Clone (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-class forall (a :: Type) (b :: Type). Nest (a :: Type) (b :: Type)
-  nest :: forall (@a :: Type) (@b :: Type). Nest (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Clone (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Nest (a :: Prim.Type) (b :: Prim.Type)
+  nest ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Nest (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Instances
-instance forall (t :: Row Type). Clone {| (t :: Row Type) } {| (t :: Row Type) }
-instance forall (t :: Row Type). Nest {| (t :: Row Type) } { inner :: {| (t :: Row Type) }, outer :: Int }
+instance forall (t :: Prim.Row Prim.Type).
+  Main.Clone {| (t :: Prim.Row Prim.Type) } {| (t :: Prim.Row Prim.Type) }
+instance forall (t :: Prim.Row Prim.Type).
+  Main.Nest
+    {| (t :: Prim.Row Prim.Type) }
+    { inner :: {| (t :: Prim.Row Prim.Type) }, outer :: Prim.Int }

--- a/tests-integration/fixtures/checking/1772823240_instance_head_invalid_row/Main.snap
+++ b/tests-integration/fixtures/checking/1772823240_instance_head_invalid_row/Main.snap
@@ -4,20 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-T :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+T :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Classes
-class forall (k :: Type) (a :: (k :: Type)). T @(k :: Type) (a :: (k :: Type))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)). Main.T @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Instances
-instance T @(Row Type) ( a :: Int )
-instance T @Type { a :: Int }
-instance T @Type (Proxy @(Row Type) ( a :: Int ))
-instance T @Type (Proxy @Type { a :: Int })
+instance Main.T @(Prim.Row Prim.Type) ( a :: Prim.Int )
+instance Main.T @Prim.Type { a :: Prim.Int }
+instance Main.T @Prim.Type (Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int ))
+instance Main.T @Prim.Type (Main.Proxy @Prim.Type { a :: Prim.Int })
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772823300_instance_kind_application_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1772823300_instance_kind_application_matching/Main.snap
@@ -5,19 +5,33 @@ expression: report
 ---
 Terms
 Endo ::
-  forall (k :: Type) (@c :: (k :: Type) -> (k :: Type) -> Type) (@a :: (k :: Type)).
-    (c :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (a :: (k :: Type)) ->
-    Endo @(k :: Type) (c :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type))
-test :: forall (b :: Type). Endo @Type Function (b :: Type) -> (b :: Type) -> (b :: Type)
+  forall (k :: Prim.Type) (@c :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+    (@a :: (k :: Prim.Type)).
+    (c :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+      (a :: (k :: Prim.Type))
+      (a :: (k :: Prim.Type)) ->
+    Main.Endo @(k :: Prim.Type)
+      (c :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+      (a :: (k :: Prim.Type))
+test ::
+  forall (b :: Prim.Type).
+    Main.Endo @Prim.Type Prim.Function (b :: Prim.Type) -> (b :: Prim.Type) -> (b :: Prim.Type)
 
 Types
-Endo :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> (k :: Type) -> Type
+Endo ::
+  forall (k :: Prim.Type).
+    ((k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type) -> (t :: Type) -> Type) (t2 :: (t :: Type)).
-  Newtype @Type
-    (Endo @(t :: Type) (t1 :: (t :: Type) -> (t :: Type) -> Type) (t2 :: (t :: Type)))
-    ((t1 :: (t :: Type) -> (t :: Type) -> Type) (t2 :: (t :: Type)) (t2 :: (t :: Type)))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+  (t2 :: (t :: Prim.Type)).
+  Data.Newtype.Newtype @Prim.Type
+    (Main.Endo @(t :: Prim.Type)
+      (t1 :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+      (t2 :: (t :: Prim.Type)))
+    ((t1 :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+      (t2 :: (t :: Prim.Type))
+      (t2 :: (t :: Prim.Type)))
 
 Roles
 Endo = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772823360_application_infix_chain/Main.snap
+++ b/tests-integration/fixtures/checking/1772823360_application_infix_chain/Main.snap
@@ -4,30 +4,39 @@ assertion_line: 50
 expression: report
 ---
 Terms
-add :: Int -> Int -> Int
-sub :: Int -> Int -> Int
-mul :: Int -> Int -> Int
-test1 :: Int
-test1' :: Int
-test2 :: Int
-test2' :: Int
-test3 :: Int
-test3' :: Int
-const :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-test4 :: Int
-test4' :: Int
-test5 :: Int
-test5' :: Int
-apply :: forall (a :: Type) (b :: Type). ((a :: Type) -> (b :: Type)) -> (a :: Type) -> (b :: Type)
+add :: Prim.Int -> Prim.Int -> Prim.Int
+sub :: Prim.Int -> Prim.Int -> Prim.Int
+mul :: Prim.Int -> Prim.Int -> Prim.Int
+test1 :: Prim.Int
+test1' :: Prim.Int
+test2 :: Prim.Int
+test2' :: Prim.Int
+test3 :: Prim.Int
+test3' :: Prim.Int
+const ::
+  forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+test4 :: Prim.Int
+test4' :: Prim.Int
+test5 :: Prim.Int
+test5' :: Prim.Int
+apply ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> (a :: Prim.Type) -> (b :: Prim.Type)
 chain ::
-  forall (a :: Type) (b :: Type) (c :: Type).
-    ((b :: Type) -> (c :: Type)) -> ((a :: Type) -> (b :: Type)) -> (a :: Type) -> (c :: Type)
-test6 :: Int
-test6' :: Int
+  forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+    ((b :: Prim.Type) -> (c :: Prim.Type)) ->
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    (a :: Prim.Type) ->
+    (c :: Prim.Type)
+test6 :: Prim.Int
+test6' :: Prim.Int
 curry ::
-  forall (a :: Type) (b :: Type) (c :: Type).
-    ((a :: Type) -> (b :: Type) -> (c :: Type)) -> (a :: Type) -> (b :: Type) -> (c :: Type)
-test7 :: Int -> Int
-test7' :: Int -> Int
+  forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type) -> (c :: Prim.Type)) ->
+    (a :: Prim.Type) ->
+    (b :: Prim.Type) ->
+    (c :: Prim.Type)
+test7 :: Prim.Int -> Prim.Int
+test7' :: Prim.Int -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772823420_application_function_subtype/Main.snap
+++ b/tests-integration/fixtures/checking/1772823420_application_function_subtype/Main.snap
@@ -5,23 +5,28 @@ expression: report
 ---
 Terms
 identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (t :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
-test :: Function Int Int
-test' :: Int -> Int
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (t :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (t :: (k :: Prim.Type))
+        (t :: (k :: Prim.Type)))
+test :: Prim.Function Prim.Int Prim.Int
+test' :: Prim.Int -> Prim.Int
 
 Types
-Category :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> Constraint
+Category ::
+  forall (k :: Prim.Type). ((k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type). Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type)
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type). Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
   identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (t :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (t :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (t :: (k :: Prim.Type))
+        (t :: (k :: Prim.Type)))
 
 Instances
-instance Category @Type Function
+instance Main.Category @Prim.Type Prim.Function

--- a/tests-integration/fixtures/checking/1772823480_application_function_decomposition/Main.snap
+++ b/tests-integration/fixtures/checking/1772823480_application_function_decomposition/Main.snap
@@ -4,79 +4,93 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
 foldMap ::
-  forall (@f :: Type -> Type).
-    Foldable (f :: Type -> Type) =>
-    (forall (a :: Type) (m :: Type).
-      ((a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Foldable (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (m :: Prim.Type).
+      ((a :: Prim.Type) -> (m :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (m :: Prim.Type))
 foldMapWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type).
-    FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    (forall (a :: Type) (m :: Type).
-      ((i :: Type) -> (a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
+  forall (@i :: Prim.Type) (@f :: Prim.Type -> Prim.Type).
+    Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (m :: Prim.Type).
+      ((i :: Prim.Type) -> (a :: Prim.Type) -> (m :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (m :: Prim.Type))
 foldlWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type).
-    FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((i :: Type) -> (b :: Type) -> (a :: Type) -> (b :: Type)) ->
-      (b :: Type) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (b :: Type))
+  forall (@i :: Prim.Type) (@f :: Prim.Type -> Prim.Type).
+    Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((i :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (b :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (b :: Prim.Type))
 foldrWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type).
-    FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((i :: Type) -> (a :: Type) -> (b :: Type) -> (b :: Type)) ->
-      (b :: Type) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (b :: Type))
+  forall (@i :: Prim.Type) (@f :: Prim.Type -> Prim.Type).
+    Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((i :: Prim.Type) -> (a :: Prim.Type) -> (b :: Prim.Type) -> (b :: Prim.Type)) ->
+      (b :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (b :: Prim.Type))
 NonEmpty ::
-  forall (@f :: Type -> Type) (@a :: Type).
-    (a :: Type) -> (f :: Type -> Type) (a :: Type) -> NonEmpty (f :: Type -> Type) (a :: Type)
+  forall (@f :: Prim.Type -> Prim.Type) (@a :: Prim.Type).
+    (a :: Prim.Type) ->
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    Main.NonEmpty (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)
 
 Types
-Maybe :: Type -> Type
-Foldable :: (Type -> Type) -> Constraint
-FoldableWithIndex :: Type -> (Type -> Type) -> Constraint
-NonEmpty :: (Type -> Type) -> Type -> Type
+Maybe :: Prim.Type -> Prim.Type
+Foldable :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+FoldableWithIndex :: Prim.Type -> (Prim.Type -> Prim.Type) -> Prim.Constraint
+NonEmpty :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
 
 Classes
-class forall (f :: Type -> Type). Foldable (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Foldable (f :: Prim.Type -> Prim.Type)
   foldMap ::
-  forall (@f :: Type -> Type).
-    Foldable (f :: Type -> Type) =>
-    (forall (a :: Type) (m :: Type).
-      ((a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
-class forall (i :: Type) (f :: Type -> Type). Foldable (f :: Type -> Type) <= FoldableWithIndex (i :: Type) (f :: Type -> Type)
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Foldable (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (m :: Prim.Type).
+      ((a :: Prim.Type) -> (m :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (m :: Prim.Type))
+class forall (i :: Prim.Type) (f :: Prim.Type -> Prim.Type). Main.Foldable (f :: Prim.Type -> Prim.Type) <= Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type)
   foldMapWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type).
-    FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    (forall (a :: Type) (m :: Type).
-      ((i :: Type) -> (a :: Type) -> (m :: Type)) -> (f :: Type -> Type) (a :: Type) -> (m :: Type))
+  forall (@i :: Prim.Type) (@f :: Prim.Type -> Prim.Type).
+    Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (m :: Prim.Type).
+      ((i :: Prim.Type) -> (a :: Prim.Type) -> (m :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (m :: Prim.Type))
   foldlWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type).
-    FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    (forall (a1 :: Type) (b :: Type).
-      ((i :: Type) -> (b :: Type) -> (a1 :: Type) -> (b :: Type)) ->
-      (b :: Type) ->
-      (f :: Type -> Type) (a1 :: Type) ->
-      (b :: Type))
+  forall (@i :: Prim.Type) (@f :: Prim.Type -> Prim.Type).
+    Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+    (forall (a1 :: Prim.Type) (b :: Prim.Type).
+      ((i :: Prim.Type) -> (b :: Prim.Type) -> (a1 :: Prim.Type) -> (b :: Prim.Type)) ->
+      (b :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (a1 :: Prim.Type) ->
+      (b :: Prim.Type))
   foldrWithIndex ::
-  forall (@i :: Type) (@f :: Type -> Type).
-    FoldableWithIndex (i :: Type) (f :: Type -> Type) =>
-    (forall (a2 :: Type) (b1 :: Type).
-      ((i :: Type) -> (a2 :: Type) -> (b1 :: Type) -> (b1 :: Type)) ->
-      (b1 :: Type) ->
-      (f :: Type -> Type) (a2 :: Type) ->
-      (b1 :: Type))
+  forall (@i :: Prim.Type) (@f :: Prim.Type -> Prim.Type).
+    Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+    (forall (a2 :: Prim.Type) (b1 :: Prim.Type).
+      ((i :: Prim.Type) -> (a2 :: Prim.Type) -> (b1 :: Prim.Type) -> (b1 :: Prim.Type)) ->
+      (b1 :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (a2 :: Prim.Type) ->
+      (b1 :: Prim.Type))
 
 Instances
-instance forall (t :: Type -> Type). Foldable (t :: Type -> Type) => Foldable (NonEmpty (t :: Type -> Type))
-instance forall (t :: Type) (t1 :: Type -> Type).
-  FoldableWithIndex (t :: Type) (t1 :: Type -> Type) =>
-  FoldableWithIndex (Maybe (t :: Type)) (NonEmpty (t1 :: Type -> Type))
+instance forall (t :: Prim.Type -> Prim.Type).
+  Main.Foldable (t :: Prim.Type -> Prim.Type) =>
+  Main.Foldable (Main.NonEmpty (t :: Prim.Type -> Prim.Type))
+instance forall (t :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Main.FoldableWithIndex (t :: Prim.Type) (t1 :: Prim.Type -> Prim.Type) =>
+  Main.FoldableWithIndex
+    (Main.Maybe (t :: Prim.Type))
+    (Main.NonEmpty (t1 :: Prim.Type -> Prim.Type))
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772823540_type_application_invalid_basic/Main.snap
+++ b/tests-integration/fixtures/checking/1772823540_type_application_invalid_basic/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
@@ -9,7 +9,7 @@ Types
 Bad :: ?[cannot apply function type]
 
 Synonyms
-type Bad = Int String
+type Bad = Prim.Int Prim.String
 
 Diagnostics
 error[InvalidTypeApplication]: Cannot apply type 'Int' to 'String'. 'Int' has kind 'Type', which is not a function kind.

--- a/tests-integration/fixtures/checking/1772823600_type_application_invalid_too_many/Main.snap
+++ b/tests-integration/fixtures/checking/1772823600_type_application_invalid_too_many/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
@@ -9,7 +9,7 @@ Types
 Bad :: ?[cannot apply function type]
 
 Synonyms
-type Bad = Array Int String
+type Bad = Prim.Array Prim.Int Prim.String
 
 Diagnostics
 error[InvalidTypeApplication]: Cannot apply type 'Array Int' to 'String'. 'Array Int' has kind 'Type', which is not a function kind.

--- a/tests-integration/fixtures/checking/1772823660_record_expression_exact/Main.snap
+++ b/tests-integration/fixtures/checking/1772823660_record_expression_exact/Main.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { a :: Int, b :: Int }
+test :: { a :: Prim.Int, b :: Prim.Int }
 
 Types

--- a/tests-integration/fixtures/checking/1772823720_record_expression_missing_field/Main.snap
+++ b/tests-integration/fixtures/checking/1772823720_record_expression_missing_field/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { a :: Int, b :: Int }
+test :: { a :: Prim.Int, b :: Prim.Int }
 
 Types
 

--- a/tests-integration/fixtures/checking/1772823780_record_expression_additional_field/Main.snap
+++ b/tests-integration/fixtures/checking/1772823780_record_expression_additional_field/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { a :: Int }
+test :: { a :: Prim.Int }
 
 Types
 

--- a/tests-integration/fixtures/checking/1772823840_record_expression_missing_and_additional/Main.snap
+++ b/tests-integration/fixtures/checking/1772823840_record_expression_missing_and_additional/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { a :: Int, b :: Int }
+test :: { a :: Prim.Int, b :: Prim.Int }
 
 Types
 

--- a/tests-integration/fixtures/checking/1772823900_record_expression_nested_additional/Main.snap
+++ b/tests-integration/fixtures/checking/1772823900_record_expression_nested_additional/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { outer :: { x :: Int } }
+test :: { outer :: { x :: Prim.Int } }
 
 Types
 

--- a/tests-integration/fixtures/checking/1772823960_record_access_sections/Main.snap
+++ b/tests-integration/fixtures/checking/1772823960_record_access_sections/Main.snap
@@ -5,55 +5,76 @@ expression: report
 ---
 Terms
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Array (a :: Type) -> Array (b :: Type)
-apply :: forall (a :: Type) (b :: Type). ((a :: Type) -> (b :: Type)) -> (a :: Type) -> (b :: Type)
-f :: ({ foo :: Int } -> Int) -> Int
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Prim.Array (a :: Prim.Type) ->
+    Prim.Array (b :: Prim.Type)
+apply ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> (a :: Prim.Type) -> (b :: Prim.Type)
+f :: ({ foo :: Prim.Int } -> Prim.Int) -> Prim.Int
 test1 ::
-  forall (t :: Type) (t1 :: Row Type). { prop :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { prop :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type)
 test2 ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Row Type).
-    { a :: { b :: { c :: (t :: Type) | (t1 :: Row Type) } | (t2 :: Row Type) }
-    | (t3 :: Row Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type)
+    (t3 :: Prim.Row Prim.Type).
+    { a ::
+        { b :: { c :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } | (t2 :: Prim.Row Prim.Type) }
+    | (t3 :: Prim.Row Prim.Type)
     } ->
-    (t :: Type)
+    (t :: Prim.Type)
 test3 ::
-  forall (t :: Type) (t1 :: Row Type). { poly :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { poly :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type)
 test4 ::
-  forall (t :: Type) (t1 :: Row Type).
-    Array { prop :: (t :: Type) | (t1 :: Row Type) } -> Array (t :: Type)
-test5 :: Int
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    Prim.Array { prop :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    Prim.Array (t :: Prim.Type)
+test5 :: Prim.Int
 test6 ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Row Type) (t3 :: Type).
-    (t :: Type) ->
-    (({ bar :: (t1 :: Type) | (t2 :: Row Type) } -> (t1 :: Type)) -> (t3 :: Type)) ->
-    (t3 :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Row Prim.Type) (t3 :: Prim.Type).
+    (t :: Prim.Type) ->
+    (({ bar :: (t1 :: Prim.Type) | (t2 :: Prim.Row Prim.Type) } -> (t1 :: Prim.Type)) ->
+    (t3 :: Prim.Type)) ->
+    (t3 :: Prim.Type)
 test7 ::
-  forall (t :: Type) (t1 :: Row Type).
-    { nonexistent :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { nonexistent :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type)
 test8 ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Type).
-    (({ foo :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)) -> (t2 :: Type)) -> (t2 :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+    (({ foo :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type)) ->
+    (t2 :: Prim.Type)) ->
+    (t2 :: Prim.Type)
 test9 ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Type).
-    Array (({ prop :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)) -> (t2 :: Type)) ->
-    Array (t2 :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+    Prim.Array
+      (({ prop :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type)) ->
+      (t2 :: Prim.Type)) ->
+    Prim.Array (t2 :: Prim.Type)
 test10 ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Row Type).
-    { a :: { b :: (t :: Type) | (t1 :: Row Type) } | (t2 :: Row Type) } -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type).
+    { a :: { b :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } | (t2 :: Prim.Row Prim.Type) } ->
+    (t :: Prim.Type)
 test11 ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Row Type).
-    (t :: Type) ->
-    { a :: (t :: Type), b :: { foo :: (t1 :: Type) | (t2 :: Row Type) } -> (t1 :: Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Row Prim.Type).
+    (t :: Prim.Type) ->
+    { a :: (t :: Prim.Type)
+    , b :: { foo :: (t1 :: Prim.Type) | (t2 :: Prim.Row Prim.Type) } -> (t1 :: Prim.Type)
+    }
 test12 ::
-  forall (t :: Type) (t1 :: Row Type).
-    ({ bar :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)) ->
-    Array ({ bar :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    ({ bar :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type)) ->
+    Prim.Array ({ bar :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } -> (t :: Prim.Type))
 test13 ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Row Type).
-    (t :: Type) -> { prop :: (t1 :: Type) | (t2 :: Row Type) } -> (t1 :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Row Prim.Type).
+    (t :: Prim.Type) ->
+    { prop :: (t1 :: Prim.Type) | (t2 :: Prim.Row Prim.Type) } ->
+    (t1 :: Prim.Type)
 test14 ::
-  forall (t :: Type) (t1 :: Row Type).
-    Boolean -> { a :: (t :: Type), b :: (t :: Type) | (t1 :: Row Type) } -> (t :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    Prim.Boolean ->
+    { a :: (t :: Prim.Type), b :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    (t :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1772824020_record_update_sections/Main.snap
+++ b/tests-integration/fixtures/checking/1772824020_record_update_sections/Main.snap
@@ -5,56 +5,74 @@ expression: report
 ---
 Terms
 singleFieldUpdate ::
-  forall (t :: Type) (t1 :: Row Type).
-    { a :: (t :: Type) | (t1 :: Row Type) } -> { a :: Int | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { a :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int | (t1 :: Prim.Row Prim.Type) }
 multipleFieldUpdate ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type) (t3 :: Row Type).
-    { a :: (t :: Type), b :: (t1 :: Type), c :: (t2 :: Type) | (t3 :: Row Type) } ->
-    { a :: Int, b :: Boolean, c :: String | (t3 :: Row Type) }
-nestedRecordUpdate ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Row Type).
-    { a :: { b :: { c :: (t :: Type) | (t1 :: Row Type) } | (t2 :: Row Type) }
-    | (t3 :: Row Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Row Prim.Type).
+    { a :: (t :: Prim.Type)
+    , b :: (t1 :: Prim.Type)
+    , c :: (t2 :: Prim.Type)
+    | (t3 :: Prim.Row Prim.Type)
     } ->
-    { a :: { b :: { c :: Int | (t1 :: Row Type) } | (t2 :: Row Type) } | (t3 :: Row Type) }
+    { a :: Prim.Int, b :: Prim.Boolean, c :: Prim.String | (t3 :: Prim.Row Prim.Type) }
+nestedRecordUpdate ::
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type)
+    (t3 :: Prim.Row Prim.Type).
+    { a ::
+        { b :: { c :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } | (t2 :: Prim.Row Prim.Type) }
+    | (t3 :: Prim.Row Prim.Type)
+    } ->
+    { a :: { b :: { c :: Prim.Int | (t1 :: Prim.Row Prim.Type) } | (t2 :: Prim.Row Prim.Type) }
+    | (t3 :: Prim.Row Prim.Type)
+    }
 updateWithValueSection ::
-  forall (t :: Type) (t1 :: Row Type).
-    { a :: (t :: Type) | (t1 :: Row Type) } -> { a :: Int -> Int | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { a :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int -> Prim.Int | (t1 :: Prim.Row Prim.Type) }
 updateWithSectionInteraction ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Type).
-    { a :: (t :: Type) | (t1 :: Row Type) } ->
-    (t2 :: Type) ->
-    { a :: (t2 :: Type) | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+    { a :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    (t2 :: Prim.Type) ->
+    { a :: (t2 :: Prim.Type) | (t1 :: Prim.Row Prim.Type) }
 polymorphicRecordUpdate ::
-  forall (t :: Type) (t1 :: Row Type).
-    { foo :: (t :: Type) | (t1 :: Row Type) } -> { foo :: Int | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    { foo :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { foo :: Prim.Int | (t1 :: Prim.Row Prim.Type) }
 higherOrderContext ::
-  forall (t :: Type) (t1 :: Row Type).
-    Array { x :: (t :: Type) | (t1 :: Row Type) } -> Array { x :: Int | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+    Prim.Array { x :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    Prim.Array { x :: Prim.Int | (t1 :: Prim.Row Prim.Type) }
 multipleSectionsInteraction ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Row Type) (t3 :: Type) (t4 :: Type).
-    { x :: (t :: Type), y :: (t1 :: Type) | (t2 :: Row Type) } ->
-    (t3 :: Type) ->
-    (t4 :: Type) ->
-    { x :: (t3 :: Type), y :: (t4 :: Type) | (t2 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Row Prim.Type) (t3 :: Prim.Type)
+    (t4 :: Prim.Type).
+    { x :: (t :: Prim.Type), y :: (t1 :: Prim.Type) | (t2 :: Prim.Row Prim.Type) } ->
+    (t3 :: Prim.Type) ->
+    (t4 :: Prim.Type) ->
+    { x :: (t3 :: Prim.Type), y :: (t4 :: Prim.Type) | (t2 :: Prim.Row Prim.Type) }
 nestedSectionInteraction ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Type).
-    { a :: { b :: (t :: Type) | (t1 :: Row Type) } | (t2 :: Row Type) } ->
-    (t3 :: Type) ->
-    { a :: { b :: (t3 :: Type) | (t1 :: Row Type) } | (t2 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type) (t3 :: Prim.Type).
+    { a :: { b :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } | (t2 :: Prim.Row Prim.Type) } ->
+    (t3 :: Prim.Type) ->
+    { a :: { b :: (t3 :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } | (t2 :: Prim.Row Prim.Type) }
 mixedSections ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Row Type).
-    { a :: (t :: Type), b :: (t1 :: Type) | (t2 :: Row Type) } ->
-    { a :: Int -> Int, b :: Int | (t2 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Row Prim.Type).
+    { a :: (t :: Prim.Type), b :: (t1 :: Prim.Type) | (t2 :: Prim.Row Prim.Type) } ->
+    { a :: Prim.Int -> Prim.Int, b :: Prim.Int | (t2 :: Prim.Row Prim.Type) }
 recordAccessSectionUpdate ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Type) (t3 :: Row Type).
-    { a :: (t :: Type) | (t1 :: Row Type) } ->
-    { a :: { b :: (t2 :: Type) | (t3 :: Row Type) } -> (t2 :: Type) | (t1 :: Row Type) }
-concreteRecordUpdateSection :: forall (t :: Type). (t :: Type) -> { a :: (t :: Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Row Prim.Type).
+    { a :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { a :: { b :: (t2 :: Prim.Type) | (t3 :: Prim.Row Prim.Type) } -> (t2 :: Prim.Type)
+    | (t1 :: Prim.Row Prim.Type)
+    }
+concreteRecordUpdateSection ::
+  forall (t :: Prim.Type). (t :: Prim.Type) -> { a :: (t :: Prim.Type) }
 map ::
-  forall (a :: Type) (b :: Type).
-    ((a :: Type) -> (b :: Type)) -> Array (a :: Type) -> Array (b :: Type)
-+ :: Int -> Int -> Int
-add :: Int -> Int -> Int
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    Prim.Array (a :: Prim.Type) ->
+    Prim.Array (b :: Prim.Type)
++ :: Prim.Int -> Prim.Int -> Prim.Int
+add :: Prim.Int -> Prim.Int -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772824080_record_binder_shrinking/Main.snap
+++ b/tests-integration/fixtures/checking/1772824080_record_binder_shrinking/Main.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { a :: Int, b :: Int } -> Int
+test :: { a :: Prim.Int, b :: Prim.Int } -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772824140_record_binder_additional_property/Main.snap
+++ b/tests-integration/fixtures/checking/1772824140_record_binder_additional_property/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { a :: Int } -> Int
+test :: { a :: Prim.Int } -> Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1772824200_record_binder_additional_property_nested/Main.snap
+++ b/tests-integration/fixtures/checking/1772824200_record_binder_additional_property_nested/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { outer :: { x :: Int } } -> Int
+test :: { outer :: { x :: Prim.Int } } -> Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1772824260_synonym_function_result_kind/Main.snap
+++ b/tests-integration/fixtures/checking/1772824260_synonym_function_result_kind/Main.snap
@@ -5,16 +5,20 @@ expression: report
 ---
 Terms
 Box ::
-  forall (@f :: Type -> Type) (@a :: Type).
-    (f :: Type -> Type) (a :: Type) -> Box (f :: Type -> Type) (a :: Type)
-test :: forall (f :: Type -> Type). Wrap (f :: Type -> Type) Int -> Wrap (f :: Type -> Type) Int
+  forall (@f :: Prim.Type -> Prim.Type) (@a :: Prim.Type).
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    Main.Box (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+test ::
+  forall (f :: Prim.Type -> Prim.Type).
+    Main.Wrap (f :: Prim.Type -> Prim.Type) Prim.Int ->
+    Main.Wrap (f :: Prim.Type -> Prim.Type) Prim.Int
 
 Types
-Box :: (Type -> Type) -> Type -> Type
-Wrap :: (Type -> Type) -> Type -> Type
+Box :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
+Wrap :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
 
 Synonyms
-type Wrap f = Box (f :: Type -> Type)
+type Wrap f = Main.Box (f :: Prim.Type -> Prim.Type)
 
 Roles
 Box = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772824320_synonym_forall_expansion/Main.snap
+++ b/tests-integration/fixtures/checking/1772824320_synonym_forall_expansion/Main.snap
@@ -5,14 +5,17 @@ expression: report
 ---
 Terms
 apply ::
-  forall (f :: Type -> Type) (g :: Type -> Type).
-    NatTrans @Type (f :: Type -> Type) (g :: Type -> Type) ->
-    (f :: Type -> Type) Int ->
-    (g :: Type -> Type) Int
+  forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+    Main.NatTrans @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type) ->
+    (f :: Prim.Type -> Prim.Type) Prim.Int ->
+    (g :: Prim.Type -> Prim.Type) Prim.Int
 
 Types
-NatTrans :: forall (t :: Type). ((t :: Type) -> Type) -> ((t :: Type) -> Type) -> Type
+NatTrans ::
+  forall (t :: Prim.Type).
+    ((t :: Prim.Type) -> Prim.Type) -> ((t :: Prim.Type) -> Prim.Type) -> Prim.Type
 
 Synonyms
-type NatTrans f g = forall (a :: (t :: Type)).
-  (f :: (t :: Type) -> Type) (a :: (t :: Type)) -> (g :: (t :: Type) -> Type) (a :: (t :: Type))
+type NatTrans f g = forall (a :: (t :: Prim.Type)).
+  (f :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type)) ->
+  (g :: (t :: Prim.Type) -> Prim.Type) (a :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772824380_binder_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1772824380_binder_instantiation/Main.snap
@@ -4,18 +4,18 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-MkId :: (forall (a :: Type). (a :: Type) -> (a :: Type)) -> Id
-identity :: forall (a :: Type). Maybe ((a :: Type) -> (a :: Type))
-test :: Partial => Int
-test2 :: Id -> Boolean
-test3 :: Partial => Int
-test4 :: Id -> Boolean
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+MkId :: (forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)) -> Main.Id
+identity :: forall (a :: Prim.Type). Main.Maybe ((a :: Prim.Type) -> (a :: Prim.Type))
+test :: Prim.Partial => Prim.Int
+test2 :: Main.Id -> Prim.Boolean
+test3 :: Prim.Partial => Prim.Int
+test4 :: Main.Id -> Prim.Boolean
 
 Types
-Maybe :: Type -> Type
-Id :: Type
+Maybe :: Prim.Type -> Prim.Type
+Id :: Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772826900_coercible_phantom/Main.snap
+++ b/tests-integration/fixtures/checking/1772826900_coercible_phantom/Main.snap
@@ -4,14 +4,17 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (t :: Type) (@a :: (t :: Type)). Proxy @(t :: Type) (a :: (t :: Type))
+Proxy ::
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type))
 coerceProxy ::
-  forall (t :: Type) (t1 :: Type) (a :: (t :: Type)) (b :: (t1 :: Type)).
-    Proxy @(t :: Type) (a :: (t :: Type)) -> Proxy @(t1 :: Type) (b :: (t1 :: Type))
-coerceProxyIntString :: Proxy @Type Int -> Proxy @Type String
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (a :: (t :: Prim.Type)) (b :: (t1 :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type)) ->
+    Main.Proxy @(t1 :: Prim.Type) (b :: (t1 :: Prim.Type))
+coerceProxyIntString :: Main.Proxy @Prim.Type Prim.Int -> Main.Proxy @Prim.Type Prim.String
 
 Types
-Proxy :: forall (t :: Type). (t :: Type) -> Type
+Proxy :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1772826960_coercible_representational/Main.snap
+++ b/tests-integration/fixtures/checking/1772826960_coercible_representational/Main.snap
@@ -1,21 +1,21 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Age :: Int -> Age
-coerceMaybe :: Maybe Age -> Maybe Int
-coerceMaybeReverse :: Maybe Int -> Maybe Age
-UserId :: Int -> UserId
-coerceNested :: Maybe UserId -> Maybe Int
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Age :: Prim.Int -> Main.Age
+coerceMaybe :: Main.Maybe Main.Age -> Main.Maybe Prim.Int
+coerceMaybeReverse :: Main.Maybe Prim.Int -> Main.Maybe Main.Age
+UserId :: Prim.Int -> Main.UserId
+coerceNested :: Main.Maybe Main.UserId -> Main.Maybe Prim.Int
 
 Types
-Maybe :: Type -> Type
-Age :: Type
-UserId :: Type
+Maybe :: Prim.Type -> Prim.Type
+Age :: Prim.Type
+UserId :: Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772827020_coercible_array/Main.snap
+++ b/tests-integration/fixtures/checking/1772827020_coercible_array/Main.snap
@@ -1,15 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-coerceArray :: Array Age -> Array Int
-coerceArrayReverse :: Array Int -> Array Age
+Age :: Prim.Int -> Main.Age
+coerceArray :: Prim.Array Main.Age -> Prim.Array Prim.Int
+coerceArrayReverse :: Prim.Array Prim.Int -> Prim.Array Main.Age
 
 Types
-Age :: Type
+Age :: Prim.Type
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772827080_coercible_record/Main.snap
+++ b/tests-integration/fixtures/checking/1772827080_coercible_record/Main.snap
@@ -1,18 +1,19 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-coerceRecord :: { age :: Age, name :: String } -> { age :: Int, name :: String }
-coerceRecordReverse :: { age :: Int, name :: String } -> { age :: Age, name :: String }
-UserId :: Int -> UserId
-coerceMultiple :: { age :: Age, id :: UserId } -> { age :: Int, id :: Int }
+Age :: Prim.Int -> Main.Age
+coerceRecord :: { age :: Main.Age, name :: Prim.String } -> { age :: Prim.Int, name :: Prim.String }
+coerceRecordReverse ::
+  { age :: Prim.Int, name :: Prim.String } -> { age :: Main.Age, name :: Prim.String }
+UserId :: Prim.Int -> Main.UserId
+coerceMultiple :: { age :: Main.Age, id :: Main.UserId } -> { age :: Prim.Int, id :: Prim.Int }
 
 Types
-Age :: Type
-UserId :: Type
+Age :: Prim.Type
+UserId :: Prim.Type
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772827140_coercible_transitivity/Main.snap
+++ b/tests-integration/fixtures/checking/1772827140_coercible_transitivity/Main.snap
@@ -1,19 +1,19 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-Years :: Age -> Years
-coerceTransitive :: Int -> Years
-unwrapTransitive :: Years -> Int
-step1 :: Int -> Age
-step2 :: Age -> Years
+Age :: Prim.Int -> Main.Age
+Years :: Main.Age -> Main.Years
+coerceTransitive :: Prim.Int -> Main.Years
+unwrapTransitive :: Main.Years -> Prim.Int
+step1 :: Prim.Int -> Main.Age
+step2 :: Main.Age -> Main.Years
 
 Types
-Age :: Type
-Years :: Type
+Age :: Prim.Type
+Years :: Prim.Type
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772827200_coercible_different_heads_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772827200_coercible_different_heads_error/Main.snap
@@ -4,15 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
-coerceDifferent :: Maybe Int -> Either Int String
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+coerceDifferent :: Main.Maybe Prim.Int -> Main.Either Prim.Int Prim.String
 
 Types
-Maybe :: Type -> Type
-Either :: Type -> Type -> Type
+Maybe :: Prim.Type -> Prim.Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772827260_coercible_nominal/Main.snap
+++ b/tests-integration/fixtures/checking/1772827260_coercible_nominal/Main.snap
@@ -1,14 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-coerceNominalSame :: Nominal Int -> Nominal Int
-coerceNominalDifferent :: Nominal Int -> Nominal String
+coerceNominalSame :: Main.Nominal Prim.Int -> Main.Nominal Prim.Int
+coerceNominalDifferent :: Main.Nominal Prim.Int -> Main.Nominal Prim.String
 
 Types
-Nominal :: Type -> Type
+Nominal :: Prim.Type -> Prim.Type
 
 Roles
 Nominal = [Nominal]

--- a/tests-integration/fixtures/checking/1772827320_coercible_newtype_hidden/Main.snap
+++ b/tests-integration/fixtures/checking/1772827320_coercible_newtype_hidden/Main.snap
@@ -1,11 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-coerceHidden :: Int -> HiddenAge
-coerceQualified :: Int -> HiddenAge
+coerceHidden :: Prim.Int -> Lib.HiddenAge
+coerceQualified :: Prim.Int -> Lib.HiddenAge
 
 Types
 

--- a/tests-integration/fixtures/checking/1772827380_coercible_newtype_qualified/Main.snap
+++ b/tests-integration/fixtures/checking/1772827380_coercible_newtype_qualified/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-coerceQualified :: Int -> Age
-unwrapQualified :: Age -> Int
+coerceQualified :: Prim.Int -> Lib.Age
+unwrapQualified :: Lib.Age -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1772827440_coercible_newtype_open_hidden/Main.snap
+++ b/tests-integration/fixtures/checking/1772827440_coercible_newtype_open_hidden/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-coerceOpen :: Int -> HiddenAge
+coerceOpen :: Prim.Int -> Lib.HiddenAge
 
 Types
 

--- a/tests-integration/fixtures/checking/1772827500_coercible_nested_records/Main.snap
+++ b/tests-integration/fixtures/checking/1772827500_coercible_nested_records/Main.snap
@@ -1,31 +1,31 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Name :: String -> Name
-Age :: Int -> Age
-Person :: { age :: Age, name :: Name } -> Person
-Company :: { ceo :: Person, name :: Name } -> Company
-unwrapCompany :: Company -> { ceo :: Person, name :: Name }
-fullyUnwrap :: Company -> RawCompany
-fullyWrap :: RawCompany -> Company
-unwrapPerson :: Person -> RawPerson
-nestedFieldCoerce :: { person :: Person } -> { person :: RawPerson }
-arrayOfRecords :: Array { name :: Name } -> Array { name :: String }
+Name :: Prim.String -> Main.Name
+Age :: Prim.Int -> Main.Age
+Person :: { age :: Main.Age, name :: Main.Name } -> Main.Person
+Company :: { ceo :: Main.Person, name :: Main.Name } -> Main.Company
+unwrapCompany :: Main.Company -> { ceo :: Main.Person, name :: Main.Name }
+fullyUnwrap :: Main.Company -> Main.RawCompany
+fullyWrap :: Main.RawCompany -> Main.Company
+unwrapPerson :: Main.Person -> Main.RawPerson
+nestedFieldCoerce :: { person :: Main.Person } -> { person :: Main.RawPerson }
+arrayOfRecords :: Prim.Array { name :: Main.Name } -> Prim.Array { name :: Prim.String }
 
 Types
-Name :: Type
-Age :: Type
-Person :: Type
-Company :: Type
-RawPerson :: Type
-RawCompany :: Type
+Name :: Prim.Type
+Age :: Prim.Type
+Person :: Prim.Type
+Company :: Prim.Type
+RawPerson :: Prim.Type
+RawCompany :: Prim.Type
 
 Synonyms
-type RawPerson = { age :: Int, name :: String }
-type RawCompany = { ceo :: RawPerson, name :: String }
+type RawPerson = { age :: Prim.Int, name :: Prim.String }
+type RawCompany = { ceo :: Main.RawPerson, name :: Prim.String }
 
 Roles
 Name = []

--- a/tests-integration/fixtures/checking/1772827560_coercible_higher_kinded_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772827560_coercible_higher_kinded_error/Main.snap
@@ -4,16 +4,18 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nil :: forall (@a :: Type). List (a :: Type)
-Cons :: forall (@a :: Type). (a :: Type) -> List (a :: Type) -> List (a :: Type)
-coerceContainerDifferent :: Container Maybe -> Container List
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nil :: forall (@a :: Prim.Type). Main.List (a :: Prim.Type)
+Cons ::
+  forall (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.List (a :: Prim.Type) -> Main.List (a :: Prim.Type)
+coerceContainerDifferent :: Main.Container Main.Maybe -> Main.Container Main.List
 
 Types
-Maybe :: Type -> Type
-List :: Type -> Type
-Container :: (Type -> Type) -> Type
+Maybe :: Prim.Type -> Prim.Type
+List :: Prim.Type -> Prim.Type
+Container :: (Prim.Type -> Prim.Type) -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772827620_coercible_higher_kinded_multi/Main.snap
+++ b/tests-integration/fixtures/checking/1772827620_coercible_higher_kinded_multi/Main.snap
@@ -4,18 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
 EitherAlias ::
-  forall (@a :: Type) (@b :: Type).
-    Either (a :: Type) (b :: Type) -> EitherAlias (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Either (a :: Prim.Type) (b :: Prim.Type) ->
+    Main.EitherAlias (a :: Prim.Type) (b :: Prim.Type)
 coerceContainer ::
-  Container @(Type -> Type -> Type) Either -> Container @(Type -> Type -> Type) EitherAlias
+  Main.Container @(Prim.Type -> Prim.Type -> Prim.Type) Main.Either ->
+  Main.Container @(Prim.Type -> Prim.Type -> Prim.Type) Main.EitherAlias
 
 Types
-Either :: Type -> Type -> Type
-EitherAlias :: Type -> Type -> Type
-Container :: forall (k :: Type). (k :: Type) -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
+EitherAlias :: Prim.Type -> Prim.Type -> Prim.Type
+Container :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772827680_coercible_higher_kinded_polykinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772827680_coercible_higher_kinded_polykinded/Main.snap
@@ -5,22 +5,24 @@ expression: report
 ---
 Terms
 Just ::
-  forall (k :: Type) (@n :: (k :: Type)) (@a :: Type).
-    (a :: Type) -> Maybe @(k :: Type) (n :: (k :: Type)) (a :: Type)
+  forall (k :: Prim.Type) (@n :: (k :: Prim.Type)) (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Maybe @(k :: Prim.Type) (n :: (k :: Prim.Type)) (a :: Prim.Type)
 Nothing ::
-  forall (k :: Type) (@n :: (k :: Type)) (@a :: Type).
-    Maybe @(k :: Type) (n :: (k :: Type)) (a :: Type)
+  forall (k :: Prim.Type) (@n :: (k :: Prim.Type)) (@a :: Prim.Type).
+    Main.Maybe @(k :: Prim.Type) (n :: (k :: Prim.Type)) (a :: Prim.Type)
 MaybeAlias ::
-  forall (k :: Type) (@n :: (k :: Type)) (@a :: Type).
-    Maybe @(k :: Type) (n :: (k :: Type)) (a :: Type) ->
-    MaybeAlias @(k :: Type) (n :: (k :: Type)) (a :: Type)
-coerceContainer :: Container (Maybe @Type) -> Container (MaybeAlias @Type)
-coerceContainerReverse :: Container (MaybeAlias @Type) -> Container (Maybe @Type)
+  forall (k :: Prim.Type) (@n :: (k :: Prim.Type)) (@a :: Prim.Type).
+    Main.Maybe @(k :: Prim.Type) (n :: (k :: Prim.Type)) (a :: Prim.Type) ->
+    Main.MaybeAlias @(k :: Prim.Type) (n :: (k :: Prim.Type)) (a :: Prim.Type)
+coerceContainer ::
+  Main.Container (Main.Maybe @Prim.Type) -> Main.Container (Main.MaybeAlias @Prim.Type)
+coerceContainerReverse ::
+  Main.Container (Main.MaybeAlias @Prim.Type) -> Main.Container (Main.Maybe @Prim.Type)
 
 Types
-Maybe :: forall (k :: Type). (k :: Type) -> Type -> Type
-MaybeAlias :: forall (k :: Type). (k :: Type) -> Type -> Type
-Container :: (Type -> Type -> Type) -> Type
+Maybe :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type -> Prim.Type
+MaybeAlias :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type -> Prim.Type
+Container :: (Prim.Type -> Prim.Type -> Prim.Type) -> Prim.Type
 
 Roles
 Maybe = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1772827740_coercible_function_decomposition/Main.snap
+++ b/tests-integration/fixtures/checking/1772827740_coercible_function_decomposition/Main.snap
@@ -4,37 +4,46 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Age :: Int -> Age
-coerceFn :: (Age -> Int) -> Int -> Age
+Age :: Prim.Int -> Main.Age
+coerceFn :: (Main.Age -> Prim.Int) -> Prim.Int -> Main.Age
 over ::
-  forall (t :: Type) (a :: Type) (s :: Type) (b :: Type).
-    Newtype @Type (t :: Type) (a :: Type) =>
-    Newtype @Type (s :: Type) (b :: Type) =>
-    ((a :: Type) -> (t :: Type)) -> ((a :: Type) -> (b :: Type)) -> (t :: Type) -> (s :: Type)
+  forall (t :: Prim.Type) (a :: Prim.Type) (s :: Prim.Type) (b :: Prim.Type).
+    Data.Newtype.Newtype @Prim.Type (t :: Prim.Type) (a :: Prim.Type) =>
+    Data.Newtype.Newtype @Prim.Type (s :: Prim.Type) (b :: Prim.Type) =>
+    ((a :: Prim.Type) -> (t :: Prim.Type)) ->
+    ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+    (t :: Prim.Type) ->
+    (s :: Prim.Type)
 under ::
-  forall (t :: Type) (a :: Type) (s :: Type) (b :: Type).
-    Newtype @Type (t :: Type) (a :: Type) =>
-    Newtype @Type (s :: Type) (b :: Type) =>
-    ((a :: Type) -> (t :: Type)) -> ((t :: Type) -> (s :: Type)) -> (a :: Type) -> (b :: Type)
+  forall (t :: Prim.Type) (a :: Prim.Type) (s :: Prim.Type) (b :: Prim.Type).
+    Data.Newtype.Newtype @Prim.Type (t :: Prim.Type) (a :: Prim.Type) =>
+    Data.Newtype.Newtype @Prim.Type (s :: Prim.Type) (b :: Prim.Type) =>
+    ((a :: Prim.Type) -> (t :: Prim.Type)) ->
+    ((t :: Prim.Type) -> (s :: Prim.Type)) ->
+    (a :: Prim.Type) ->
+    (b :: Prim.Type)
 alaF ::
-  forall (t :: Type) (f :: Type -> Type) (g :: (t :: Type) -> Type) (t1 :: Type) (a :: Type)
-    (s :: (t :: Type)) (b :: (t :: Type)).
-    Coercible @Type ((f :: Type -> Type) (t1 :: Type)) ((f :: Type -> Type) (a :: Type)) =>
-    Coercible @Type
-      ((g :: (t :: Type) -> Type) (s :: (t :: Type)))
-      ((g :: (t :: Type) -> Type) (b :: (t :: Type))) =>
-    Newtype @Type (t1 :: Type) (a :: Type) =>
-    Newtype @(t :: Type) (s :: (t :: Type)) (b :: (t :: Type)) =>
-    ((a :: Type) -> (t1 :: Type)) ->
-    ((f :: Type -> Type) (t1 :: Type) -> (g :: (t :: Type) -> Type) (s :: (t :: Type))) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (g :: (t :: Type) -> Type) (b :: (t :: Type))
+  forall (t :: Prim.Type) (f :: Prim.Type -> Prim.Type) (g :: (t :: Prim.Type) -> Prim.Type)
+    (t1 :: Prim.Type) (a :: Prim.Type) (s :: (t :: Prim.Type)) (b :: (t :: Prim.Type)).
+    Prim.Coerce.Coercible @Prim.Type
+      ((f :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+      ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type)) =>
+    Prim.Coerce.Coercible @Prim.Type
+      ((g :: (t :: Prim.Type) -> Prim.Type) (s :: (t :: Prim.Type)))
+      ((g :: (t :: Prim.Type) -> Prim.Type) (b :: (t :: Prim.Type))) =>
+    Data.Newtype.Newtype @Prim.Type (t1 :: Prim.Type) (a :: Prim.Type) =>
+    Data.Newtype.Newtype @(t :: Prim.Type) (s :: (t :: Prim.Type)) (b :: (t :: Prim.Type)) =>
+    ((a :: Prim.Type) -> (t1 :: Prim.Type)) ->
+    ((f :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) ->
+    (g :: (t :: Prim.Type) -> Prim.Type) (s :: (t :: Prim.Type))) ->
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (g :: (t :: Prim.Type) -> Prim.Type) (b :: (t :: Prim.Type))
 
 Types
-Age :: Type
+Age :: Prim.Type
 
 Derived
-derive Newtype @Type Age Int
+derive Data.Newtype.Newtype @Prim.Type Main.Age Prim.Int
 
 Roles
 Age = []

--- a/tests-integration/fixtures/checking/1772866020_derive_newtype_not_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772866020_derive_newtype_not_constructor/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
@@ -8,7 +8,7 @@ Terms
 Types
 
 Derived
-derive Show (Int -> Int)
+derive Data.Show.Show (Prim.Int -> Prim.Int)
 
 Diagnostics
 error[CannotDeriveForType]: Cannot derive for type: Int -> Int

--- a/tests-integration/fixtures/checking/1772866080_derive_newtype_class_not_constructor/Main.snap
+++ b/tests-integration/fixtures/checking/1772866080_derive_newtype_class_not_constructor/Main.snap
@@ -8,7 +8,7 @@ Terms
 Types
 
 Derived
-derive forall (t :: Type). Newtype @Type (Int -> Int) (t :: Type)
+derive forall (t :: Prim.Type). Data.Newtype.Newtype @Prim.Type (Prim.Int -> Prim.Int) (t :: Prim.Type)
 
 Diagnostics
 error[CannotDeriveForType]: Cannot derive for type: Int -> Int

--- a/tests-integration/fixtures/checking/1772866140_derive_newtype_not_local/Main.snap
+++ b/tests-integration/fixtures/checking/1772866140_derive_newtype_not_local/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
@@ -8,7 +8,7 @@ Terms
 Types
 
 Derived
-derive Show Wrapper
+derive Data.Show.Show Lib.Wrapper
 
 Diagnostics
 error[NonLocalNewtype]: Expected a local newtype, got: Wrapper

--- a/tests-integration/fixtures/checking/1772866200_derive_newtype_class_not_local/Main.snap
+++ b/tests-integration/fixtures/checking/1772866200_derive_newtype_class_not_local/Main.snap
@@ -8,7 +8,7 @@ Terms
 Types
 
 Derived
-derive forall (t :: Type). Newtype @Type Wrapper (t :: Type)
+derive forall (t :: Prim.Type). Data.Newtype.Newtype @Prim.Type Lib.Wrapper (t :: Prim.Type)
 
 Diagnostics
 error[NonLocalNewtype]: Expected a local newtype, got: Wrapper

--- a/tests-integration/fixtures/checking/1772866260_derive_newtype_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772866260_derive_newtype_insufficient_params/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
@@ -8,7 +8,7 @@ Terms
 Types
 
 Derived
-derive Show
+derive Data.Show.Show
 
 Diagnostics
 error[DeriveInvalidArity]: Invalid arity for derive: expected 1, got 0

--- a/tests-integration/fixtures/checking/1772866320_derive_newtype_class_insufficient_params/Main.snap
+++ b/tests-integration/fixtures/checking/1772866320_derive_newtype_class_insufficient_params/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Wrapper :: Int -> Wrapper
+Wrapper :: Prim.Int -> Main.Wrapper
 
 Types
-Wrapper :: Type
+Wrapper :: Prim.Type
 
 Derived
-derive Newtype @Type Wrapper
+derive Data.Newtype.Newtype @Prim.Type Main.Wrapper
 
 Roles
 Wrapper = []

--- a/tests-integration/fixtures/checking/1773005580_equation_synonym_expansion/Main.snap
+++ b/tests-integration/fixtures/checking/1773005580_equation_synonym_expansion/Main.snap
@@ -4,12 +4,15 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
-test :: forall (f :: Type -> Type). NaturalTransformation Array (f :: Type -> Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
+test ::
+  forall (f :: Prim.Type -> Prim.Type).
+    Main.NaturalTransformation Prim.Array (f :: Prim.Type -> Prim.Type)
 
 Types
-NaturalTransformation :: (Type -> Type) -> (Type -> Type) -> Type
-~> :: (Type -> Type) -> (Type -> Type) -> Type
+NaturalTransformation :: (Prim.Type -> Prim.Type) -> (Prim.Type -> Prim.Type) -> Prim.Type
+~> :: (Prim.Type -> Prim.Type) -> (Prim.Type -> Prim.Type) -> Prim.Type
 
 Synonyms
-type NaturalTransformation f g = forall (a :: Type). (f :: Type -> Type) (a :: Type) -> (g :: Type -> Type) (a :: Type)
+type NaturalTransformation f g = forall (a :: Prim.Type).
+  (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) -> (g :: Prim.Type -> Prim.Type) (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1773152280_derive_newtype_invalid_skolem_layout/Main.snap
+++ b/tests-integration/fixtures/checking/1773152280_derive_newtype_invalid_skolem_layout/Main.snap
@@ -4,29 +4,36 @@ assertion_line: 50
 expression: report
 ---
 Terms
-empty :: forall (@f :: Type -> Type). Empty (f :: Type -> Type) => (f :: Type -> Type) Int
+empty ::
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Empty (f :: Prim.Type -> Prim.Type) => (f :: Prim.Type -> Prim.Type) Prim.Int
 Vector ::
-  forall (t :: Type) (@n :: (t :: Type)) (@a :: Type).
-    Array (a :: Type) -> Vector @(t :: Type) (n :: (t :: Type)) (a :: Type)
+  forall (t :: Prim.Type) (@n :: (t :: Prim.Type)) (@a :: Prim.Type).
+    Prim.Array (a :: Prim.Type) ->
+    Main.Vector @(t :: Prim.Type) (n :: (t :: Prim.Type)) (a :: Prim.Type)
 InvalidVector ::
-  forall (t :: Type) (@a :: Type) (@n :: (t :: Type)).
-    Array (a :: Type) -> InvalidVector @(t :: Type) (a :: Type) (n :: (t :: Type))
+  forall (t :: Prim.Type) (@a :: Prim.Type) (@n :: (t :: Prim.Type)).
+    Prim.Array (a :: Prim.Type) ->
+    Main.InvalidVector @(t :: Prim.Type) (a :: Prim.Type) (n :: (t :: Prim.Type))
 
 Types
-Empty :: (Type -> Type) -> Constraint
-Vector :: forall (t :: Type). (t :: Type) -> Type -> Type
-InvalidVector :: forall (t :: Type). Type -> (t :: Type) -> Type
+Empty :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Vector :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type -> Prim.Type
+InvalidVector :: forall (t :: Prim.Type). Prim.Type -> (t :: Prim.Type) -> Prim.Type
 
 Classes
-class forall (f :: Type -> Type). Empty (f :: Type -> Type)
-  empty :: forall (@f :: Type -> Type). Empty (f :: Type -> Type) => (f :: Type -> Type) Int
+class forall (f :: Prim.Type -> Prim.Type). Main.Empty (f :: Prim.Type -> Prim.Type)
+  empty ::
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Empty (f :: Prim.Type -> Prim.Type) => (f :: Prim.Type -> Prim.Type) Prim.Int
 
 Instances
-instance Empty Array
+instance Main.Empty Prim.Array
 
 Derived
-derive forall (t :: Type) (t1 :: (t :: Type)). Empty (Vector @(t :: Type) (t1 :: (t :: Type)))
-derive Empty (InvalidVector @Type Int)
+derive forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.Empty (Main.Vector @(t :: Prim.Type) (t1 :: (t :: Prim.Type)))
+derive Main.Empty (Main.InvalidVector @Prim.Type Prim.Int)
 
 Roles
 Vector = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1773174840_instance_implicit_variable_freshening/Main.snap
+++ b/tests-integration/fixtures/checking/1773174840_instance_implicit_variable_freshening/Main.snap
@@ -4,19 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-top :: forall (@a :: Type). Top (a :: Type) => (a :: Type)
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+top :: forall (@a :: Prim.Type). Main.Top (a :: Prim.Type) => (a :: Prim.Type)
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-Top :: Type -> Constraint
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Top :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Top (a :: Type)
-  top :: forall (@a :: Type). Top (a :: Type) => (a :: Type)
+class forall (a :: Prim.Type). Main.Top (a :: Prim.Type)
+  top :: forall (@a :: Prim.Type). Main.Top (a :: Prim.Type) => (a :: Prim.Type)
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type)). Top (Proxy @(t :: Type) (t1 :: (t :: Type)))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.Top (Main.Proxy @(t :: Prim.Type) (t1 :: (t :: Prim.Type)))
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1773326220_type_operator_synonym_partial_arguments/Main.snap
+++ b/tests-integration/fixtures/checking/1773326220_type_operator_synonym_partial_arguments/Main.snap
@@ -7,14 +7,21 @@ Terms
 
 Types
 RowApply ::
-  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-+ :: forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-AddField :: Type -> Row Type -> Row Type
-Bad :: Type -> Row Type
-Good :: Type -> Row Type
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
++ ::
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
+AddField :: Prim.Type -> Prim.Row Prim.Type -> Prim.Row Prim.Type
+Bad :: Prim.Type -> Prim.Row Prim.Type
+Good :: Prim.Type -> Prim.Row Prim.Type
 
 Synonyms
-type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
-type AddField a r = ( field :: (a :: Type) | (r :: Row Type) )
-type Bad a = RowApply @Type (AddField (a :: Type)) ()
-type Good a = RowApply @Type (AddField (a :: Type)) ()
+type RowApply f a = (f :: Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) (a :: Prim.Row (k :: Prim.Type))
+type AddField a r = ( field :: (a :: Prim.Type) | (r :: Prim.Row Prim.Type) )
+type Bad a = Main.RowApply @Prim.Type (Main.AddField (a :: Prim.Type)) ()
+type Good a = Main.RowApply @Prim.Type (Main.AddField (a :: Prim.Type)) ()

--- a/tests-integration/fixtures/checking/1773330180_type_synonym_higher_order/Main.snap
+++ b/tests-integration/fixtures/checking/1773330180_type_synonym_higher_order/Main.snap
@@ -4,17 +4,20 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: {| Test }
+test :: {| Main.Test }
 
 Types
 RowApply ::
-  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-AddInt :: Row Type -> Row Type
-AddString :: Row Type -> Row Type
-Test :: Row Type
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
+AddInt :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+AddString :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+Test :: Prim.Row Prim.Type
 
 Synonyms
-type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
-type AddInt r = ( int :: Int | (r :: Row Type) )
-type AddString r = ( string :: String | (r :: Row Type) )
-type Test = RowApply @Type AddInt (RowApply @Type AddString ())
+type RowApply f a = (f :: Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) (a :: Prim.Row (k :: Prim.Type))
+type AddInt r = ( int :: Prim.Int | (r :: Prim.Row Prim.Type) )
+type AddString r = ( string :: Prim.String | (r :: Prim.Row Prim.Type) )
+type Test = Main.RowApply @Prim.Type Main.AddInt (Main.RowApply @Prim.Type Main.AddString ())

--- a/tests-integration/fixtures/checking/1773330240_type_synonym_higher_order_operator/Main.snap
+++ b/tests-integration/fixtures/checking/1773330240_type_synonym_higher_order_operator/Main.snap
@@ -4,18 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: {| Test }
+test :: {| Main.Test }
 
 Types
 RowApply ::
-  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-+ :: forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-AddInt :: Row Type -> Row Type
-AddString :: Row Type -> Row Type
-Test :: Row Type
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
++ ::
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
+AddInt :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+AddString :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+Test :: Prim.Row Prim.Type
 
 Synonyms
-type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
-type AddInt r = ( int :: Int | (r :: Row Type) )
-type AddString r = ( string :: String | (r :: Row Type) )
-type Test = RowApply @Type AddInt (RowApply @Type AddString ())
+type RowApply f a = (f :: Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) (a :: Prim.Row (k :: Prim.Type))
+type AddInt r = ( int :: Prim.Int | (r :: Prim.Row Prim.Type) )
+type AddString r = ( string :: Prim.String | (r :: Prim.Row Prim.Type) )
+type Test = Main.RowApply @Prim.Type Main.AddInt (Main.RowApply @Prim.Type Main.AddString ())

--- a/tests-integration/fixtures/checking/1773478800_category_identity_operator_alias/Main.snap
+++ b/tests-integration/fixtures/checking/1773478800_category_identity_operator_alias/Main.snap
@@ -5,44 +5,64 @@ expression: report
 ---
 Terms
 compose ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (b :: (k :: Type)) (c :: (k :: Type)) (d :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (c :: (k :: Type)) (d :: (k :: Type)) ->
-      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (d :: (k :: Type)))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Semigroupoid @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (b :: (k :: Prim.Type)) (c :: (k :: Prim.Type)) (d :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (c :: (k :: Prim.Type))
+        (d :: (k :: Prim.Type)) ->
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (b :: (k :: Prim.Type))
+        (c :: (k :: Prim.Type)) ->
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (b :: (k :: Prim.Type))
+        (d :: (k :: Prim.Type)))
 identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (t :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (t :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (t :: (k :: Prim.Type))
+        (t :: (k :: Prim.Type)))
 <<$>> ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (t :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
-test :: forall (a :: Type). (a :: Type) -> (a :: Type)
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (t :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (t :: (k :: Prim.Type))
+        (t :: (k :: Prim.Type)))
+test :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-Semigroupoid :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> Constraint
-Category :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> Constraint
+Semigroupoid ::
+  forall (k :: Prim.Type). ((k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) -> Prim.Constraint
+Category ::
+  forall (k :: Prim.Type). ((k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type). Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type)
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type). Main.Semigroupoid @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
   compose ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (b :: (k :: Type)) (c :: (k :: Type)) (d :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (c :: (k :: Type)) (d :: (k :: Type)) ->
-      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-      (a :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (d :: (k :: Type)))
-class forall (k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type). Semigroupoid @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) <= Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type)
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Semigroupoid @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (b :: (k :: Prim.Type)) (c :: (k :: Prim.Type)) (d :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (c :: (k :: Prim.Type))
+        (d :: (k :: Prim.Type)) ->
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (b :: (k :: Prim.Type))
+        (c :: (k :: Prim.Type)) ->
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (b :: (k :: Prim.Type))
+        (d :: (k :: Prim.Type)))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type). Main.Semigroupoid @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) <= Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
   identity ::
-  forall (k :: Type) (@a :: (k :: Type) -> (k :: Type) -> Type).
-    Category @(k :: Type) (a :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (t :: (k :: Type)).
-      (a :: (k :: Type) -> (k :: Type) -> Type) (t :: (k :: Type)) (t :: (k :: Type)))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Category @(k :: Prim.Type) (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (t :: (k :: Prim.Type)).
+      (a :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (t :: (k :: Prim.Type))
+        (t :: (k :: Prim.Type)))
 
 Instances
-instance Semigroupoid @Type Function
-instance Category @Type Function
+instance Main.Semigroupoid @Prim.Type Prim.Function
+instance Main.Category @Prim.Type Prim.Function

--- a/tests-integration/fixtures/checking/1773490920_operator_alias_kind_application/Main.snap
+++ b/tests-integration/fixtures/checking/1773490920_operator_alias_kind_application/Main.snap
@@ -1,16 +1,16 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 Pair ::
-  forall (k :: Type) (@a :: (k :: Type)) (@b :: (k :: Type)).
-    Pair @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)) (@b :: (k :: Prim.Type)).
+    Main.Pair @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
 
 Types
-Pair :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Type
-& :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Type
+Pair :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type
+& :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type
 
 Roles
 Pair = [Phantom, Phantom]

--- a/tests-integration/fixtures/checking/1773491520_instance_function_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1773491520_instance_function_unification/Main.snap
@@ -5,21 +5,26 @@ expression: report
 ---
 Terms
 identity ::
-  forall (t :: Type) (@f :: (t :: Type) -> (t :: Type) -> Type).
-    Category @(t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type) =>
-    (forall (a :: (t :: Type)).
-      (f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type)))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type).
+    Main.Category @(t :: Prim.Type) (f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type) =>
+    (forall (a :: (t :: Prim.Type)).
+      (f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+        (a :: (t :: Prim.Type))
+        (a :: (t :: Prim.Type)))
 
 Types
-Category :: forall (t :: Type). ((t :: Type) -> (t :: Type) -> Type) -> Constraint
+Category ::
+  forall (t :: Prim.Type). ((t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type). Category @(t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type)
+class forall (t :: Prim.Type) (f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type). Main.Category @(t :: Prim.Type) (f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
   identity ::
-  forall (t :: Type) (@f :: (t :: Type) -> (t :: Type) -> Type).
-    Category @(t :: Type) (f :: (t :: Type) -> (t :: Type) -> Type) =>
-    (forall (a :: (t :: Type)).
-      (f :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type)))
+  forall (t :: Prim.Type) (@f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type).
+    Main.Category @(t :: Prim.Type) (f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type) =>
+    (forall (a :: (t :: Prim.Type)).
+      (f :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+        (a :: (t :: Prim.Type))
+        (a :: (t :: Prim.Type)))
 
 Instances
-instance Category @Type Function
+instance Main.Category @Prim.Type Prim.Function

--- a/tests-integration/fixtures/checking/1773501960_derive_eq_ord_1_kind_arguments/Main.snap
+++ b/tests-integration/fixtures/checking/1773501960_derive_eq_ord_1_kind_arguments/Main.snap
@@ -5,24 +5,32 @@ expression: report
 ---
 Terms
 App ::
-  forall (k :: Type) (@f :: (k :: Type) -> Type) (@a :: (k :: Type)).
-    (f :: (k :: Type) -> Type) (a :: (k :: Type)) ->
-    App @(k :: Type) (f :: (k :: Type) -> Type) (a :: (k :: Type))
+  forall (k :: Prim.Type) (@f :: (k :: Prim.Type) -> Prim.Type) (@a :: (k :: Prim.Type)).
+    (f :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type)) ->
+    Main.App @(k :: Prim.Type) (f :: (k :: Prim.Type) -> Prim.Type) (a :: (k :: Prim.Type))
 
 Types
-App :: forall (k :: Type). ((k :: Type) -> Type) -> (k :: Type) -> Type
+App :: forall (k :: Prim.Type). ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t :: Type) (t1 :: (t :: Type) -> Type) (t2 :: (t :: Type)).
-  Newtype @Type
-    (App @(t :: Type) (t1 :: (t :: Type) -> Type) (t2 :: (t :: Type)))
-    ((t1 :: (t :: Type) -> Type) (t2 :: (t :: Type)))
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Eq1 (t :: Type -> Type) => Eq (t1 :: Type) => Eq (App @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type). Eq1 (t :: Type -> Type) => Eq1 (App @Type (t :: Type -> Type))
-derive forall (t :: Type -> Type) (t1 :: Type).
-  Ord1 (t :: Type -> Type) => Ord (t1 :: Type) => Ord (App @Type (t :: Type -> Type) (t1 :: Type))
-derive forall (t :: Type -> Type). Ord1 (t :: Type -> Type) => Ord1 (App @Type (t :: Type -> Type))
+derive forall (t :: Prim.Type) (t1 :: (t :: Prim.Type) -> Prim.Type) (t2 :: (t :: Prim.Type)).
+  Data.Newtype.Newtype @Prim.Type
+    (Main.App @(t :: Prim.Type) (t1 :: (t :: Prim.Type) -> Prim.Type) (t2 :: (t :: Prim.Type)))
+    ((t1 :: (t :: Prim.Type) -> Prim.Type) (t2 :: (t :: Prim.Type)))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (t1 :: Prim.Type) =>
+  Data.Eq.Eq (Main.App @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1 (Main.App @Prim.Type (t :: Prim.Type -> Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (t1 :: Prim.Type) =>
+  Data.Ord.Ord (Main.App @Prim.Type (t :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
+derive forall (t :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (t :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord1 (Main.App @Prim.Type (t :: Prim.Type -> Prim.Type))
 
 Roles
 App = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1773504480_exhaustive_record/Main.snap
+++ b/tests-integration/fixtures/checking/1773504480_exhaustive_record/Main.snap
@@ -1,19 +1,19 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-test1 :: { x :: Int, y :: Int } -> Int
-test2 :: { x :: Maybe Int } -> Int
-test3 :: { x :: Int, y :: Int } -> Int
-test4 :: { a :: Maybe Int, b :: Maybe String } -> Int
-test5 :: { inner :: { x :: Int } } -> Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+test1 :: { x :: Prim.Int, y :: Prim.Int } -> Prim.Int
+test2 :: { x :: Main.Maybe Prim.Int } -> Prim.Int
+test3 :: { x :: Prim.Int, y :: Prim.Int } -> Prim.Int
+test4 :: { a :: Main.Maybe Prim.Int, b :: Main.Maybe Prim.String } -> Prim.Int
+test5 :: { inner :: { x :: Prim.Int } } -> Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1773504540_exhaustive_array/Main.snap
+++ b/tests-integration/fixtures/checking/1773504540_exhaustive_array/Main.snap
@@ -1,12 +1,12 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-testNonExhaustive :: Array Int -> Int
-testRedundant :: Array Int -> Int
-testExhaustive :: Array Int -> Int
+testNonExhaustive :: Prim.Array Prim.Int -> Prim.Int
+testRedundant :: Prim.Array Prim.Int -> Prim.Int
+testExhaustive :: Prim.Array Prim.Int -> Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1773504600_exhaustive_missing_patterns/Main.snap
+++ b/tests-integration/fixtures/checking/1773504600_exhaustive_missing_patterns/Main.snap
@@ -4,13 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-fromJust :: forall (a :: Type). Partial => Maybe (a :: Type) -> (a :: Type)
-test :: forall (a :: Type). Int
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+fromJust :: forall (a :: Prim.Type). Prim.Partial => Main.Maybe (a :: Prim.Type) -> (a :: Prim.Type)
+test :: forall (a :: Prim.Type). Prim.Int
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1773504660_exhaustive_unsafe_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1773504660_exhaustive_unsafe_partial/Main.snap
@@ -1,11 +1,11 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-safeZero :: Partial => Int -> Int
-unsafeZeroLambda :: Int -> Int
-unsafeZeroName :: Int -> Int
+safeZero :: Prim.Partial => Prim.Int -> Prim.Int
+unsafeZeroLambda :: Prim.Int -> Prim.Int
+unsafeZeroName :: Prim.Int -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1773712800_visible_type_application_value/Main.snap
+++ b/tests-integration/fixtures/checking/1773712800_visible_type_application_value/Main.snap
@@ -4,9 +4,11 @@ assertion_line: 50
 expression: report
 ---
 Terms
-identity :: forall (@a :: Type). (a :: Type) -> (a :: Type)
-const :: forall (a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-testIdentity :: Int -> Int
-testConst :: forall (t :: Type). (t :: Type) -> String -> (t :: Type)
+identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+const ::
+  forall (a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+testIdentity :: Prim.Int -> Prim.Int
+testConst :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.String -> (t :: Prim.Type)
 
 Types

--- a/tests-integration/fixtures/checking/1773712860_visible_type_application_data_newtype/Main.snap
+++ b/tests-integration/fixtures/checking/1773712860_visible_type_application_data_newtype/Main.snap
@@ -4,14 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-Identity :: forall (@a :: Type). (a :: Type) -> Identity (a :: Type)
-testProxy :: Proxy @Int 42
-testIdentity :: Proxy @Type Int
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+Identity :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Identity (a :: Prim.Type)
+testProxy :: Main.Proxy @Prim.Int 42
+testIdentity :: Main.Proxy @Prim.Type Prim.Int
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-Identity :: Type -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Identity :: Prim.Type -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1773712920_visible_type_application_class/Main.snap
+++ b/tests-integration/fixtures/checking/1773712920_visible_type_application_class/Main.snap
@@ -5,28 +5,30 @@ expression: report
 ---
 Terms
 map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 testMap ::
-  forall (t :: Type) (t1 :: Type).
-    ((t :: Type) -> (t1 :: Type)) -> Array (t :: Type) -> Array (t1 :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    ((t :: Prim.Type) -> (t1 :: Prim.Type)) ->
+    Prim.Array (t :: Prim.Type) ->
+    Prim.Array (t1 :: Prim.Type)
 
 Types
-Functor :: (Type -> Type) -> Constraint
+Functor :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (f :: Type -> Type). Functor (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Functor (f :: Prim.Type -> Prim.Type)
   map ::
-  forall (@f :: Type -> Type).
-    Functor (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      (f :: Type -> Type) (a :: Type) ->
-      (f :: Type -> Type) (b :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Functor (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 
 Instances
-instance Functor Array
+instance Main.Functor Prim.Array

--- a/tests-integration/fixtures/checking/1773712980_visible_type_application_tuple/Main.snap
+++ b/tests-integration/fixtures/checking/1773712980_visible_type_application_tuple/Main.snap
@@ -5,13 +5,17 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-testBoth :: Int -> String -> Tuple Int String
-testLeft :: forall (t :: Type). Int -> (t :: Type) -> Tuple Int (t :: Type)
-testRight :: forall (t :: Type). (t :: Type) -> String -> Tuple (t :: Type) String
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+testBoth :: Prim.Int -> Prim.String -> Main.Tuple Prim.Int Prim.String
+testLeft ::
+  forall (t :: Prim.Type). Prim.Int -> (t :: Prim.Type) -> Main.Tuple Prim.Int (t :: Prim.Type)
+testRight ::
+  forall (t :: Prim.Type).
+    (t :: Prim.Type) -> Prim.String -> Main.Tuple (t :: Prim.Type) Prim.String
 
 Types
-Tuple :: Type -> Type -> Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1773713040_visible_type_application_either/Main.snap
+++ b/tests-integration/fixtures/checking/1773713040_visible_type_application_either/Main.snap
@@ -4,17 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
-testBothLeft :: Int -> Either Int String
-testBothRight :: String -> Either Int String
-testLeftLeft :: forall (t :: Type). Int -> Either Int (t :: Type)
-testLeftRight :: forall (t :: Type). (t :: Type) -> Either (t :: Type) String
-testRightLeft :: forall (t :: Type). (t :: Type) -> Either Int (t :: Type)
-testRightRight :: forall (t :: Type). String -> Either (t :: Type) String
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+testBothLeft :: Prim.Int -> Main.Either Prim.Int Prim.String
+testBothRight :: Prim.String -> Main.Either Prim.Int Prim.String
+testLeftLeft :: forall (t :: Prim.Type). Prim.Int -> Main.Either Prim.Int (t :: Prim.Type)
+testLeftRight ::
+  forall (t :: Prim.Type). (t :: Prim.Type) -> Main.Either (t :: Prim.Type) Prim.String
+testRightLeft :: forall (t :: Prim.Type). (t :: Prim.Type) -> Main.Either Prim.Int (t :: Prim.Type)
+testRightRight :: forall (t :: Prim.Type). Prim.String -> Main.Either (t :: Prim.Type) Prim.String
 
 Types
-Either :: Type -> Type -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1773713100_visible_type_application_error/Main.snap
+++ b/tests-integration/fixtures/checking/1773713100_visible_type_application_error/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 50
 expression: report
 ---
 Terms
-identity :: forall (a :: Type). (a :: Type) -> (a :: Type)
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
 test :: ?[invalid visible type application]
 
 Types

--- a/tests-integration/fixtures/checking/1773745500_record_quoted_label/Main.snap
+++ b/tests-integration/fixtures/checking/1773745500_record_quoted_label/Main.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: { module :: String }
+test :: { module :: Prim.String }
 
 Types

--- a/tests-integration/fixtures/checking/1773773820_record_field_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1773773820_record_field_instantiation/Main.snap
@@ -4,19 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
 constructor ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Type).
-    { example :: (t :: Type) | (t1 :: Row Type) } ->
-    { example :: Maybe (t2 :: Type) | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+    { example :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { example :: Main.Maybe (t2 :: Prim.Type) | (t1 :: Prim.Row Prim.Type) }
 variable ::
-  forall (t :: Type) (t1 :: Row Type) (t2 :: Type).
-    { example :: (t :: Type) | (t1 :: Row Type) } ->
-    { example :: Maybe (t2 :: Type) | (t1 :: Row Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+    { example :: (t :: Prim.Type) | (t1 :: Prim.Row Prim.Type) } ->
+    { example :: Main.Maybe (t2 :: Prim.Type) | (t1 :: Prim.Row Prim.Type) }
 
 Types
-Maybe :: Type -> Type
+Maybe :: Prim.Type -> Prim.Type
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1773823020_data_argument_kind_applications/Main.snap
+++ b/tests-integration/fixtures/checking/1773823020_data_argument_kind_applications/Main.snap
@@ -4,20 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-force :: forall (a :: Type). Lazy (a :: Type) -> (a :: Type)
+force :: forall (a :: Prim.Type). Main.Lazy (a :: Prim.Type) -> (a :: Prim.Type)
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
 Node ::
-  forall (t :: Type) (@s :: (t :: Type)) (@a :: Type).
-    Lazy (a :: Type) ->
-    Lazy (Supply @(t :: Type) (s :: (t :: Type)) (a :: Type)) ->
-    Lazy (Supply @(t :: Type) (s :: (t :: Type)) (a :: Type)) ->
-    Supply @(t :: Type) (s :: (t :: Type)) (a :: Type)
+  forall (t :: Prim.Type) (@s :: (t :: Prim.Type)) (@a :: Prim.Type).
+    Main.Lazy (a :: Prim.Type) ->
+    Main.Lazy (Main.Supply @(t :: Prim.Type) (s :: (t :: Prim.Type)) (a :: Prim.Type)) ->
+    Main.Lazy (Main.Supply @(t :: Prim.Type) (s :: (t :: Prim.Type)) (a :: Prim.Type)) ->
+    Main.Supply @(t :: Prim.Type) (s :: (t :: Prim.Type)) (a :: Prim.Type)
 
 Types
-Lazy :: Type -> Type
-Tuple :: Type -> Type -> Type
-Supply :: forall (t :: Type). (t :: Type) -> Type -> Type
+Lazy :: Prim.Type -> Prim.Type
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
+Supply :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type -> Prim.Type
 
 Roles
 Lazy = [Nominal]

--- a/tests-integration/fixtures/checking/1773841860_instance_kind_substitution/Main.snap
+++ b/tests-integration/fixtures/checking/1773841860_instance_kind_substitution/Main.snap
@@ -4,26 +4,32 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 use ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    Use @(k :: Type) (a :: (k :: Type)) => Proxy @(k :: Type) (a :: (k :: Type))
-test :: Proxy @Type String
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Use @(k :: Prim.Type) (a :: (k :: Prim.Type)) =>
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+test :: Main.Proxy @Prim.Type Prim.String
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-Use :: forall (k :: Type). (k :: Type) -> Constraint
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Use :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (k :: Type) (a :: (k :: Type)). Use @(k :: Type) (a :: (k :: Type))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)). Main.Use @(k :: Prim.Type) (a :: (k :: Prim.Type))
   use ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    Use @(k :: Type) (a :: (k :: Type)) => Proxy @(k :: Type) (a :: (k :: Type))
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Use @(k :: Prim.Type) (a :: (k :: Prim.Type)) =>
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type)) (t2 :: RowList (t :: Type)).
-  RowToList @(t :: Type) ( x :: (t1 :: (t :: Type)) ) (t2 :: RowList (t :: Type)) =>
-  Use @(t :: Type) (t1 :: (t :: Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t2 :: Prim.RowList.RowList (t :: Prim.Type)).
+  Prim.RowList.RowToList @(t :: Prim.Type)
+    ( x :: (t1 :: (t :: Prim.Type)) )
+    (t2 :: Prim.RowList.RowList (t :: Prim.Type)) =>
+  Main.Use @(t :: Prim.Type) (t1 :: (t :: Prim.Type))
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1773852780_prim_row_cons_tail_synonym/Main.snap
+++ b/tests-integration/fixtures/checking/1773852780_prim_row_cons_tail_synonym/Main.snap
@@ -5,22 +5,41 @@ expression: report
 ---
 Terms
 mk ::
-  forall (a :: Type) (r :: Row Type) (r' :: Row Type) (s :: Symbol).
-    Cons @Type (s :: Symbol) (a :: Type) (r' :: Row Type) (CombinedRow (r :: Row Type)) =>
-    Proxy @Symbol (s :: Symbol) -> (a :: Type) -> Proxy @(Row Type) (CombinedRow (r :: Row Type))
-test :: forall (r :: Row Type). Proxy @(Row Type) (CombinedRow (r :: Row Type))
-forceSolve :: forall (t :: Row Type). { test :: Proxy @(Row Type) (CombinedRow (t :: Row Type)) }
+  forall (a :: Prim.Type) (r :: Prim.Row Prim.Type) (r' :: Prim.Row Prim.Type) (s :: Prim.Symbol).
+    Prim.Row.Cons @Prim.Type
+      (s :: Prim.Symbol)
+      (a :: Prim.Type)
+      (r' :: Prim.Row Prim.Type)
+      (Main.CombinedRow (r :: Prim.Row Prim.Type)) =>
+    Type.Proxy.Proxy @Prim.Symbol (s :: Prim.Symbol) ->
+    (a :: Prim.Type) ->
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (Main.CombinedRow (r :: Prim.Row Prim.Type))
+test ::
+  forall (r :: Prim.Row Prim.Type).
+    Type.Proxy.Proxy @(Prim.Row Prim.Type) (Main.CombinedRow (r :: Prim.Row Prim.Type))
+forceSolve ::
+  forall (t :: Prim.Row Prim.Type).
+    { test :: Type.Proxy.Proxy @(Prim.Row Prim.Type) (Main.CombinedRow (t :: Prim.Row Prim.Type)) }
 
 Types
 RowApply ::
-  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-+ :: forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-LeftRow :: Row Type -> Row Type
-RightRow :: Row Type -> Row Type
-CombinedRow :: Row Type -> Row Type
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
++ ::
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
+LeftRow :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+RightRow :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+CombinedRow :: Prim.Row Prim.Type -> Prim.Row Prim.Type
 
 Synonyms
-type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
-type LeftRow r = ( left :: Boolean | (r :: Row Type) )
-type RightRow r = ( right :: String | (r :: Row Type) )
-type CombinedRow r = RowApply @Type LeftRow (RowApply @Type RightRow (r :: Row Type))
+type RowApply f a = (f :: Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) (a :: Prim.Row (k :: Prim.Type))
+type LeftRow r = ( left :: Prim.Boolean | (r :: Prim.Row Prim.Type) )
+type RightRow r = ( right :: Prim.String | (r :: Prim.Row Prim.Type) )
+type CombinedRow r = Main.RowApply @Prim.Type
+  Main.LeftRow
+  (Main.RowApply @Prim.Type Main.RightRow (r :: Prim.Row Prim.Type))

--- a/tests-integration/fixtures/checking/1774024080_prim_int_given_improvement/Main.snap
+++ b/tests-integration/fixtures/checking/1774024080_prim_int_given_improvement/Main.snap
@@ -5,10 +5,17 @@ expression: report
 ---
 Terms
 addChain ::
-  forall (n :: Int) (m :: Int).
-    Add 1 2 (n :: Int) => Add 1 (n :: Int) (m :: Int) => Proxy @Int (m :: Int)
-addContradiction :: forall (m :: Int). Add 1 2 4 => Add 1 4 (m :: Int) => Proxy @Int (m :: Int)
-forceSolve :: { addChain :: Proxy @Int 4, addContradiction :: Proxy @Int 5 }
+  forall (n :: Prim.Int) (m :: Prim.Int).
+    Prim.Int.Add 1 2 (n :: Prim.Int) =>
+    Prim.Int.Add 1 (n :: Prim.Int) (m :: Prim.Int) =>
+    Type.Proxy.Proxy @Prim.Int (m :: Prim.Int)
+addContradiction ::
+  forall (m :: Prim.Int).
+    Prim.Int.Add 1 2 4 =>
+    Prim.Int.Add 1 4 (m :: Prim.Int) =>
+    Type.Proxy.Proxy @Prim.Int (m :: Prim.Int)
+forceSolve ::
+  { addChain :: Type.Proxy.Proxy @Prim.Int 4, addContradiction :: Type.Proxy.Proxy @Prim.Int 5 }
 
 Types
 

--- a/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.snap
+++ b/tests-integration/fixtures/checking/1774024140_given_deep_name_improvement/Main.snap
@@ -1,13 +1,19 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-needsAdd :: forall (x :: Int). Add 1 (x :: Int) 3 => Proxy @Int (x :: Int)
+needsAdd ::
+  forall (x :: Prim.Int).
+    Prim.Int.Add 1 (x :: Prim.Int) 3 => Type.Proxy.Proxy @Prim.Int (x :: Prim.Int)
 nonHeadGivenImprovement ::
-  forall (n :: Int).
-    Union @Type ( a :: Proxy @Int (n :: Int) ) () ( a :: Proxy @Int 2 ) => Proxy @Int (n :: Int)
-forceSolve :: { nonHeadGivenImprovement :: Proxy @Int 2 }
+  forall (n :: Prim.Int).
+    Prim.Row.Union @Prim.Type
+      ( a :: Type.Proxy.Proxy @Prim.Int (n :: Prim.Int) )
+      ()
+      ( a :: Type.Proxy.Proxy @Prim.Int 2 ) =>
+    Type.Proxy.Proxy @Prim.Int (n :: Prim.Int)
+forceSolve :: { nonHeadGivenImprovement :: Type.Proxy.Proxy @Prim.Int 2 }
 
 Types

--- a/tests-integration/fixtures/checking/1774024440_prim_row_nub_union_class_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1774024440_prim_row_nub_union_class_constraint/Main.snap
@@ -4,38 +4,61 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 consume ::
-  forall (given :: Row Type) (given_ :: Row Type).
-    Union @Type (given :: Row Type) (given_ :: Row Type) Required =>
-    {| (given :: Row Type) } -> String
+  forall (given :: Prim.Row Prim.Type) (given_ :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (given :: Prim.Row Prim.Type)
+      (given_ :: Prim.Row Prim.Type)
+      Main.Required =>
+    {| (given :: Prim.Row Prim.Type) } -> Prim.String
 merge ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type).
-    Union @Type (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) =>
-    Nub @Type (r3 :: Row Type) (r4 :: Row Type) =>
-    {| (r1 :: Row Type) } -> {| (r2 :: Row Type) } -> {| (r4 :: Row Type) }
-collect :: forall (@a :: Type). Collect (a :: Type) => (a :: Type) -> Array String
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (r3 :: Prim.Row Prim.Type)
+    (r4 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (r1 :: Prim.Row Prim.Type)
+      (r2 :: Prim.Row Prim.Type)
+      (r3 :: Prim.Row Prim.Type) =>
+    Prim.Row.Nub @Prim.Type (r3 :: Prim.Row Prim.Type) (r4 :: Prim.Row Prim.Type) =>
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) } ->
+    {| (r4 :: Prim.Row Prim.Type) }
+collect ::
+  forall (@a :: Prim.Type).
+    Main.Collect (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Array Prim.String
 combine ::
-  forall (partial :: Row Type) (duplicated :: Row Type) (deduped :: Row Type) (deduped_ :: Row Type)
-    (items :: Type).
-    Collect (items :: Type) =>
-    Union @Type ( key :: String ) (partial :: Row Type) (duplicated :: Row Type) =>
-    Nub @Type ( key :: String | (partial :: Row Type) ) (deduped :: Row Type) =>
-    Union @Type (deduped :: Row Type) (deduped_ :: Row Type) Required =>
-    {| (partial :: Row Type) } -> (items :: Type) -> String
-combine' :: forall (items :: Type). Collect (items :: Type) => (items :: Type) -> String
-repro :: String
+  forall (partial :: Prim.Row Prim.Type) (duplicated :: Prim.Row Prim.Type)
+    (deduped :: Prim.Row Prim.Type) (deduped_ :: Prim.Row Prim.Type) (items :: Prim.Type).
+    Main.Collect (items :: Prim.Type) =>
+    Prim.Row.Union @Prim.Type
+      ( key :: Prim.String )
+      (partial :: Prim.Row Prim.Type)
+      (duplicated :: Prim.Row Prim.Type) =>
+    Prim.Row.Nub @Prim.Type
+      ( key :: Prim.String | (partial :: Prim.Row Prim.Type) )
+      (deduped :: Prim.Row Prim.Type) =>
+    Prim.Row.Union @Prim.Type
+      (deduped :: Prim.Row Prim.Type)
+      (deduped_ :: Prim.Row Prim.Type)
+      Main.Required =>
+    {| (partial :: Prim.Row Prim.Type) } -> (items :: Prim.Type) -> Prim.String
+combine' ::
+  forall (items :: Prim.Type).
+    Main.Collect (items :: Prim.Type) => (items :: Prim.Type) -> Prim.String
+repro :: Prim.String
 
 Types
-Required :: Row Type
-Collect :: Type -> Constraint
+Required :: Prim.Row Prim.Type
+Collect :: Prim.Type -> Prim.Constraint
 
 Synonyms
-type Required = ( key :: String )
+type Required = ( key :: Prim.String )
 
 Classes
-class forall (a :: Type). Collect (a :: Type)
-  collect :: forall (@a :: Type). Collect (a :: Type) => (a :: Type) -> Array String
+class forall (a :: Prim.Type). Main.Collect (a :: Prim.Type)
+  collect ::
+  forall (@a :: Prim.Type).
+    Main.Collect (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Array Prim.String
 
 Instances
-instance Collect (Array String)
+instance Main.Collect (Prim.Array Prim.String)

--- a/tests-integration/fixtures/checking/1774448100_self_recursive_through_operator/Main.snap
+++ b/tests-integration/fixtures/checking/1774448100_self_recursive_through_operator/Main.snap
@@ -4,13 +4,17 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Nil :: forall (@a :: Type). List (a :: Type)
-Cons :: forall (@a :: Type). List (a :: Type) -> List (a :: Type)
-append :: forall (a :: Type). List (a :: Type) -> List Int -> List (a :: Type)
-<+> :: forall (a :: Type). List (a :: Type) -> List Int -> List (a :: Type)
+Nil :: forall (@a :: Prim.Type). Main.List (a :: Prim.Type)
+Cons :: forall (@a :: Prim.Type). Main.List (a :: Prim.Type) -> Main.List (a :: Prim.Type)
+append ::
+  forall (a :: Prim.Type).
+    Main.List (a :: Prim.Type) -> Main.List Prim.Int -> Main.List (a :: Prim.Type)
+<+> ::
+  forall (a :: Prim.Type).
+    Main.List (a :: Prim.Type) -> Main.List Prim.Int -> Main.List (a :: Prim.Type)
 
 Types
-List :: Type -> Type
+List :: Prim.Type -> Prim.Type
 
 Roles
 List = [Representational]

--- a/tests-integration/fixtures/checking/1774448160_kind_applied_reference_double_application/Main.snap
+++ b/tests-integration/fixtures/checking/1774448160_kind_applied_reference_double_application/Main.snap
@@ -1,18 +1,26 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 Fix ::
-  forall (k :: Type) (@f :: ((k :: Type) -> Type) -> (k :: Type) -> Type) (@a :: (k :: Type)).
-    (f :: ((k :: Type) -> Type) -> (k :: Type) -> Type)
-      (Fix @(k :: Type) (f :: ((k :: Type) -> Type) -> (k :: Type) -> Type))
-      (a :: (k :: Type)) ->
-    Fix @(k :: Type) (f :: ((k :: Type) -> Type) -> (k :: Type) -> Type) (a :: (k :: Type))
+  forall (k :: Prim.Type) (@f :: ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+    (@a :: (k :: Prim.Type)).
+    (f :: ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+      (Main.Fix @(k :: Prim.Type)
+        (f :: ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type))
+      (a :: (k :: Prim.Type)) ->
+    Main.Fix @(k :: Prim.Type)
+      (f :: ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+      (a :: (k :: Prim.Type))
 
 Types
-Fix :: forall (k :: Type). (((k :: Type) -> Type) -> (k :: Type) -> Type) -> (k :: Type) -> Type
+Fix ::
+  forall (k :: Prim.Type).
+    (((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type) ->
+    (k :: Prim.Type) ->
+    Prim.Type
 
 Roles
 Fix = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1774448220_section_rule_progress/Main.snap
+++ b/tests-integration/fixtures/checking/1774448220_section_rule_progress/Main.snap
@@ -4,91 +4,105 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Done :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Step (a :: Type) (b :: Type)
-Loop :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Step (a :: Type) (b :: Type)
-append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-mempty :: forall (@a :: Type). Monoid (a :: Type) => (a :: Type)
+Done ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Step (a :: Prim.Type) (b :: Prim.Type)
+Loop ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Step (a :: Prim.Type) (b :: Prim.Type)
+append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+mempty :: forall (@a :: Prim.Type). Main.Monoid (a :: Prim.Type) => (a :: Prim.Type)
 tailRecM ::
-  forall (@m :: Type -> Type).
-    MonadRec (m :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))) ->
-      (a :: Type) ->
-      (m :: Type -> Type) (b :: Type))
+  forall (@m :: Prim.Type -> Prim.Type).
+    Main.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) ->
+      (m :: Prim.Type -> Prim.Type) (Main.Step (a :: Prim.Type) (b :: Prim.Type))) ->
+      (a :: Prim.Type) ->
+      (m :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 ifM ::
-  forall (m :: Type -> Type) (a :: Type).
-    Bind (m :: Type -> Type) =>
-    (m :: Type -> Type) Boolean ->
-    (m :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) (a :: Type)
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    Control.Bind.Bind (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) Prim.Boolean ->
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type)
 lift2 ::
-  forall (f :: Type -> Type) (a :: Type) (b :: Type) (c :: Type).
-    Apply (f :: Type -> Type) =>
-    ((a :: Type) -> (b :: Type) -> (c :: Type)) ->
-    (f :: Type -> Type) (a :: Type) ->
-    (f :: Type -> Type) (b :: Type) ->
-    (f :: Type -> Type) (c :: Type)
+  forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+    Control.Apply.Apply (f :: Prim.Type -> Prim.Type) =>
+    ((a :: Prim.Type) -> (b :: Prim.Type) -> (c :: Prim.Type)) ->
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (f :: Prim.Type -> Prim.Type) (b :: Prim.Type) ->
+    (f :: Prim.Type -> Prim.Type) (c :: Prim.Type)
 liftIfM ::
-  forall (m :: Type -> Type) (f :: Type -> Type) (a :: Type).
-    Apply (f :: Type -> Type) =>
-    Bind (m :: Type -> Type) =>
-    (m :: Type -> Type) Boolean ->
-    (f :: Type -> Type) ((m :: Type -> Type) (a :: Type)) ->
-    (f :: Type -> Type) ((m :: Type -> Type) (a :: Type)) ->
-    (f :: Type -> Type) ((m :: Type -> Type) (a :: Type))
+  forall (m :: Prim.Type -> Prim.Type) (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    Control.Apply.Apply (f :: Prim.Type -> Prim.Type) =>
+    Control.Bind.Bind (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) Prim.Boolean ->
+    (f :: Prim.Type -> Prim.Type) ((m :: Prim.Type -> Prim.Type) (a :: Prim.Type)) ->
+    (f :: Prim.Type -> Prim.Type) ((m :: Prim.Type -> Prim.Type) (a :: Prim.Type)) ->
+    (f :: Prim.Type -> Prim.Type) ((m :: Prim.Type -> Prim.Type) (a :: Prim.Type))
 appendM ::
-  forall (m :: Type -> Type) (f :: Type -> Type) (a :: Type) (b :: Type).
-    MonadRec (m :: Type -> Type) =>
-    Applicative (f :: Type -> Type) =>
-    Semigroup ((f :: Type -> Type) (a :: Type)) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) (Step ((f :: Type -> Type) (a :: Type)) (b :: Type))
+  forall (m :: Prim.Type -> Prim.Type) (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+    (b :: Prim.Type).
+    Main.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    Control.Applicative.Applicative (f :: Prim.Type -> Prim.Type) =>
+    Main.Semigroup ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type)) =>
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type)
+      (Main.Step ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type)) (b :: Prim.Type))
 <+> ::
-  forall (m :: Type -> Type) (f :: Type -> Type) (a :: Type) (b :: Type).
-    MonadRec (m :: Type -> Type) =>
-    Applicative (f :: Type -> Type) =>
-    Semigroup ((f :: Type -> Type) (a :: Type)) =>
-    (f :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) (Step ((f :: Type -> Type) (a :: Type)) (b :: Type))
+  forall (m :: Prim.Type -> Prim.Type) (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+    (b :: Prim.Type).
+    Main.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    Control.Applicative.Applicative (f :: Prim.Type -> Prim.Type) =>
+    Main.Semigroup ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type)) =>
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type)
+      (Main.Step ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type)) (b :: Prim.Type))
 loop ::
-  forall (m :: Type -> Type) (a :: Type) (b :: Type).
-    Applicative (m :: Type -> Type) =>
-    (a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    Control.Applicative.Applicative (m :: Prim.Type -> Prim.Type) =>
+    (a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (Main.Step (a :: Prim.Type) (b :: Prim.Type))
 done ::
-  forall (m :: Type -> Type) (a :: Type) (b :: Type).
-    Applicative (m :: Type -> Type) =>
-    (b :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    Control.Applicative.Applicative (m :: Prim.Type -> Prim.Type) =>
+    (b :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) (Main.Step (a :: Prim.Type) (b :: Prim.Type))
 whileM' ::
-  forall (a :: Type) (f :: Type -> Type) (m :: Type -> Type).
-    MonadRec (m :: Type -> Type) =>
-    Applicative (f :: Type -> Type) =>
-    Monoid ((f :: Type -> Type) (a :: Type)) =>
-    (m :: Type -> Type) Boolean ->
-    (m :: Type -> Type) (a :: Type) ->
-    (m :: Type -> Type) ((f :: Type -> Type) (a :: Type))
+  forall (a :: Prim.Type) (f :: Prim.Type -> Prim.Type) (m :: Prim.Type -> Prim.Type).
+    Main.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    Control.Applicative.Applicative (f :: Prim.Type -> Prim.Type) =>
+    Main.Monoid ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type)) =>
+    (m :: Prim.Type -> Prim.Type) Prim.Boolean ->
+    (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    (m :: Prim.Type -> Prim.Type) ((f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
 
 Types
-Step :: Type -> Type -> Type
-Semigroup :: Type -> Constraint
-Monoid :: Type -> Constraint
-MonadRec :: (Type -> Type) -> Constraint
+Step :: Prim.Type -> Prim.Type -> Prim.Type
+Semigroup :: Prim.Type -> Prim.Constraint
+Monoid :: Prim.Type -> Prim.Constraint
+MonadRec :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semigroup (a :: Type)
-  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-class forall (a :: Type). Semigroup (a :: Type) <= Monoid (a :: Type)
-  mempty :: forall (@a :: Type). Monoid (a :: Type) => (a :: Type)
-class forall (m :: Type -> Type). Applicative (m :: Type -> Type), Bind (m :: Type -> Type) <= MonadRec (m :: Type -> Type)
+class forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type)
+  append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+class forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type) <= Main.Monoid (a :: Prim.Type)
+  mempty :: forall (@a :: Prim.Type). Main.Monoid (a :: Prim.Type) => (a :: Prim.Type)
+class forall (m :: Prim.Type -> Prim.Type). Control.Applicative.Applicative (m :: Prim.Type -> Prim.Type), Control.Bind.Bind (m :: Prim.Type -> Prim.Type) <= Main.MonadRec (m :: Prim.Type -> Prim.Type)
   tailRecM ::
-  forall (@m :: Type -> Type).
-    MonadRec (m :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((a :: Type) -> (m :: Type -> Type) (Step (a :: Type) (b :: Type))) ->
-      (a :: Type) ->
-      (m :: Type -> Type) (b :: Type))
+  forall (@m :: Prim.Type -> Prim.Type).
+    Main.MonadRec (m :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((a :: Prim.Type) ->
+      (m :: Prim.Type -> Prim.Type) (Main.Step (a :: Prim.Type) (b :: Prim.Type))) ->
+      (a :: Prim.Type) ->
+      (m :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 
 Roles
 Step = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1774448280_given_synonym_expansion/Main.snap
+++ b/tests-integration/fixtures/checking/1774448280_given_synonym_expansion/Main.snap
@@ -4,37 +4,46 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
 coerceRecord ::
-  forall (a :: Row Type) (b :: Row Type).
-    TypeEquals @(Row Type) (a :: Row Type) (b :: Row Type) =>
-    {| (a :: Row Type) } -> {| (b :: Row Type) }
+  forall (a :: Prim.Row Prim.Type) (b :: Prim.Row Prim.Type).
+    Main.TypeEquals @(Prim.Row Prim.Type) (a :: Prim.Row Prim.Type) (b :: Prim.Row Prim.Type) =>
+    {| (a :: Prim.Row Prim.Type) } -> {| (b :: Prim.Row Prim.Type) }
 transform ::
-  forall (a :: Row Type).
-    TypeEquals @(Row Type) (a :: Row Type) Include =>
-    {| (a :: Row Type) } -> { x :: Int, y :: String, z :: Boolean }
-test :: { x :: Int, y :: String, z :: Boolean }
+  forall (a :: Prim.Row Prim.Type).
+    Main.TypeEquals @(Prim.Row Prim.Type) (a :: Prim.Row Prim.Type) Main.Include =>
+    {| (a :: Prim.Row Prim.Type) } -> { x :: Prim.Int, y :: Prim.String, z :: Prim.Boolean }
+test :: { x :: Prim.Int, y :: Prim.String, z :: Prim.Boolean }
 
 Types
 RowApply ::
-  forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-+ :: forall (k :: Type). (Row (k :: Type) -> Row (k :: Type)) -> Row (k :: Type) -> Row (k :: Type)
-IncludeX :: Row Type -> Row Type
-IncludeY :: Row Type -> Row Type
-IncludeZ :: Row Type -> Row Type
-Include :: Row Type
-TypeEquals :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
++ ::
+  forall (k :: Prim.Type).
+    (Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) ->
+    Prim.Row (k :: Prim.Type) ->
+    Prim.Row (k :: Prim.Type)
+IncludeX :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+IncludeY :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+IncludeZ :: Prim.Row Prim.Type -> Prim.Row Prim.Type
+Include :: Prim.Row Prim.Type
+TypeEquals :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Constraint
 
 Synonyms
-type RowApply f a = (f :: Row (k :: Type) -> Row (k :: Type)) (a :: Row (k :: Type))
-type IncludeX r = ( x :: Int | (r :: Row Type) )
-type IncludeY r = ( y :: String | (r :: Row Type) )
-type IncludeZ r = ( z :: Boolean | (r :: Row Type) )
-type Include = RowApply @Type IncludeX (RowApply @Type IncludeY (RowApply @Type IncludeZ ()))
+type RowApply f a = (f :: Prim.Row (k :: Prim.Type) -> Prim.Row (k :: Prim.Type)) (a :: Prim.Row (k :: Prim.Type))
+type IncludeX r = ( x :: Prim.Int | (r :: Prim.Row Prim.Type) )
+type IncludeY r = ( y :: Prim.String | (r :: Prim.Row Prim.Type) )
+type IncludeZ r = ( z :: Prim.Boolean | (r :: Prim.Row Prim.Type) )
+type Include = Main.RowApply @Prim.Type
+  Main.IncludeX
+  (Main.RowApply @Prim.Type Main.IncludeY (Main.RowApply @Prim.Type Main.IncludeZ ()))
 
 Classes
-class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). TypeEquals @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEquals @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type)).
-  TypeEquals @(t :: Type) (t1 :: (t :: Type)) (t1 :: (t :: Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.TypeEquals @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t1 :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1774448340_operator_result_ordering/Main.snap
+++ b/tests-integration/fixtures/checking/1774448340_operator_result_ordering/Main.snap
@@ -4,50 +4,64 @@ assertion_line: 50
 expression: report
 ---
 Terms
-$ :: forall (a :: Type) (b :: Type). ((a :: Type) -> (b :: Type)) -> (a :: Type) -> (b :: Type)
-apply :: forall (a :: Type) (b :: Type). ((a :: Type) -> (b :: Type)) -> (a :: Type) -> (b :: Type)
-identity :: forall (a :: Type). (a :: Type) -> (a :: Type)
-Wrap :: forall (@a :: Type). (a :: Type) -> Wrap (a :: Type)
+$ ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> (a :: Prim.Type) -> (b :: Prim.Type)
+apply ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    ((a :: Prim.Type) -> (b :: Prim.Type)) -> (a :: Prim.Type) -> (b :: Prim.Type)
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
+Wrap :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Wrap (a :: Prim.Type)
 dimap ::
-  forall (@p :: Type -> Type -> Type).
-    Profunctor (p :: Type -> Type -> Type) =>
-    (forall (a :: Type) (b :: Type) (c :: Type) (d :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      ((c :: Type) -> (d :: Type)) ->
-      (p :: Type -> Type -> Type) (b :: Type) (c :: Type) ->
-      (p :: Type -> Type -> Type) (a :: Type) (d :: Type))
+  forall (@p :: Prim.Type -> Prim.Type -> Prim.Type).
+    Main.Profunctor (p :: Prim.Type -> Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      ((c :: Prim.Type) -> (d :: Prim.Type)) ->
+      (p :: Prim.Type -> Prim.Type -> Prim.Type) (b :: Prim.Type) (c :: Prim.Type) ->
+      (p :: Prim.Type -> Prim.Type -> Prim.Type) (a :: Prim.Type) (d :: Prim.Type))
 lens ::
-  forall (s :: Type) (a :: Type).
-    ((a :: Type) -> (s :: Type)) -> ((s :: Type) -> (a :: Type)) -> Lens (s :: Type) (a :: Type)
-wrapped :: forall (a :: Type). Lens (Wrap (a :: Type)) (a :: Type)
+  forall (s :: Prim.Type) (a :: Prim.Type).
+    ((a :: Prim.Type) -> (s :: Prim.Type)) ->
+    ((s :: Prim.Type) -> (a :: Prim.Type)) ->
+    Main.Lens (s :: Prim.Type) (a :: Prim.Type)
+wrapped :: forall (a :: Prim.Type). Main.Lens (Main.Wrap (a :: Prim.Type)) (a :: Prim.Type)
 
 Types
-Wrap :: Type -> Type
-Profunctor :: (Type -> Type -> Type) -> Constraint
+Wrap :: Prim.Type -> Prim.Type
+Profunctor :: (Prim.Type -> Prim.Type -> Prim.Type) -> Prim.Constraint
 Optic ::
-  forall (t :: Type). ((t :: Type) -> (t :: Type) -> Type) -> (t :: Type) -> (t :: Type) -> Type
-Lens :: Type -> Type -> Type
+  forall (t :: Prim.Type).
+    ((t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type) ->
+    (t :: Prim.Type) ->
+    (t :: Prim.Type) ->
+    Prim.Type
+Lens :: Prim.Type -> Prim.Type -> Prim.Type
 
 Synonyms
-type Optic p s a = (p :: (t :: Type) -> (t :: Type) -> Type) (a :: (t :: Type)) (a :: (t :: Type)) ->
-(p :: (t :: Type) -> (t :: Type) -> Type) (s :: (t :: Type)) (s :: (t :: Type))
-type Lens s a = forall (p :: Type -> Type -> Type).
-  Profunctor (p :: Type -> Type -> Type) =>
-  Optic @Type (p :: Type -> Type -> Type) (s :: Type) (a :: Type)
+type Optic p s a = (p :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+  (a :: (t :: Prim.Type))
+  (a :: (t :: Prim.Type)) ->
+(p :: (t :: Prim.Type) -> (t :: Prim.Type) -> Prim.Type)
+  (s :: (t :: Prim.Type))
+  (s :: (t :: Prim.Type))
+type Lens s a = forall (p :: Prim.Type -> Prim.Type -> Prim.Type).
+  Main.Profunctor (p :: Prim.Type -> Prim.Type -> Prim.Type) =>
+  Main.Optic @Prim.Type (p :: Prim.Type -> Prim.Type -> Prim.Type) (s :: Prim.Type) (a :: Prim.Type)
 
 Classes
-class forall (p :: Type -> Type -> Type). Profunctor (p :: Type -> Type -> Type)
+class forall (p :: Prim.Type -> Prim.Type -> Prim.Type). Main.Profunctor (p :: Prim.Type -> Prim.Type -> Prim.Type)
   dimap ::
-  forall (@p :: Type -> Type -> Type).
-    Profunctor (p :: Type -> Type -> Type) =>
-    (forall (a :: Type) (b :: Type) (c :: Type) (d :: Type).
-      ((a :: Type) -> (b :: Type)) ->
-      ((c :: Type) -> (d :: Type)) ->
-      (p :: Type -> Type -> Type) (b :: Type) (c :: Type) ->
-      (p :: Type -> Type -> Type) (a :: Type) (d :: Type))
+  forall (@p :: Prim.Type -> Prim.Type -> Prim.Type).
+    Main.Profunctor (p :: Prim.Type -> Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+      ((a :: Prim.Type) -> (b :: Prim.Type)) ->
+      ((c :: Prim.Type) -> (d :: Prim.Type)) ->
+      (p :: Prim.Type -> Prim.Type -> Prim.Type) (b :: Prim.Type) (c :: Prim.Type) ->
+      (p :: Prim.Type -> Prim.Type -> Prim.Type) (a :: Prim.Type) (d :: Prim.Type))
 
 Instances
-instance Profunctor Function
+instance Main.Profunctor Prim.Function
 
 Roles
 Wrap = [Representational]

--- a/tests-integration/fixtures/checking/1774448400_record_field_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1774448400_record_field_polymorphic/Main.snap
@@ -4,22 +4,38 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
 FFIUtil ::
-  { isLeft :: forall (a :: Type) (b :: Type). Either (a :: Type) (b :: Type) -> Boolean
-  , isRight :: forall (a1 :: Type) (b1 :: Type). Either (a1 :: Type) (b1 :: Type) -> Boolean
-  , left :: forall (a2 :: Type) (b2 :: Type). (a2 :: Type) -> Either (a2 :: Type) (b2 :: Type)
-  , right :: forall (a3 :: Type) (b3 :: Type). (b3 :: Type) -> Either (a3 :: Type) (b3 :: Type)
+  { isLeft ::
+      forall (a :: Prim.Type) (b :: Prim.Type).
+        Main.Either (a :: Prim.Type) (b :: Prim.Type) -> Prim.Boolean
+  , isRight ::
+      forall (a1 :: Prim.Type) (b1 :: Prim.Type).
+        Main.Either (a1 :: Prim.Type) (b1 :: Prim.Type) -> Prim.Boolean
+  , left ::
+      forall (a2 :: Prim.Type) (b2 :: Prim.Type).
+        (a2 :: Prim.Type) -> Main.Either (a2 :: Prim.Type) (b2 :: Prim.Type)
+  , right ::
+      forall (a3 :: Prim.Type) (b3 :: Prim.Type).
+        (b3 :: Prim.Type) -> Main.Either (a3 :: Prim.Type) (b3 :: Prim.Type)
   } ->
-  FFIUtil
-isLeft :: forall (a :: Type) (b :: Type). Either (a :: Type) (b :: Type) -> Boolean
-isRight :: forall (a :: Type) (b :: Type). Either (a :: Type) (b :: Type) -> Boolean
-test :: FFIUtil
+  Main.FFIUtil
+isLeft ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Either (a :: Prim.Type) (b :: Prim.Type) -> Prim.Boolean
+isRight ::
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Either (a :: Prim.Type) (b :: Prim.Type) -> Prim.Boolean
+test :: Main.FFIUtil
 
 Types
-Either :: Type -> Type -> Type
-FFIUtil :: Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
+FFIUtil :: Prim.Type
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1774448460_hidden_forall_scope_check/Main.snap
+++ b/tests-integration/fixtures/checking/1774448460_hidden_forall_scope_check/Main.snap
@@ -4,38 +4,79 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Unit :: Unit
+Unit :: Main.Unit
 Respond ::
-  forall (@x' :: Type) (@x :: Type) (@a' :: Type) (@a :: Type) (@m :: Type -> Type) (@r :: Type).
-    (a :: Type) ->
-    ((a' :: Type) ->
-    Proxy (x' :: Type) (x :: Type) (a' :: Type) (a :: Type) (m :: Type -> Type) (r :: Type)) ->
-    Proxy (x' :: Type) (x :: Type) (a' :: Type) (a :: Type) (m :: Type -> Type) (r :: Type)
+  forall (@x' :: Prim.Type) (@x :: Prim.Type) (@a' :: Prim.Type) (@a :: Prim.Type)
+    (@m :: Prim.Type -> Prim.Type) (@r :: Prim.Type).
+    (a :: Prim.Type) ->
+    ((a' :: Prim.Type) ->
+    Main.Proxy
+      (x' :: Prim.Type)
+      (x :: Prim.Type)
+      (a' :: Prim.Type)
+      (a :: Prim.Type)
+      (m :: Prim.Type -> Prim.Type)
+      (r :: Prim.Type)) ->
+    Main.Proxy
+      (x' :: Prim.Type)
+      (x :: Prim.Type)
+      (a' :: Prim.Type)
+      (a :: Prim.Type)
+      (m :: Prim.Type -> Prim.Type)
+      (r :: Prim.Type)
 Pure ::
-  forall (@x' :: Type) (@x :: Type) (@a' :: Type) (@a :: Type) (@m :: Type -> Type) (@r :: Type).
-    (r :: Type) ->
-    Proxy (x' :: Type) (x :: Type) (a' :: Type) (a :: Type) (m :: Type -> Type) (r :: Type)
+  forall (@x' :: Prim.Type) (@x :: Prim.Type) (@a' :: Prim.Type) (@a :: Prim.Type)
+    (@m :: Prim.Type -> Prim.Type) (@r :: Prim.Type).
+    (r :: Prim.Type) ->
+    Main.Proxy
+      (x' :: Prim.Type)
+      (x :: Prim.Type)
+      (a' :: Prim.Type)
+      (a :: Prim.Type)
+      (m :: Prim.Type -> Prim.Type)
+      (r :: Prim.Type)
 respond ::
-  forall (m :: Type -> Type) (a :: Type) (a' :: Type) (x :: Type) (x' :: Type).
-    Monad (m :: Type -> Type) =>
-    (a :: Type) ->
-    Proxy (x' :: Type) (x :: Type) (a' :: Type) (a :: Type) (m :: Type -> Type) (a' :: Type)
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type) (a' :: Prim.Type) (x :: Prim.Type)
+    (x' :: Prim.Type).
+    Main.Monad (m :: Prim.Type -> Prim.Type) =>
+    (a :: Prim.Type) ->
+    Main.Proxy
+      (x' :: Prim.Type)
+      (x :: Prim.Type)
+      (a' :: Prim.Type)
+      (a :: Prim.Type)
+      (m :: Prim.Type -> Prim.Type)
+      (a' :: Prim.Type)
 yield ::
-  forall (m :: Type -> Type) (a :: Type).
-    Monad (m :: Type -> Type) => (a :: Type) -> Producer_ (a :: Type) (m :: Type -> Type) Unit
+  forall (m :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+    Main.Monad (m :: Prim.Type -> Prim.Type) =>
+    (a :: Prim.Type) -> Main.Producer_ (a :: Prim.Type) (m :: Prim.Type -> Prim.Type) Main.Unit
 
 Types
-Unit :: Type
-Monad :: (Type -> Type) -> Constraint
-Proxy :: Type -> Type -> Type -> Type -> (Type -> Type) -> Type -> Type
-Producer_ :: Type -> (Type -> Type) -> Type -> Type
+Unit :: Prim.Type
+Monad :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Proxy ::
+  Prim.Type ->
+  Prim.Type ->
+  Prim.Type ->
+  Prim.Type ->
+  (Prim.Type -> Prim.Type) ->
+  Prim.Type ->
+  Prim.Type
+Producer_ :: Prim.Type -> (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
 
 Synonyms
-type Producer_ b m r = forall (x' :: Type) (x :: Type).
-  Proxy (x' :: Type) (x :: Type) Unit (b :: Type) (m :: Type -> Type) (r :: Type)
+type Producer_ b m r = forall (x' :: Prim.Type) (x :: Prim.Type).
+  Main.Proxy
+    (x' :: Prim.Type)
+    (x :: Prim.Type)
+    Main.Unit
+    (b :: Prim.Type)
+    (m :: Prim.Type -> Prim.Type)
+    (r :: Prim.Type)
 
 Classes
-class forall (m :: Type -> Type). Monad (m :: Type -> Type)
+class forall (m :: Prim.Type -> Prim.Type). Main.Monad (m :: Prim.Type -> Prim.Type)
 
 Roles
 Unit = []

--- a/tests-integration/fixtures/checking/1774448520_hidden_forall_compose_application_subtype/Main.snap
+++ b/tests-integration/fixtures/checking/1774448520_hidden_forall_compose_application_subtype/Main.snap
@@ -5,40 +5,57 @@ expression: report
 ---
 Terms
 compose ::
-  forall (k :: Type) (@f :: (k :: Type) -> (k :: Type) -> Type).
-    Semigroupoid @(k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)).
-      (f :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (b :: (k :: Type)) ->
-      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (c :: (k :: Type)))
-Tagged :: forall (@n :: Int) (@a :: Type). (a :: Type) -> Tagged (n :: Int) (a :: Type)
-make :: forall (a :: Type). (a :: Type) -> HiddenTagged (a :: Type)
-ConcreteNewtype :: forall (@a :: Type). ConcreteTagged (a :: Type) -> ConcreteNewtype (a :: Type)
-test :: forall (a :: Type). (a :: Type) -> ConcreteNewtype (a :: Type)
+  forall (k :: Prim.Type) (@f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Semigroupoid @(k :: Prim.Type) (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)) (c :: (k :: Prim.Type)).
+      (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (b :: (k :: Prim.Type))
+        (c :: (k :: Prim.Type)) ->
+      (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (a :: (k :: Prim.Type))
+        (b :: (k :: Prim.Type)) ->
+      (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (a :: (k :: Prim.Type))
+        (c :: (k :: Prim.Type)))
+Tagged ::
+  forall (@n :: Prim.Int) (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Tagged (n :: Prim.Int) (a :: Prim.Type)
+make :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.HiddenTagged (a :: Prim.Type)
+ConcreteNewtype ::
+  forall (@a :: Prim.Type).
+    Main.ConcreteTagged (a :: Prim.Type) -> Main.ConcreteNewtype (a :: Prim.Type)
+test :: forall (a :: Prim.Type). (a :: Prim.Type) -> Main.ConcreteNewtype (a :: Prim.Type)
 
 Types
-Semigroupoid :: forall (k :: Type). ((k :: Type) -> (k :: Type) -> Type) -> Constraint
-Tagged :: Int -> Type -> Type
-ConcreteTagged :: Type -> Type
-HiddenTagged :: Type -> Type
-ConcreteNewtype :: Type -> Type
+Semigroupoid ::
+  forall (k :: Prim.Type). ((k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) -> Prim.Constraint
+Tagged :: Prim.Int -> Prim.Type -> Prim.Type
+ConcreteTagged :: Prim.Type -> Prim.Type
+HiddenTagged :: Prim.Type -> Prim.Type
+ConcreteNewtype :: Prim.Type -> Prim.Type
 
 Synonyms
-type ConcreteTagged a = Tagged 42 (a :: Type)
-type HiddenTagged a = forall (n :: Int). Tagged (n :: Int) (a :: Type)
+type ConcreteTagged a = Main.Tagged 42 (a :: Prim.Type)
+type HiddenTagged a = forall (n :: Prim.Int). Main.Tagged (n :: Prim.Int) (a :: Prim.Type)
 
 Classes
-class forall (k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type). Semigroupoid @(k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type)
+class forall (k :: Prim.Type) (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type). Main.Semigroupoid @(k :: Prim.Type) (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
   compose ::
-  forall (k :: Type) (@f :: (k :: Type) -> (k :: Type) -> Type).
-    Semigroupoid @(k :: Type) (f :: (k :: Type) -> (k :: Type) -> Type) =>
-    (forall (a :: (k :: Type)) (b :: (k :: Type)) (c :: (k :: Type)).
-      (f :: (k :: Type) -> (k :: Type) -> Type) (b :: (k :: Type)) (c :: (k :: Type)) ->
-      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (b :: (k :: Type)) ->
-      (f :: (k :: Type) -> (k :: Type) -> Type) (a :: (k :: Type)) (c :: (k :: Type)))
+  forall (k :: Prim.Type) (@f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type).
+    Main.Semigroupoid @(k :: Prim.Type) (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) =>
+    (forall (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)) (c :: (k :: Prim.Type)).
+      (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (b :: (k :: Prim.Type))
+        (c :: (k :: Prim.Type)) ->
+      (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (a :: (k :: Prim.Type))
+        (b :: (k :: Prim.Type)) ->
+      (f :: (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type)
+        (a :: (k :: Prim.Type))
+        (c :: (k :: Prim.Type)))
 
 Instances
-instance Semigroupoid @Type Function
+instance Main.Semigroupoid @Prim.Type Prim.Function
 
 Roles
 Tagged = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1774448580_forall_row_field/Main.snap
+++ b/tests-integration/fixtures/checking/1774448580_forall_row_field/Main.snap
@@ -1,12 +1,12 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-Test :: Row Type
+Test :: Prim.Row Prim.Type
 
 Synonyms
-type Test = ( test :: forall (a :: Type). (a :: Type) )
+type Test = ( test :: forall (a :: Prim.Type). (a :: Prim.Type) )

--- a/tests-integration/fixtures/checking/1774553700_instance_chain_stuck_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1774553700_instance_chain_stuck_matching/Main.snap
@@ -4,28 +4,32 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Unit :: Unit
-Spec :: forall (@g :: Type -> Type). Spec (g :: Type -> Type)
+Unit :: Main.Unit
+Spec :: forall (@g :: Prim.Type -> Prim.Type). Main.Spec (g :: Prim.Type -> Prim.Type)
 it ::
-  forall (t :: Type) (g :: Type -> Type).
-    Convert (t :: Type) (g :: Type -> Type) => String -> (t :: Type) -> Spec (g :: Type -> Type)
-action :: forall (m :: Type -> Type). (m :: Type -> Type) Unit
-test :: Spec Aff
-test2 :: Spec Aff
-test3 :: Spec Aff
+  forall (t :: Prim.Type) (g :: Prim.Type -> Prim.Type).
+    Main.Convert (t :: Prim.Type) (g :: Prim.Type -> Prim.Type) =>
+    Prim.String -> (t :: Prim.Type) -> Main.Spec (g :: Prim.Type -> Prim.Type)
+action :: forall (m :: Prim.Type -> Prim.Type). (m :: Prim.Type -> Prim.Type) Main.Unit
+test :: Main.Spec Effect.Aff.Aff
+test2 :: Main.Spec Effect.Aff.Aff
+test3 :: Main.Spec Effect.Aff.Aff
 
 Types
-Unit :: Type
-Spec :: (Type -> Type) -> Type
-Convert :: Type -> (Type -> Type) -> Constraint
+Unit :: Prim.Type
+Spec :: (Prim.Type -> Prim.Type) -> Prim.Type
+Convert :: Prim.Type -> (Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (m :: Type -> Type). Convert (t :: Type) (m :: Type -> Type)
+class forall (t :: Prim.Type) (m :: Prim.Type -> Prim.Type). Main.Convert (t :: Prim.Type) (m :: Prim.Type -> Prim.Type)
 
 Instances
-instance forall (t :: Type) (t1 :: Type -> Type).
-  Convert ((t :: Type) -> (t1 :: Type -> Type) Unit) (t1 :: Type -> Type)
-instance forall (t :: Type -> Type). Convert ((t :: Type -> Type) Unit) (t :: Type -> Type)
+instance forall (t :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+  Main.Convert
+    ((t :: Prim.Type) -> (t1 :: Prim.Type -> Prim.Type) Main.Unit)
+    (t1 :: Prim.Type -> Prim.Type)
+instance forall (t :: Prim.Type -> Prim.Type).
+  Main.Convert ((t :: Prim.Type -> Prim.Type) Main.Unit) (t :: Prim.Type -> Prim.Type)
 
 Roles
 Unit = []

--- a/tests-integration/fixtures/checking/1774667040_given_stuck_match_collapse/Main.snap
+++ b/tests-integration/fixtures/checking/1774667040_given_stuck_match_collapse/Main.snap
@@ -4,40 +4,43 @@ assertion_line: 50
 expression: report
 ---
 Terms
-show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
+show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 use ::
-  forall (f :: Type) (g :: Type) (h :: Type).
-    Match3 @Type @Type @Type (f :: Type) (g :: Type) (h :: Type) =>
-    (f :: Type) -> (g :: Type) -> (h :: Type) -> Int
-test :: Show A => Show B => Show C => Int
+  forall (f :: Prim.Type) (g :: Prim.Type) (h :: Prim.Type).
+    Main.Match3 @Prim.Type @Prim.Type @Prim.Type
+      (f :: Prim.Type)
+      (g :: Prim.Type)
+      (h :: Prim.Type) =>
+    (f :: Prim.Type) -> (g :: Prim.Type) -> (h :: Prim.Type) -> Prim.Int
+test :: Main.Show Main.A => Main.Show Main.B => Main.Show Main.C => Prim.Int
 
 Types
-Show :: Type -> Constraint
-A :: Type
-B :: Type
-C :: Type
-TypeEquals :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+Show :: Prim.Type -> Prim.Constraint
+A :: Prim.Type
+B :: Prim.Type
+C :: Prim.Type
+TypeEquals :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Constraint
 Match3 ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> Constraint
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Show (a :: Type)
-  show :: forall (@a :: Type). Show (a :: Type) => (a :: Type) -> String
-class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). TypeEquals @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
-class forall (t :: Type) (t1 :: Type) (t2 :: Type) (f :: (t :: Type)) (g :: (t1 :: Type)) (h :: (t2 :: Type)). Match3 @(t :: Type) @(t1 :: Type) @(t2 :: Type)
-  (f :: (t :: Type))
-  (g :: (t1 :: Type))
-  (h :: (t2 :: Type))
+class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
+  show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEquals @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
+class forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (f :: (t :: Prim.Type)) (g :: (t1 :: Prim.Type)) (h :: (t2 :: Prim.Type)). Main.Match3 @(t :: Prim.Type) @(t1 :: Prim.Type) @(t2 :: Prim.Type)
+  (f :: (t :: Prim.Type))
+  (g :: (t1 :: Prim.Type))
+  (h :: (t2 :: Prim.Type))
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type)).
-  TypeEquals @(t :: Type) (t1 :: (t :: Type)) (t1 :: (t :: Type))
-instance forall (t :: Type) (t1 :: Type) (t2 :: Type).
-  TypeEquals @Type (t :: Type) (A -> String) =>
-  TypeEquals @Type (t1 :: Type) (B -> String) =>
-  TypeEquals @Type (t2 :: Type) (C -> String) =>
-  Match3 @Type @Type @Type (t :: Type) (t1 :: Type) (t2 :: Type)
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.TypeEquals @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t1 :: (t :: Prim.Type))
+instance forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+  Main.TypeEquals @Prim.Type (t :: Prim.Type) (Main.A -> Prim.String) =>
+  Main.TypeEquals @Prim.Type (t1 :: Prim.Type) (Main.B -> Prim.String) =>
+  Main.TypeEquals @Prim.Type (t2 :: Prim.Type) (Main.C -> Prim.String) =>
+  Main.Match3 @Prim.Type @Prim.Type @Prim.Type (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type)
 
 Roles
 A = []

--- a/tests-integration/fixtures/checking/1774799580_let_binding_ambiguous_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1774799580_let_binding_ambiguous_constraint/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-delay :: Int -> Effect Unit
-test :: Effect Unit
+delay :: Prim.Int -> Effect.Effect Data.Unit.Unit
+test :: Effect.Effect Data.Unit.Unit
 
 Types

--- a/tests-integration/fixtures/checking/1777091040_row_union_open_duplicates/Main.snap
+++ b/tests-integration/fixtures/checking/1777091040_row_union_open_duplicates/Main.snap
@@ -4,29 +4,43 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 rightmostDuplicate ::
-  forall (l :: Row Type).
-    Union @Type (l :: Row Type) ( a :: String ) ( a :: Int, a :: String ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( a :: Prim.String )
+      ( a :: Prim.Int, a :: Prim.String ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 leftmostDuplicateMismatch ::
-  forall (l :: Row Type).
-    Union @Type (l :: Row Type) ( a :: String ) ( a :: String, a :: Int ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( a :: Prim.String )
+      ( a :: Prim.String, a :: Prim.Int ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 openOutputBackwards ::
-  forall (l :: Row Type) (r :: Row Type).
-    Union @Type (l :: Row Type) ( b :: String ) ( a :: Int, b :: String | (r :: Row Type) ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String | (r :: Prim.Row Prim.Type) ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 forceSolve ::
-  forall (t :: Row Type) (t1 :: Row Type).
-    Union @Type (t :: Row Type) ( b :: String ) ( a :: Int, b :: String | (t1 :: Row Type) ) =>
-    { leftmostDuplicateMismatch :: Proxy @(Row Type) ( a :: String )
-    , openOutputBackwards :: Proxy @(Row Type) (t :: Row Type)
-    , rightmostDuplicate :: Proxy @(Row Type) ( a :: Int )
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String | (t1 :: Prim.Row Prim.Type) ) =>
+    { leftmostDuplicateMismatch :: Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.String )
+    , openOutputBackwards :: Main.Proxy @(Prim.Row Prim.Type) (t :: Prim.Row Prim.Type)
+    , rightmostDuplicate :: Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int )
     }
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1777091100_row_union_documentation/Main.snap
+++ b/tests-integration/fixtures/checking/1777091100_row_union_documentation/Main.snap
@@ -4,61 +4,92 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 closedLeftOpenRight ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int ) ( b :: String | (r :: Row Type) ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int )
+      ( b :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 closedLeftKnownFields ::
-  forall (u :: Row Type).
-    Union @Type ( a :: Int ) ( b :: String ) (u :: Row Type) => Proxy @(Row Type) (u :: Row Type)
+  forall (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type ( a :: Prim.Int ) ( b :: Prim.String ) (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 closedLeftEmpty ::
-  forall (r :: Row Type) (u :: Row Type).
-    Union @Type () ( b :: String | (r :: Row Type) ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ()
+      ( b :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 closedRightOutputOpenLeft ::
-  forall (l :: Row Type).
-    Union @Type (l :: Row Type) ( b :: String ) ( a :: Int, b :: String ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 closedRightOutputKnownLeft ::
-  forall (l :: Row Type).
-    Union @Type
-      ( a :: Int | (l :: Row Type) )
-      ( b :: String )
-      ( a :: Int, b :: String, c :: Boolean ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int | (l :: Prim.Row Prim.Type) )
+      ( b :: Prim.String )
+      ( a :: Prim.Int, b :: Prim.String, c :: Prim.Boolean ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 closedRightOutputDuplicate ::
-  forall (l :: Row Type).
-    Union @Type (l :: Row Type) ( x :: String ) ( x :: Int, x :: String ) =>
-    Proxy @(Row Type) (l :: Row Type)
+  forall (l :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (l :: Prim.Row Prim.Type)
+      ( x :: Prim.String )
+      ( x :: Prim.Int, x :: Prim.String ) =>
+    Main.Proxy @(Prim.Row Prim.Type) (l :: Prim.Row Prim.Type)
 openLeftPrefixOne ::
-  forall (rest :: Row Type) (r :: Row Type) (u :: Row Type).
-    Union @Type
-      ( a :: Int | (rest :: Row Type) )
-      ( b :: String | (r :: Row Type) )
-      (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (rest :: Prim.Row Prim.Type) (r :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int | (rest :: Prim.Row Prim.Type) )
+      ( b :: Prim.String | (r :: Prim.Row Prim.Type) )
+      (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 openLeftPrefixMany ::
-  forall (rest :: Row Type) (u :: Row Type).
-    Union @Type ( a :: Int, b :: String | (rest :: Row Type) ) ( c :: Boolean ) (u :: Row Type) =>
-    Proxy @(Row Type) (u :: Row Type)
+  forall (rest :: Prim.Row Prim.Type) (u :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      ( a :: Prim.Int, b :: Prim.String | (rest :: Prim.Row Prim.Type) )
+      ( c :: Prim.Boolean )
+      (u :: Prim.Row Prim.Type) =>
+    Main.Proxy @(Prim.Row Prim.Type) (u :: Prim.Row Prim.Type)
 forceSolve ::
-  forall (t :: Row Type) (t1 :: Row Type) (t2 :: Row Type) (t3 :: Row Type) (t4 :: Row Type)
-    (t5 :: Row Type) (t6 :: Row Type).
-    Union @Type (t :: Row Type) ( b :: String | (t1 :: Row Type) ) (t2 :: Row Type) =>
-    Union @Type (t3 :: Row Type) ( c :: Boolean ) (t4 :: Row Type) =>
-    { closedLeftEmpty :: Proxy @(Row Type) ( b :: String | (t5 :: Row Type) )
-    , closedLeftKnownFields :: Proxy @(Row Type) ( a :: Int, b :: String )
-    , closedLeftOpenRight :: Proxy @(Row Type) ( a :: Int, b :: String | (t6 :: Row Type) )
-    , closedRightOutputDuplicate :: Proxy @(Row Type) ( x :: Int )
-    , closedRightOutputKnownLeft :: Proxy @(Row Type) ( c :: Boolean )
-    , closedRightOutputOpenLeft :: Proxy @(Row Type) ( a :: Int )
-    , openLeftPrefixMany :: Proxy @(Row Type) ( a :: Int, b :: String | (t4 :: Row Type) )
-    , openLeftPrefixOne :: Proxy @(Row Type) ( a :: Int | (t2 :: Row Type) )
+  forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Row Prim.Type)
+    (t3 :: Prim.Row Prim.Type) (t4 :: Prim.Row Prim.Type) (t5 :: Prim.Row Prim.Type)
+    (t6 :: Prim.Row Prim.Type).
+    Prim.Row.Union @Prim.Type
+      (t :: Prim.Row Prim.Type)
+      ( b :: Prim.String | (t1 :: Prim.Row Prim.Type) )
+      (t2 :: Prim.Row Prim.Type) =>
+    Prim.Row.Union @Prim.Type
+      (t3 :: Prim.Row Prim.Type)
+      ( c :: Prim.Boolean )
+      (t4 :: Prim.Row Prim.Type) =>
+    { closedLeftEmpty ::
+        Main.Proxy @(Prim.Row Prim.Type) ( b :: Prim.String | (t5 :: Prim.Row Prim.Type) )
+    , closedLeftKnownFields :: Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int, b :: Prim.String )
+    , closedLeftOpenRight ::
+        Main.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.Int, b :: Prim.String | (t6 :: Prim.Row Prim.Type) )
+    , closedRightOutputDuplicate :: Main.Proxy @(Prim.Row Prim.Type) ( x :: Prim.Int )
+    , closedRightOutputKnownLeft :: Main.Proxy @(Prim.Row Prim.Type) ( c :: Prim.Boolean )
+    , closedRightOutputOpenLeft :: Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int )
+    , openLeftPrefixMany ::
+        Main.Proxy @(Prim.Row Prim.Type)
+          ( a :: Prim.Int, b :: Prim.String | (t4 :: Prim.Row Prim.Type) )
+    , openLeftPrefixOne ::
+        Main.Proxy @(Prim.Row Prim.Type) ( a :: Prim.Int | (t2 :: Prim.Row Prim.Type) )
     }
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1777130640_instance_given_is_not_blocking/Main.snap
+++ b/tests-integration/fixtures/checking/1777130640_instance_given_is_not_blocking/Main.snap
@@ -5,23 +5,30 @@ expression: report
 ---
 Terms
 unsafeSet ::
-  forall (r1 :: Row Type) (r2 :: Row Type) (a :: Type).
-    String -> (a :: Type) -> {| (r1 :: Row Type) } -> {| (r2 :: Row Type) }
+  forall (r1 :: Prim.Row Prim.Type) (r2 :: Prim.Row Prim.Type) (a :: Prim.Type).
+    Prim.String ->
+    (a :: Prim.Type) ->
+    {| (r1 :: Prim.Row Prim.Type) } ->
+    {| (r2 :: Prim.Row Prim.Type) }
 buildIt ::
-  forall (@row :: Row Type) (@subrow :: Row Type).
-    BuildRecord (row :: Row Type) (subrow :: Row Type) => {| (subrow :: Row Type) }
+  forall (@row :: Prim.Row Prim.Type) (@subrow :: Prim.Row Prim.Type).
+    Main.BuildRecord (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type) =>
+    {| (subrow :: Prim.Row Prim.Type) }
 test ::
-  forall (r :: Row Type) (s :: Row Type).
-    BuildRecord (r :: Row Type) (s :: Row Type) => {| (s :: Row Type) }
+  forall (r :: Prim.Row Prim.Type) (s :: Prim.Row Prim.Type).
+    Main.BuildRecord (r :: Prim.Row Prim.Type) (s :: Prim.Row Prim.Type) =>
+    {| (s :: Prim.Row Prim.Type) }
 
 Types
-BuildRecord :: Row Type -> Row Type -> Constraint
+BuildRecord :: Prim.Row Prim.Type -> Prim.Row Prim.Type -> Prim.Constraint
 
 Classes
-class forall (row :: Row Type) (subrow :: Row Type). BuildRecord (row :: Row Type) (subrow :: Row Type)
+class forall (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type). Main.BuildRecord (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type)
   buildIt ::
-  forall (@row :: Row Type) (@subrow :: Row Type).
-    BuildRecord (row :: Row Type) (subrow :: Row Type) => {| (subrow :: Row Type) }
+  forall (@row :: Prim.Row Prim.Type) (@subrow :: Prim.Row Prim.Type).
+    Main.BuildRecord (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type) =>
+    {| (subrow :: Prim.Row Prim.Type) }
 
 Instances
-instance forall (t :: Row Type) (t1 :: Row Type). BuildRecord (t :: Row Type) (t1 :: Row Type)
+instance forall (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type).
+  Main.BuildRecord (t :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type)

--- a/tests-integration/fixtures/checking/1777201800_row_tail/Main.snap
+++ b/tests-integration/fixtures/checking/1777201800_row_tail/Main.snap
@@ -4,18 +4,28 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-tail :: forall (t :: Type) (r :: (t :: Type)). Proxy @(t :: Type) (r :: (t :: Type)) -> Int
-nonTail :: forall (t :: Type) (r :: (t :: Type)). Proxy @(t :: Type) (r :: (t :: Type)) -> Int
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+tail ::
+  forall (t :: Prim.Type) (r :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type)) -> Prim.Int
+nonTail ::
+  forall (t :: Prim.Type) (r :: (t :: Prim.Type)).
+    Main.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type)) -> Prim.Int
 asTail ::
-  forall (t :: Type).
-    Array (forall (r :: (t :: Type)). Proxy @(t :: Type) (r :: (t :: Type)) -> Int)
+  forall (t :: Prim.Type).
+    Prim.Array
+      (forall (r :: (t :: Prim.Type)).
+        Main.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type)) -> Prim.Int)
 asNonTail ::
-  forall (t :: Type).
-    Array (forall (r :: (t :: Type)). Proxy @(t :: Type) (r :: (t :: Type)) -> Int)
+  forall (t :: Prim.Type).
+    Prim.Array
+      (forall (r :: (t :: Prim.Type)).
+        Main.Proxy @(t :: Prim.Type) (r :: (t :: Prim.Type)) -> Prim.Int)
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1777201860_row_tail_record/Main.snap
+++ b/tests-integration/fixtures/checking/1777201860_row_tail_record/Main.snap
@@ -4,9 +4,10 @@ assertion_line: 50
 expression: report
 ---
 Terms
-tail :: forall (r :: Row Type). {| (r :: Row Type) } -> Int
-nonTail :: forall (r :: Row Type). {| (r :: Row Type) } -> Int
-asTail :: Array (forall (r :: Row Type). {| (r :: Row Type) } -> Int)
-asNonTail :: Array (forall (r :: Row Type). {| (r :: Row Type) } -> Int)
+tail :: forall (r :: Prim.Row Prim.Type). {| (r :: Prim.Row Prim.Type) } -> Prim.Int
+nonTail :: forall (r :: Prim.Row Prim.Type). {| (r :: Prim.Row Prim.Type) } -> Prim.Int
+asTail :: Prim.Array (forall (r :: Prim.Row Prim.Type). {| (r :: Prim.Row Prim.Type) } -> Prim.Int)
+asNonTail ::
+  Prim.Array (forall (r :: Prim.Row Prim.Type). {| (r :: Prim.Row Prim.Type) } -> Prim.Int)
 
 Types

--- a/tests-integration/fixtures/checking/1777287480_guarded_conditionals_checking/Main.snap
+++ b/tests-integration/fixtures/checking/1777287480_guarded_conditionals_checking/Main.snap
@@ -5,30 +5,35 @@ expression: report
 ---
 Terms
 singleton ::
-  forall (@f :: Type -> Type).
-    Build (f :: Type -> Type) =>
-    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Build (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type). (a :: Prim.Type) -> (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
 produce ::
-  forall (@f :: Type -> Type).
-    Build (f :: Type -> Type) =>
-    (forall (a :: Type) (b :: Type).
-      ((b :: Type) -> (a :: Type)) -> (b :: Type) -> (f :: Type -> Type) (a :: Type))
-identity :: forall (a :: Type). (a :: Type) -> (a :: Type)
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Build (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type) (b :: Prim.Type).
+      ((b :: Prim.Type) -> (a :: Prim.Type)) ->
+      (b :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+identity :: forall (a :: Prim.Type). (a :: Prim.Type) -> (a :: Prim.Type)
 test ::
-  forall (f :: Type -> Type).
-    Build (f :: Type -> Type) => Boolean -> Boolean -> (f :: Type -> Type) Boolean
+  forall (f :: Prim.Type -> Prim.Type).
+    Main.Build (f :: Prim.Type -> Prim.Type) =>
+    Prim.Boolean -> Prim.Boolean -> (f :: Prim.Type -> Prim.Type) Prim.Boolean
 
 Types
-Build :: (Type -> Type) -> Constraint
+Build :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (f :: Type -> Type). Build (f :: Type -> Type)
+class forall (f :: Prim.Type -> Prim.Type). Main.Build (f :: Prim.Type -> Prim.Type)
   singleton ::
-  forall (@f :: Type -> Type).
-    Build (f :: Type -> Type) =>
-    (forall (a :: Type). (a :: Type) -> (f :: Type -> Type) (a :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Build (f :: Prim.Type -> Prim.Type) =>
+    (forall (a :: Prim.Type). (a :: Prim.Type) -> (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
   produce ::
-  forall (@f :: Type -> Type).
-    Build (f :: Type -> Type) =>
-    (forall (a1 :: Type) (b :: Type).
-      ((b :: Type) -> (a1 :: Type)) -> (b :: Type) -> (f :: Type -> Type) (a1 :: Type))
+  forall (@f :: Prim.Type -> Prim.Type).
+    Main.Build (f :: Prim.Type -> Prim.Type) =>
+    (forall (a1 :: Prim.Type) (b :: Prim.Type).
+      ((b :: Prim.Type) -> (a1 :: Prim.Type)) ->
+      (b :: Prim.Type) ->
+      (f :: Prim.Type -> Prim.Type) (a1 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1777298160_instance_context_fail_deferred/Main.snap
+++ b/tests-integration/fixtures/checking/1777298160_instance_context_fail_deferred/Main.snap
@@ -1,17 +1,17 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-lazyFail :: forall (@a :: Type). LazyFail (a :: Type) => (a :: Type)
+lazyFail :: forall (@a :: Prim.Type). Main.LazyFail (a :: Prim.Type) => (a :: Prim.Type)
 
 Types
-LazyFail :: Type -> Constraint
+LazyFail :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). LazyFail (a :: Type)
-  lazyFail :: forall (@a :: Type). LazyFail (a :: Type) => (a :: Type)
+class forall (a :: Prim.Type). Main.LazyFail (a :: Prim.Type)
+  lazyFail :: forall (@a :: Prim.Type). Main.LazyFail (a :: Prim.Type) => (a :: Prim.Type)
 
 Instances
-instance Fail (Text "LazyFail") => LazyFail Int
+instance Prim.TypeError.Fail (Prim.TypeError.Text "LazyFail") => Main.LazyFail Prim.Int

--- a/tests-integration/fixtures/checking/1777298340_top_level_fail_eager/Main.snap
+++ b/tests-integration/fixtures/checking/1777298340_top_level_fail_eager/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-boom :: Fail (Text "top-level Fail was checked") => Int
-test :: Int
+boom :: Prim.TypeError.Fail (Prim.TypeError.Text "top-level Fail was checked") => Prim.Int
+test :: Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1777303980_let_retain_polymorphism/Main.snap
+++ b/tests-integration/fixtures/checking/1777303980_let_retain_polymorphism/Main.snap
@@ -5,21 +5,30 @@ expression: report
 ---
 Terms
 Tuple ::
-  forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
-append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
+append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 test ::
-  forall (a :: Type) (b :: Type).
-    Semigroup (a :: Type) =>
-    Semigroup (b :: Type) =>
-    (a :: Type) -> (a :: Type) -> (b :: Type) -> (b :: Type) -> Tuple (a :: Type) (b :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) =>
+    Main.Semigroup (b :: Prim.Type) =>
+    (a :: Prim.Type) ->
+    (a :: Prim.Type) ->
+    (b :: Prim.Type) ->
+    (b :: Prim.Type) ->
+    Main.Tuple (a :: Prim.Type) (b :: Prim.Type)
 
 Types
-Tuple :: Type -> Type -> Type
-Semigroup :: Type -> Constraint
+Tuple :: Prim.Type -> Prim.Type -> Prim.Type
+Semigroup :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semigroup (a :: Type)
-  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type)
+  append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 
 Roles
 Tuple = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1777463820_stress_test_row/Main.snap
+++ b/tests-integration/fixtures/checking/1777463820_stress_test_row/Main.snap
@@ -4,13 +4,18 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 build ::
-  forall (t :: Type) (t1 :: Type) (n :: (t :: Type)) (r :: (t1 :: Type)).
-    Build @(t :: Type) @(t1 :: Type) (n :: (t :: Type)) (r :: (t1 :: Type)) =>
-    Proxy @(t :: Type) (n :: (t :: Type)) -> Proxy @(t1 :: Type) (r :: (t1 :: Type))
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (n :: (t :: Prim.Type)) (r :: (t1 :: Prim.Type)).
+    Main.Build @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (n :: (t :: Prim.Type))
+      (r :: (t1 :: Prim.Type)) =>
+    Main.Proxy @(t :: Prim.Type) (n :: (t :: Prim.Type)) ->
+    Main.Proxy @(t1 :: Prim.Type) (r :: (t1 :: Prim.Type))
 test ::
-  Proxy @(Row Int)
+  Main.Proxy @(Prim.Row Prim.Int)
     ( n1 :: 1
     , n10 :: 10
     , n100 :: 100
@@ -10014,21 +10019,28 @@ test ::
     )
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-Build :: forall (t :: Type) (t1 :: Type). (t :: Type) -> (t1 :: Type) -> Constraint
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Build ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (t1 :: Type) (n :: (t :: Type)) (r :: (t1 :: Type)). Build @(t :: Type) @(t1 :: Type) (n :: (t :: Type)) (r :: (t1 :: Type))
+class forall (t :: Prim.Type) (t1 :: Prim.Type) (n :: (t :: Prim.Type)) (r :: (t1 :: Prim.Type)). Main.Build @(t :: Prim.Type) @(t1 :: Prim.Type) (n :: (t :: Prim.Type)) (r :: (t1 :: Prim.Type))
 
 Instances
-instance forall (t :: Type). Build @Int @(Row (t :: Type)) 0 ()
-instance forall (t :: Int) (t1 :: Int) (t2 :: Symbol) (t3 :: Symbol) (t4 :: Row Int) (t5 :: Row Int).
-  Add (t :: Int) 1 (t1 :: Int) =>
-  ToString (t1 :: Int) (t2 :: Symbol) =>
-  Append "n" (t2 :: Symbol) (t3 :: Symbol) =>
-  Build @Int @(Row Int) (t :: Int) (t4 :: Row Int) =>
-  Cons @Int (t3 :: Symbol) (t1 :: Int) (t4 :: Row Int) (t5 :: Row Int) =>
-  Build @Int @(Row Int) (t1 :: Int) (t5 :: Row Int)
+instance forall (t :: Prim.Type). Main.Build @Prim.Int @(Prim.Row (t :: Prim.Type)) 0 ()
+instance forall (t :: Prim.Int) (t1 :: Prim.Int) (t2 :: Prim.Symbol) (t3 :: Prim.Symbol)
+  (t4 :: Prim.Row Prim.Int) (t5 :: Prim.Row Prim.Int).
+  Prim.Int.Add (t :: Prim.Int) 1 (t1 :: Prim.Int) =>
+  Prim.Int.ToString (t1 :: Prim.Int) (t2 :: Prim.Symbol) =>
+  Prim.Symbol.Append "n" (t2 :: Prim.Symbol) (t3 :: Prim.Symbol) =>
+  Main.Build @Prim.Int @(Prim.Row Prim.Int) (t :: Prim.Int) (t4 :: Prim.Row Prim.Int) =>
+  Prim.Row.Cons @Prim.Int
+    (t3 :: Prim.Symbol)
+    (t1 :: Prim.Int)
+    (t4 :: Prim.Row Prim.Int)
+    (t5 :: Prim.Row Prim.Int) =>
+  Main.Build @Prim.Int @(Prim.Row Prim.Int) (t1 :: Prim.Int) (t5 :: Prim.Row Prim.Int)
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
+++ b/tests-integration/fixtures/checking/1777489980_expression_hole/Main.snap
@@ -4,7 +4,7 @@ assertion_line: 50
 expression: report
 ---
 Terms
-hole :: forall (t :: Type). (t :: Type)
+hole :: forall (t :: Prim.Type). (t :: Prim.Type)
 
 Types
 

--- a/tests-integration/fixtures/checking/1777626000_indexed_do_discard_continuation/Main.snap
+++ b/tests-integration/fixtures/checking/1777626000_indexed_do_discard_continuation/Main.snap
@@ -4,25 +4,29 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Unit :: Unit
+Unit :: Main.Unit
 pure ::
-  forall (hooks :: Type) (a :: Type).
-    (a :: Type) -> Render (hooks :: Type) (hooks :: Type) (a :: Type)
+  forall (hooks :: Prim.Type) (a :: Prim.Type).
+    (a :: Prim.Type) -> Main.Render (hooks :: Prim.Type) (hooks :: Prim.Type) (a :: Prim.Type)
 discard ::
-  forall (a :: Type) (b :: Type) (x :: Type) (y :: Type) (z :: Type).
-    Render (x :: Type) (y :: Type) (a :: Type) ->
-    ((a :: Type) -> Render (y :: Type) (z :: Type) (b :: Type)) ->
-    Render (x :: Type) (z :: Type) (b :: Type)
-use1 :: forall (hooks :: Type). Render (hooks :: Type) (Use1 (hooks :: Type)) Unit
-use2 :: forall (hooks :: Type). Render (hooks :: Type) (Use2 (hooks :: Type)) Unit
-test :: Render Start (Use2 (Use1 Start)) Unit
+  forall (a :: Prim.Type) (b :: Prim.Type) (x :: Prim.Type) (y :: Prim.Type) (z :: Prim.Type).
+    Main.Render (x :: Prim.Type) (y :: Prim.Type) (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Render (y :: Prim.Type) (z :: Prim.Type) (b :: Prim.Type)) ->
+    Main.Render (x :: Prim.Type) (z :: Prim.Type) (b :: Prim.Type)
+use1 ::
+  forall (hooks :: Prim.Type).
+    Main.Render (hooks :: Prim.Type) (Main.Use1 (hooks :: Prim.Type)) Main.Unit
+use2 ::
+  forall (hooks :: Prim.Type).
+    Main.Render (hooks :: Prim.Type) (Main.Use2 (hooks :: Prim.Type)) Main.Unit
+test :: Main.Render Main.Start (Main.Use2 (Main.Use1 Main.Start)) Main.Unit
 
 Types
-Render :: Type -> Type -> Type -> Type
-Unit :: Type
-Start :: Type
-Use1 :: Type -> Type
-Use2 :: Type -> Type
+Render :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Type
+Unit :: Prim.Type
+Start :: Prim.Type
+Use1 :: Prim.Type -> Prim.Type
+Use2 :: Prim.Type -> Prim.Type
 
 Roles
 Render = [Nominal, Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1777708740_row_tails_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1777708740_row_tails_higher_kinded/Main.snap
@@ -5,16 +5,24 @@ expression: report
 ---
 Terms
 unify ::
-  forall (r :: Row (Type -> Type)).
-    Box (r :: Row (Type -> Type)) -> Box (r :: Row (Type -> Type)) -> Box (r :: Row (Type -> Type))
-withF :: forall (r :: Row (Type -> Type)). Box ( f :: F | (r :: Row (Type -> Type)) )
-withG :: forall (r :: Row (Type -> Type)). Box ( g :: G | (r :: Row (Type -> Type)) )
-test :: forall (t :: Row (Type -> Type)). Box ( f :: F, g :: G | (t :: Row (Type -> Type)) )
+  forall (r :: Prim.Row (Prim.Type -> Prim.Type)).
+    Main.Box (r :: Prim.Row (Prim.Type -> Prim.Type)) ->
+    Main.Box (r :: Prim.Row (Prim.Type -> Prim.Type)) ->
+    Main.Box (r :: Prim.Row (Prim.Type -> Prim.Type))
+withF ::
+  forall (r :: Prim.Row (Prim.Type -> Prim.Type)).
+    Main.Box ( f :: Main.F | (r :: Prim.Row (Prim.Type -> Prim.Type)) )
+withG ::
+  forall (r :: Prim.Row (Prim.Type -> Prim.Type)).
+    Main.Box ( g :: Main.G | (r :: Prim.Row (Prim.Type -> Prim.Type)) )
+test ::
+  forall (t :: Prim.Row (Prim.Type -> Prim.Type)).
+    Main.Box ( f :: Main.F, g :: Main.G | (t :: Prim.Row (Prim.Type -> Prim.Type)) )
 
 Types
-F :: Type -> Type
-G :: Type -> Type
-Box :: Row (Type -> Type) -> Type
+F :: Prim.Type -> Prim.Type
+G :: Prim.Type -> Prim.Type
+Box :: Prim.Row (Prim.Type -> Prim.Type) -> Prim.Type
 
 Roles
 F = [Nominal]

--- a/tests-integration/fixtures/checking/1777708800_cross_module_instance_lookup/Main.snap
+++ b/tests-integration/fixtures/checking/1777708800_cross_module_instance_lookup/Main.snap
@@ -1,12 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 useBoth ::
-  forall (s :: Type) (m :: Type).
-    Marker (m :: Type) => Lookup (s :: Type) (m :: Type) => (s :: Type) -> Int
-test :: Int
+  forall (s :: Prim.Type) (m :: Prim.Type).
+    Class.Marker (m :: Prim.Type) =>
+    Class.Lookup (s :: Prim.Type) (m :: Prim.Type) =>
+    (s :: Prim.Type) -> Prim.Int
+test :: Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1777708860_local_instance_conflict/Main.snap
+++ b/tests-integration/fixtures/checking/1777708860_local_instance_conflict/Main.snap
@@ -1,20 +1,20 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-classInt :: Int
-test :: Array Int
+classInt :: Prim.Int
+test :: Prim.Array Prim.Int
 
 Types
-Class :: Type -> Constraint
+Class :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Class (a :: Type)
+class forall (a :: Prim.Type). Main.Class (a :: Prim.Type)
 
 Instances
-instance Class
+instance Main.Class
 
 Diagnostics
 error[InstanceHeadMismatch]: Instance head mismatch: expected 1 arguments, got 0

--- a/tests-integration/fixtures/checking/1777710900_prim_int_compare_concrete_seed/Main.snap
+++ b/tests-integration/fixtures/checking/1777710900_prim_int_compare_concrete_seed/Main.snap
@@ -5,23 +5,29 @@ expression: report
 ---
 Terms
 assertGreater ::
-  forall (l :: Int) (r :: Int).
-    Compare (l :: Int) (r :: Int) GT => Proxy @(Row Int) ( left :: (l :: Int), right :: (r :: Int) )
+  forall (l :: Prim.Int) (r :: Prim.Int).
+    Prim.Int.Compare (l :: Prim.Int) (r :: Prim.Int) Prim.Ordering.GT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (l :: Prim.Int), right :: (r :: Prim.Int) )
 assertLesser ::
-  forall (l :: Int) (r :: Int).
-    Compare (l :: Int) (r :: Int) LT => Proxy @(Row Int) ( left :: (l :: Int), right :: (r :: Int) )
+  forall (l :: Prim.Int) (r :: Prim.Int).
+    Prim.Int.Compare (l :: Prim.Int) (r :: Prim.Int) Prim.Ordering.LT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (l :: Prim.Int), right :: (r :: Prim.Int) )
 weakenZeroToNegOne ::
-  forall (h :: Int).
-    Compare (h :: Int) 0 GT => Proxy @(Row Int) ( left :: (h :: Int), right :: (-1) )
+  forall (h :: Prim.Int).
+    Prim.Int.Compare (h :: Prim.Int) 0 Prim.Ordering.GT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (h :: Prim.Int), right :: (-1) )
 weakenZeroToNegTwo ::
-  forall (h :: Int).
-    Compare (h :: Int) 0 GT => Proxy @(Row Int) ( left :: (h :: Int), right :: (-2) )
+  forall (h :: Prim.Int).
+    Prim.Int.Compare (h :: Prim.Int) 0 Prim.Ordering.GT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (h :: Prim.Int), right :: (-2) )
 weakenZeroLT ::
-  forall (h :: Int). Compare (h :: Int) 0 LT => Proxy @(Row Int) ( left :: (h :: Int), right :: 1 )
+  forall (h :: Prim.Int).
+    Prim.Int.Compare (h :: Prim.Int) 0 Prim.Ordering.LT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (h :: Prim.Int), right :: 1 )
 chainAbstractAndConcrete ::
-  forall (h :: Int) (k :: Int).
-    Compare (h :: Int) (k :: Int) GT =>
-    Compare (k :: Int) 5 GT =>
-    Proxy @(Row Int) ( left :: (h :: Int), right :: 4 )
+  forall (h :: Prim.Int) (k :: Prim.Int).
+    Prim.Int.Compare (h :: Prim.Int) (k :: Prim.Int) Prim.Ordering.GT =>
+    Prim.Int.Compare (k :: Prim.Int) 5 Prim.Ordering.GT =>
+    Type.Proxy.Proxy @(Prim.Row Prim.Int) ( left :: (h :: Prim.Int), right :: 4 )
 
 Types

--- a/tests-integration/fixtures/checking/1777725840_derive_newtype_recursive_record/Main.snap
+++ b/tests-integration/fixtures/checking/1777725840_derive_newtype_recursive_record/Main.snap
@@ -4,22 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Nothing :: forall (@a :: Type). Maybe (a :: Type)
-Just :: forall (@a :: Type). (a :: Type) -> Maybe (a :: Type)
+Nothing :: forall (@a :: Prim.Type). Main.Maybe (a :: Prim.Type)
+Just :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Maybe (a :: Prim.Type)
 List ::
-  forall (t :: Type) (@a :: (t :: Type)).
-    { head :: Int, tail :: Maybe (List @(t :: Type) (a :: (t :: Type))) } ->
-    List @(t :: Type) (a :: (t :: Type))
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)).
+    { head :: Prim.Int
+    , tail :: Main.Maybe (Main.List @(t :: Prim.Type) (a :: (t :: Prim.Type)))
+    } ->
+    Main.List @(t :: Prim.Type) (a :: (t :: Prim.Type))
 
 Types
-Maybe :: Type -> Type
-List :: forall (t :: Type). (t :: Type) -> Type
+Maybe :: Prim.Type -> Prim.Type
+List :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
 
 Instances
-instance forall (t :: Type). Eq (t :: Type) => Eq (Maybe (t :: Type))
+instance forall (t :: Prim.Type). Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.Maybe (t :: Prim.Type))
 
 Derived
-derive forall (t :: Type). Eq (t :: Type) => Eq (List @Type (t :: Type))
+derive forall (t :: Prim.Type).
+  Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Main.List @Prim.Type (t :: Prim.Type))
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1777825440_irrefutable_variable_pattern/Main.snap
+++ b/tests-integration/fixtures/checking/1777825440_irrefutable_variable_pattern/Main.snap
@@ -1,13 +1,13 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-variable :: Array Int -> Int
-wildcard :: Array Int -> Int
-refutable :: Array Int -> Int
-arrayLength :: forall (a :: Type). Array (a :: Type) -> Int
+variable :: Prim.Array Prim.Int -> Prim.Int
+wildcard :: Prim.Array Prim.Int -> Prim.Int
+refutable :: Prim.Array Prim.Int -> Prim.Int
+arrayLength :: forall (a :: Prim.Type). Prim.Array (a :: Prim.Type) -> Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1777825620_instance_chain_skolem/Main.snap
+++ b/tests-integration/fixtures/checking/1777825620_instance_chain_skolem/Main.snap
@@ -5,40 +5,45 @@ expression: report
 ---
 Terms
 step ::
-  forall (@f :: Type) (@a :: Type) (@x :: Type) (@a' :: Type).
-    Step (f :: Type) (a :: Type) (x :: Type) (a' :: Type) =>
-    (f :: Type) -> (a :: Type) -> (x :: Type) -> (a' :: Type)
+  forall (@f :: Prim.Type) (@a :: Prim.Type) (@x :: Prim.Type) (@a' :: Prim.Type).
+    Main.Step (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) (a' :: Prim.Type) =>
+    (f :: Prim.Type) -> (a :: Prim.Type) -> (x :: Prim.Type) -> (a' :: Prim.Type)
 done ::
-  forall (@f :: Type) (@a :: Type) (@x :: Type).
-    Done (f :: Type) (a :: Type) (x :: Type) => (f :: Type) -> (a :: Type) -> (x :: Type)
+  forall (@f :: Prim.Type) (@a :: Prim.Type) (@x :: Prim.Type).
+    Main.Done (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) =>
+    (f :: Prim.Type) -> (a :: Prim.Type) -> (x :: Prim.Type)
 walk ::
-  forall (@f :: Type) (@a :: Type) (@r :: Type).
-    Walk (f :: Type) (a :: Type) (r :: Type) => (f :: Type) -> (a :: Type) -> (r :: Type)
+  forall (@f :: Prim.Type) (@a :: Prim.Type) (@r :: Prim.Type).
+    Main.Walk (f :: Prim.Type) (a :: Prim.Type) (r :: Prim.Type) =>
+    (f :: Prim.Type) -> (a :: Prim.Type) -> (r :: Prim.Type)
 
 Types
-Step :: Type -> Type -> Type -> Type -> Constraint
-Done :: Type -> Type -> Type -> Constraint
-Walk :: Type -> Type -> Type -> Constraint
+Step :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Type -> Prim.Constraint
+Done :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Constraint
+Walk :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (f :: Type) (a :: Type) (x :: Type) (a' :: Type). Step (f :: Type) (a :: Type) (x :: Type) (a' :: Type)
+class forall (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) (a' :: Prim.Type). Main.Step (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) (a' :: Prim.Type)
   step ::
-  forall (@f :: Type) (@a :: Type) (@x :: Type) (@a' :: Type).
-    Step (f :: Type) (a :: Type) (x :: Type) (a' :: Type) =>
-    (f :: Type) -> (a :: Type) -> (x :: Type) -> (a' :: Type)
-class forall (f :: Type) (a :: Type) (x :: Type). Done (f :: Type) (a :: Type) (x :: Type)
+  forall (@f :: Prim.Type) (@a :: Prim.Type) (@x :: Prim.Type) (@a' :: Prim.Type).
+    Main.Step (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) (a' :: Prim.Type) =>
+    (f :: Prim.Type) -> (a :: Prim.Type) -> (x :: Prim.Type) -> (a' :: Prim.Type)
+class forall (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type). Main.Done (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type)
   done ::
-  forall (@f :: Type) (@a :: Type) (@x :: Type).
-    Done (f :: Type) (a :: Type) (x :: Type) => (f :: Type) -> (a :: Type) -> (x :: Type)
-class forall (f :: Type) (a :: Type) (r :: Type). Walk (f :: Type) (a :: Type) (r :: Type)
+  forall (@f :: Prim.Type) (@a :: Prim.Type) (@x :: Prim.Type).
+    Main.Done (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) =>
+    (f :: Prim.Type) -> (a :: Prim.Type) -> (x :: Prim.Type)
+class forall (f :: Prim.Type) (a :: Prim.Type) (r :: Prim.Type). Main.Walk (f :: Prim.Type) (a :: Prim.Type) (r :: Prim.Type)
   walk ::
-  forall (@f :: Type) (@a :: Type) (@r :: Type).
-    Walk (f :: Type) (a :: Type) (r :: Type) => (f :: Type) -> (a :: Type) -> (r :: Type)
+  forall (@f :: Prim.Type) (@a :: Prim.Type) (@r :: Prim.Type).
+    Main.Walk (f :: Prim.Type) (a :: Prim.Type) (r :: Prim.Type) =>
+    (f :: Prim.Type) -> (a :: Prim.Type) -> (r :: Prim.Type)
 
 Instances
-instance forall (t :: Type) (t1 :: Type) (t2 :: Type) (t3 :: Type) (t4 :: Type).
-  Step (t :: Type) (t1 :: Type) (t2 :: Type) (t3 :: Type) =>
-  Walk (t :: Type) (t3 :: Type) (t4 :: Type) =>
-  Walk (t :: Type) (t1 :: Type) ((t2 :: Type) -> (t4 :: Type))
-instance forall (t :: Type) (t1 :: Type) (t2 :: Type).
-  Done (t :: Type) (t1 :: Type) (t2 :: Type) => Walk (t :: Type) (t1 :: Type) (t2 :: Type)
+instance forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type).
+  Main.Step (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) =>
+  Main.Walk (t :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type) =>
+  Main.Walk (t :: Prim.Type) (t1 :: Prim.Type) ((t2 :: Prim.Type) -> (t4 :: Prim.Type))
+instance forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+  Main.Done (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) =>
+  Main.Walk (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type)

--- a/tests-integration/fixtures/checking/1777829280_lacks_empty_closed_row_skolem/Main.snap
+++ b/tests-integration/fixtures/checking/1777829280_lacks_empty_closed_row_skolem/Main.snap
@@ -5,8 +5,10 @@ expression: report
 ---
 Terms
 useLacksEmpty ::
-  forall (t :: Type) (name :: Symbol).
-    Lacks @(t :: Type) (name :: Symbol) () => Proxy @Symbol (name :: Symbol) -> Int
-forwardLacksEmpty :: forall (name :: Symbol). Proxy @Symbol (name :: Symbol) -> Int
+  forall (t :: Prim.Type) (name :: Prim.Symbol).
+    Prim.Row.Lacks @(t :: Prim.Type) (name :: Prim.Symbol) () =>
+    Type.Proxy.Proxy @Prim.Symbol (name :: Prim.Symbol) -> Prim.Int
+forwardLacksEmpty ::
+  forall (name :: Prim.Symbol). Type.Proxy.Proxy @Prim.Symbol (name :: Prim.Symbol) -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1777834140_coercible_via_newtype_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1777834140_coercible_via_newtype_superclass/Main.snap
@@ -4,7 +4,13 @@ assertion_line: 50
 expression: report
 ---
 Terms
-useUnwrap :: forall (t :: Type). Newtype @Type (t :: Type) HiddenInt => (t :: Type) -> HiddenInt
-useCoerce :: forall (t :: Type). Newtype @Type (t :: Type) HiddenInt => (t :: Type) -> HiddenInt
+useUnwrap ::
+  forall (t :: Prim.Type).
+    Data.Newtype.Newtype @Prim.Type (t :: Prim.Type) Lib.HiddenInt =>
+    (t :: Prim.Type) -> Lib.HiddenInt
+useCoerce ::
+  forall (t :: Prim.Type).
+    Data.Newtype.Newtype @Prim.Type (t :: Prim.Type) Lib.HiddenInt =>
+    (t :: Prim.Type) -> Lib.HiddenInt
 
 Types

--- a/tests-integration/fixtures/checking/1777993860_type_application_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1777993860_type_application_instantiation/Main.snap
@@ -4,18 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-const :: forall (@a :: Type) (b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-Left :: forall (@a :: Type) (@b :: Type). (a :: Type) -> Either (a :: Type) (b :: Type)
-Right :: forall (@a :: Type) (@b :: Type). (b :: Type) -> Either (a :: Type) (b :: Type)
+const ::
+  forall (@a :: Prim.Type) (b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+Left ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
+Right ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (b :: Prim.Type) -> Main.Either (a :: Prim.Type) (b :: Prim.Type)
 forceSolve ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    { const :: Int -> (t :: Type) -> Int
-    , left :: Int -> Either Int (t1 :: Type)
-    , right :: (t2 :: Type) -> Either Int (t2 :: Type)
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    { const :: Prim.Int -> (t :: Prim.Type) -> Prim.Int
+    , left :: Prim.Int -> Main.Either Prim.Int (t1 :: Prim.Type)
+    , right :: (t2 :: Prim.Type) -> Main.Either Prim.Int (t2 :: Prim.Type)
     }
 
 Types
-Either :: Type -> Type -> Type
+Either :: Prim.Type -> Prim.Type -> Prim.Type
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1778008860_kind_variable_visibility/Main.snap
+++ b/tests-integration/fixtures/checking/1778008860_kind_variable_visibility/Main.snap
@@ -1,13 +1,15 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Types
-Proxy :: forall (@k :: Type). (k :: Type) -> Type
+Proxy :: forall (@k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1778010840_wildcard_arity/Main.snap
+++ b/tests-integration/fixtures/checking/1778010840_wildcard_arity/Main.snap
@@ -4,6 +4,8 @@ assertion_line: 50
 expression: report
 ---
 Terms
-example :: forall (t :: Type) (t1 :: Type). Int -> (t :: Type) -> (t1 :: Type) -> Int
+example ::
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    Prim.Int -> (t :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1778051400_record_pun_constrained_field/Main.snap
+++ b/tests-integration/fixtures/checking/1778051400_record_pun_constrained_field/Main.snap
@@ -5,17 +5,21 @@ expression: report
 ---
 Terms
 fetch ::
-  forall (m :: Type -> Type). Capability (m :: Type -> Type) => Int -> (m :: Type -> Type) Int
-test :: Setup
+  forall (m :: Prim.Type -> Prim.Type).
+    Main.Capability (m :: Prim.Type -> Prim.Type) =>
+    Prim.Int -> (m :: Prim.Type -> Prim.Type) Prim.Int
+test :: Main.Setup
 
 Types
-Capability :: (Type -> Type) -> Constraint
-Setup :: Type
+Capability :: (Prim.Type -> Prim.Type) -> Prim.Constraint
+Setup :: Prim.Type
 
 Synonyms
 type Setup = { fetch ::
-    forall (m :: Type -> Type). Capability (m :: Type -> Type) => Int -> (m :: Type -> Type) Int
+    forall (m :: Prim.Type -> Prim.Type).
+      Main.Capability (m :: Prim.Type -> Prim.Type) =>
+      Prim.Int -> (m :: Prim.Type -> Prim.Type) Prim.Int
 }
 
 Classes
-class forall (m :: Type -> Type). Capability (m :: Type -> Type)
+class forall (m :: Prim.Type -> Prim.Type). Main.Capability (m :: Prim.Type -> Prim.Type)

--- a/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.snap
+++ b/tests-integration/fixtures/checking/1778051460_bare_row_tail_syntax/Main.snap
@@ -4,11 +4,11 @@ assertion_line: 50
 expression: report
 ---
 Terms
-bareTail :: forall (opts :: Type). (opts :: Type) -> Int
-plainTail :: forall (opts :: Type). (opts :: Type) -> Int
-recordTail :: forall (opts :: Row Type). {| (opts :: Row Type) } -> Int
-withBareTail :: Int
-withPlainTail :: Int
-withRecordTail :: Int
+bareTail :: forall (opts :: Prim.Type). (opts :: Prim.Type) -> Prim.Int
+plainTail :: forall (opts :: Prim.Type). (opts :: Prim.Type) -> Prim.Int
+recordTail :: forall (opts :: Prim.Row Prim.Type). {| (opts :: Prim.Row Prim.Type) } -> Prim.Int
+withBareTail :: Prim.Int
+withPlainTail :: Prim.Int
+withRecordTail :: Prim.Int
 
 Types

--- a/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.snap
+++ b/tests-integration/fixtures/checking/1778051520_constrained_pattern_scrutinee/Main.snap
@@ -4,19 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
-method :: forall (@route :: Type). Route (route :: Type) => Box (route :: Type)
-routeCase :: forall (@route :: Type). Route (route :: Type) => (route :: Type)
-routeLet :: forall (@route :: Type). Route (route :: Type) => (route :: Type)
-routeGuard :: forall (@route :: Type). Route (route :: Type) => (route :: Type)
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
+method ::
+  forall (@route :: Prim.Type). Main.Route (route :: Prim.Type) => Main.Box (route :: Prim.Type)
+routeCase :: forall (@route :: Prim.Type). Main.Route (route :: Prim.Type) => (route :: Prim.Type)
+routeLet :: forall (@route :: Prim.Type). Main.Route (route :: Prim.Type) => (route :: Prim.Type)
+routeGuard :: forall (@route :: Prim.Type). Main.Route (route :: Prim.Type) => (route :: Prim.Type)
 
 Types
-Box :: Type -> Type
-Route :: Type -> Constraint
+Box :: Prim.Type -> Prim.Type
+Route :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (route :: Type). Route (route :: Type)
-  method :: forall (@route :: Type). Route (route :: Type) => Box (route :: Type)
+class forall (route :: Prim.Type). Main.Route (route :: Prim.Type)
+  method ::
+  forall (@route :: Prim.Type). Main.Route (route :: Prim.Type) => Main.Box (route :: Prim.Type)
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
+++ b/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
@@ -5,47 +5,51 @@ expression: report
 ---
 Terms
 isEq ::
-  forall (@a :: Type) (@b :: Type) (@o :: Type).
-    IsEq (a :: Type) (b :: Type) (o :: Type) => (a :: Type) -> (b :: Type) -> (o :: Type)
-Unit :: Unit
-Output :: Output
-testEqConcrete :: Output
-testSkolemRight :: forall (x :: Type). (x :: Type) -> Output
-testSkolemLeft :: forall (x :: Type). (x :: Type) -> Output
-testSkolemIsEq :: forall (x :: Type) (y :: Type). (x :: Type) -> (y :: Type) -> Output
+  forall (@a :: Prim.Type) (@b :: Prim.Type) (@o :: Prim.Type).
+    Main.IsEq (a :: Prim.Type) (b :: Prim.Type) (o :: Prim.Type) =>
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (o :: Prim.Type)
+Unit :: Main.Unit
+Output :: Main.Output
+testEqConcrete :: Main.Output
+testSkolemRight :: forall (x :: Prim.Type). (x :: Prim.Type) -> Main.Output
+testSkolemLeft :: forall (x :: Prim.Type). (x :: Prim.Type) -> Main.Output
+testSkolemIsEq ::
+  forall (x :: Prim.Type) (y :: Prim.Type). (x :: Prim.Type) -> (y :: Prim.Type) -> Main.Output
 typeEquals ::
-  forall (t :: Type) (@a :: (t :: Type)) (@b :: (t :: Type)).
-    TypeEquals @(t :: Type) (a :: (t :: Type)) (b :: (t :: Type)) => Unit
-testOpenRows :: Unit
+  forall (t :: Prim.Type) (@a :: (t :: Prim.Type)) (@b :: (t :: Prim.Type)).
+    Main.TypeEquals @(t :: Prim.Type) (a :: (t :: Prim.Type)) (b :: (t :: Prim.Type)) => Main.Unit
+testOpenRows :: Main.Unit
 rowSame ::
-  forall (k :: Type) (@a :: (k :: Type)) (@b :: (k :: Type)).
-    RowSame @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) => Unit
-testOpenRowsNoFd :: Unit
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)) (@b :: (k :: Prim.Type)).
+    Main.RowSame @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)) => Main.Unit
+testOpenRowsNoFd :: Main.Unit
 
 Types
-IsEq :: Type -> Type -> Type -> Constraint
-Unit :: Type
-Output :: Type
-TypeEquals :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
-RowSame :: forall (k :: Type). (k :: Type) -> (k :: Type) -> Constraint
+IsEq :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Constraint
+Unit :: Prim.Type
+Output :: Prim.Type
+TypeEquals :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Constraint
+RowSame :: forall (k :: Prim.Type). (k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (a :: Type) (b :: Type) (o :: Type). IsEq (a :: Type) (b :: Type) (o :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type) (o :: Prim.Type). Main.IsEq (a :: Prim.Type) (b :: Prim.Type) (o :: Prim.Type)
   isEq ::
-  forall (@a :: Type) (@b :: Type) (@o :: Type).
-    IsEq (a :: Type) (b :: Type) (o :: Type) => (a :: Type) -> (b :: Type) -> (o :: Type)
-class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). TypeEquals @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
-class forall (k :: Type) (a :: (k :: Type)) (b :: (k :: Type)). RowSame @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type))
+  forall (@a :: Prim.Type) (@b :: Prim.Type) (@o :: Prim.Type).
+    Main.IsEq (a :: Prim.Type) (b :: Prim.Type) (o :: Prim.Type) =>
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (o :: Prim.Type)
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEquals @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.RowSame @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
   rowSame ::
-  forall (k :: Type) (@a :: (k :: Type)) (@b :: (k :: Type)).
-    RowSame @(k :: Type) (a :: (k :: Type)) (b :: (k :: Type)) => Unit
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)) (@b :: (k :: Prim.Type)).
+    Main.RowSame @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)) => Main.Unit
 
 Instances
-instance forall (t :: Type). IsEq (t :: Type) (t :: Type) Output
-instance forall (t :: Type) (t1 :: Type). IsEq (t :: Type) (t1 :: Type) Output
-instance forall (t :: Type) (t1 :: (t :: Type)).
-  TypeEquals @(t :: Type) (t1 :: (t :: Type)) (t1 :: (t :: Type))
-instance forall (t :: Type) (t1 :: (t :: Type)). RowSame @(t :: Type) (t1 :: (t :: Type)) (t1 :: (t :: Type))
+instance forall (t :: Prim.Type). Main.IsEq (t :: Prim.Type) (t :: Prim.Type) Main.Output
+instance forall (t :: Prim.Type) (t1 :: Prim.Type). Main.IsEq (t :: Prim.Type) (t1 :: Prim.Type) Main.Output
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.TypeEquals @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t1 :: (t :: Prim.Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.RowSame @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) (t1 :: (t :: Prim.Type))
 
 Roles
 Unit = []

--- a/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
@@ -4,31 +4,38 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-K1 :: K1
-Unit :: Unit
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+K1 :: Main.K1
+Unit :: Main.Unit
 c ::
-  forall (@key :: Type) (@row :: Row Type).
-    C (key :: Type) (row :: Row Type) =>
-    Proxy @Type (key :: Type) -> Proxy @(Row Type) (row :: Row Type) -> Unit
-test :: forall (key :: Type). Proxy @Type (key :: Type) -> Unit
+  forall (@key :: Prim.Type) (@row :: Prim.Row Prim.Type).
+    Main.C (key :: Prim.Type) (row :: Prim.Row Prim.Type) =>
+    Main.Proxy @Prim.Type (key :: Prim.Type) ->
+    Main.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type) ->
+    Main.Unit
+test :: forall (key :: Prim.Type). Main.Proxy @Prim.Type (key :: Prim.Type) -> Main.Unit
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-K1 :: Type
-Unit :: Type
-C :: Type -> Row Type -> Constraint
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+K1 :: Prim.Type
+Unit :: Prim.Type
+C :: Prim.Type -> Prim.Row Prim.Type -> Prim.Constraint
 
 Classes
-class forall (key :: Type) (row :: Row Type). C (key :: Type) (row :: Row Type)
+class forall (key :: Prim.Type) (row :: Prim.Row Prim.Type). Main.C (key :: Prim.Type) (row :: Prim.Row Prim.Type)
   c ::
-  forall (@key :: Type) (@row :: Row Type).
-    C (key :: Type) (row :: Row Type) =>
-    Proxy @Type (key :: Type) -> Proxy @(Row Type) (row :: Row Type) -> Unit
+  forall (@key :: Prim.Type) (@row :: Prim.Row Prim.Type).
+    Main.C (key :: Prim.Type) (row :: Prim.Row Prim.Type) =>
+    Main.Proxy @Prim.Type (key :: Prim.Type) ->
+    Main.Proxy @(Prim.Row Prim.Type) (row :: Prim.Row Prim.Type) ->
+    Main.Unit
 
 Instances
-instance C K1 ( a :: Int, b :: Boolean )
-instance forall (t :: Type) (t1 :: Row Type). C (t :: Type) ( a :: String, b :: Boolean | (t1 :: Row Type) )
+instance Main.C Main.K1 ( a :: Prim.Int, b :: Prim.Boolean )
+instance forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type).
+  Main.C (t :: Prim.Type) ( a :: Prim.String, b :: Prim.Boolean | (t1 :: Prim.Row Prim.Type) )
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.snap
+++ b/tests-integration/fixtures/checking/1778051700_record_field_parenthesized_instantiation/Main.snap
@@ -4,13 +4,24 @@ assertion_line: 50
 expression: report
 ---
 Terms
-const :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-choose :: Int -> (forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type))
+const ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+choose ::
+  Prim.Int ->
+  (forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type))
 normal ::
-  forall (t :: Type) (t1 :: Type). { parenthesised :: (t :: Type) -> (t1 :: Type) -> (t :: Type) }
+  forall (t :: Prim.Type) (t1 :: Prim.Type).
+    { parenthesised :: (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t :: Prim.Type) }
 prenex ::
-  { application :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type)
-  , variable :: Int -> (forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> (a :: Type))
+  { application ::
+      forall (@a :: Prim.Type) (@b :: Prim.Type).
+        (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type)
+  , variable ::
+      Prim.Int ->
+      (forall (@a :: Prim.Type) (@b :: Prim.Type).
+        (a :: Prim.Type) -> (b :: Prim.Type) -> (a :: Prim.Type))
   }
 
 Types

--- a/tests-integration/fixtures/checking/1778758320_function_application_instance_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1778758320_function_application_instance_matching/Main.snap
@@ -4,17 +4,25 @@ assertion_line: 50
 expression: report
 ---
 Terms
-disj :: forall (@a :: Type). HeytingAlgebra (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-test :: Function Char Boolean -> Function Char Boolean -> Function Char Boolean
+disj ::
+  forall (@a :: Prim.Type).
+    Main.HeytingAlgebra (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+test ::
+  Prim.Function Prim.Char Prim.Boolean ->
+  Prim.Function Prim.Char Prim.Boolean ->
+  Prim.Function Prim.Char Prim.Boolean
 
 Types
-HeytingAlgebra :: Type -> Constraint
+HeytingAlgebra :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). HeytingAlgebra (a :: Type)
-  disj :: forall (@a :: Type). HeytingAlgebra (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.HeytingAlgebra (a :: Prim.Type)
+  disj ::
+  forall (@a :: Prim.Type).
+    Main.HeytingAlgebra (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance HeytingAlgebra Boolean
-instance forall (t :: Type) (t1 :: Type).
-  HeytingAlgebra (t :: Type) => HeytingAlgebra ((t1 :: Type) -> (t :: Type))
+instance Main.HeytingAlgebra Prim.Boolean
+instance forall (t :: Prim.Type) (t1 :: Prim.Type).
+  Main.HeytingAlgebra (t :: Prim.Type) =>
+  Main.HeytingAlgebra ((t1 :: Prim.Type) -> (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1778814600_synonym_kind_expansion/Main.snap
+++ b/tests-integration/fixtures/checking/1778814600_synonym_kind_expansion/Main.snap
@@ -1,14 +1,14 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
 
 Types
-TypeToType :: Type
-ApplyAliasKind :: TypeToType -> Type
+TypeToType :: Prim.Type
+ApplyAliasKind :: Main.TypeToType -> Prim.Type
 
 Synonyms
-type TypeToType = Type -> Type
-type ApplyAliasKind f = (f :: TypeToType) Int
+type TypeToType = Prim.Type -> Prim.Type
+type ApplyAliasKind f = (f :: Main.TypeToType) Prim.Int

--- a/tests-integration/fixtures/checking/1778816760_higher_rank_newtype_argument_binder/Main.snap
+++ b/tests-integration/fixtures/checking/1778816760_higher_rank_newtype_argument_binder/Main.snap
@@ -5,19 +5,22 @@ expression: report
 ---
 Terms
 Z3 ::
-  forall (@r :: Type) (@mode :: Type) (@a :: Type).
-    Aff (a :: Type) -> Z3 (r :: Type) (mode :: Type) (a :: Type)
+  forall (@r :: Prim.Type) (@mode :: Prim.Type) (@a :: Prim.Type).
+    Main.Aff (a :: Prim.Type) -> Main.Z3 (r :: Prim.Type) (mode :: Prim.Type) (a :: Prim.Type)
 run ::
-  forall (a :: Type).
-    (forall (r :: Type) (mode :: Type). Z3 (r :: Type) (mode :: Type) (a :: Type)) ->
-    Aff (a :: Type)
-Box :: forall (@a :: Type). (a :: Type) -> Box (a :: Type)
-unbox :: (forall (a :: Type). Box (a :: Type)) -> (forall (a1 :: Type). (a1 :: Type))
+  forall (a :: Prim.Type).
+    (forall (r :: Prim.Type) (mode :: Prim.Type).
+      Main.Z3 (r :: Prim.Type) (mode :: Prim.Type) (a :: Prim.Type)) ->
+    Main.Aff (a :: Prim.Type)
+Box :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Box (a :: Prim.Type)
+unbox ::
+  (forall (a :: Prim.Type). Main.Box (a :: Prim.Type)) ->
+  (forall (a1 :: Prim.Type). (a1 :: Prim.Type))
 
 Types
-Aff :: Type -> Type
-Z3 :: Type -> Type -> Type -> Type
-Box :: Type -> Type
+Aff :: Prim.Type -> Prim.Type
+Z3 :: Prim.Type -> Prim.Type -> Prim.Type -> Prim.Type
+Box :: Prim.Type -> Prim.Type
 
 Roles
 Aff = [Nominal]

--- a/tests-integration/fixtures/checking/1778848440_polymorphic_row_field_cons/Main.snap
+++ b/tests-integration/fixtures/checking/1778848440_polymorphic_row_field_cons/Main.snap
@@ -4,30 +4,34 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
-Html :: forall (@slots :: Row Type). Html (slots :: Row Type)
-_child :: Proxy @Symbol "child"
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
+Html :: forall (@slots :: Prim.Row Prim.Type). Main.Html (slots :: Prim.Row Prim.Type)
+_child :: Main.Proxy @Prim.Symbol "child"
 slot ::
-  forall (query :: Type -> Type) (output :: Type) (slots :: Row Type) (label :: Symbol)
-    (key :: Type) (tail :: Row Type).
-    Cons @Type
-      (label :: Symbol)
-      (Slot (query :: Type -> Type) (output :: Type) (key :: Type))
-      (tail :: Row Type)
-      (slots :: Row Type) =>
-    Proxy @Symbol (label :: Symbol) -> (key :: Type) -> Html (slots :: Row Type)
-test :: forall (key :: Type). (key :: Type) -> Html (Slots (key :: Type))
+  forall (query :: Prim.Type -> Prim.Type) (output :: Prim.Type) (slots :: Prim.Row Prim.Type)
+    (label :: Prim.Symbol) (key :: Prim.Type) (tail :: Prim.Row Prim.Type).
+    Prim.Row.Cons @Prim.Type
+      (label :: Prim.Symbol)
+      (Main.Slot (query :: Prim.Type -> Prim.Type) (output :: Prim.Type) (key :: Prim.Type))
+      (tail :: Prim.Row Prim.Type)
+      (slots :: Prim.Row Prim.Type) =>
+    Main.Proxy @Prim.Symbol (label :: Prim.Symbol) ->
+    (key :: Prim.Type) ->
+    Main.Html (slots :: Prim.Row Prim.Type)
+test :: forall (key :: Prim.Type). (key :: Prim.Type) -> Main.Html (Main.Slots (key :: Prim.Type))
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-Slot :: (Type -> Type) -> Type -> Type -> Type
-Html :: Row Type -> Type
-Slots :: Type -> Row Type
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Slot :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type -> Prim.Type
+Html :: Prim.Row Prim.Type -> Prim.Type
+Slots :: Prim.Type -> Prim.Row Prim.Type
 
 Synonyms
 type Slots key = ( child ::
-    forall (query :: Type -> Type) (output :: Type).
-      Slot (query :: Type -> Type) (output :: Type) (key :: Type)
+    forall (query :: Prim.Type -> Prim.Type) (output :: Prim.Type).
+      Main.Slot (query :: Prim.Type -> Prim.Type) (output :: Prim.Type) (key :: Prim.Type)
 )
 
 Roles

--- a/tests-integration/fixtures/checking/1778850120_constrained_partial_application/Main.snap
+++ b/tests-integration/fixtures/checking/1778850120_constrained_partial_application/Main.snap
@@ -1,9 +1,9 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: JSX -> JSX
+test :: Module2.JSX -> Module2.JSX
 
 Types

--- a/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
+++ b/tests-integration/fixtures/checking/1778856960_instance_member_signature_weakening/Main.snap
@@ -5,60 +5,71 @@ expression: report
 ---
 Terms
 lift ::
-  forall (@t :: (Type -> Type) -> Type -> Type).
-    Transform (t :: (Type -> Type) -> Type -> Type) =>
-    (forall (f :: Type -> Type) (a :: Type).
-      Functor (f :: Type -> Type) =>
-      (f :: Type -> Type) (a :: Type) ->
-      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
+  forall (@t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type).
+    Main.Transform (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type) =>
+    (forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+      Data.Functor.Functor (f :: Prim.Type -> Prim.Type) =>
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type)
+        (f :: Prim.Type -> Prim.Type)
+        (a :: Prim.Type))
 Wrap ::
-  forall (@f :: Type -> Type) (@a :: Type).
-    (f :: Type -> Type) (a :: Type) -> Wrap (f :: Type -> Type) (a :: Type)
-render :: forall (@a :: Type). Render (a :: Type) => (a :: Type) -> String
+  forall (@f :: Prim.Type -> Prim.Type) (@a :: Prim.Type).
+    (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+    Main.Wrap (f :: Prim.Type -> Prim.Type) (a :: Prim.Type)
+render :: forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 renderer ::
-  forall (@t :: Type).
-    Renderer (t :: Type) => (forall (a :: Type). Render (a :: Type) => (a :: Type) -> (t :: Type))
+  forall (@t :: Prim.Type).
+    Main.Renderer (t :: Prim.Type) =>
+    (forall (a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> (t :: Prim.Type))
 liftPlain ::
-  forall (@t :: (Type -> Type) -> Type -> Type).
-    TransformPlain (t :: (Type -> Type) -> Type -> Type) =>
-    (forall (f :: Type -> Type) (a :: Type).
-      (f :: Type -> Type) (a :: Type) ->
-      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
+  forall (@t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type).
+    Main.TransformPlain (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type) =>
+    (forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type)
+        (f :: Prim.Type -> Prim.Type)
+        (a :: Prim.Type))
 
 Types
-Transform :: ((Type -> Type) -> Type -> Type) -> Constraint
-Wrap :: (Type -> Type) -> Type -> Type
-Render :: Type -> Constraint
-Renderer :: Type -> Constraint
-TransformPlain :: ((Type -> Type) -> Type -> Type) -> Constraint
+Transform :: ((Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type) -> Prim.Constraint
+Wrap :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type
+Render :: Prim.Type -> Prim.Constraint
+Renderer :: Prim.Type -> Prim.Constraint
+TransformPlain :: ((Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: (Type -> Type) -> Type -> Type). Transform (t :: (Type -> Type) -> Type -> Type)
+class forall (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type). Main.Transform (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type)
   lift ::
-  forall (@t :: (Type -> Type) -> Type -> Type).
-    Transform (t :: (Type -> Type) -> Type -> Type) =>
-    (forall (f :: Type -> Type) (a :: Type).
-      Functor (f :: Type -> Type) =>
-      (f :: Type -> Type) (a :: Type) ->
-      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
-class forall (a :: Type). Render (a :: Type)
-  render :: forall (@a :: Type). Render (a :: Type) => (a :: Type) -> String
-class forall (t :: Type). Renderer (t :: Type)
+  forall (@t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type).
+    Main.Transform (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type) =>
+    (forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+      Data.Functor.Functor (f :: Prim.Type -> Prim.Type) =>
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type)
+        (f :: Prim.Type -> Prim.Type)
+        (a :: Prim.Type))
+class forall (a :: Prim.Type). Main.Render (a :: Prim.Type)
+  render :: forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+class forall (t :: Prim.Type). Main.Renderer (t :: Prim.Type)
   renderer ::
-  forall (@t :: Type).
-    Renderer (t :: Type) => (forall (a :: Type). Render (a :: Type) => (a :: Type) -> (t :: Type))
-class forall (t :: (Type -> Type) -> Type -> Type). TransformPlain (t :: (Type -> Type) -> Type -> Type)
+  forall (@t :: Prim.Type).
+    Main.Renderer (t :: Prim.Type) =>
+    (forall (a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> (t :: Prim.Type))
+class forall (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type). Main.TransformPlain (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type)
   liftPlain ::
-  forall (@t :: (Type -> Type) -> Type -> Type).
-    TransformPlain (t :: (Type -> Type) -> Type -> Type) =>
-    (forall (f :: Type -> Type) (a :: Type).
-      (f :: Type -> Type) (a :: Type) ->
-      (t :: (Type -> Type) -> Type -> Type) (f :: Type -> Type) (a :: Type))
+  forall (@t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type).
+    Main.TransformPlain (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type) =>
+    (forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+      (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) ->
+      (t :: (Prim.Type -> Prim.Type) -> Prim.Type -> Prim.Type)
+        (f :: Prim.Type -> Prim.Type)
+        (a :: Prim.Type))
 
 Instances
-instance Transform Wrap
-instance Renderer String
-instance TransformPlain Wrap
+instance Main.Transform Main.Wrap
+instance Main.Renderer Prim.String
+instance Main.TransformPlain Main.Wrap
 
 Roles
 Wrap = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
+++ b/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
@@ -4,25 +4,28 @@ assertion_line: 50
 expression: report
 ---
 Terms
-defaultOptions :: {| Optional @Type }
+defaultOptions :: {| Main.Optional @Prim.Type }
 
 Types
-Optional :: forall (k :: Type). Row (k :: Type)
-All :: Row Type
+Optional :: forall (k :: Prim.Type). Prim.Row (k :: Prim.Type)
+All :: Prim.Row Prim.Type
 ConvertOptions ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> Constraint
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> Prim.Constraint
 
 Synonyms
 type Optional = ()
-type All = ( value :: Int | Optional @Type )
+type All = ( value :: Prim.Int | Main.Optional @Prim.Type )
 
 Classes
-class forall (t :: Type) (t1 :: Type) (t2 :: Type) (defaults :: (t :: Type)) (provided :: (t1 :: Type)) (all :: (t2 :: Type)). ConvertOptions @(t :: Type) @(t1 :: Type) @(t2 :: Type)
-  (defaults :: (t :: Type))
-  (provided :: (t1 :: Type))
-  (all :: (t2 :: Type))
+class forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (defaults :: (t :: Prim.Type)) (provided :: (t1 :: Prim.Type)) (all :: (t2 :: Prim.Type)). Main.ConvertOptions @(t :: Prim.Type) @(t1 :: Prim.Type) @(t2 :: Prim.Type)
+  (defaults :: (t :: Prim.Type))
+  (provided :: (t1 :: Prim.Type))
+  (all :: (t2 :: Prim.Type))
 
 Instances
-instance forall (t :: Row Type).
-  ConvertOptions @Type @Type @Type {| Optional @Type } {| (t :: Row Type) } {| All }
+instance forall (t :: Prim.Row Prim.Type).
+  Main.ConvertOptions @Prim.Type @Prim.Type @Prim.Type
+    {| Main.Optional @Prim.Type }
+    {| (t :: Prim.Row Prim.Type) }
+    {| Main.All }

--- a/tests-integration/fixtures/checking/1779044580_binderless_guard_predicate_boolean/Main.snap
+++ b/tests-integration/fixtures/checking/1779044580_binderless_guard_predicate_boolean/Main.snap
@@ -1,10 +1,10 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 39
+assertion_line: 50
 expression: report
 ---
 Terms
-test :: Int -> Int
+test :: Prim.Int -> Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
+++ b/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
@@ -5,59 +5,63 @@ expression: report
 ---
 Terms
 recordDef ::
-  forall (@token :: Type) (@row :: Row Type).
-    RecordDef (token :: Type) (row :: Row Type) =>
+  forall (@token :: Prim.Type) (@row :: Prim.Row Prim.Type).
+    Main.RecordDef (token :: Prim.Type) (row :: Prim.Row Prim.Type) =>
     { handle ::
-        forall (a :: Type).
-          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+        forall (a :: Prim.Type).
+          Main.Encode (token :: Prim.Type) (a :: Prim.Type) =>
+          (token :: Prim.Type) -> Type.Proxy.Proxy @Prim.Type (a :: Prim.Type) -> Prim.String
     } ->
-    (token :: Type) ->
-    {| (row :: Row Type) } ->
-    String
+    (token :: Prim.Type) ->
+    {| (row :: Prim.Row Prim.Type) } ->
+    Prim.String
 recordDefRowList ::
-  forall (@token :: Type) (@row :: Row Type) (@rowList :: Type).
-    RecordDefRowList (token :: Type) (row :: Row Type) (rowList :: Type) =>
+  forall (@token :: Prim.Type) (@row :: Prim.Row Prim.Type) (@rowList :: Prim.Type).
+    Main.RecordDefRowList (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.Type) =>
     { handle ::
-        forall (a :: Type).
-          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+        forall (a :: Prim.Type).
+          Main.Encode (token :: Prim.Type) (a :: Prim.Type) =>
+          (token :: Prim.Type) -> Type.Proxy.Proxy @Prim.Type (a :: Prim.Type) -> Prim.String
     } ->
-    (token :: Type) ->
-    {| (row :: Row Type) } ->
-    Proxy @Type (rowList :: Type) ->
-    String
+    (token :: Prim.Type) ->
+    {| (row :: Prim.Row Prim.Type) } ->
+    Type.Proxy.Proxy @Prim.Type (rowList :: Prim.Type) ->
+    Prim.String
 
 Types
-Encode :: Type -> Type -> Constraint
-RecordDef :: Type -> Row Type -> Constraint
-RecordDefRowList :: Type -> Row Type -> Type -> Constraint
+Encode :: Prim.Type -> Prim.Type -> Prim.Constraint
+RecordDef :: Prim.Type -> Prim.Row Prim.Type -> Prim.Constraint
+RecordDefRowList :: Prim.Type -> Prim.Row Prim.Type -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (token :: Type) (a :: Type). Encode (token :: Type) (a :: Type)
-class forall (token :: Type) (row :: Row Type). RecordDef (token :: Type) (row :: Row Type)
+class forall (token :: Prim.Type) (a :: Prim.Type). Main.Encode (token :: Prim.Type) (a :: Prim.Type)
+class forall (token :: Prim.Type) (row :: Prim.Row Prim.Type). Main.RecordDef (token :: Prim.Type) (row :: Prim.Row Prim.Type)
   recordDef ::
-  forall (@token :: Type) (@row :: Row Type).
-    RecordDef (token :: Type) (row :: Row Type) =>
+  forall (@token :: Prim.Type) (@row :: Prim.Row Prim.Type).
+    Main.RecordDef (token :: Prim.Type) (row :: Prim.Row Prim.Type) =>
     { handle ::
-        forall (a :: Type).
-          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+        forall (a :: Prim.Type).
+          Main.Encode (token :: Prim.Type) (a :: Prim.Type) =>
+          (token :: Prim.Type) -> Type.Proxy.Proxy @Prim.Type (a :: Prim.Type) -> Prim.String
     } ->
-    (token :: Type) ->
-    {| (row :: Row Type) } ->
-    String
-class forall (token :: Type) (row :: Row Type) (rowList :: Type). RecordDefRowList (token :: Type) (row :: Row Type) (rowList :: Type)
+    (token :: Prim.Type) ->
+    {| (row :: Prim.Row Prim.Type) } ->
+    Prim.String
+class forall (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.Type). Main.RecordDefRowList (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.Type)
   recordDefRowList ::
-  forall (@token :: Type) (@row :: Row Type) (@rowList :: Type).
-    RecordDefRowList (token :: Type) (row :: Row Type) (rowList :: Type) =>
+  forall (@token :: Prim.Type) (@row :: Prim.Row Prim.Type) (@rowList :: Prim.Type).
+    Main.RecordDefRowList (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.Type) =>
     { handle ::
-        forall (a :: Type).
-          Encode (token :: Type) (a :: Type) => (token :: Type) -> Proxy @Type (a :: Type) -> String
+        forall (a :: Prim.Type).
+          Main.Encode (token :: Prim.Type) (a :: Prim.Type) =>
+          (token :: Prim.Type) -> Type.Proxy.Proxy @Prim.Type (a :: Prim.Type) -> Prim.String
     } ->
-    (token :: Type) ->
-    {| (row :: Row Type) } ->
-    Proxy @Type (rowList :: Type) ->
-    String
+    (token :: Prim.Type) ->
+    {| (row :: Prim.Row Prim.Type) } ->
+    Type.Proxy.Proxy @Prim.Type (rowList :: Prim.Type) ->
+    Prim.String
 
 Instances
-instance forall (t :: Type) (t1 :: Row Type) (t2 :: Type).
-  RecordDefRowList (t :: Type) (t1 :: Row Type) (t2 :: Type) =>
-  RecordDef (t :: Type) (t1 :: Row Type)
+instance forall (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
+  Main.RecordDefRowList (t :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type) =>
+  Main.RecordDef (t :: Prim.Type) (t1 :: Prim.Row Prim.Type)

--- a/tests-integration/fixtures/checking/1779694800_constraint_solving_priority/Main.snap
+++ b/tests-integration/fixtures/checking/1779694800_constraint_solving_priority/Main.snap
@@ -4,51 +4,81 @@ assertion_line: 50
 expression: report
 ---
 Terms
-unsafeCoerce :: forall (a :: Type) (b :: Type). (a :: Type) -> (b :: Type)
-M :: forall (@context :: Row Type) (@a :: Type). (a :: Type) -> M (context :: Row Type) (a :: Type)
+unsafeCoerce :: forall (a :: Prim.Type) (b :: Prim.Type). (a :: Prim.Type) -> (b :: Prim.Type)
+M ::
+  forall (@context :: Prim.Row Prim.Type) (@a :: Prim.Type).
+    (a :: Prim.Type) -> Main.M (context :: Prim.Row Prim.Type) (a :: Prim.Type)
 bind ::
-  forall (context :: Row Type) (a :: Type) (b :: Type).
-    M (context :: Row Type) (a :: Type) ->
-    ((a :: Type) -> M (context :: Row Type) (b :: Type)) ->
-    M (context :: Row Type) (b :: Type)
+  forall (context :: Prim.Row Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+    Main.M (context :: Prim.Row Prim.Type) (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.M (context :: Prim.Row Prim.Type) (b :: Prim.Type)) ->
+    Main.M (context :: Prim.Row Prim.Type) (b :: Prim.Type)
 ask ::
-  forall (@context :: Row Type) (@m :: Type -> Type).
-    Ask (context :: Row Type) (m :: Type -> Type) => (m :: Type -> Type) {| (context :: Row Type) }
+  forall (@context :: Prim.Row Prim.Type) (@m :: Prim.Type -> Prim.Type).
+    Main.Ask (context :: Prim.Row Prim.Type) (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) {| (context :: Prim.Row Prim.Type) }
 consume ::
-  forall (row :: Row Type) (list :: RowList Type).
-    RowToList @Type (row :: Row Type) (list :: RowList Type) => {| (row :: Row Type) } -> {}
+  forall (row :: Prim.Row Prim.Type) (list :: Prim.RowList.RowList Prim.Type).
+    Prim.RowList.RowToList @Prim.Type
+      (row :: Prim.Row Prim.Type)
+      (list :: Prim.RowList.RowList Prim.Type) =>
+    {| (row :: Prim.Row Prim.Type) } -> {}
 produce ::
-  forall (@context :: Row Type) (@input :: Row Type) (@output :: Row Type).
-    Produce (context :: Row Type) (input :: Row Type) (output :: Row Type) =>
-    {| (context :: Row Type) } -> {| (input :: Row Type) } -> {| (output :: Row Type) }
+  forall (@context :: Prim.Row Prim.Type) (@input :: Prim.Row Prim.Type)
+    (@output :: Prim.Row Prim.Type).
+    Main.Produce
+      (context :: Prim.Row Prim.Type)
+      (input :: Prim.Row Prim.Type)
+      (output :: Prim.Row Prim.Type) =>
+    {| (context :: Prim.Row Prim.Type) } ->
+    {| (input :: Prim.Row Prim.Type) } ->
+    {| (output :: Prim.Row Prim.Type) }
 test ::
-  forall (context :: Row Type) (input :: Row Type) (output :: Row Type)
-    (outputList :: RowList Type).
-    RowToList @Type (output :: Row Type) (outputList :: RowList Type) =>
-    Produce (context :: Row Type) (input :: Row Type) (output :: Row Type) =>
-    {| (input :: Row Type) } -> M (context :: Row Type) {}
+  forall (context :: Prim.Row Prim.Type) (input :: Prim.Row Prim.Type)
+    (output :: Prim.Row Prim.Type) (outputList :: Prim.RowList.RowList Prim.Type).
+    Prim.RowList.RowToList @Prim.Type
+      (output :: Prim.Row Prim.Type)
+      (outputList :: Prim.RowList.RowList Prim.Type) =>
+    Main.Produce
+      (context :: Prim.Row Prim.Type)
+      (input :: Prim.Row Prim.Type)
+      (output :: Prim.Row Prim.Type) =>
+    {| (input :: Prim.Row Prim.Type) } -> Main.M (context :: Prim.Row Prim.Type) {}
 
 Types
-M :: Row Type -> Type -> Type
-Ask :: Row Type -> (Type -> Type) -> Constraint
-Produce :: Row Type -> Row Type -> Row Type -> Constraint
+M :: Prim.Row Prim.Type -> Prim.Type -> Prim.Type
+Ask :: Prim.Row Prim.Type -> (Prim.Type -> Prim.Type) -> Prim.Constraint
+Produce :: Prim.Row Prim.Type -> Prim.Row Prim.Type -> Prim.Row Prim.Type -> Prim.Constraint
 
 Classes
-class forall (context :: Row Type) (m :: Type -> Type). Ask (context :: Row Type) (m :: Type -> Type)
+class forall (context :: Prim.Row Prim.Type) (m :: Prim.Type -> Prim.Type). Main.Ask (context :: Prim.Row Prim.Type) (m :: Prim.Type -> Prim.Type)
   ask ::
-  forall (@context :: Row Type) (@m :: Type -> Type).
-    Ask (context :: Row Type) (m :: Type -> Type) => (m :: Type -> Type) {| (context :: Row Type) }
-class forall (context :: Row Type) (input :: Row Type) (output :: Row Type). Produce (context :: Row Type) (input :: Row Type) (output :: Row Type)
+  forall (@context :: Prim.Row Prim.Type) (@m :: Prim.Type -> Prim.Type).
+    Main.Ask (context :: Prim.Row Prim.Type) (m :: Prim.Type -> Prim.Type) =>
+    (m :: Prim.Type -> Prim.Type) {| (context :: Prim.Row Prim.Type) }
+class forall (context :: Prim.Row Prim.Type) (input :: Prim.Row Prim.Type) (output :: Prim.Row Prim.Type). Main.Produce
+  (context :: Prim.Row Prim.Type)
+  (input :: Prim.Row Prim.Type)
+  (output :: Prim.Row Prim.Type)
   produce ::
-  forall (@context :: Row Type) (@input :: Row Type) (@output :: Row Type).
-    Produce (context :: Row Type) (input :: Row Type) (output :: Row Type) =>
-    {| (context :: Row Type) } -> {| (input :: Row Type) } -> {| (output :: Row Type) }
+  forall (@context :: Prim.Row Prim.Type) (@input :: Prim.Row Prim.Type)
+    (@output :: Prim.Row Prim.Type).
+    Main.Produce
+      (context :: Prim.Row Prim.Type)
+      (input :: Prim.Row Prim.Type)
+      (output :: Prim.Row Prim.Type) =>
+    {| (context :: Prim.Row Prim.Type) } ->
+    {| (input :: Prim.Row Prim.Type) } ->
+    {| (output :: Prim.Row Prim.Type) }
 
 Instances
-instance forall (t :: Row Type). Ask (t :: Row Type) (M (t :: Row Type))
-instance forall (t :: Row Type) (t1 :: RowList Type) (t2 :: Row Type).
-  RowToList @Type (t :: Row Type) (t1 :: RowList Type) =>
-  Produce (t2 :: Row Type) (t :: Row Type) (t :: Row Type)
+instance forall (t :: Prim.Row Prim.Type).
+  Main.Ask (t :: Prim.Row Prim.Type) (Main.M (t :: Prim.Row Prim.Type))
+instance forall (t :: Prim.Row Prim.Type) (t1 :: Prim.RowList.RowList Prim.Type) (t2 :: Prim.Row Prim.Type).
+  Prim.RowList.RowToList @Prim.Type
+    (t :: Prim.Row Prim.Type)
+    (t1 :: Prim.RowList.RowList Prim.Type) =>
+  Main.Produce (t2 :: Prim.Row Prim.Type) (t :: Prim.Row Prim.Type) (t :: Prim.Row Prim.Type)
 
 Roles
 M = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
@@ -4,19 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
-value :: Int
+test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
+value :: Prim.Int
 
 Types
-Test :: Type -> Constraint
+Test :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Test (a :: Type)
-  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
+  test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance forall (t :: Type). Test (t :: Type)
-instance Test Int
+instance forall (t :: Prim.Type). Main.Test (t :: Prim.Type)
+instance Main.Test Prim.Int
 
 Diagnostics
 error[OverlappingInstances]: Overlapping type class instances found for: Test Int

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.snap
@@ -4,16 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
-value :: Int
+test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
+value :: Prim.Int
 
 Types
-Test :: Type -> Constraint
+Test :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Test (a :: Type)
-  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
+  test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance Test Int
-instance forall (t :: Type). Test (t :: Type)
+instance Main.Test Prim.Int
+instance forall (t :: Prim.Type). Main.Test (t :: Prim.Type)

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
@@ -4,14 +4,14 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Y :: Y
-value :: Int
+Y :: Main.Y
+value :: Prim.Int
 
 Types
-Y :: Type
+Y :: Prim.Type
 
 Instances
-instance C X Y
+instance Lib.C Lib.X Main.Y
 
 Roles
 Y = []

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
@@ -4,18 +4,18 @@ assertion_line: 50
 expression: report
 ---
 Terms
-test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-Test :: Type -> Constraint
+Test :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Test (a :: Type)
-  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
+  test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance forall (t :: Type). Test (t :: Type)
-instance Test Int
+instance forall (t :: Prim.Type). Main.Test (t :: Prim.Type)
+instance Main.Test Prim.Int
 
 Diagnostics
 error[OverlappingInstances]: Overlapping type class instances found for: Test Int

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
@@ -4,25 +4,31 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Proxy :: forall (k :: Type) (@a :: (k :: Type)). Proxy @(k :: Type) (a :: (k :: Type))
+Proxy ::
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 showP ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    ShowP @(k :: Type) (a :: (k :: Type)) => Proxy @(k :: Type) (a :: (k :: Type)) -> String
-value :: String
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.ShowP @(k :: Prim.Type) (a :: (k :: Prim.Type)) =>
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type)) -> Prim.String
+value :: Prim.String
 
 Types
-Proxy :: forall (k :: Type). (k :: Type) -> Type
-ShowP :: forall (k :: Type). (k :: Type) -> Constraint
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+ShowP :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (k :: Type) (a :: (k :: Type)). ShowP @(k :: Type) (a :: (k :: Type))
+class forall (k :: Prim.Type) (a :: (k :: Prim.Type)). Main.ShowP @(k :: Prim.Type) (a :: (k :: Prim.Type))
   showP ::
-  forall (k :: Type) (@a :: (k :: Type)).
-    ShowP @(k :: Type) (a :: (k :: Type)) => Proxy @(k :: Type) (a :: (k :: Type)) -> String
+  forall (k :: Prim.Type) (@a :: (k :: Prim.Type)).
+    Main.ShowP @(k :: Prim.Type) (a :: (k :: Prim.Type)) =>
+    Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type)) -> Prim.String
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type)). ShowP @(t :: Type) (t1 :: (t :: Type))
-instance forall (t :: Type) (t1 :: (t :: Type)). ShowP @(t :: Type) (t1 :: (t :: Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.ShowP @(t :: Prim.Type) (t1 :: (t :: Prim.Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.ShowP @(t :: Prim.Type) (t1 :: (t :: Prim.Type))
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_synonym/Main.snap
@@ -5,24 +5,26 @@ expression: report
 ---
 Terms
 convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
-value :: String
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
+value :: Prim.String
 
 Types
-Convert :: Type -> Type -> Constraint
-Bar :: Type
+Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
+Bar :: Prim.Type
 
 Synonyms
-type Bar = String
+type Bar = Prim.String
 
 Classes
-class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Convert (a :: Prim.Type) (b :: Prim.Type)
   convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Instances
-instance Convert String Bar
-instance Convert String String
+instance Main.Convert Prim.String Main.Bar
+instance Main.Convert Prim.String Prim.String
 
 Diagnostics
 error[OverlappingInstances]: Overlapping type class instances found for: Convert String String

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_derive_no_use/Main.snap
@@ -4,16 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Box :: Box
+Box :: Main.Box
 
 Types
-Box :: Type
+Box :: Prim.Type
 
 Instances
-instance Eq Box
+instance Data.Eq.Eq Main.Box
 
 Derived
-derive Eq Box
+derive Data.Eq.Eq Main.Box
 
 Roles
 Box = []

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
@@ -4,20 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Pair :: forall (@a :: Type) (@b :: Type). (a :: Type) -> (b :: Type) -> Pair (a :: Type) (b :: Type)
-test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> Int
+Pair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Pair (a :: Prim.Type) (b :: Prim.Type)
+test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Types
-Pair :: Type -> Type -> Type
-Test :: Type -> Constraint
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+Test :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Test (a :: Type)
-  test :: forall (@a :: Type). Test (a :: Type) => (a :: Type) -> Int
+class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
+  test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Instances
-instance forall (t :: Type). Test (Pair (t :: Type) Int)
-instance forall (t :: Type). Test (Pair String (t :: Type))
+instance forall (t :: Prim.Type). Main.Test (Main.Pair (t :: Prim.Type) Prim.Int)
+instance forall (t :: Prim.Type). Main.Test (Main.Pair Prim.String (t :: Prim.Type))
 
 Roles
 Pair = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1780673760_do_final_let/Main.snap
+++ b/tests-integration/fixtures/checking/1780673760_do_final_let/Main.snap
@@ -5,14 +5,16 @@ expression: report
 ---
 Terms
 bind ::
-  forall (a :: Type) (b :: Type).
-    Effect (a :: Type) -> ((a :: Type) -> Effect (b :: Type)) -> Effect (b :: Type)
-before :: Effect { field :: Int }
-expectString :: String -> Int
-test :: forall (t :: Type). Effect (t :: Type)
+  forall (a :: Prim.Type) (b :: Prim.Type).
+    Main.Effect (a :: Prim.Type) ->
+    ((a :: Prim.Type) -> Main.Effect (b :: Prim.Type)) ->
+    Main.Effect (b :: Prim.Type)
+before :: Main.Effect { field :: Prim.Int }
+expectString :: Prim.String -> Prim.Int
+test :: forall (t :: Prim.Type). Main.Effect (t :: Prim.Type)
 
 Types
-Effect :: Type -> Type
+Effect :: Prim.Type -> Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -4,27 +4,29 @@ assertion_line: 50
 expression: report
 ---
 Terms
-termHole :: Int -> Int
-recordPunHole :: { punInt :: Int, punString :: String } -> Int
+termHole :: Prim.Int -> Prim.Int
+recordPunHole :: { punInt :: Prim.Int, punString :: Prim.String } -> Prim.Int
 instanceTypeHoleMember ::
-  forall (@implicit :: Type).
-    InstanceTypeHole (implicit :: Type) => (implicit :: Type) -> (implicit :: Type)
+  forall (@implicit :: Prim.Type).
+    Main.InstanceTypeHole (implicit :: Prim.Type) =>
+    (implicit :: Prim.Type) -> (implicit :: Prim.Type)
 
 Types
-TypeHole :: forall (t :: Type). (t :: Type) -> Type
-InstanceTypeHole :: Type -> Constraint
+TypeHole :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Type
+InstanceTypeHole :: Prim.Type -> Prim.Constraint
 
 Synonyms
 type TypeHole a = ?3
 
 Classes
-class forall (implicit :: Type). InstanceTypeHole (implicit :: Type)
+class forall (implicit :: Prim.Type). Main.InstanceTypeHole (implicit :: Prim.Type)
   instanceTypeHoleMember ::
-  forall (@implicit :: Type).
-    InstanceTypeHole (implicit :: Type) => (implicit :: Type) -> (implicit :: Type)
+  forall (@implicit :: Prim.Type).
+    Main.InstanceTypeHole (implicit :: Prim.Type) =>
+    (implicit :: Prim.Type) -> (implicit :: Prim.Type)
 
 Instances
-instance forall (t :: Type). InstanceTypeHole (t :: Type)
+instance forall (t :: Prim.Type). Main.InstanceTypeHole (t :: Prim.Type)
 
 Diagnostics
 error[TypeHole]: Type hole '?type' has inferred type: ?3 :: Type

--- a/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
+++ b/tests-integration/fixtures/checking/1781587680_typed_holes_constructors/Main.snap
@@ -4,21 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Yes :: Option
-No :: Option
-localOption :: Option
-option :: Option
-imported :: ImportedOption
-select :: forall (@a :: Type). Select (a :: Type) => (a :: Type) -> Option
-method :: forall (a :: Type). Select (a :: Type) => (a :: Type) -> Option
+Yes :: Main.Option
+No :: Main.Option
+localOption :: Main.Option
+option :: Main.Option
+imported :: Lib.ImportedOption
+select :: forall (@a :: Prim.Type). Main.Select (a :: Prim.Type) => (a :: Prim.Type) -> Main.Option
+method :: forall (a :: Prim.Type). Main.Select (a :: Prim.Type) => (a :: Prim.Type) -> Main.Option
 
 Types
-Option :: Type
-Select :: Type -> Constraint
+Option :: Prim.Type
+Select :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Select (a :: Type)
-  select :: forall (@a :: Type). Select (a :: Type) => (a :: Type) -> Option
+class forall (a :: Prim.Type). Main.Select (a :: Prim.Type)
+  select :: forall (@a :: Prim.Type). Main.Select (a :: Prim.Type) => (a :: Prim.Type) -> Main.Option
 
 Roles
 Option = []

--- a/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
+++ b/tests-integration/fixtures/checking/1781589300_typed_holes_constructor_resolution/Main.snap
@@ -4,16 +4,16 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Shared :: Local
-LocalOnly :: Local
-localValue :: Local
-shadowedValue :: Local
-local :: Local
-remote :: Remote
-binderShadow :: Local -> Remote
+Shared :: Main.Local
+LocalOnly :: Main.Local
+localValue :: Main.Local
+shadowedValue :: Main.Local
+local :: Main.Local
+remote :: Lib.Remote
+binderShadow :: Main.Local -> Lib.Remote
 
 Types
-Local :: Type
+Local :: Prim.Type
 
 Roles
 Local = []

--- a/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1781607840_prim_row_union_kind_polymorphic/Main.snap
@@ -5,21 +5,26 @@ expression: report
 ---
 Terms
 openLeftHigherKinded ::
-  forall (tail :: Row (Type -> Type)) (output :: Row (Type -> Type)).
-    Union @(Type -> Type)
-      ( effect :: Effect | (tail :: Row (Type -> Type)) )
+  forall (tail :: Prim.Row (Prim.Type -> Prim.Type)) (output :: Prim.Row (Prim.Type -> Prim.Type)).
+    Prim.Row.Union @(Prim.Type -> Prim.Type)
+      ( effect :: Main.Effect | (tail :: Prim.Row (Prim.Type -> Prim.Type)) )
       ()
-      (output :: Row (Type -> Type)) =>
-    Proxy @(Row (Type -> Type)) (output :: Row (Type -> Type))
+      (output :: Prim.Row (Prim.Type -> Prim.Type)) =>
+    Type.Proxy.Proxy @(Prim.Row (Prim.Type -> Prim.Type))
+      (output :: Prim.Row (Prim.Type -> Prim.Type))
 forceSolve ::
-  forall (tail :: Row (Type -> Type)) (output :: Row (Type -> Type)).
-    Union @(Type -> Type) (tail :: Row (Type -> Type)) () (output :: Row (Type -> Type)) =>
+  forall (tail :: Prim.Row (Prim.Type -> Prim.Type)) (output :: Prim.Row (Prim.Type -> Prim.Type)).
+    Prim.Row.Union @(Prim.Type -> Prim.Type)
+      (tail :: Prim.Row (Prim.Type -> Prim.Type))
+      ()
+      (output :: Prim.Row (Prim.Type -> Prim.Type)) =>
     { openLeftHigherKinded ::
-        Proxy @(Row (Type -> Type)) ( effect :: Effect | (output :: Row (Type -> Type)) )
+        Type.Proxy.Proxy @(Prim.Row (Prim.Type -> Prim.Type))
+          ( effect :: Main.Effect | (output :: Prim.Row (Prim.Type -> Prim.Type)) )
     }
 
 Types
-Effect :: Type -> Type
+Effect :: Prim.Type -> Prim.Type
 
 Roles
 Effect = [Nominal]

--- a/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
@@ -5,36 +5,37 @@ expression: report
 ---
 Terms
 choose ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type) (a :: (t :: Type)) (b :: (t1 :: Type))
-    (result :: (t2 :: Type)).
-    Pick @(t :: Type) @(t1 :: Type) @(t2 :: Type)
-      (a :: (t :: Type))
-      (b :: (t1 :: Type))
-      (result :: (t2 :: Type)) =>
-    Proxy @(t :: Type) (a :: (t :: Type)) ->
-    Proxy @(t1 :: Type) (b :: (t1 :: Type)) ->
-    Proxy @(t2 :: Type) (result :: (t2 :: Type))
-x :: Proxy @Type Int
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (a :: (t :: Prim.Type))
+    (b :: (t1 :: Prim.Type)) (result :: (t2 :: Prim.Type)).
+    Main.Pick @(t :: Prim.Type) @(t1 :: Prim.Type) @(t2 :: Prim.Type)
+      (a :: (t :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
+      (result :: (t2 :: Prim.Type)) =>
+    Type.Proxy.Proxy @(t :: Prim.Type) (a :: (t :: Prim.Type)) ->
+    Type.Proxy.Proxy @(t1 :: Prim.Type) (b :: (t1 :: Prim.Type)) ->
+    Type.Proxy.Proxy @(t2 :: Prim.Type) (result :: (t2 :: Prim.Type))
+x :: Type.Proxy.Proxy @Prim.Type Prim.Int
 
 Types
 Pick ::
-  forall (t :: Type) (t1 :: Type) (t2 :: Type).
-    (t :: Type) -> (t1 :: Type) -> (t2 :: Type) -> Constraint
+  forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (t1 :: Type) (t2 :: Type) (a :: (t :: Type)) (b :: (t1 :: Type)) (result :: (t2 :: Type)). Pick @(t :: Type) @(t1 :: Type) @(t2 :: Type)
-  (a :: (t :: Type))
-  (b :: (t1 :: Type))
-  (result :: (t2 :: Type))
+class forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (a :: (t :: Prim.Type)) (b :: (t1 :: Prim.Type)) (result :: (t2 :: Prim.Type)). Main.Pick @(t :: Prim.Type) @(t1 :: Prim.Type) @(t2 :: Prim.Type)
+  (a :: (t :: Prim.Type))
+  (b :: (t1 :: Prim.Type))
+  (result :: (t2 :: Prim.Type))
 
 Instances
-instance forall (t :: Int).
-  Compare (t :: Int) (t :: Int) EQ => Pick @Int @Int @Int (t :: Int) (t :: Int) (t :: Int)
-instance forall (t :: Type) (t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type)).
-  Pick @(t :: Type) @(t1 :: Type) @(t1 :: Type)
-    (t2 :: (t :: Type))
-    (t3 :: (t1 :: Type))
-    (t3 :: (t1 :: Type))
+instance forall (t :: Prim.Int).
+  Prim.Int.Compare (t :: Prim.Int) (t :: Prim.Int) Prim.Ordering.EQ =>
+  Main.Pick @Prim.Int @Prim.Int @Prim.Int (t :: Prim.Int) (t :: Prim.Int) (t :: Prim.Int)
+instance forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: (t :: Prim.Type)) (t3 :: (t1 :: Prim.Type)).
+  Main.Pick @(t :: Prim.Type) @(t1 :: Prim.Type) @(t1 :: Prim.Type)
+    (t2 :: (t :: Prim.Type))
+    (t3 :: (t1 :: Prim.Type))
+    (t3 :: (t1 :: Prim.Type))
 
 Diagnostics
 error[CannotUnify]: Cannot unify 'Type' with 'Int'

--- a/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/checking/1781827200_overlapping_instances_functional_dependency/Main.snap
@@ -5,19 +5,21 @@ expression: report
 ---
 Terms
 convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Types
-Convert :: Type -> Type -> Constraint
+Convert :: Prim.Type -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type) (b :: Type). Convert (a :: Type) (b :: Type)
+class forall (a :: Prim.Type) (b :: Prim.Type). Main.Convert (a :: Prim.Type) (b :: Prim.Type)
   convert ::
-  forall (@a :: Type) (@b :: Type). Convert (a :: Type) (b :: Type) => (a :: Type) -> (b :: Type)
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Instances
-instance Convert String Int
-instance Convert String Boolean
+instance Main.Convert Prim.String Prim.Int
+instance Main.Convert Prim.String Prim.Boolean
 
 Diagnostics
 error[OverlappingInstances]: Overlapping type class instances found for: Convert String Boolean

--- a/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.snap
+++ b/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.snap
@@ -6,25 +6,35 @@ expression: report
 Terms
 
 Types
-ResultA :: Type
-ResultB :: Type
-Inner :: forall (left :: Type) (right :: Type). (left :: Type) -> (right :: Type) -> Type
-Outer :: forall (left :: Type) (right :: Type). (left :: Type) -> (right :: Type) -> Type
-Test :: forall (input :: Type). (input :: Type) -> Type -> Constraint
+ResultA :: Prim.Type
+ResultB :: Prim.Type
+Inner ::
+  forall (left :: Prim.Type) (right :: Prim.Type).
+    (left :: Prim.Type) -> (right :: Prim.Type) -> Prim.Type
+Outer ::
+  forall (left :: Prim.Type) (right :: Prim.Type).
+    (left :: Prim.Type) -> (right :: Prim.Type) -> Prim.Type
+Test :: forall (input :: Prim.Type). (input :: Prim.Type) -> Prim.Type -> Prim.Constraint
 
 Classes
-class forall (input :: Type) (input1 :: (input :: Type)) (output :: Type). Test @(input :: Type) (input1 :: (input :: Type)) (output :: Type)
+class forall (input :: Prim.Type) (input1 :: (input :: Prim.Type)) (output :: Prim.Type). Main.Test @(input :: Prim.Type) (input1 :: (input :: Prim.Type)) (output :: Prim.Type)
 
 Instances
-instance forall (t :: Type) (t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type)).
-  Test @Type (Outer @(t :: Type) @(t1 :: Type) (t2 :: (t :: Type)) (t3 :: (t1 :: Type))) ResultA
-instance forall (t :: Type) (t1 :: Type) (t2 :: Type) (t3 :: (t1 :: Type)) (t4 :: (t2 :: Type))
-  (t5 :: (t :: Type)).
-  Test @Type
-    (Outer @Type @(t :: Type)
-      (Inner @(t1 :: Type) @(t2 :: Type) (t3 :: (t1 :: Type)) (t4 :: (t2 :: Type)))
-      (t5 :: (t :: Type)))
-    ResultB
+instance forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: (t :: Prim.Type)) (t3 :: (t1 :: Prim.Type)).
+  Main.Test @Prim.Type
+    (Main.Outer @(t :: Prim.Type) @(t1 :: Prim.Type)
+      (t2 :: (t :: Prim.Type))
+      (t3 :: (t1 :: Prim.Type)))
+    Main.ResultA
+instance forall (t :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: (t1 :: Prim.Type))
+  (t4 :: (t2 :: Prim.Type)) (t5 :: (t :: Prim.Type)).
+  Main.Test @Prim.Type
+    (Main.Outer @Prim.Type @(t :: Prim.Type)
+      (Main.Inner @(t1 :: Prim.Type) @(t2 :: Prim.Type)
+        (t3 :: (t1 :: Prim.Type))
+        (t4 :: (t2 :: Prim.Type)))
+      (t5 :: (t :: Prim.Type)))
+    Main.ResultB
 
 Roles
 ResultA = []

--- a/tests-integration/fixtures/checking/1784275320_transitive_superclass_minimisation_evidence/Main.snap
+++ b/tests-integration/fixtures/checking/1784275320_transitive_superclass_minimisation_evidence/Main.snap
@@ -4,17 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-useBottom :: forall (a :: Type). Bottom @Type (a :: Type) => (a :: Type) -> Int
-useMiddle :: forall (a :: Type). Middle @Type (a :: Type) => (a :: Type) -> Int
-useTop :: forall (a :: Type). Top @Type (a :: Type) => (a :: Type) -> Int
-test :: forall (t :: Type). Top @Type (t :: Type) => (t :: Type) -> Int
+useBottom ::
+  forall (a :: Prim.Type). Main.Bottom @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+useMiddle ::
+  forall (a :: Prim.Type). Main.Middle @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+useTop ::
+  forall (a :: Prim.Type). Main.Top @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+test ::
+  forall (t :: Prim.Type). Main.Top @Prim.Type (t :: Prim.Type) => (t :: Prim.Type) -> Prim.Int
 
 Types
-Bottom :: forall (t :: Type). (t :: Type) -> Constraint
-Middle :: forall (t :: Type). (t :: Type) -> Constraint
-Top :: forall (t :: Type). (t :: Type) -> Constraint
+Bottom :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
+Middle :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
+Top :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type))
-class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type)) <= Middle @(t :: Type) (a :: (t :: Type))
-class forall (t :: Type) (a :: (t :: Type)). Middle @(t :: Type) (a :: (t :: Type)) <= Top @(t :: Type) (a :: (t :: Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Bottom @(t :: Prim.Type) (a :: (t :: Prim.Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Bottom @(t :: Prim.Type) (a :: (t :: Prim.Type)) <= Main.Middle @(t :: Prim.Type) (a :: (t :: Prim.Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Middle @(t :: Prim.Type) (a :: (t :: Prim.Type)) <= Main.Top @(t :: Prim.Type) (a :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1784281200_diamond_superclass_projection_paths/Main.snap
+++ b/tests-integration/fixtures/checking/1784281200_diamond_superclass_projection_paths/Main.snap
@@ -4,22 +4,30 @@ assertion_line: 50
 expression: report
 ---
 Terms
-useBottom :: forall (a :: Type). Bottom @Type (a :: Type) => (a :: Type) -> Int
-useLeft :: forall (a :: Type). Left @Type (a :: Type) => (a :: Type) -> Int
-useRight :: forall (a :: Type). Right @Type (a :: Type) => (a :: Type) -> Int
-useTop :: forall (a :: Type). Top @Type (a :: Type) => (a :: Type) -> Int
-testDiamond :: forall (t :: Type). Top @Type (t :: Type) => (t :: Type) -> Int
+useBottom ::
+  forall (a :: Prim.Type). Main.Bottom @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+useLeft ::
+  forall (a :: Prim.Type). Main.Left @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+useRight ::
+  forall (a :: Prim.Type). Main.Right @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+useTop ::
+  forall (a :: Prim.Type). Main.Top @Prim.Type (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
+testDiamond ::
+  forall (t :: Prim.Type). Main.Top @Prim.Type (t :: Prim.Type) => (t :: Prim.Type) -> Prim.Int
 testShared ::
-  forall (t :: Type). Left @Type (t :: Type) => Right @Type (t :: Type) => (t :: Type) -> Int
+  forall (t :: Prim.Type).
+    Main.Left @Prim.Type (t :: Prim.Type) =>
+    Main.Right @Prim.Type (t :: Prim.Type) =>
+    (t :: Prim.Type) -> Prim.Int
 
 Types
-Bottom :: forall (t :: Type). (t :: Type) -> Constraint
-Left :: forall (t :: Type). (t :: Type) -> Constraint
-Right :: forall (t :: Type). (t :: Type) -> Constraint
-Top :: forall (t :: Type). (t :: Type) -> Constraint
+Bottom :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
+Left :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
+Right :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
+Top :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type))
-class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type)) <= Left @(t :: Type) (a :: (t :: Type))
-class forall (t :: Type) (a :: (t :: Type)). Bottom @(t :: Type) (a :: (t :: Type)) <= Right @(t :: Type) (a :: (t :: Type))
-class forall (t :: Type) (a :: (t :: Type)). Left @(t :: Type) (a :: (t :: Type)), Right @(t :: Type) (a :: (t :: Type)) <= Top @(t :: Type) (a :: (t :: Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Bottom @(t :: Prim.Type) (a :: (t :: Prim.Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Bottom @(t :: Prim.Type) (a :: (t :: Prim.Type)) <= Main.Left @(t :: Prim.Type) (a :: (t :: Prim.Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Bottom @(t :: Prim.Type) (a :: (t :: Prim.Type)) <= Main.Right @(t :: Prim.Type) (a :: (t :: Prim.Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Left @(t :: Prim.Type) (a :: (t :: Prim.Type)), Main.Right @(t :: Prim.Type) (a :: (t :: Prim.Type)) <= Main.Top @(t :: Prim.Type) (a :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.snap
+++ b/tests-integration/fixtures/checking/1784393160_defer_type_error_given_diagnostics/Main.snap
@@ -4,21 +4,21 @@ assertion_line: 50
 expression: report
 ---
 Terms
-value :: forall (@a :: Type). Value (a :: Type) => (a :: Type)
-guardedFailure :: Fail (Text "failure was demanded") => Int
-useFailure :: Int
-guardedWarning :: Warn (Text "warning was demanded") => Int
-useWarning :: Int
+value :: forall (@a :: Prim.Type). Main.Value (a :: Prim.Type) => (a :: Prim.Type)
+guardedFailure :: Prim.TypeError.Fail (Prim.TypeError.Text "failure was demanded") => Prim.Int
+useFailure :: Prim.Int
+guardedWarning :: Prim.TypeError.Warn (Prim.TypeError.Text "warning was demanded") => Prim.Int
+useWarning :: Prim.Int
 
 Types
-Value :: Type -> Constraint
+Value :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Value (a :: Type)
-  value :: forall (@a :: Type). Value (a :: Type) => (a :: Type)
+class forall (a :: Prim.Type). Main.Value (a :: Prim.Type)
+  value :: forall (@a :: Prim.Type). Main.Value (a :: Prim.Type) => (a :: Prim.Type)
 
 Instances
-instance Value Int
+instance Main.Value Prim.Int
 
 Diagnostics
 error[CustomFailure]: failure was demanded

--- a/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_mutual_infer_constraint/Main.snap
@@ -4,16 +4,22 @@ assertion_line: 50
 expression: report
 ---
 Terms
-append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-first :: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
-second :: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+first ::
+  forall (t :: Prim.Type). Main.Semigroup (t :: Prim.Type) => (t :: Prim.Type) -> (t :: Prim.Type)
+second ::
+  forall (t :: Prim.Type). Main.Semigroup (t :: Prim.Type) => (t :: Prim.Type) -> (t :: Prim.Type)
 
 Types
-Semigroup :: Type -> Constraint
+Semigroup :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semigroup (a :: Type)
-  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type)
+  append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 
 Diagnostics
 error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_check_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_check_constraint/Main.snap
@@ -4,12 +4,17 @@ assertion_line: 50
 expression: report
 ---
 Terms
-append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-test :: forall (a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type)
+append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+test ::
+  forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Types
-Semigroup :: Type -> Constraint
+Semigroup :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semigroup (a :: Type)
-  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type)
+  append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_constraint/Main.snap
@@ -4,15 +4,20 @@ assertion_line: 50
 expression: report
 ---
 Terms
-append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
-test :: forall (t :: Type). Semigroup (t :: Type) => (t :: Type) -> (t :: Type)
+append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
+test ::
+  forall (t :: Prim.Type). Main.Semigroup (t :: Prim.Type) => (t :: Prim.Type) -> (t :: Prim.Type)
 
 Types
-Semigroup :: Type -> Constraint
+Semigroup :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (a :: Type). Semigroup (a :: Type)
-  append :: forall (@a :: Type). Semigroup (a :: Type) => (a :: Type) -> (a :: Type) -> (a :: Type)
+class forall (a :: Prim.Type). Main.Semigroup (a :: Prim.Type)
+  append ::
+  forall (@a :: Prim.Type).
+    Main.Semigroup (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type) -> (a :: Prim.Type)
 
 Diagnostics
 error[CannotGeneraliseRecursiveFunction]: Unable to generalise the type of this recursive function.

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_infer_partial/Main.snap
@@ -4,8 +4,8 @@ assertion_line: 50
 expression: report
 ---
 Terms
-partialValue :: Partial => Int
-test :: Partial => Int
+partialValue :: Prim.Partial => Prim.Int
+test :: Prim.Partial => Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.snap
+++ b/tests-integration/fixtures/checking/1784457540_value_recursive_inferred_fail/Main.snap
@@ -4,8 +4,8 @@ assertion_line: 50
 expression: report
 ---
 Terms
-guardedFailure :: Fail (Text "failure was demanded") => Int
-test :: Int
+guardedFailure :: Prim.TypeError.Fail (Prim.TypeError.Text "failure was demanded") => Prim.Int
+test :: Prim.Int
 
 Types
 

--- a/tests-integration/fixtures/checking/1784700360_callable_head_interleaving/Main.snap
+++ b/tests-integration/fixtures/checking/1784700360_callable_head_interleaving/Main.snap
@@ -5,19 +5,21 @@ expression: report
 ---
 Terms
 interleaved ::
-  forall (a :: Type).
-    First @Type (a :: Type) =>
-    (forall (b :: Type). Second @Type (b :: Type) => (a :: Type) -> (b :: Type) -> String)
-test :: String
+  forall (a :: Prim.Type).
+    Main.First @Prim.Type (a :: Prim.Type) =>
+    (forall (b :: Prim.Type).
+      Main.Second @Prim.Type (b :: Prim.Type) =>
+      (a :: Prim.Type) -> (b :: Prim.Type) -> Prim.String)
+test :: Prim.String
 
 Types
-First :: forall (t :: Type). (t :: Type) -> Constraint
-Second :: forall (t :: Type). (t :: Type) -> Constraint
+First :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
+Second :: forall (t :: Prim.Type). (t :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (t :: Type) (a :: (t :: Type)). First @(t :: Type) (a :: (t :: Type))
-class forall (t :: Type) (a :: (t :: Type)). Second @(t :: Type) (a :: (t :: Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.First @(t :: Prim.Type) (a :: (t :: Prim.Type))
+class forall (t :: Prim.Type) (a :: (t :: Prim.Type)). Main.Second @(t :: Prim.Type) (a :: (t :: Prim.Type))
 
 Instances
-instance First @Type Int
-instance Second @Type Boolean
+instance Main.First @Prim.Type Prim.Int
+instance Main.Second @Prim.Type Prim.Boolean

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.snap
@@ -6,13 +6,14 @@ expression: report
 Terms
 
 Types
-Parent :: forall (k :: Type). (k :: Type) -> Constraint
-Child :: forall (k :: Type). (k :: Type) -> Constraint
+Parent :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Constraint
+Child :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Constraint
 
 Classes
-class forall (k :: Type) (value :: (k :: Type)). Parent @(k :: Type) (value :: (k :: Type))
-class forall (k :: Type) (value :: (k :: Type)). Parent @(k :: Type) (value :: (k :: Type)) <= Child @(k :: Type) (value :: (k :: Type))
+class forall (k :: Prim.Type) (value :: (k :: Prim.Type)). Main.Parent @(k :: Prim.Type) (value :: (k :: Prim.Type))
+class forall (k :: Prim.Type) (value :: (k :: Prim.Type)). Main.Parent @(k :: Prim.Type) (value :: (k :: Prim.Type)) <= Main.Child @(k :: Prim.Type) (value :: (k :: Prim.Type))
 
 Instances
-instance forall (t :: Type) (t1 :: (t :: Type)).
-  Parent @(t :: Type) (t1 :: (t :: Type)) => Child @(t :: Type) (t1 :: (t :: Type))
+instance forall (t :: Prim.Type) (t1 :: (t :: Prim.Type)).
+  Main.Parent @(t :: Prim.Type) (t1 :: (t :: Prim.Type)) =>
+  Main.Child @(t :: Prim.Type) (t1 :: (t :: Prim.Type))

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_instance/Main.snap
@@ -6,13 +6,13 @@ expression: report
 Terms
 
 Types
-Parent :: Type -> Constraint
-Child :: Type -> Constraint
+Parent :: Prim.Type -> Prim.Constraint
+Child :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (value :: Type). Parent (value :: Type)
-class forall (value :: Type). Parent (value :: Type) <= Child (value :: Type)
+class forall (value :: Prim.Type). Main.Parent (value :: Prim.Type)
+class forall (value :: Prim.Type). Main.Parent (value :: Prim.Type) <= Main.Child (value :: Prim.Type)
 
 Instances
-instance Parent Int
-instance Child Int
+instance Main.Parent Prim.Int
+instance Main.Child Prim.Int

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_missing/Main.snap
@@ -4,19 +4,19 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Missing :: Missing
+Missing :: Main.Missing
 
 Types
-Missing :: Type
-Parent :: Type -> Constraint
-Child :: Type -> Constraint
+Missing :: Prim.Type
+Parent :: Prim.Type -> Prim.Constraint
+Child :: Prim.Type -> Prim.Constraint
 
 Classes
-class forall (value :: Type). Parent (value :: Type)
-class forall (value :: Type). Parent (value :: Type) <= Child (value :: Type)
+class forall (value :: Prim.Type). Main.Parent (value :: Prim.Type)
+class forall (value :: Prim.Type). Main.Parent (value :: Prim.Type) <= Main.Child (value :: Prim.Type)
 
 Instances
-instance Child Missing
+instance Main.Child Main.Missing
 
 Roles
 Missing = []

--- a/tests-integration/fixtures/checking/1784872200_do_higher_rank_action/Main.snap
+++ b/tests-integration/fixtures/checking/1784872200_do_higher_rank_action/Main.snap
@@ -4,17 +4,17 @@ assertion_line: 50
 expression: report
 ---
 Terms
-polymorphic :: forall (value :: Type). Box (value :: Type)
+polymorphic :: forall (value :: Prim.Type). Main.Box (value :: Prim.Type)
 bind ::
-  forall (result :: Type).
-    (forall (value :: Type). Box (value :: Type)) ->
-    ((forall (value1 :: Type). Box (value1 :: Type)) -> (result :: Type)) ->
-    (result :: Type)
-test :: Int
-test' :: Int
+  forall (result :: Prim.Type).
+    (forall (value :: Prim.Type). Main.Box (value :: Prim.Type)) ->
+    ((forall (value1 :: Prim.Type). Main.Box (value1 :: Prim.Type)) -> (result :: Prim.Type)) ->
+    (result :: Prim.Type)
+test :: Prim.Int
+test' :: Prim.Int
 
 Types
-Box :: Type -> Type
+Box :: Prim.Type -> Prim.Type
 
 Roles
 Box = [Nominal]

--- a/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785133080_reject_eq_derive_for_foreign_data/Main.snap
@@ -6,11 +6,11 @@ expression: report
 Terms
 
 Types
-Opaque :: Type
+Opaque :: Prim.Type
 
 Derived
-derive Eq Opaque
-derive Ord Opaque
+derive Data.Eq.Eq Main.Opaque
+derive Data.Ord.Ord Main.Opaque
 
 Roles
 Opaque = []

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
@@ -6,15 +6,17 @@ expression: report
 Terms
 
 Types
-Opaque1 :: Type -> Type
+Opaque1 :: Prim.Type -> Prim.Type
 
 Derived
-derive Eq1 Opaque1
-derive Ord1 Opaque1
-derive forall (t :: Type). Eq (t :: Type) => Eq (Imported (t :: Type))
-derive Eq1 Imported
-derive forall (t :: Type). Ord (t :: Type) => Ord (Imported (t :: Type))
-derive Ord1 Imported
+derive Data.Eq.Eq1 Main.Opaque1
+derive Data.Ord.Ord1 Main.Opaque1
+derive forall (t :: Prim.Type).
+  Data.Eq.Eq (t :: Prim.Type) => Data.Eq.Eq (Library.Imported (t :: Prim.Type))
+derive Data.Eq.Eq1 Library.Imported
+derive forall (t :: Prim.Type).
+  Data.Ord.Ord (t :: Prim.Type) => Data.Ord.Ord (Library.Imported (t :: Prim.Type))
+derive Data.Ord.Ord1 Library.Imported
 
 Roles
 Opaque1 = [Nominal]

--- a/tests-integration/fixtures/checking/1785144660_derive_eq_ord_record_field/Main.snap
+++ b/tests-integration/fixtures/checking/1785144660_derive_eq_ord_record_field/Main.snap
@@ -4,14 +4,14 @@ assertion_line: 50
 expression: report
 ---
 Terms
-Box :: { value :: Int } -> Box
+Box :: { value :: Prim.Int } -> Main.Box
 
 Types
-Box :: Type
+Box :: Prim.Type
 
 Derived
-derive Eq Box
-derive Ord Box
+derive Data.Eq.Eq Main.Box
+derive Data.Ord.Ord Main.Box
 
 Roles
 Box = []

--- a/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.snap
+++ b/tests-integration/fixtures/semantic/1784637780_data_declarations/Main.snap
@@ -3,15 +3,15 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Proxy :: forall (k :: Type). k -> Type
+data Proxy :: forall (k :: Prim.Type). k -> Prim.Type
 data Proxy @a
-  | Proxy :: Proxy a
+  | Proxy :: Main.Proxy a
 
-newtype Tagged :: forall (k :: Type). k -> Type -> Type
+newtype Tagged :: forall (k :: Prim.Type). k -> Prim.Type -> Prim.Type
 newtype Tagged @t @a
-  | Tagged :: a -> Tagged t a
+  | Tagged :: a -> Main.Tagged t a
 
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Just :: a -> Maybe a
-  | Nothing :: Maybe a
+  | Just :: a -> Main.Maybe a
+  | Nothing :: Main.Maybe a

--- a/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.snap
+++ b/tests-integration/fixtures/semantic/1784643600_constructor_binder_value_declaration/Main.snap
@@ -3,11 +3,11 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Just :: a -> Maybe a
-  | Nothing :: Maybe a
+  | Just :: a -> Main.Maybe a
+  | Nothing :: Main.Maybe a
 
-fromMaybe :: forall t. t -> Maybe t -> t
+fromMaybe :: forall t. t -> Main.Maybe t -> t
 fromMaybe = \default -> \(Just value) -> value
 fromMaybe = \default -> \Nothing -> default

--- a/tests-integration/fixtures/semantic/1784704260_automatic_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_automatic_applications/Main.snap
@@ -3,20 +3,20 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Default :: Type -> Constraint
+interface Default :: Prim.Type -> Prim.Constraint
 interface Default a where
   default :: a
 
-interface First :: Type -> Constraint
+interface First :: Prim.Type -> Prim.Constraint
 interface First a where
 
-interface Second :: Type -> Constraint
+interface Second :: Prim.Type -> Prim.Constraint
 interface Second a where
 
-useDefault :: forall a. Default a => a
+useDefault :: forall a. Main.Default a => a
 useDefault = \{defaultDict} -> default @a {defaultDict}
 
-foreign import interleaved :: forall a. First a => (forall b. Second b => a -> b)
+foreign import interleaved :: forall a. Main.First a => (forall b. Main.Second b => a -> b)
 
-useInterleaved :: forall a b. First a => Second b => a -> b
+useInterleaved :: forall a b. Main.First a => Main.Second b => a -> b
 useInterleaved = \{firstDict} -> \{secondDict} -> interleaved @a {firstDict} @b {secondDict}

--- a/tests-integration/fixtures/semantic/1784704260_constructor_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_constructor_expressions/Main.snap
@@ -3,10 +3,10 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Just :: a -> Maybe a
-  | Nothing :: Maybe a
+  | Just :: a -> Main.Maybe a
+  | Nothing :: Main.Maybe a
 
-nothing :: forall a. Maybe a
+nothing :: forall a. Main.Maybe a
 nothing = Nothing @a

--- a/tests-integration/fixtures/semantic/1784704260_guarded_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784704260_guarded_expressions/Main.snap
@@ -3,12 +3,12 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Just :: a -> Maybe a
-  | Nothing :: Maybe a
+  | Just :: a -> Main.Maybe a
+  | Nothing :: Main.Maybe a
 
-recover :: forall a. a -> Maybe a -> a
+recover :: forall a. a -> Main.Maybe a -> a
 recover = \fallback -> \input ->
   | (Just value) <- input -> value
   | true -> fallback

--- a/tests-integration/fixtures/semantic/1784705640_array_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_array_binders/Main.snap
@@ -3,6 +3,6 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-headOr :: forall a. a -> Array a -> a
+headOr :: forall a. a -> Prim.Array a -> a
 headOr = \fallback -> \[first, _] -> first
 headOr = \fallback -> \_ -> fallback

--- a/tests-integration/fixtures/semantic/1784705640_literal_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_literal_binders/Main.snap
@@ -3,22 +3,22 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-integer :: forall a. Int -> a -> a
+integer :: forall a. Prim.Int -> a -> a
 integer = \(-1) -> \value -> value
 integer = \_ -> \value -> value
 
-number :: forall a. Number -> a -> a
+number :: forall a. Prim.Number -> a -> a
 number = \(-1.5) -> \value -> value
 number = \_ -> \value -> value
 
-string :: forall a. String -> a -> a
+string :: forall a. Prim.String -> a -> a
 string = \"life" -> \value -> value
 string = \_ -> \value -> value
 
-character :: forall a. Char -> a -> a
+character :: forall a. Prim.Char -> a -> a
 character = \'a' -> \value -> value
 character = \_ -> \value -> value
 
-boolean :: forall a. Boolean -> a -> a
+boolean :: forall a. Prim.Boolean -> a -> a
 boolean = \true -> \value -> value
 boolean = \false -> \value -> value

--- a/tests-integration/fixtures/semantic/1784705640_named_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_named_binders/Main.snap
@@ -3,11 +3,11 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Just :: a -> Maybe a
-  | Nothing :: Maybe a
+  | Just :: a -> Main.Maybe a
+  | Nothing :: Main.Maybe a
 
-fromMaybe :: forall a. a -> Maybe a -> a
+fromMaybe :: forall a. a -> Main.Maybe a -> a
 fromMaybe = \fallback -> \whole@(Just value) -> value
 fromMaybe = \fallback -> \Nothing -> fallback

--- a/tests-integration/fixtures/semantic/1784705640_typed_binders/Main.snap
+++ b/tests-integration/fixtures/semantic/1784705640_typed_binders/Main.snap
@@ -3,5 +3,5 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-identity :: Int -> Int
-identity = \(value :: Int) -> value
+identity :: Prim.Int -> Prim.Int
+identity = \(value :: Prim.Int) -> value

--- a/tests-integration/fixtures/semantic/1784708400_failed_explicit_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_failed_explicit_applications/Main.snap
@@ -3,9 +3,9 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-foreign import identityInt :: Int -> Int
+foreign import identityInt :: Prim.Int -> Prim.Int
 
-foreign import integer :: Int
+foreign import integer :: Prim.Int
 
-test :: Int
+test :: Prim.Int
 test = <error>

--- a/tests-integration/fixtures/semantic/1784708400_failed_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_failed_visible_type_application/Main.snap
@@ -6,5 +6,5 @@ expression: report
 identity :: forall @a. a -> a
 identity = \value -> value
 
-test :: Int -> Int
+test :: Prim.Int -> Prim.Int
 test = <error>

--- a/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_interleaved_explicit_applications/Main.snap
@@ -3,14 +3,14 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface First :: Type -> Constraint
+interface First :: Prim.Type -> Prim.Constraint
 interface First a where
 
-interface Second :: Type -> Constraint
+interface Second :: Prim.Type -> Prim.Constraint
 interface Second a where
 
-foreign import interleaved :: forall a. First a => a -> (forall b. Second b => b -> a)
+foreign import interleaved :: forall a. Main.First a => a -> (forall b. Main.Second b => b -> a)
 
-applyInterleaved :: forall a b. First a => Second b => a -> b -> a
+applyInterleaved :: forall a b. Main.First a => Main.Second b => a -> b -> a
 applyInterleaved = \{firstDict} -> \{secondDict} -> \first -> \second ->
   interleaved @a {firstDict} first @b {secondDict} second

--- a/tests-integration/fixtures/semantic/1784708400_visible_type_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708400_visible_type_applications/Main.snap
@@ -9,8 +9,8 @@ identity = \value -> value
 const :: forall a @b. a -> b -> a
 const = \value -> \_ -> value
 
-testIdentity :: Int -> Int
-testIdentity = identity @Int
+testIdentity :: Prim.Int -> Prim.Int
+testIdentity = identity @Prim.Int
 
-testConst :: forall t. t -> String -> t
-testConst = const @t @String
+testConst :: forall t. t -> Prim.String -> t
+testConst = const @t @Prim.String

--- a/tests-integration/fixtures/semantic/1784708580_interleaved_visible_type_application/Main.snap
+++ b/tests-integration/fixtures/semantic/1784708580_interleaved_visible_type_application/Main.snap
@@ -3,10 +3,10 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Default :: Type -> Constraint
+interface Default :: Prim.Type -> Prim.Constraint
 interface Default a where
 
-foreign import select :: forall a. Default a => (forall @b. a -> b -> a)
+foreign import select :: forall a. Main.Default a => (forall @b. a -> b -> a)
 
-specialize :: forall a. Default a => a -> String -> a
-specialize = \{defaultDict} -> select @a {defaultDict} @String
+specialize :: forall a. Main.Default a => a -> Prim.String -> a
+specialize = \{defaultDict} -> select @a {defaultDict} @Prim.String

--- a/tests-integration/fixtures/semantic/1784738940_class_interfaces/Main.snap
+++ b/tests-integration/fixtures/semantic/1784738940_class_interfaces/Main.snap
@@ -3,11 +3,11 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Empty :: Type -> Constraint
+interface Empty :: Prim.Type -> Prim.Constraint
 interface Empty a where
 
-interface Example :: forall (k :: Type). k -> Type -> Constraint
+interface Example :: forall (k :: Prim.Type). k -> Prim.Type -> Prim.Constraint
 interface Example value result where
   identity :: result -> result
-  alternate :: forall (intermediate :: Type). intermediate -> result
-  constrained :: forall (intermediate :: Type). Empty intermediate => intermediate -> result
+  alternate :: forall (intermediate :: Prim.Type). intermediate -> result
+  constrained :: forall (intermediate :: Prim.Type). Main.Empty intermediate => intermediate -> result

--- a/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Main.snap
+++ b/tests-integration/fixtures/semantic/1784738940_class_superclass_fields/Main.snap
@@ -3,23 +3,23 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Ordering :: Type
+data Ordering :: Prim.Type
 data Ordering
-  | LT :: Ordering
-  | EQ :: Ordering
-  | GT :: Ordering
+  | LT :: Main.Ordering
+  | EQ :: Main.Ordering
+  | GT :: Main.Ordering
 
-interface Eq :: Type -> Constraint
+interface Eq :: Prim.Type -> Prim.Constraint
 interface Eq a where
-  eq :: a -> a -> Boolean
+  eq :: a -> a -> Prim.Boolean
 
-interface Ord :: Type -> Constraint
+interface Ord :: Prim.Type -> Prim.Constraint
 interface Ord a where
-  superclass eqDict :: Eq a
-  compare :: a -> a -> Ordering
+  superclass eqDict :: Main.Eq a
+  compare :: a -> a -> Main.Ordering
 
-interface Child :: Type -> Constraint
+interface Child :: Prim.Type -> Prim.Constraint
 interface Child a where
-  superclass parentDict1 :: Parent a
-  superclass parentDict2 :: Parent a
+  superclass parentDict1 :: First.Parent a
+  superclass parentDict2 :: Second.Parent a
   parentDict :: a -> a

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
@@ -3,26 +3,26 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface First :: Type -> Constraint
+interface First :: Prim.Type -> Prim.Constraint
 interface First a where
 
-interface Second :: Type -> Constraint
+interface Second :: Prim.Type -> Prim.Constraint
 interface Second b where
 
-interface Example :: Type -> Type -> Constraint
+interface Example :: Prim.Type -> Prim.Type -> Prim.Constraint
 interface Example a b where
-  example :: a -> b -> Boolean
+  example :: a -> b -> Prim.Boolean
 
-implementation :: forall b a. Second b => a -> b -> Boolean
+implementation :: forall b a. Main.Second b => a -> b -> Prim.Boolean
 implementation = \{secondDict} -> \_ -> \_ -> boolean
 
-foreign import boolean :: Boolean
+foreign import boolean :: Prim.Boolean
 
 dictionary exampleAB ::
   forall t t1.
-  { firstDict :: First t } =>
-  { secondDict :: Second t1 } =>
-  Example t t1
+  { firstDict :: Main.First t } =>
+  { secondDict :: Main.Second t1 } =>
+  Main.Example t t1
   where
-  example :: t -> t1 -> Boolean
+  example :: t -> t1 -> Prim.Boolean
   example = implementation @t1 @t {secondDict}

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_members/Main.snap
@@ -3,18 +3,18 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Token :: Type
+data Token :: Prim.Type
 data Token
-  | FirstToken :: Token
-  | SecondToken :: Token
+  | FirstToken :: Main.Token
+  | SecondToken :: Main.Token
 
-interface Example :: Type -> Constraint
+interface Example :: Prim.Type -> Prim.Constraint
 interface Example a where
   first :: a
   second :: a
 
-dictionary exampleToken :: Example Token where
-  first :: Token
+dictionary exampleToken :: Main.Example Main.Token where
+  first :: Main.Token
   first = FirstToken
-  second :: Token
+  second :: Main.Token
   second = SecondToken

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_superclasses/Main.snap
@@ -3,17 +3,17 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Eq :: Type -> Constraint
+interface Eq :: Prim.Type -> Prim.Constraint
 interface Eq a where
 
-interface Ord :: Type -> Constraint
+interface Ord :: Prim.Type -> Prim.Constraint
 interface Ord a where
-  superclass eqDict :: Eq a
-  compare :: a -> a -> Int
+  superclass eqDict :: Main.Eq a
+  compare :: a -> a -> Prim.Int
 
-foreign import compareImpl :: Int -> Int -> Int
+foreign import compareImpl :: Prim.Int -> Prim.Int -> Prim.Int
 
-dictionary ordInt :: { eqDict :: Eq Int } => Ord Int where
+dictionary ordInt :: { eqDict :: Main.Eq Prim.Int } => Main.Ord Prim.Int where
   superclass eqDict = eqDict
-  compare :: Int -> Int -> Int
+  compare :: Prim.Int -> Prim.Int -> Prim.Int
   compare = compareImpl

--- a/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741520_instance_dictionary_member_constraints/Main.snap
@@ -3,18 +3,18 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Required :: Type -> Constraint
+interface Required :: Prim.Type -> Prim.Constraint
 interface Required value where
 
-interface Example :: Type -> Constraint
+interface Example :: Prim.Type -> Prim.Constraint
 interface Example a where
-  apply :: forall (b :: Type). Required b => a -> b -> Boolean
+  apply :: forall (b :: Prim.Type). Main.Required b => a -> b -> Prim.Boolean
 
-implementation :: forall a b. Required b => a -> b -> Boolean
+implementation :: forall a b. Main.Required b => a -> b -> Prim.Boolean
 implementation = \{requiredDict} -> \_ -> \_ -> boolean
 
-foreign import boolean :: Boolean
+foreign import boolean :: Prim.Boolean
 
-dictionary exampleInt :: Example Int where
-  apply :: forall (b :: Type). Required b => Int -> b -> Boolean
-  apply = \{requiredDict} -> implementation @Int @b {requiredDict}
+dictionary exampleInt :: Main.Example Prim.Int where
+  apply :: forall (b :: Prim.Type). Main.Required b => Prim.Int -> b -> Prim.Boolean
+  apply = \{requiredDict} -> implementation @Prim.Int @b {requiredDict}

--- a/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742060_instance_dictionary_nullary_constraints/Main.snap
@@ -3,23 +3,26 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Required :: Type -> Constraint
+interface Required :: Prim.Type -> Prim.Constraint
 interface Required value where
 
-interface Example :: Type -> Constraint
+interface Example :: Prim.Type -> Prim.Constraint
 interface Example a where
-  example :: Boolean
+  example :: Prim.Boolean
 
-implementation :: Fail (Text "first deferred error") => Required Int => Fail (Text "second deferred error") => Boolean
+implementation :: Prim.TypeError.Fail (Prim.TypeError.Text "first deferred error") =>
+Main.Required Prim.Int =>
+Prim.TypeError.Fail (Prim.TypeError.Text "second deferred error") =>
+Prim.Boolean
 implementation = \{failDict} -> \{requiredDict} -> \{failDict1} -> boolean
 
-foreign import boolean :: Boolean
+foreign import boolean :: Prim.Boolean
 
 dictionary exampleInt ::
-  { failDict :: Fail (Text "first deferred error") } =>
-  { requiredDict :: Required Int } =>
-  { failDict1 :: Fail (Text "second deferred error") } =>
-  Example Int
+  { failDict :: Prim.TypeError.Fail (Prim.TypeError.Text "first deferred error") } =>
+  { requiredDict :: Main.Required Prim.Int } =>
+  { failDict1 :: Prim.TypeError.Fail (Prim.TypeError.Text "second deferred error") } =>
+  Main.Example Prim.Int
   where
-  example :: Boolean
+  example :: Prim.Boolean
   example = implementation {failDict} {requiredDict} {failDict1}

--- a/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742120_instance_dictionary_imported_class/Main.snap
@@ -3,11 +3,12 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Token :: Type
+data Token :: Prim.Type
 data Token
-  | Token :: Token
+  | Token :: Main.Token
 
-dictionary childToken :: { parentDict :: Parent Token } => Child Token where
+dictionary childToken :: { parentDict :: Classes.Parent Main.Token } => Classes.Child Main.Token
+  where
   superclass parentDict = parentDict
-  child :: Token
+  child :: Main.Token
   child = Token

--- a/tests-integration/fixtures/semantic/1784742180_value_nullary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784742180_value_nullary_constraints/Main.snap
@@ -3,7 +3,9 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-foreign import boolean :: Boolean
+foreign import boolean :: Prim.Boolean
 
-deferred :: Fail (Text "first deferred error") => Fail (Text "second deferred error") => Boolean
+deferred :: Prim.TypeError.Fail (Prim.TypeError.Text "first deferred error") =>
+Prim.TypeError.Fail (Prim.TypeError.Text "second deferred error") =>
+Prim.Boolean
 deferred = \{failDict} -> \{failDict1} -> boolean

--- a/tests-integration/fixtures/semantic/1784777100_numeric_and_boolean_expression_literals/Main.snap
+++ b/tests-integration/fixtures/semantic/1784777100_numeric_and_boolean_expression_literals/Main.snap
@@ -3,23 +3,23 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-booleanTrue :: Boolean
+booleanTrue :: Prim.Boolean
 booleanTrue = true
 
-booleanFalse :: Boolean
+booleanFalse :: Prim.Boolean
 booleanFalse = false
 
-integer :: Int
+integer :: Prim.Int
 integer = 1
 
-integerHexadecimal :: Int
+integerHexadecimal :: Prim.Int
 integerHexadecimal = 42
 
-integerMaximum :: Int
+integerMaximum :: Prim.Int
 integerMaximum = 2147483647
 
-numberDecimal :: Number
+numberDecimal :: Prim.Number
 numberDecimal = 1.0
 
-numberExponent :: Number
+numberExponent :: Prim.Number
 numberExponent = 6.02e23

--- a/tests-integration/fixtures/semantic/1784777100_text_expression_literals/Main.snap
+++ b/tests-integration/fixtures/semantic/1784777100_text_expression_literals/Main.snap
@@ -3,38 +3,38 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-string :: String
+string :: Prim.String
 string = "line\n\"quote\"\\end"
 
-rawString :: String
+rawString :: Prim.String
 rawString = """line\n"quoted"\\end"""
 
-character :: Char
+character :: Prim.Char
 character = 'λ'
 
-characterNewline :: Char
+characterNewline :: Prim.Char
 characterNewline = '\n'
 
-characterCarriageReturn :: Char
+characterCarriageReturn :: Prim.Char
 characterCarriageReturn = '\r'
 
-characterTab :: Char
+characterTab :: Prim.Char
 characterTab = '\t'
 
-characterQuote :: Char
+characterQuote :: Prim.Char
 characterQuote = '\''
 
-characterBackslash :: Char
+characterBackslash :: Prim.Char
 characterBackslash = '\\'
 
-characterNull :: Char
+characterNull :: Prim.Char
 characterNull = '\0'
 
-characterHexadecimal :: Char
+characterHexadecimal :: Prim.Char
 characterHexadecimal = '☃'
 
-characterDelete :: Char
+characterDelete :: Prim.Char
 characterDelete = '\x7f'
 
-characterControl :: Char
+characterControl :: Prim.Char
 characterControl = '\x85'

--- a/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_array_expressions/Main.snap
@@ -6,26 +6,26 @@ expression: report
 identity :: forall t. t -> t
 identity = \value -> value
 
-empty :: Array Int
+empty :: Prim.Array Prim.Int
 empty = []
 
-values :: Array Int
+values :: Prim.Array Prim.Int
 values = [1, 2]
 
-nested :: Array (Array Int)
+nested :: Prim.Array (Prim.Array Prim.Int)
 nested = [[1], [2, 3]]
 
-inferredFunctions :: forall t. Array (t -> t)
+inferredFunctions :: forall t. Prim.Array (t -> t)
 inferredFunctions = [identity]
 
-checkedFunctions :: Array (Int -> Int)
-checkedFunctions = [identity @Int]
+checkedFunctions :: Prim.Array (Prim.Int -> Prim.Int)
+checkedFunctions = [identity @Prim.Int]
 
-checkedIdentity :: Array Int -> Array Int
-checkedIdentity = identity @(Array Int)
+checkedIdentity :: Prim.Array Prim.Int -> Prim.Array Prim.Int
+checkedIdentity = identity @(Prim.Array Prim.Int)
 
-consume :: Array Int -> Array Int
+consume :: Prim.Array Prim.Int -> Prim.Array Prim.Int
 consume = \value -> value
 
-application :: Array Int
+application :: Prim.Array Prim.Int
 application = consume [1, 2]

--- a/tests-integration/fixtures/semantic/1784779800_record_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_expressions/Main.snap
@@ -3,23 +3,23 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-value :: Int
+value :: Prim.Int
 value = 42
 
 empty :: {}
 empty = { }
 
-explicit :: { a :: String, z :: Int }
+explicit :: { a :: Prim.String, z :: Prim.Int }
 explicit = { z: 1, a: "text" }
 
-punned :: { value :: Int }
+punned :: { value :: Prim.Int }
 punned = { value }
 
-nested :: { array :: Array Int, record :: { boolean :: Boolean } }
+nested :: { array :: Prim.Array Prim.Int, record :: { boolean :: Prim.Boolean } }
 nested = { array: [1, 2], record: { boolean: true } }
 
-consume :: { value :: Int } -> Int
+consume :: { value :: Prim.Int } -> Prim.Int
 consume = \{ value: inner } -> inner
 
-application :: Int
+application :: Prim.Int
 application = consume { value: 1 }

--- a/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779800_record_pun_applications/Main.snap
@@ -3,38 +3,38 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface First :: Type -> Constraint
+interface First :: Prim.Type -> Prim.Constraint
 interface First a where
 
-interface Second :: Type -> Constraint
+interface Second :: Prim.Type -> Prim.Constraint
 interface Second a where
 
-interface Capability :: (Type -> Type) -> Constraint
+interface Capability :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 interface Capability m where
 
-foreign import interleaved :: forall a. First a => (forall b. Second b => a -> b)
+foreign import interleaved :: forall a. Main.First a => (forall b. Main.Second b => a -> b)
 
-inferredPun :: forall t t1. First t => Second t1 => { interleaved :: t -> t1 }
+inferredPun :: forall t t1. Main.First t => Main.Second t1 => { interleaved :: t -> t1 }
 inferredPun = \{firstDict} -> \{secondDict} ->
   { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
 
-inferredExplicit :: forall t t1. First t => Second t1 => { interleaved :: t -> t1 }
+inferredExplicit :: forall t t1. Main.First t => Main.Second t1 => { interleaved :: t -> t1 }
 inferredExplicit = \{firstDict} -> \{secondDict} ->
   { interleaved: interleaved @t {firstDict} @t1 {secondDict} }
 
-aliased :: Alias
+aliased :: Main.Alias
 aliased = 1
 
-inferredAliasPun :: { aliased :: Int }
+inferredAliasPun :: { aliased :: Prim.Int }
 inferredAliasPun = { aliased }
 
-inferredAliasExplicit :: { aliased :: Int }
+inferredAliasExplicit :: { aliased :: Prim.Int }
 inferredAliasExplicit = { aliased: aliased }
 
-foreign import fetch :: forall m. Capability m => Int -> m Int
+foreign import fetch :: forall m. Main.Capability m => Prim.Int -> m Prim.Int
 
-expectedPun :: Setup
+expectedPun :: Main.Setup
 expectedPun = { fetch: fetch @m {capabilityDict} }
 
-expectedExplicit :: Setup
+expectedExplicit :: Main.Setup
 expectedExplicit = { fetch: fetch @m {capabilityDict} }

--- a/tests-integration/fixtures/semantic/1784779860_record_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784779860_record_expression_recovery/Main.snap
@@ -3,7 +3,7 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-missingField :: { valid :: Int }
+missingField :: { valid :: Prim.Int }
 missingField = <error>
 
 unresolvedPun :: {}

--- a/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_infix_expressions/Main.snap
@@ -6,14 +6,14 @@ expression: report
 choose :: forall a b. a -> b -> a
 choose = \left -> \right -> left
 
-singleInfix :: Int
-singleInfix = choose @Int @String 1 "text"
+singleInfix :: Prim.Int
+singleInfix = choose @Prim.Int @Prim.String 1 "text"
 
-multipleInfix :: Int
-multipleInfix = choose @Int @Boolean (choose @Int @String 1 "first") true
+multipleInfix :: Prim.Int
+multipleInfix = choose @Prim.Int @Prim.Boolean (choose @Prim.Int @Prim.String 1 "first") true
 
 identity :: forall a. a -> a
 identity = \value -> value
 
 polymorphicHead :: forall t. t -> t
-polymorphicHead = choose @(t -> t) @Int identity 1
+polymorphicHead = choose @(t -> t) @Prim.Int identity 1

--- a/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_chains/Main.snap
@@ -3,32 +3,32 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface First :: Type -> Constraint
+interface First :: Prim.Type -> Prim.Constraint
 interface First a where
 
-interface Second :: Type -> Constraint
+interface Second :: Prim.Type -> Prim.Constraint
 interface Second a where
 
-add :: Int -> Int -> Int
+add :: Prim.Int -> Prim.Int -> Prim.Int
 add = \left -> \right -> left
 
-multiply :: Int -> Int -> Int
+multiply :: Prim.Int -> Prim.Int -> Prim.Int
 multiply = \left -> \right -> right
 
-precedence :: Int
+precedence :: Prim.Int
 precedence = add 1 (multiply 2 3)
 
-leftAssociative :: Int
+leftAssociative :: Prim.Int
 leftAssociative = add (add 1 2) 3
 
-append :: Int -> Int -> Int
+append :: Prim.Int -> Prim.Int -> Prim.Int
 append = \left -> \right -> left
 
-rightAssociative :: Int
+rightAssociative :: Prim.Int
 rightAssociative = append 1 (append 2 3)
 
-foreign import interleaved :: forall a. First a => a -> (forall b. Second b => b -> a)
+foreign import interleaved :: forall a. Main.First a => a -> (forall b. Main.Second b => b -> a)
 
-implicitApplications :: forall a b. First a => Second b => a -> b -> a
+implicitApplications :: forall a b. Main.First a => Main.Second b => a -> b -> a
 implicitApplications = \{firstDict} -> \{secondDict} -> \left -> \right ->
   interleaved @a {firstDict} left @b {secondDict} right

--- a/tests-integration/fixtures/semantic/1784789520_operator_names/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789520_operator_names/Main.snap
@@ -3,20 +3,20 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Combine :: Type -> Constraint
+interface Combine :: Prim.Type -> Prim.Constraint
 interface Combine a where
   combine :: a -> a -> a
 
-data List :: Type -> Type
+data List :: Prim.Type -> Prim.Type
 data List @a
-  | Cons :: a -> List a -> List a
-  | Nil :: List a
+  | Cons :: a -> Main.List a -> Main.List a
+  | Nil :: Main.List a
 
-operatorName :: forall a. Combine a => a -> a -> a
+operatorName :: forall a. Main.Combine a => a -> a -> a
 operatorName = \{combineDict} -> combine @a {combineDict}
 
-operatorApplication :: forall a. Combine a => a -> a -> a
+operatorApplication :: forall a. Main.Combine a => a -> a -> a
 operatorApplication = \{combineDict} -> \left -> \right -> combine @a {combineDict} left right
 
-constructorOperator :: forall t. t -> List t -> List t
+constructorOperator :: forall t. t -> Main.List t -> Main.List t
 constructorOperator = Cons @t

--- a/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789640_negate_expressions/Main.snap
@@ -3,13 +3,13 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Negative :: Type -> Constraint
+interface Negative :: Prim.Type -> Prim.Constraint
 interface Negative a where
 
-foreign import negate :: forall a. Negative a => a -> a
+foreign import negate :: forall a. Main.Negative a => a -> a
 
-negative :: forall a. Negative a => a -> a
+negative :: forall a. Main.Negative a => a -> a
 negative = \{negativeDict} -> \value -> negate @a {negativeDict} value
 
-shadowedNegate :: (Int -> Int) -> Int -> Int
+shadowedNegate :: (Prim.Int -> Prim.Int) -> Prim.Int -> Prim.Int
 shadowedNegate = \negate -> \value -> negate value

--- a/tests-integration/fixtures/semantic/1784789700_operator_chain_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784789700_operator_chain_recovery/Main.snap
@@ -3,8 +3,8 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-add :: Int -> Int -> Int
+add :: Prim.Int -> Prim.Int -> Prim.Int
 add = \left -> \right -> left
 
-missingRightOperand :: Int
+missingRightOperand :: Prim.Int
 missingRightOperand = <error>

--- a/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
+++ b/tests-integration/fixtures/semantic/1784814060_local_named_let_bindings/Main.snap
@@ -3,9 +3,9 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Identity :: Type -> Type
+data Identity :: Prim.Type -> Prim.Type
 data Identity @a
-  | Identity :: a -> Identity a
+  | Identity :: a -> Main.Identity a
 
 letBinding :: forall a. a -> a
 letBinding = \value ->
@@ -21,7 +21,7 @@ whereBinding = \value -> local
   local :: a
   local = value
 
-unIdentity :: forall a. Identity a -> a
+unIdentity :: forall a. Main.Identity a -> a
 unIdentity = \value ->
   let
     (Identity inner) = value

--- a/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784824200_case_expressions/Main.snap
@@ -3,27 +3,27 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Choice :: Type -> Type
+data Choice :: Prim.Type -> Prim.Type
 data Choice @a
-  | Empty :: Choice a
-  | One :: a -> Choice a
-  | Pair :: a -> a -> Choice a
+  | Empty :: Main.Choice a
+  | One :: a -> Main.Choice a
+  | Pair :: a -> a -> Main.Choice a
 
-checked :: Choice Int -> Int
+checked :: Main.Choice Prim.Int -> Prim.Int
 checked = \choice ->
   case choice of
     Empty -> 0
     (One value) -> value
     (Pair left _) -> left
 
-inferred :: Choice Int -> Int
+inferred :: Main.Choice Prim.Int -> Prim.Int
 inferred = \choice ->
   case choice of
     Empty -> 0
     (One value) -> value
     (Pair left _) -> left
 
-multiple :: Choice Int -> Choice Int -> Int
+multiple :: Main.Choice Prim.Int -> Main.Choice Prim.Int -> Prim.Int
 multiple = \first -> \second ->
   case first, second of
     (One left), (One _) -> left
@@ -31,7 +31,7 @@ multiple = \first -> \second ->
     _, (One right) -> right
     _, _ -> 0
 
-partial :: forall t. Partial => Choice t -> t
+partial :: forall t. Prim.Partial => Main.Choice t -> t
 partial = \{trivial} -> \choice ->
   case choice of
     (One value) -> value

--- a/tests-integration/fixtures/semantic/1784825100_guarded_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825100_guarded_case_expressions/Main.snap
@@ -3,13 +3,13 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Choice :: Type -> Type
+data Choice :: Prim.Type -> Prim.Type
 data Choice @a
-  | Empty :: Choice a
-  | One :: a -> Choice a
-  | Pair :: a -> a -> Choice a
+  | Empty :: Main.Choice a
+  | One :: a -> Main.Choice a
+  | Pair :: a -> a -> Main.Choice a
 
-guarded :: Boolean -> Choice (Choice Int) -> Int
+guarded :: Prim.Boolean -> Main.Choice (Main.Choice Prim.Int) -> Prim.Int
 guarded = \condition -> \choice ->
   case choice of
     (One nested)
@@ -19,11 +19,11 @@ guarded = \condition -> \choice ->
       | (One value) <- right -> value
     _ -> 0
 
-withWhere :: Choice Int -> Int
+withWhere :: Main.Choice Prim.Int -> Prim.Int
 withWhere = \choice ->
   case choice of
     (One value) -> local
       where
-      local :: Int
+      local :: Prim.Int
       local = value
     _ -> 0

--- a/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825100_nested_case_expressions/Main.snap
@@ -3,16 +3,16 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Choice :: Type -> Type
+data Choice :: Prim.Type -> Prim.Type
 data Choice @a
-  | Empty :: Choice a
-  | One :: a -> Choice a
-  | Pair :: a -> a -> Choice a
+  | Empty :: Main.Choice a
+  | One :: a -> Main.Choice a
+  | Pair :: a -> a -> Main.Choice a
 
 identity :: forall a. a -> a
 identity = \value -> value
 
-nested :: Choice (Choice Int) -> Int
+nested :: Main.Choice (Main.Choice Prim.Int) -> Prim.Int
 nested = \choice ->
   case choice of
     (One inner) ->
@@ -22,8 +22,8 @@ nested = \choice ->
         _ -> 0
     _ -> 0
 
-applied :: Choice Int -> Int
+applied :: Main.Choice Prim.Int -> Prim.Int
 applied = \choice ->
-  identity @Int case choice of
+  identity @Prim.Int case choice of
     (One value) -> value
     _ -> 0

--- a/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784825400_case_expression_recovery/Main.snap
@@ -3,12 +3,12 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-missingScrutinee :: Boolean
+missingScrutinee :: Prim.Boolean
 missingScrutinee =
   case <error> of
     <error> -> true
 
-mismatchedBinders :: forall t t1. t -> t1 -> Boolean
+mismatchedBinders :: forall t t1. t -> t1 -> Prim.Boolean
 mismatchedBinders = \first -> \second ->
   case first, second of
     _ -> true

--- a/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828280_lambda_expression_recovery/Main.snap
@@ -3,7 +3,7 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-missingBinder :: Boolean
+missingBinder :: Prim.Boolean
 missingBinder = \<error> -> true
 
 missingBody :: forall t t1. t -> t1

--- a/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_nested_lambda_expressions/Main.snap
@@ -3,15 +3,15 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Nothing :: Maybe a
-  | Just :: a -> Maybe a
+  | Nothing :: Main.Maybe a
+  | Just :: a -> Main.Maybe a
 
 nested :: forall t t1. t -> t1 -> t
 nested = \first -> \second -> first
 
-caseBody :: Maybe Int -> Int
+caseBody :: Main.Maybe Prim.Int -> Prim.Int
 caseBody = \maybe ->
   case maybe of
     Nothing -> 0

--- a/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784828400_partial_lambda_expressions/Main.snap
@@ -3,13 +3,13 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Nothing :: Maybe a
-  | Just :: a -> Maybe a
+  | Nothing :: Main.Maybe a
+  | Just :: a -> Main.Maybe a
 
-checked :: Partial => Maybe Int -> Int
+checked :: Prim.Partial => Main.Maybe Prim.Int -> Prim.Int
 checked = \{partialDict} -> \(Just value) -> value
 
-inferred :: forall t. Partial => Maybe t -> t
+inferred :: forall t. Prim.Partial => Main.Maybe t -> t
 inferred = \{trivial} -> \(Just value) -> value

--- a/tests-integration/fixtures/semantic/1784872680_do_action_applications/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872680_do_action_applications/Main.snap
@@ -3,14 +3,15 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Select :: forall (k :: Type). k -> Constraint
+interface Select :: forall (k :: Prim.Type). k -> Prim.Constraint
 interface Select value where
 
-foreign import constrained :: forall value. Select @Type value => Effect value
+foreign import constrained :: forall value. Main.Select @Prim.Type value => Main.Effect value
 
-foreign import pure :: forall value. value -> Effect value
+foreign import pure :: forall value. value -> Main.Effect value
 
-foreign import bind :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+foreign import bind :: forall value result. Main.Effect value -> (value -> Main.Effect result) -> Main.Effect result
 
-selected :: Select @Type Int => Effect Int
-selected = \{selectDict} -> bind @Int @Int (constrained @Int {selectDict}) \value -> pure @Int value
+selected :: Main.Select @Prim.Type Prim.Int => Main.Effect Prim.Int
+selected = \{selectDict} ->
+  bind @Prim.Int @Prim.Int (constrained @Prim.Int {selectDict}) \value -> pure @Prim.Int value

--- a/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872680_do_expressions/Main.snap
@@ -3,27 +3,29 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-foreign import pure :: forall value. value -> Effect value
+foreign import pure :: forall value. value -> Main.Effect value
 
-foreign import bind :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+foreign import bind :: forall value result. Main.Effect value -> (value -> Main.Effect result) -> Main.Effect result
 
-foreign import discard :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+foreign import discard :: forall value result. Main.Effect value -> (value -> Main.Effect result) -> Main.Effect result
 
-bound :: Effect Int
-bound = bind @Int @Int (pure @Int 1) \value -> pure @Int value
+bound :: Main.Effect Prim.Int
+bound = bind @Prim.Int @Prim.Int (pure @Prim.Int 1) \value -> pure @Prim.Int value
 
-discarded :: Effect String
-discarded = discard @Int @String (pure @Int 1) \_ -> pure @String "done"
+discarded :: Main.Effect Prim.String
+discarded = discard @Prim.Int @Prim.String (pure @Prim.Int 1) \_ -> pure @Prim.String "done"
 
-withLet :: Effect Int
+withLet :: Main.Effect Prim.Int
 withLet =
-  bind @Int @Int (pure @Int 1) \value ->
+  bind @Prim.Int @Prim.Int (pure @Prim.Int 1) \value ->
     let
-      next :: Int
+      next :: Prim.Int
       next = value
     in
-      pure @Int next
+      pure @Prim.Int next
 
-nested :: Effect Int
+nested :: Main.Effect Prim.Int
 nested =
-  bind @Int @Int (bind @Int @Int (pure @Int 1) \inner -> pure @Int inner) \value -> pure @Int value
+  bind @Prim.Int @Prim.Int
+    (bind @Prim.Int @Prim.Int (pure @Prim.Int 1) \inner -> pure @Prim.Int inner) \value ->
+    pure @Prim.Int value

--- a/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784872980_ado_expressions/Main.snap
@@ -3,54 +3,58 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Tuple :: Type -> Type -> Type
+data Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 data Tuple @first @second
-  | Tuple :: first -> second -> Tuple first second
+  | Tuple :: first -> second -> Main.Tuple first second
 
-foreign import pure :: forall value. value -> Effect value
+foreign import pure :: forall value. value -> Main.Effect value
 
-foreign import map :: forall value result. (value -> result) -> Effect value -> Effect result
+foreign import map :: forall value result. (value -> result) -> Main.Effect value -> Main.Effect result
 
-foreign import apply :: forall value result. Effect (value -> result) -> Effect value -> Effect result
+foreign import apply :: forall value result. Main.Effect (value -> result) -> Main.Effect value -> Main.Effect result
 
-zero :: Effect Int
-zero = pure @Int 1
+zero :: Main.Effect Prim.Int
+zero = pure @Prim.Int 1
 
-zeroWithLet :: Effect Int
+zeroWithLet :: Main.Effect Prim.Int
 zeroWithLet =
   let
-    value :: Int
+    value :: Prim.Int
     value = 1
   in
-    pure @Int value
+    pure @Prim.Int value
 
-one :: Effect Int
-one = map @Int @Int (\value -> value) (pure @Int 1)
+one :: Main.Effect Prim.Int
+one = map @Prim.Int @Prim.Int (\value -> value) (pure @Prim.Int 1)
 
-multiple :: Effect (Tuple Int String)
+multiple :: Main.Effect (Main.Tuple Prim.Int Prim.String)
 multiple =
-  apply @String @(Tuple Int String)
-    (map @Int @(String -> Tuple Int String) (\first second -> Tuple @Int @String first second)
-      (pure @Int 1))
-    (pure @String "two")
+  apply @Prim.String @(Main.Tuple Prim.Int Prim.String)
+    (map @Prim.Int @(Prim.String -> Main.Tuple Prim.Int Prim.String)
+      (\first second -> Tuple @Prim.Int @Prim.String first second)
+      (pure @Prim.Int 1))
+    (pure @Prim.String "two")
 
-discarded :: Effect String
+discarded :: Main.Effect Prim.String
 discarded =
-  apply @String @String (map @Int @(String -> String) (\_ value -> value) (pure @Int 1))
-    (pure @String "kept")
+  apply @Prim.String @Prim.String
+    (map @Prim.Int @(Prim.String -> Prim.String) (\_ value -> value) (pure @Prim.Int 1))
+    (pure @Prim.String "kept")
 
-withLet :: Effect (Tuple Int Int)
+withLet :: Main.Effect (Main.Tuple Prim.Int Prim.Int)
 withLet =
-  apply @Int @(Tuple Int Int)
-    (map @Int @(Int -> Tuple Int Int)
+  apply @Prim.Int @(Main.Tuple Prim.Int Prim.Int)
+    (map @Prim.Int @(Prim.Int -> Main.Tuple Prim.Int Prim.Int)
       (\first second ->
         let
-          next :: Int
+          next :: Prim.Int
           next = first
         in
-          Tuple @Int @Int next second)
-      (pure @Int 1))
-    (pure @Int 2)
+          Tuple @Prim.Int @Prim.Int next second)
+      (pure @Prim.Int 1))
+    (pure @Prim.Int 2)
 
-nested :: Effect Int
-nested = map @Int @Int (\value -> value) (map @Int @Int (\inner -> inner) (pure @Int 1))
+nested :: Main.Effect Prim.Int
+nested =
+  map @Prim.Int @Prim.Int (\value -> value)
+    (map @Prim.Int @Prim.Int (\inner -> inner) (pure @Prim.Int 1))

--- a/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873220_do_expression_recovery/Main.snap
@@ -3,22 +3,22 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-foreign import pure :: forall value. value -> Effect value
+foreign import pure :: forall value. value -> Main.Effect value
 
-foreign import bind :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+foreign import bind :: forall value result. Main.Effect value -> (value -> Main.Effect result) -> Main.Effect result
 
-foreign import discard :: forall value result. Effect value -> (value -> Effect result) -> Effect result
+foreign import discard :: forall value result. Main.Effect value -> (value -> Main.Effect result) -> Main.Effect result
 
 emptyDo :: ?[empty do block]
 emptyDo = <error>
 
-finalBind :: Effect Int
-finalBind = pure @Int 1
+finalBind :: Main.Effect Prim.Int
+finalBind = pure @Prim.Int 1
 
 finalLet :: forall t. t
 finalLet =
   let
-    value :: Int
+    value :: Prim.Int
     value = 1
   in
     <error>

--- a/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873221_ado_expression_recovery/Main.snap
@@ -3,11 +3,11 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-foreign import pure :: forall value. value -> Effect value
+foreign import pure :: forall value. value -> Main.Effect value
 
-foreign import map :: forall value result. (value -> result) -> Effect value -> Effect result
+foreign import map :: forall value result. (value -> result) -> Main.Effect value -> Main.Effect result
 
-foreign import apply :: forall value result. Effect (value -> result) -> Effect value -> Effect result
+foreign import apply :: forall value result. Main.Effect (value -> result) -> Main.Effect value -> Main.Effect result
 
 emptyAdo :: ?[empty ado block]
 emptyAdo = <error>
@@ -15,5 +15,5 @@ emptyAdo = <error>
 missingAdoAction :: forall t t1. t t1
 missingAdoAction = <error> <error>
 
-missingAdoResult :: forall t. Effect t
-missingAdoResult = map @Int @t (\value -> <error>) (pure @Int 1)
+missingAdoResult :: forall t. Main.Effect t
+missingAdoResult = map @Prim.Int @t (\value -> <error>) (pure @Prim.Int 1)

--- a/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873280_do_constrained_functions/Main.snap
@@ -3,18 +3,22 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Operations :: (Type -> Type) -> Constraint
+interface Operations :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 interface Operations effect where
-  pure :: forall (value :: Type). value -> effect value
-  bind :: forall (value :: Type) (result :: Type). effect value -> (value -> effect result) -> effect result
-  discard :: forall (value :: Type) (result :: Type). effect value -> (value -> effect result) -> effect result
+  pure :: forall (value :: Prim.Type). value -> effect value
+  bind :: forall (value :: Prim.Type) (result :: Prim.Type).
+  effect value -> (value -> effect result) -> effect result
+  discard :: forall (value :: Prim.Type) (result :: Prim.Type).
+  effect value -> (value -> effect result) -> effect result
 
-usingBind :: forall effect. Operations effect => effect Int
+usingBind :: forall effect. Main.Operations effect => effect Prim.Int
 usingBind = \{operationsDict} ->
-  bind @effect {operationsDict} @Int @Int (pure @effect {operationsDict} @Int 1) \value ->
-    pure @effect {operationsDict} @Int value
+  bind @effect {operationsDict} @Prim.Int @Prim.Int
+    (pure @effect {operationsDict} @Prim.Int 1) \value ->
+    pure @effect {operationsDict} @Prim.Int value
 
-usingDiscard :: forall effect. Operations effect => effect Int
+usingDiscard :: forall effect. Main.Operations effect => effect Prim.Int
 usingDiscard = \{operationsDict} ->
-  discard @effect {operationsDict} @String @Int
-    (pure @effect {operationsDict} @String "ignored") \_ -> pure @effect {operationsDict} @Int 1
+  discard @effect {operationsDict} @Prim.String @Prim.Int
+    (pure @effect {operationsDict} @Prim.String "ignored") \_ ->
+    pure @effect {operationsDict} @Prim.Int 1

--- a/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873281_ado_constrained_functions/Main.snap
@@ -3,23 +3,25 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Tuple :: Type -> Type -> Type
+data Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 data Tuple @first @second
-  | Tuple :: first -> second -> Tuple first second
+  | Tuple :: first -> second -> Main.Tuple first second
 
-interface Operations :: (Type -> Type) -> Constraint
+interface Operations :: (Prim.Type -> Prim.Type) -> Prim.Constraint
 interface Operations effect where
-  pure :: forall (value :: Type). value -> effect value
-  map :: forall (value :: Type) (result :: Type). (value -> result) -> effect value -> effect result
-  apply :: forall (value :: Type) (result :: Type). effect (value -> result) -> effect value -> effect result
+  pure :: forall (value :: Prim.Type). value -> effect value
+  map :: forall (value :: Prim.Type) (result :: Prim.Type).
+  (value -> result) -> effect value -> effect result
+  apply :: forall (value :: Prim.Type) (result :: Prim.Type).
+  effect (value -> result) -> effect value -> effect result
 
-usingMapApply :: forall effect. Operations effect => effect (Tuple Int String)
+usingMapApply :: forall effect. Main.Operations effect => effect (Main.Tuple Prim.Int Prim.String)
 usingMapApply = \{operationsDict} ->
-  apply @effect {operationsDict} @String @(Tuple Int String)
-    (map @effect {operationsDict} @Int @(String -> Tuple Int String)
-      (\first second -> Tuple @Int @String first second)
-      (pure @effect {operationsDict} @Int 1))
-    (pure @effect {operationsDict} @String "two")
+  apply @effect {operationsDict} @Prim.String @(Main.Tuple Prim.Int Prim.String)
+    (map @effect {operationsDict} @Prim.Int @(Prim.String -> Main.Tuple Prim.Int Prim.String)
+      (\first second -> Tuple @Prim.Int @Prim.String first second)
+      (pure @effect {operationsDict} @Prim.Int 1))
+    (pure @effect {operationsDict} @Prim.String "two")
 
-usingPure :: forall effect. Operations effect => effect Int
-usingPure = \{operationsDict} -> pure @effect {operationsDict} @Int 1
+usingPure :: forall effect. Main.Operations effect => effect Prim.Int
+usingPure = \{operationsDict} -> pure @effect {operationsDict} @Prim.Int 1

--- a/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873341_ado_unresolved_functions/Main.snap
@@ -9,5 +9,5 @@ unresolvedMap = <error> (\value -> value) 1
 unresolvedApply :: forall t t1. t t1
 unresolvedApply = <error> (<error> (\first second -> first) 1) 2
 
-unresolvedPure :: forall t. t Int
+unresolvedPure :: forall t. t Prim.Int
 unresolvedPure = <error> 1

--- a/tests-integration/fixtures/semantic/1784873460_do_higher_rank_action/Main.snap
+++ b/tests-integration/fixtures/semantic/1784873460_do_higher_rank_action/Main.snap
@@ -3,9 +3,10 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-foreign import polymorphic :: forall value. Box value
+foreign import polymorphic :: forall value. Main.Box value
 
-foreign import bind :: forall result. (forall value. Box value) -> ((forall value1. Box value1) -> result) -> result
+foreign import bind :: forall result.
+  (forall value. Main.Box value) -> ((forall value1. Main.Box value1) -> result) -> result
 
-higherRank :: Int
-higherRank = bind @Int polymorphic \value -> 42
+higherRank :: Prim.Int
+higherRank = bind @Prim.Int polymorphic \value -> 42

--- a/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
+++ b/tests-integration/fixtures/semantic/1784875466_evidence_rendering/Main.snap
@@ -3,24 +3,24 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Parent :: Type -> Constraint
+interface Parent :: Prim.Type -> Prim.Constraint
 interface Parent value where
 
-interface Child :: Type -> Constraint
+interface Child :: Prim.Type -> Prim.Constraint
 interface Child value where
-  superclass parentDict :: Parent value
+  superclass parentDict :: Main.Parent value
 
-dictionary parentInt :: Parent Int
+dictionary parentInt :: Main.Parent Prim.Int
 
-dictionary childInt :: { parentDict :: Parent Int } => Child Int where
+dictionary childInt :: { parentDict :: Main.Parent Prim.Int } => Main.Child Prim.Int where
   superclass parentDict = parentDict
 
-foreign import useParent :: forall value. Parent value => value -> value
+foreign import useParent :: forall value. Main.Parent value => value -> value
 
-foreign import useChild :: forall value. Child value => value -> value
+foreign import useChild :: forall value. Main.Child value => value -> value
 
-instanceEvidence :: Int
-instanceEvidence = useChild @Int {childInt {parentInt}} 1
+instanceEvidence :: Prim.Int
+instanceEvidence = useChild @Prim.Int {childInt {parentInt}} 1
 
-superclassEvidence :: forall value. Child value => value -> value
+superclassEvidence :: forall value. Main.Child value => value -> value
 superclassEvidence = \{childDict} -> useParent @value {childDict.parentDict}

--- a/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
@@ -3,44 +3,45 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface OnStep :: Int -> Constraint
+interface OnStep :: Prim.Int -> Prim.Constraint
 interface OnStep step where
 
-dictionary onZero :: OnStep 0
+dictionary onZero :: Main.OnStep 0
 
-dictionary onTwo :: OnStep 2
+dictionary onTwo :: Main.OnStep 2
 
-dictionary onDefault :: forall t. OnStep t
+dictionary onDefault :: forall t. Main.OnStep t
 
 foreign import map :: forall step.
-  OnStep step => (forall value result. (value -> result) -> Action step value -> Action step result)
+  Main.OnStep step =>
+  (forall value result. (value -> result) -> Main.Action step value -> Main.Action step result)
 
 foreign import apply :: forall step.
-  OnStep step =>
+  Main.OnStep step =>
   (forall previous value result.
-    Action previous (value -> result) -> Action step value -> Action step result)
+    Main.Action previous (value -> result) -> Main.Action step value -> Main.Action step result)
 
-foreign import pure :: forall step. OnStep step => (forall value. value -> Action step value)
+foreign import pure :: forall step. Main.OnStep step => (forall value. value -> Main.Action step value)
 
-foreign import stepZero :: Action 0 Int
+foreign import stepZero :: Main.Action 0 Prim.Int
 
-foreign import stepOne :: Action 1 String
+foreign import stepOne :: Main.Action 1 Prim.String
 
-foreign import stepTwo :: Action 2 Boolean
+foreign import stepTwo :: Main.Action 2 Prim.Boolean
 
-foreign import stepThree :: Action 3 String
+foreign import stepThree :: Main.Action 3 Prim.String
 
-indexedApply :: Action 3 String
+indexedApply :: Main.Action 3 Prim.String
 indexedApply =
-  apply @3 {onDefault} @2 @String @String
-    (apply @2 {onTwo} @1 @Boolean @(String -> String)
-      (apply @1 {onDefault} @0 @String @(Boolean -> String -> String)
-        (map @0 {onZero} @Int @(String -> Boolean -> String -> String)
+  apply @3 {onDefault} @2 @Prim.String @Prim.String
+    (apply @2 {onTwo} @1 @Prim.Boolean @(Prim.String -> Prim.String)
+      (apply @1 {onDefault} @0 @Prim.String @(Prim.Boolean -> Prim.String -> Prim.String)
+        (map @0 {onZero} @Prim.Int @(Prim.String -> Prim.Boolean -> Prim.String -> Prim.String)
           (\zero one two three -> three)
           stepZero)
         stepOne)
       stepTwo)
     stepThree
 
-indexedPure :: Action 2 Int
-indexedPure = pure @2 {onTwo} @Int 1
+indexedPure :: Main.Action 2 Prim.Int
+indexedPure = pure @2 {onTwo} @Prim.Int 1

--- a/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
@@ -3,41 +3,41 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface OnStep :: Int -> Constraint
+interface OnStep :: Prim.Int -> Prim.Constraint
 interface OnStep step where
 
-dictionary onZero :: OnStep 0
+dictionary onZero :: Main.OnStep 0
 
-dictionary onTwo :: OnStep 2
+dictionary onTwo :: Main.OnStep 2
 
-dictionary onDefault :: forall t. OnStep t
+dictionary onDefault :: forall t. Main.OnStep t
 
 foreign import bind :: forall step.
-  OnStep step =>
+  Main.OnStep step =>
   (forall next value result.
-    Action step value -> (value -> Action next result) -> Action step result)
+    Main.Action step value -> (value -> Main.Action next result) -> Main.Action step result)
 
 foreign import discard :: forall step.
-  OnStep step =>
+  Main.OnStep step =>
   (forall next value result.
-    Action step value -> (value -> Action next result) -> Action step result)
+    Main.Action step value -> (value -> Main.Action next result) -> Main.Action step result)
 
-foreign import stepZero :: Action 0 Int
+foreign import stepZero :: Main.Action 0 Prim.Int
 
-foreign import stepOne :: Action 1 String
+foreign import stepOne :: Main.Action 1 Prim.String
 
-foreign import stepTwo :: Action 2 Boolean
+foreign import stepTwo :: Main.Action 2 Prim.Boolean
 
-foreign import stepThree :: Action 3 String
+foreign import stepThree :: Main.Action 3 Prim.String
 
-foreign import stepFour :: Action 4 Number
+foreign import stepFour :: Main.Action 4 Prim.Number
 
-indexedBind :: Action 0 Number
+indexedBind :: Main.Action 0 Prim.Number
 indexedBind =
-  bind @0 {onZero} @1 @Int @Number stepZero \zero ->
-    bind @1 {onDefault} @2 @String @Number stepOne \one ->
-      bind @2 {onTwo} @3 @Boolean @Number stepTwo \two ->
-        bind @3 {onDefault} @4 @String @Number stepThree \three -> stepFour
+  bind @0 {onZero} @1 @Prim.Int @Prim.Number stepZero \zero ->
+    bind @1 {onDefault} @2 @Prim.String @Prim.Number stepOne \one ->
+      bind @2 {onTwo} @3 @Prim.Boolean @Prim.Number stepTwo \two ->
+        bind @3 {onDefault} @4 @Prim.String @Prim.Number stepThree \three -> stepFour
 
-indexedDiscard :: Action 4 Boolean
-indexedDiscard = discard @4 {onDefault} @2 @Number @Boolean stepFour \_ -> stepTwo
+indexedDiscard :: Main.Action 4 Prim.Boolean
+indexedDiscard = discard @4 {onDefault} @2 @Prim.Number @Prim.Boolean stepFour \_ -> stepTwo

--- a/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784882000_if_then_else_expressions/Main.snap
@@ -3,40 +3,40 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-interface Predicate :: Type -> Constraint
+interface Predicate :: Prim.Type -> Prim.Constraint
 interface Predicate a where
-  predicate :: a -> Boolean
+  predicate :: a -> Prim.Boolean
 
-interface Default :: Type -> Constraint
+interface Default :: Prim.Type -> Prim.Constraint
 interface Default value where
   defaultValue :: value
 
-checked :: Boolean -> Int
+checked :: Prim.Boolean -> Prim.Int
 checked = \condition ->
   if condition then 1 else 2
 
-inferred :: Boolean -> String
+inferred :: Prim.Boolean -> Prim.String
 inferred = \condition ->
   if condition then "yes" else "no"
 
-constrained :: forall value. Predicate value => value -> Int
+constrained :: forall value. Main.Predicate value => value -> Prim.Int
 constrained = \{predicateDict} -> \value ->
   if predicate @value {predicateDict} value then 1 else 2
 
-constrainedBranches :: forall value. Default value => Boolean -> value
+constrainedBranches :: forall value. Main.Default value => Prim.Boolean -> value
 constrainedBranches = \{defaultDict} -> \condition ->
   if condition then defaultValue @value {defaultDict} else defaultValue @value {defaultDict}
 
-higherRank :: Boolean -> (forall value. value -> value)
+higherRank :: Prim.Boolean -> (forall value. value -> value)
 higherRank = \condition ->
   if condition then identity @value else identity @value
 
-nested :: Boolean -> Boolean -> Int
+nested :: Prim.Boolean -> Prim.Boolean -> Prim.Int
 nested = \first -> \second ->
   if first then if second then 1 else 2 else 3
 
-asArgument :: Boolean -> Int
-asArgument = \condition -> identity @Int if condition then 1 else 2
+asArgument :: Prim.Boolean -> Prim.Int
+asArgument = \condition -> identity @Prim.Int if condition then 1 else 2
 
 identity :: forall value. value -> value
 identity = \value -> value

--- a/tests-integration/fixtures/semantic/1784882060_if_then_else_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784882060_if_then_else_recovery/Main.snap
@@ -3,14 +3,14 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-missingCondition :: Int
+missingCondition :: Prim.Int
 missingCondition =
   if <error> then 1 else 2
 
-missingThen :: Int
+missingThen :: Prim.Int
 missingThen =
   if true then <error> else 2
 
-missingElse :: Int
+missingElse :: Prim.Int
 missingElse =
   if true then 1 else <error>

--- a/tests-integration/fixtures/semantic/1784905140_typed_expression/Main.snap
+++ b/tests-integration/fixtures/semantic/1784905140_typed_expression/Main.snap
@@ -3,5 +3,5 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-life :: Int
+life :: Prim.Int
 life = 42

--- a/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906340_record_access_expressions/Main.snap
@@ -6,21 +6,22 @@ expression: report
 identity :: forall a. a -> a
 identity = \value -> value
 
-record :: { function :: Int -> Int, nested :: { value :: Int } }
-record = { function: identity @Int, nested: { value: 42 } }
+record :: { function :: Prim.Int -> Prim.Int, nested :: { value :: Prim.Int } }
+record = { function: identity @Prim.Int, nested: { value: 42 } }
 
-direct :: { value :: Int }
+direct :: { value :: Prim.Int }
 direct = record.nested
 
-chained :: Int
+chained :: Prim.Int
 chained = record.nested.value
 
-functionPosition :: Int
+functionPosition :: Prim.Int
 functionPosition = record.function 1
 
-argument :: { value :: Int }
-argument = identity @{ value :: Int } record.nested
+argument :: { value :: Prim.Int }
+argument = identity @{ value :: Prim.Int } record.nested
 
-applicationBase :: Int
+applicationBase :: Prim.Int
 applicationBase =
-  (identity @{ function :: Int -> Int, nested :: { value :: Int } } record).nested.value
+  (identity @{ function :: Prim.Int -> Prim.Int, nested :: { value :: Prim.Int } }
+    record).nested.value

--- a/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906340_record_update_expressions/Main.snap
@@ -6,30 +6,30 @@ expression: report
 identity :: forall a. a -> a
 identity = \value -> value
 
-record :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
-record = { first: 1, nested: { value: 2 }, transform: identity @Int }
+record :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
+record = { first: 1, nested: { value: 2 }, transform: identity @Prim.Int }
 
-leaf :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+leaf :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 leaf = record { first = 2 }
 
-typeChanging :: { first :: String, nested :: { value :: Int }, transform :: Int -> Int }
+typeChanging :: { first :: Prim.String, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 typeChanging = record { first = "two" }
 
-multiple :: forall t. { first :: Int, nested :: { value :: Int }, transform :: t -> t }
+multiple :: forall t. { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: t -> t }
 multiple = record { first = 2, transform = identity @t }
 
-nested :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+nested :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 nested = record { nested { value = 3 } }
 
-accessValue :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+accessValue :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 accessValue = record { first = record.nested.value }
 
-applicationBase :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+applicationBase :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 applicationBase =
-  (identity @{ first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+  (identity @{ first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
     record) { first = 2 }
 
-argument :: { first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+argument :: { first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
 argument =
-  identity @{ first :: Int, nested :: { value :: Int }, transform :: Int -> Int }
+  identity @{ first :: Prim.Int, nested :: { value :: Prim.Int }, transform :: Prim.Int -> Prim.Int }
     record { first = 2 }

--- a/tests-integration/fixtures/semantic/1784906400_record_update_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784906400_record_update_recovery/Main.snap
@@ -3,14 +3,14 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-record :: { nested :: { value :: Int }, value :: Int }
+record :: { nested :: { value :: Prim.Int }, value :: Prim.Int }
 record = { nested: { value: 1 }, value: 2 }
 
-missingValue :: { nested :: { value :: Int }, value :: ?[missing record update expression] }
+missingValue :: { nested :: { value :: Prim.Int }, value :: ?[missing record update expression] }
 missingValue = record { value = <error> }
 
-nestedMissingValue :: { nested :: { value :: ?[missing record update expression] }, value :: Int }
+nestedMissingValue :: { nested :: { value :: ?[missing record update expression] }, value :: Prim.Int }
 nestedMissingValue = record { nested { value = <error> } }
 
-validSibling :: { nested :: { value :: ?[missing record update expression] }, value :: Int }
+validSibling :: { nested :: { value :: ?[missing record update expression] }, value :: Prim.Int }
 validSibling = record { nested { value = <error> }, value = 3 }

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
@@ -3,22 +3,22 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-add :: Int -> Int -> Int
+add :: Prim.Int -> Prim.Int -> Prim.Int
 add = \left -> \right -> left
 
-use :: Int -> String -> String
+use :: Prim.Int -> Prim.String -> Prim.String
 use = \integer -> \string -> string
 
-checked :: Int -> Int
+checked :: Prim.Int -> Prim.Int
 checked = \v40 -> add v40 1
 
-inferred :: Int -> Int
+inferred :: Prim.Int -> Prim.Int
 inferred = \v48 -> add v48 1
 
-ordered :: Int -> String -> String
+ordered :: Prim.Int -> Prim.String -> Prim.String
 ordered = \v64 v66 -> use v64 v66
 
-nested :: forall t t1. (((Int -> t) -> t) -> t1) -> t1
+nested :: forall t t1. (((Prim.Int -> t) -> t) -> t1) -> t1
 nested = \v71 -> v71 \v75 -> v75 1
 
 access :: forall t t1. { value :: t | t1 } -> t
@@ -28,23 +28,23 @@ update :: forall t t1 t2 t3 t4.
   { first :: t, second :: t1 | t2 } -> t3 -> t4 -> { first :: t3, second :: t4 | t2 }
 update = \v87 v90 v92 -> v87 { first = v90, second = v92 }
 
-conditional :: forall t. Boolean -> t -> t -> t
+conditional :: forall t. Prim.Boolean -> t -> t -> t
 conditional = \v98 v100 v102 ->
   if v98 then v100 else v102
 
-caseScrutinee :: Boolean -> Int
+caseScrutinee :: Prim.Boolean -> Prim.Int
 caseScrutinee = \v108 ->
   case v108 of
     true -> 1
     false -> 0
 
-caseScrutinees :: Boolean -> Int -> Int
+caseScrutinees :: Prim.Boolean -> Prim.Int -> Prim.Int
 caseScrutinees = \v127 v128 ->
   case v127, v128 of
     true, value -> value
     false, _ -> 0
 
-caseAlternatives :: forall t t1. Boolean -> { value :: t | t1 } -> t
+caseAlternatives :: forall t t1. Prim.Boolean -> { value :: t | t1 } -> t
 caseAlternatives = \v149 ->
   case v149 of
     true -> \v157 -> v157.value

--- a/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908740_section_expression_recovery/Main.snap
@@ -18,5 +18,5 @@ orphanInLambda = \value -> <error>
 failedBody :: forall t. (?[missing expression] -> t) -> t
 failedBody = \v56 -> apply @?[missing expression] @t v56 <error>
 
-invalidExpected :: Int
-invalidExpected = \v67 -> identity @Int v67
+invalidExpected :: Prim.Int
+invalidExpected = \v67 -> identity @Prim.Int v67

--- a/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
@@ -3,13 +3,13 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-map :: forall a b. (a -> b) -> Array a -> Array b
+map :: forall a b. (a -> b) -> Prim.Array a -> Prim.Array b
 map = \f -> \x -> []
 
 apply :: forall a b. (a -> b) -> a -> b
 apply = \f -> \x -> f x
 
-f :: ({ foo :: Int } -> Int) -> Int
+f :: ({ foo :: Prim.Int } -> Prim.Int) -> Prim.Int
 f = \g -> g { foo: 1 }
 
 test1 :: forall t t1. { prop :: t | t1 } -> t
@@ -21,10 +21,10 @@ test2 = \v79 -> v79.a.b.c
 test3 :: forall t t1. { poly :: t | t1 } -> t
 test3 = \v84 -> v84.poly
 
-test4 :: forall t t1. Array { prop :: t | t1 } -> Array t
+test4 :: forall t t1. Prim.Array { prop :: t | t1 } -> Prim.Array t
 test4 = map @{ prop :: t | t1 } @t \v92 -> v92.prop
 
-test5 :: Int
+test5 :: Prim.Int
 test5 = f \v100 -> v100.foo
 
 test6 :: forall t t1 t2 t3. t -> (({ bar :: t1 | t2 } -> t1) -> t3) -> t3
@@ -36,7 +36,7 @@ test7 = \r -> (\v120 -> v120.nonexistent) r
 test8 :: forall t t1 t2. (({ foo :: t | t1 } -> t) -> t2) -> t2
 test8 = \v128 -> v128 \v131 -> v131.foo
 
-test9 :: forall t t1 t2. Array (({ prop :: t | t1 } -> t) -> t2) -> Array t2
+test9 :: forall t t1 t2. Prim.Array (({ prop :: t | t1 } -> t) -> t2) -> Prim.Array t2
 test9 = map @(({ prop :: t | t1 } -> t) -> t2) @t2 \v140 -> v140 \v143 -> v143.prop
 
 test10 :: forall t t1 t2. { a :: { b :: t | t1 } | t2 } -> t
@@ -45,7 +45,7 @@ test10 = apply @{ a :: { b :: t | t1 } | t2 } @t \v152 -> v152.a.b
 test11 :: forall t t1 t2. t -> { a :: t, b :: { foo :: t1 | t2 } -> t1 }
 test11 = \v158 -> { a: v158, b: \v161 -> v161.foo }
 
-test12 :: forall t t1. ({ bar :: t | t1 } -> t) -> Array ({ bar :: t | t1 } -> t)
+test12 :: forall t t1. ({ bar :: t | t1 } -> t) -> Prim.Array ({ bar :: t | t1 } -> t)
 test12 = \v166 -> [v166, \v168 -> v168.bar]
 
 test13 :: forall t t1 t2. t -> { prop :: t1 | t2 } -> t1
@@ -53,6 +53,6 @@ test13 = \v174 ->
   case v174 of
     _ -> \v182 -> v182.prop
 
-test14 :: forall t t1. Boolean -> { a :: t, b :: t | t1 } -> t
+test14 :: forall t t1. Prim.Boolean -> { a :: t, b :: t | t1 } -> t
 test14 = \v188 ->
   if v188 then \v191 -> v191.a else \v194 -> v194.b

--- a/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
@@ -3,27 +3,28 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-singleFieldUpdate :: forall t t1. { a :: t | t1 } -> { a :: Int | t1 }
+singleFieldUpdate :: forall t t1. { a :: t | t1 } -> { a :: Prim.Int | t1 }
 singleFieldUpdate = \v9 -> v9 { a = 1 }
 
-multipleFieldUpdate :: forall t t1 t2 t3. { a :: t, b :: t1, c :: t2 | t3 } -> { a :: Int, b :: Boolean, c :: String | t3 }
+multipleFieldUpdate :: forall t t1 t2 t3.
+  { a :: t, b :: t1, c :: t2 | t3 } -> { a :: Prim.Int, b :: Prim.Boolean, c :: Prim.String | t3 }
 multipleFieldUpdate = \v17 -> v17 { a = 2, b = true, c = "three" }
 
 nestedRecordUpdate :: forall t t1 t2 t3.
-  { a :: { b :: { c :: t | t1 } | t2 } | t3 } -> { a :: { b :: { c :: Int | t1 } | t2 } | t3 }
+  { a :: { b :: { c :: t | t1 } | t2 } | t3 } -> { a :: { b :: { c :: Prim.Int | t1 } | t2 } | t3 }
 nestedRecordUpdate = \v29 -> v29 { a { b { c = 42 } } }
 
-updateWithValueSection :: forall t t1. { a :: t | t1 } -> { a :: Int -> Int | t1 }
+updateWithValueSection :: forall t t1. { a :: t | t1 } -> { a :: Prim.Int -> Prim.Int | t1 }
 updateWithValueSection = \v41 -> v41 { a = \v46 -> add v46 1 }
 
 updateWithSectionInteraction :: forall t t1 t2. { a :: t | t1 } -> t2 -> { a :: t2 | t1 }
 updateWithSectionInteraction = \v54 v57 -> v54 { a = v57 }
 
-polymorphicRecordUpdate :: forall t t1. { foo :: t | t1 } -> { foo :: Int | t1 }
+polymorphicRecordUpdate :: forall t t1. { foo :: t | t1 } -> { foo :: Prim.Int | t1 }
 polymorphicRecordUpdate = \v62 -> v62 { foo = 0 }
 
-higherOrderContext :: forall t t1. Array { x :: t | t1 } -> Array { x :: Int | t1 }
-higherOrderContext = map @{ x :: t | t1 } @{ x :: Int | t1 } \v74 -> v74 { x = 10 }
+higherOrderContext :: forall t t1. Prim.Array { x :: t | t1 } -> Prim.Array { x :: Prim.Int | t1 }
+higherOrderContext = map @{ x :: t | t1 } @{ x :: Prim.Int | t1 } \v74 -> v74 { x = 10 }
 
 multipleSectionsInteraction :: forall t t1 t2 t3 t4. { x :: t, y :: t1 | t2 } -> t3 -> t4 -> { x :: t3, y :: t4 | t2 }
 multipleSectionsInteraction = \v82 v85 v87 -> v82 { x = v85, y = v87 }
@@ -31,7 +32,7 @@ multipleSectionsInteraction = \v82 v85 v87 -> v82 { x = v85, y = v87 }
 nestedSectionInteraction :: forall t t1 t2 t3. { a :: { b :: t | t1 } | t2 } -> t3 -> { a :: { b :: t3 | t1 } | t2 }
 nestedSectionInteraction = \v92 v97 -> v92 { a { b = v97 } }
 
-mixedSections :: forall t t1 t2. { a :: t, b :: t1 | t2 } -> { a :: Int -> Int, b :: Int | t2 }
+mixedSections :: forall t t1 t2. { a :: t, b :: t1 | t2 } -> { a :: Prim.Int -> Prim.Int, b :: Prim.Int | t2 }
 mixedSections = \v102 -> v102 { a = \v106 -> add v106 1, b = 2 }
 
 recordAccessSectionUpdate :: forall t t1 t2 t3. { a :: t | t1 } -> { a :: { b :: t2 | t3 } -> t2 | t1 }
@@ -40,8 +41,8 @@ recordAccessSectionUpdate = \v116 -> v116 { a = \v120 -> v120.b }
 concreteRecordUpdateSection :: forall t. t -> { a :: t }
 concreteRecordUpdateSection = \v131 -> { a: 1 } { a = v131 }
 
-map :: forall a b. (a -> b) -> Array a -> Array b
+map :: forall a b. (a -> b) -> Prim.Array a -> Prim.Array b
 map = \f -> \x -> []
 
-add :: Int -> Int -> Int
+add :: Prim.Int -> Prim.Int -> Prim.Int
 add = \x -> \y -> x

--- a/tests-integration/fixtures/semantic/1784913480_binder_operator_chains/Main.snap
+++ b/tests-integration/fixtures/semantic/1784913480_binder_operator_chains/Main.snap
@@ -3,24 +3,24 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data List :: Type -> Type
+data List :: Prim.Type -> Prim.Type
 data List @a
-  | Cons :: a -> List a -> List a
-  | Nil :: List a
+  | Cons :: a -> Main.List a -> Main.List a
+  | Nil :: Main.List a
 
-data Snoc :: Type -> Type
+data Snoc :: Prim.Type -> Prim.Type
 data Snoc @a
-  | Empty :: Snoc a
-  | Snoc :: Snoc a -> a -> Snoc a
+  | Empty :: Main.Snoc a
+  | Snoc :: Main.Snoc a -> a -> Main.Snoc a
 
-first :: forall a. List a -> a
+first :: forall a. Main.List a -> a
 first = \(Cons value _) -> value
 
-second :: forall a. List a -> a
+second :: forall a. Main.List a -> a
 second = \(Cons _ (Cons value _)) -> value
 
-inferred :: forall t. Partial => List t -> t
+inferred :: forall t. Prim.Partial => Main.List t -> t
 inferred = \{trivial} -> \(Cons value _) -> value
 
-second' :: forall a. Snoc a -> a
+second' :: forall a. Main.Snoc a -> a
 second' = \(Snoc (Snoc _ value) _) -> value

--- a/tests-integration/fixtures/semantic/1785073620_derive_eq_unit_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785073620_derive_eq_unit_body/Main.snap
@@ -3,12 +3,12 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Unit :: Type
+data Unit :: Prim.Type
 data Unit
-  | Unit :: Unit
+  | Unit :: Main.Unit
 
-dictionary eqUnit :: Eq Unit where
-  eq :: Unit -> Unit -> Boolean
+dictionary eqUnit :: Data.Eq.Eq Main.Unit where
+  eq :: Main.Unit -> Main.Unit -> Prim.Boolean
   eq = \left right ->
   case left, right of
     Unit, Unit -> true

--- a/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.snap
@@ -3,13 +3,13 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Nothing :: Maybe a
-  | Just :: a -> Maybe a
+  | Nothing :: Main.Maybe a
+  | Just :: a -> Main.Maybe a
 
-dictionary eqMaybe :: forall t. { eqDict :: Eq t } => Eq (Maybe t) where
-  eq :: Maybe t -> Maybe t -> Boolean
+dictionary eqMaybe :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Maybe t) where
+  eq :: Main.Maybe t -> Main.Maybe t -> Prim.Boolean
   eq = \left right ->
   case left, right of
     Nothing, Nothing -> true

--- a/tests-integration/fixtures/semantic/1785088080_derive_ord_unit_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785088080_derive_ord_unit_body/Main.snap
@@ -3,19 +3,19 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Unit :: Type
+data Unit :: Prim.Type
 data Unit
-  | Unit :: Unit
+  | Unit :: Main.Unit
 
-dictionary eqUnit :: Eq Unit where
-  eq :: Unit -> Unit -> Boolean
+dictionary eqUnit :: Data.Eq.Eq Main.Unit where
+  eq :: Main.Unit -> Main.Unit -> Prim.Boolean
   eq = \left right ->
   case left, right of
     Unit, Unit -> true
 
-dictionary ordUnit :: Ord Unit where
+dictionary ordUnit :: Data.Ord.Ord Main.Unit where
   superclass eqDict = eqUnit
-  compare :: Unit -> Unit -> Ordering
+  compare :: Main.Unit -> Main.Unit -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     Unit, Unit -> EQ

--- a/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
@@ -3,13 +3,13 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Maybe :: Type -> Type
+data Maybe :: Prim.Type -> Prim.Type
 data Maybe @a
-  | Nothing :: Maybe a
-  | Just :: a -> Maybe a
+  | Nothing :: Main.Maybe a
+  | Just :: a -> Main.Maybe a
 
-dictionary eqMaybe :: forall t. { eqDict :: Eq t } => Eq (Maybe t) where
-  eq :: Maybe t -> Maybe t -> Boolean
+dictionary eqMaybe :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Maybe t) where
+  eq :: Main.Maybe t -> Main.Maybe t -> Prim.Boolean
   eq = \left right ->
   case left, right of
     Nothing, Nothing -> true
@@ -17,9 +17,9 @@ dictionary eqMaybe :: forall t. { eqDict :: Eq t } => Eq (Maybe t) where
       if eq @t {eqDict} left0 right0 then true else false
     _, _ -> false
 
-dictionary ordMaybe :: forall t. { ordDict :: Ord t } => Ord (Maybe t) where
+dictionary ordMaybe :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.Maybe t) where
   superclass eqDict = eqMaybe {ordDict.eqDict}
-  compare :: Maybe t -> Maybe t -> Ordering
+  compare :: Main.Maybe t -> Main.Maybe t -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     Nothing, Nothing -> EQ

--- a/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.snap
@@ -3,13 +3,17 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Tuple :: Type -> Type -> Type
+data Tuple :: Prim.Type -> Prim.Type -> Prim.Type
 data Tuple @a @b
-  | Tuple :: a -> b -> Tuple a b
+  | Tuple :: a -> b -> Main.Tuple a b
 
-dictionary eqTuple :: forall t t1. { eqDict :: Eq t } => { eqDict1 :: Eq t1 } => Eq (Tuple t t1)
+dictionary eqTuple ::
+  forall t t1.
+  { eqDict :: Data.Eq.Eq t } =>
+  { eqDict1 :: Data.Eq.Eq t1 } =>
+  Data.Eq.Eq (Main.Tuple t t1)
   where
-  eq :: Tuple t t1 -> Tuple t t1 -> Boolean
+  eq :: Main.Tuple t t1 -> Main.Tuple t t1 -> Prim.Boolean
   eq = \left right ->
   case left, right of
     (Tuple left0 left1), (Tuple right0 right1) ->
@@ -20,12 +24,12 @@ dictionary eqTuple :: forall t t1. { eqDict :: Eq t } => { eqDict1 :: Eq t1 } =>
 
 dictionary ordTuple ::
   forall t t1.
-  { ordDict :: Ord t } =>
-  { ordDict1 :: Ord t1 } =>
-  Ord (Tuple t t1)
+  { ordDict :: Data.Ord.Ord t } =>
+  { ordDict1 :: Data.Ord.Ord t1 } =>
+  Data.Ord.Ord (Main.Tuple t t1)
   where
   superclass eqDict = eqTuple {ordDict.eqDict} {ordDict1.eqDict}
-  compare :: Tuple t t1 -> Tuple t t1 -> Ordering
+  compare :: Main.Tuple t t1 -> Main.Tuple t t1 -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     (Tuple left0 left1), (Tuple right0 right1) ->

--- a/tests-integration/fixtures/semantic/1785133080_derive_eq_ord_constructor_ordering/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133080_derive_eq_ord_constructor_ordering/Main.snap
@@ -3,28 +3,28 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Void :: Type
+data Void :: Prim.Type
 data Void
 
-data Ordering :: Type
+data Ordering :: Prim.Type
 data Ordering
-  | First :: Ordering
-  | Second :: Ordering
-  | Third :: Ordering
+  | First :: Main.Ordering
+  | Second :: Main.Ordering
+  | Third :: Main.Ordering
 
-dictionary eqVoid :: Eq Void where
-  eq :: Void -> Void -> Boolean
+dictionary eqVoid :: Data.Eq.Eq Main.Void where
+  eq :: Main.Void -> Main.Void -> Prim.Boolean
   eq = \left right ->
   case left, right of
     _, _ -> false
 
-dictionary ordVoid :: Ord Void where
+dictionary ordVoid :: Data.Ord.Ord Main.Void where
   superclass eqDict = eqVoid
-  compare :: Void -> Void -> Ordering
+  compare :: Main.Void -> Main.Void -> Data.Ordering.Ordering
   compare = \left right -> EQ
 
-dictionary eqOrdering :: Eq Ordering where
-  eq :: Ordering -> Ordering -> Boolean
+dictionary eqOrdering :: Data.Eq.Eq Main.Ordering where
+  eq :: Main.Ordering -> Main.Ordering -> Prim.Boolean
   eq = \left right ->
   case left, right of
     First, First -> true
@@ -32,9 +32,9 @@ dictionary eqOrdering :: Eq Ordering where
     Third, Third -> true
     _, _ -> false
 
-dictionary ordOrdering :: Ord Ordering where
+dictionary ordOrdering :: Data.Ord.Ord Main.Ordering where
   superclass eqDict = eqOrdering
-  compare :: Ordering -> Ordering -> Ordering
+  compare :: Main.Ordering -> Main.Ordering -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     First, First -> EQ

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -3,24 +3,25 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Identity :: Type -> Type
+data Identity :: Prim.Type -> Prim.Type
 data Identity @a
-  | Identity :: a -> Identity a
+  | Identity :: a -> Main.Identity a
 
-dictionary eqIdentity :: forall t. { eqDict :: Eq t } => Eq (Identity t) where
-  eq :: Identity t -> Identity t -> Boolean
+dictionary eqIdentity :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Identity t) where
+  eq :: Main.Identity t -> Main.Identity t -> Prim.Boolean
   eq = \left right ->
   case left, right of
     (Identity left0), (Identity right0) ->
       if eq @t {eqDict} left0 right0 then true else false
 
-dictionary eq1Identity :: Eq1 Identity where
-  eq1 :: forall (t :: Type). Eq t => Identity t -> Identity t -> Boolean
-  eq1 = \{eqDict} -> eq @(Identity t) {eqIdentity {eqDict}}
+dictionary eq1Identity :: Data.Eq.Eq1 Main.Identity where
+  eq1 :: forall (t :: Prim.Type). Data.Eq.Eq t => Main.Identity t -> Main.Identity t -> Prim.Boolean
+  eq1 = \{eqDict} -> eq @(Main.Identity t) {eqIdentity {eqDict}}
 
-dictionary ordIdentity :: forall t. { ordDict :: Ord t } => Ord (Identity t) where
+dictionary ordIdentity :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.Identity t)
+  where
   superclass eqDict = eqIdentity {ordDict.eqDict}
-  compare :: Identity t -> Identity t -> Ordering
+  compare :: Main.Identity t -> Main.Identity t -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     (Identity left0), (Identity right0) ->
@@ -28,7 +29,8 @@ dictionary ordIdentity :: forall t. { ordDict :: Ord t } => Ord (Identity t) whe
         EQ -> EQ
         ordering -> ordering
 
-dictionary ord1Identity :: Ord1 Identity where
+dictionary ord1Identity :: Data.Ord.Ord1 Main.Identity where
   superclass eq1Dict = eq1Identity
-  compare1 :: forall (t :: Type). Ord t => Identity t -> Identity t -> Ordering
-  compare1 = \{ordDict} -> compare @(Identity t) {ordIdentity {ordDict}}
+  compare1 :: forall (t :: Prim.Type).
+  Data.Ord.Ord t => Main.Identity t -> Main.Identity t -> Data.Ordering.Ordering
+  compare1 = \{ordDict} -> compare @(Main.Identity t) {ordIdentity {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -3,34 +3,36 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data Wrap :: forall (k :: Type). (k -> Type) -> k -> Type
+data Wrap :: forall (k :: Prim.Type). (k -> Prim.Type) -> k -> Prim.Type
 data Wrap @f @a
-  | Wrap :: f a -> Wrap f a
+  | Wrap :: f a -> Main.Wrap f a
 
 dictionary eqWrap ::
   forall t t1.
-  { eq1Dict :: Eq1 t } =>
-  { eqDict :: Eq t1 } =>
-  Eq (Wrap @Type t t1)
+  { eq1Dict :: Data.Eq.Eq1 t } =>
+  { eqDict :: Data.Eq.Eq t1 } =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type t t1)
   where
-  eq :: Wrap @Type t t1 -> Wrap @Type t t1 -> Boolean
+  eq :: Main.Wrap @Prim.Type t t1 -> Main.Wrap @Prim.Type t t1 -> Prim.Boolean
   eq = \left right ->
   case left, right of
     (Wrap left0), (Wrap right0) ->
       if eq1 @t {eq1Dict} @t1 {eqDict} left0 right0 then true else false
 
-dictionary eq1Wrap :: forall t. { eq1Dict :: Eq1 t } => Eq1 (Wrap @Type t) where
-  eq1 :: forall (t1 :: Type). Eq t1 => Wrap @Type t t1 -> Wrap @Type t t1 -> Boolean
-  eq1 = \{eqDict} -> eq @(Wrap @Type t t1) {eqWrap {eq1Dict} {eqDict}}
+dictionary eq1Wrap :: forall t. { eq1Dict :: Data.Eq.Eq1 t } => Data.Eq.Eq1 (Main.Wrap @Prim.Type t)
+  where
+  eq1 :: forall (t1 :: Prim.Type).
+  Data.Eq.Eq t1 => Main.Wrap @Prim.Type t t1 -> Main.Wrap @Prim.Type t t1 -> Prim.Boolean
+  eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type t t1) {eqWrap {eq1Dict} {eqDict}}
 
 dictionary ordWrap ::
   forall t t1.
-  { ord1Dict :: Ord1 t } =>
-  { ordDict :: Ord t1 } =>
-  Ord (Wrap @Type t t1)
+  { ord1Dict :: Data.Ord.Ord1 t } =>
+  { ordDict :: Data.Ord.Ord t1 } =>
+  Data.Ord.Ord (Main.Wrap @Prim.Type t t1)
   where
   superclass eqDict = eqWrap {ord1Dict.eq1Dict} {ordDict.eqDict}
-  compare :: Wrap @Type t t1 -> Wrap @Type t t1 -> Ordering
+  compare :: Main.Wrap @Prim.Type t t1 -> Main.Wrap @Prim.Type t t1 -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     (Wrap left0), (Wrap right0) ->
@@ -38,7 +40,13 @@ dictionary ordWrap ::
         EQ -> EQ
         ordering -> ordering
 
-dictionary ord1Wrap :: forall t. { ord1Dict :: Ord1 t } => Ord1 (Wrap @Type t) where
+dictionary ord1Wrap ::
+  forall t.
+  { ord1Dict :: Data.Ord.Ord1 t } =>
+  Data.Ord.Ord1 (Main.Wrap @Prim.Type t)
+  where
   superclass eq1Dict = eq1Wrap {ord1Dict.eq1Dict}
-  compare1 :: forall (t1 :: Type). Ord t1 => Wrap @Type t t1 -> Wrap @Type t t1 -> Ordering
-  compare1 = \{ordDict} -> compare @(Wrap @Type t t1) {ordWrap {ord1Dict} {ordDict}}
+  compare1 :: forall (t1 :: Prim.Type).
+  Data.Ord.Ord t1 =>
+  Main.Wrap @Prim.Type t t1 -> Main.Wrap @Prim.Type t t1 -> Data.Ordering.Ordering
+  compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type t t1) {ordWrap {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
@@ -3,35 +3,35 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-data List :: Type -> Type
+data List :: Prim.Type -> Prim.Type
 data List @a
-  | Nil :: List a
-  | Cons :: a -> List a -> List a
+  | Nil :: Main.List a
+  | Cons :: a -> Main.List a -> Main.List a
 
-data Tree :: Type -> Type
+data Tree :: Prim.Type -> Prim.Type
 data Tree @a
-  | Leaf :: a -> Tree a
-  | Branch :: Tree a -> Tree a -> Tree a
+  | Leaf :: a -> Main.Tree a
+  | Branch :: Main.Tree a -> Main.Tree a -> Main.Tree a
 
-dictionary eqList :: forall t. { eqDict :: Eq t } => Eq (List t) where
-  eq :: List t -> List t -> Boolean
+dictionary eqList :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.List t) where
+  eq :: Main.List t -> Main.List t -> Prim.Boolean
   eq = \left right ->
   case left, right of
     Nil, Nil -> true
     (Cons left0 left1), (Cons right0 right1) ->
       if eq @t {eqDict} left0 right0 then
-        if eq @(List t) {eqList {eqDict}} left1 right1 then true else false
+        if eq @(Main.List t) {eqList {eqDict}} left1 right1 then true else false
       else
         false
     _, _ -> false
 
-dictionary eq1List :: Eq1 List where
-  eq1 :: forall (t :: Type). Eq t => List t -> List t -> Boolean
-  eq1 = \{eqDict} -> eq @(List t) {eqList {eqDict}}
+dictionary eq1List :: Data.Eq.Eq1 Main.List where
+  eq1 :: forall (t :: Prim.Type). Data.Eq.Eq t => Main.List t -> Main.List t -> Prim.Boolean
+  eq1 = \{eqDict} -> eq @(Main.List t) {eqList {eqDict}}
 
-dictionary ordList :: forall t. { ordDict :: Ord t } => Ord (List t) where
+dictionary ordList :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.List t) where
   superclass eqDict = eqList {ordDict.eqDict}
-  compare :: List t -> List t -> Ordering
+  compare :: Main.List t -> Main.List t -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     Nil, Nil -> EQ
@@ -40,36 +40,36 @@ dictionary ordList :: forall t. { ordDict :: Ord t } => Ord (List t) where
     (Cons left0 left1), (Cons right0 right1) ->
       case compare @t {ordDict} left0 right0 of
         EQ ->
-          case compare @(List t) {ordList {ordDict}} left1 right1 of
+          case compare @(Main.List t) {ordList {ordDict}} left1 right1 of
             EQ -> EQ
             ordering -> ordering
         ordering -> ordering
 
-dictionary ord1List :: Ord1 List where
+dictionary ord1List :: Data.Ord.Ord1 Main.List where
   superclass eq1Dict = eq1List
-  compare1 :: forall (t :: Type). Ord t => List t -> List t -> Ordering
-  compare1 = \{ordDict} -> compare @(List t) {ordList {ordDict}}
+  compare1 :: forall (t :: Prim.Type). Data.Ord.Ord t => Main.List t -> Main.List t -> Data.Ordering.Ordering
+  compare1 = \{ordDict} -> compare @(Main.List t) {ordList {ordDict}}
 
-dictionary eqTree :: forall t. { eqDict :: Eq t } => Eq (Tree t) where
-  eq :: Tree t -> Tree t -> Boolean
+dictionary eqTree :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Tree t) where
+  eq :: Main.Tree t -> Main.Tree t -> Prim.Boolean
   eq = \left right ->
   case left, right of
     (Leaf left0), (Leaf right0) ->
       if eq @t {eqDict} left0 right0 then true else false
     (Branch left0 left1), (Branch right0 right1) ->
-      if eq @(Tree t) {eqTree {eqDict}} left0 right0 then
-        if eq @(Tree t) {eqTree {eqDict}} left1 right1 then true else false
+      if eq @(Main.Tree t) {eqTree {eqDict}} left0 right0 then
+        if eq @(Main.Tree t) {eqTree {eqDict}} left1 right1 then true else false
       else
         false
     _, _ -> false
 
-dictionary eq1Tree :: Eq1 Tree where
-  eq1 :: forall (t :: Type). Eq t => Tree t -> Tree t -> Boolean
-  eq1 = \{eqDict} -> eq @(Tree t) {eqTree {eqDict}}
+dictionary eq1Tree :: Data.Eq.Eq1 Main.Tree where
+  eq1 :: forall (t :: Prim.Type). Data.Eq.Eq t => Main.Tree t -> Main.Tree t -> Prim.Boolean
+  eq1 = \{eqDict} -> eq @(Main.Tree t) {eqTree {eqDict}}
 
-dictionary ordTree :: forall t. { ordDict :: Ord t } => Ord (Tree t) where
+dictionary ordTree :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.Tree t) where
   superclass eqDict = eqTree {ordDict.eqDict}
-  compare :: Tree t -> Tree t -> Ordering
+  compare :: Main.Tree t -> Main.Tree t -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     (Leaf left0), (Leaf right0) ->
@@ -79,14 +79,14 @@ dictionary ordTree :: forall t. { ordDict :: Ord t } => Ord (Tree t) where
     (Leaf _), _ -> LT
     _, (Leaf _) -> GT
     (Branch left0 left1), (Branch right0 right1) ->
-      case compare @(Tree t) {ordTree {ordDict}} left0 right0 of
+      case compare @(Main.Tree t) {ordTree {ordDict}} left0 right0 of
         EQ ->
-          case compare @(Tree t) {ordTree {ordDict}} left1 right1 of
+          case compare @(Main.Tree t) {ordTree {ordDict}} left1 right1 of
             EQ -> EQ
             ordering -> ordering
         ordering -> ordering
 
-dictionary ord1Tree :: Ord1 Tree where
+dictionary ord1Tree :: Data.Ord.Ord1 Main.Tree where
   superclass eq1Dict = eq1Tree
-  compare1 :: forall (t :: Type). Ord t => Tree t -> Tree t -> Ordering
-  compare1 = \{ordDict} -> compare @(Tree t) {ordTree {ordDict}}
+  compare1 :: forall (t :: Prim.Type). Data.Ord.Ord t => Main.Tree t -> Main.Tree t -> Data.Ordering.Ordering
+  compare1 = \{ordDict} -> compare @(Main.Tree t) {ordTree {ordDict}}

--- a/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.snap
@@ -3,23 +3,23 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-newtype Mu :: (Type -> Type) -> Type
+newtype Mu :: (Prim.Type -> Prim.Type) -> Prim.Type
 newtype Mu @f
-  | In :: f (Mu f) -> Mu f
+  | In :: f (Main.Mu f) -> Main.Mu f
 
-dictionary eqMu :: forall t. { eq1Dict :: Eq1 t } => Eq (Mu t) where
-  eq :: Mu t -> Mu t -> Boolean
+dictionary eqMu :: forall t. { eq1Dict :: Data.Eq.Eq1 t } => Data.Eq.Eq (Main.Mu t) where
+  eq :: Main.Mu t -> Main.Mu t -> Prim.Boolean
   eq = \left right ->
   case left, right of
     (In left0), (In right0) ->
-      if eq1 @t {eq1Dict} @(Mu t) {eqMu {eq1Dict}} left0 right0 then true else false
+      if eq1 @t {eq1Dict} @(Main.Mu t) {eqMu {eq1Dict}} left0 right0 then true else false
 
-dictionary ordMu :: forall t. { ord1Dict :: Ord1 t } => Ord (Mu t) where
+dictionary ordMu :: forall t. { ord1Dict :: Data.Ord.Ord1 t } => Data.Ord.Ord (Main.Mu t) where
   superclass eqDict = eqMu {ord1Dict.eq1Dict}
-  compare :: Mu t -> Mu t -> Ordering
+  compare :: Main.Mu t -> Main.Mu t -> Data.Ordering.Ordering
   compare = \left right ->
   case left, right of
     (In left0), (In right0) ->
-      case compare1 @t {ord1Dict} @(Mu t) {ordMu {ord1Dict}} left0 right0 of
+      case compare1 @t {ord1Dict} @(Main.Mu t) {ordMu {ord1Dict}} left0 right0 of
         EQ -> EQ
         ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.snap
@@ -3,8 +3,11 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-newtype Identity :: Type -> Type
+newtype Identity :: Prim.Type -> Prim.Type
 newtype Identity @a
-  | Identity :: a -> Identity a
+  | Identity :: a -> Main.Identity a
 
-dictionary showIdentity :: forall t. { showDict :: Show t } => Show (Identity t) = showDict
+dictionary showIdentity ::
+  forall t.
+  { showDict :: Data.Show.Show t } =>
+  Data.Show.Show (Main.Identity t) = showDict

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.snap
@@ -3,11 +3,11 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-newtype NonEmpty :: Type -> Type
+newtype NonEmpty :: Prim.Type -> Prim.Type
 newtype NonEmpty @a
-  | NonEmpty :: Array a -> NonEmpty a
+  | NonEmpty :: Prim.Array a -> Main.NonEmpty a
 
 dictionary showNonEmpty ::
   forall t.
-  { showDict :: Show t } =>
-  Show (NonEmpty t) = showArray {showDict}
+  { showDict :: Data.Show.Show t } =>
+  Data.Show.Show (Main.NonEmpty t) = showArray {showDict}

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_concrete_representation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_concrete_representation/Main.snap
@@ -3,8 +3,8 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 68
 expression: report
 ---
-newtype NonZero :: Type
+newtype NonZero :: Prim.Type
 newtype NonZero
-  | NonZero :: Int -> NonZero
+  | NonZero :: Prim.Int -> Main.NonZero
 
-dictionary showNonZero :: Show NonZero = showInt
+dictionary showNonZero :: Data.Show.Show Main.NonZero = showInt

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -219,7 +219,8 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
 pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     let indexed = engine.indexed(id).unwrap();
     let checked = engine.checked(id).unwrap();
-    let pretty = pretty::Pretty::new(engine, &checked);
+    let config = pretty::PrettyConfig::new().fully_qualified_names();
+    let pretty = pretty::Pretty::with_config(engine, &checked, config);
 
     let mut out = String::default();
 

--- a/tests-integration/src/generated/semantic.rs
+++ b/tests-integration/src/generated/semantic.rs
@@ -4,5 +4,6 @@ use files::FileId;
 
 pub fn report(engine: &QueryEngine, id: FileId) -> String {
     let checked = engine.checked(id).unwrap();
-    pretty::Pretty::new(engine, &checked).render(id).unwrap().to_string()
+    let config = pretty::PrettyConfig::new().fully_qualified_names();
+    pretty::Pretty::with_config(engine, &checked, config).render(id).unwrap().to_string()
 }


### PR DESCRIPTION
## Intent

Checking and semantic snapshots currently print bare type constructor names, which hides the module that defines a type and can make similarly named types ambiguous. These reports should expose canonical type identities while editor-facing pretty printing remains concise by default.

## Changes

- Add an opt-in `fully_qualified_names` setting to the core checking pretty printer.
- Resolve constructor prefixes from the defining file's declared module name, rather than from an import alias.
- Propagate the setting through checked semantic-tree rendering, including manually assembled data-constructor result types.
- Enable fully qualified names for checking and semantic integration reports while preserving the unqualified default for diagnostics and LSP output.
- Regenerate affected checking and semantic snapshots.

## Verification

- `cargo check -p checking --tests`
- `cargo check -p tests-integration --tests`
- `just t checking`
- `just t semantic`
- `just format`
- `git diff --check`