### PR TITLE
[checking] Preserve type variable names in instance members

### DIFF
--- a/compiler-core/checking/src/core/signature.rs
+++ b/compiler-core/checking/src/core/signature.rs
@@ -4,7 +4,7 @@ use lowering::TypeVariableBinding;
 
 use crate::context::CheckContext;
 use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{ForallBinder, Type, TypeId, normalise, unification};
+use crate::core::{ForallBinder, Type, TypeId, normalise, toolkit, unification};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -199,7 +199,7 @@ where
 
     for binder in &signature.binders {
         let kind = SubstituteName::many(state, context, &substitution, binder.kind)?;
-        let text = state.checked.lookup_name(binder.name);
+        let text = toolkit::lookup_name(state, context, binder.name)?;
         let rigid = state.fresh_rigid_named(context.queries, kind, text);
         substitution.insert(binder.name, rigid);
     }

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -13,8 +13,8 @@ use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
 use crate::core::walk::{self, TypeWalker};
 use crate::core::{
-    CheckedClass, CheckedSynonym, ForallBinder, KindOrType, Name, Role, Type, TypeId, constraint,
-    normalise, unification,
+    CheckedClass, CheckedSynonym, ForallBinder, KindOrType, Name, Role, SmolStrId, Type, TypeId,
+    constraint, normalise, unification,
 };
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -185,6 +185,22 @@ where
     } else {
         let checked = context.checked_dependency(file_id)?;
         Ok(checked.lookup_class(item_id))
+    }
+}
+
+pub fn lookup_name<Q>(
+    state: &CheckState,
+    context: &CheckContext<Q>,
+    name: Name,
+) -> QueryResult<Option<SmolStrId>>
+where
+    Q: ExternalQueries,
+{
+    if name.file == context.id {
+        Ok(state.checked.lookup_name(name))
+    } else {
+        let checked = context.checked_dependency(name.file)?;
+        Ok(checked.lookup_name(name))
     }
 }
 

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -484,7 +484,8 @@ where
 
     for binder in &instance.binders {
         let kind = SubstituteName::many(state, context, &substitution, binder.kind)?;
-        let text = state.checked.lookup_name(binder.name);
+        let text = toolkit::lookup_name(state, context, binder.name)?
+            .or_else(|| state.bindings.lookup_implicit_text(binder.name));
         let rigid = state.fresh_rigid_named(context.queries, kind, text);
         substitution.insert(binder.name, rigid);
         rigids.push(rigid);

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -272,7 +272,9 @@ where
                     let n = state.names.fresh();
                     let k = state.fresh_unification(context.queries, context.prim.t);
 
-                    state.bindings.bind_implicit(implicit.node, implicit.id, n, k);
+                    let text = name.clone().map(|text| context.queries.intern_smol_str(text));
+
+                    state.bindings.bind_implicit(implicit.node, implicit.id, n, k, text);
                     state.checked.nodes.implicit_bindings.insert((implicit.node, implicit.id), k);
 
                     let t = context.intern_rigid(n, state.depth, k);

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -104,6 +104,7 @@ struct ImplicitBinding {
     id: lowering::ImplicitBindingId,
     name: Name,
     kind: TypeId,
+    text: Option<SmolStrId>,
 }
 
 impl Bindings {
@@ -125,8 +126,9 @@ impl Bindings {
         id: lowering::ImplicitBindingId,
         name: Name,
         kind: TypeId,
+        text: Option<SmolStrId>,
     ) {
-        self.implicit.push(ImplicitBinding { node, id, name, kind });
+        self.implicit.push(ImplicitBinding { node, id, name, kind, text });
     }
 
     fn bind_implicit_substitution<Q>(
@@ -140,7 +142,7 @@ impl Bindings {
         let scope = state.bindings.implicit.len();
 
         for binding in 0..scope {
-            let ImplicitBinding { node, id, name, kind } = state.bindings.implicit[binding];
+            let ImplicitBinding { node, id, name, kind, text } = state.bindings.implicit[binding];
             let Some(&replacement) = substitution.get(&name) else { continue };
 
             let Type::Rigid(name, _, _) = context.lookup_type(replacement) else {
@@ -148,7 +150,7 @@ impl Bindings {
             };
 
             let kind = SubstituteName::many(state, context, substitution, kind)?;
-            state.bindings.implicit.push(ImplicitBinding { node, id, name, kind });
+            state.bindings.implicit.push(ImplicitBinding { node, id, name, kind, text });
         }
 
         Ok(())
@@ -189,6 +191,14 @@ impl Bindings {
             .rev()
             .find(|binding| binding.node == node && binding.id == id)
             .map(|binding| (binding.name, binding.kind))
+    }
+
+    pub fn lookup_implicit_text(&self, name: Name) -> Option<SmolStrId> {
+        self.implicit
+            .iter()
+            .rev()
+            .find(|binding| binding.name == name)
+            .and_then(|binding| binding.text)
     }
 }
 

--- a/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
@@ -22,7 +22,7 @@ Roles
 Box = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Show (t :: Type)
+error[NoInstanceFound]: No instance found for: Show (a :: Type)
   --> 9:1..11:24
   |
 9 | instance Show (Box a) where

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -48,7 +48,7 @@ error[TermHole]: Hole '?pun' has inferred type: Int
 17 | recordPunHole { punInt, punString } = ?pun
    |                                       ^~~~
   trivia: punInt :: Int is in scope
-error[TypeHole]: Type hole '?implicit' has inferred type: (t1 :: Type) :: Type
+error[TypeHole]: Type hole '?implicit' has inferred type: (implicit :: Type) :: Type
   --> 23:29..23:38
    |
 23 |   instanceTypeHoleMember :: ?implicit -> implicit

--- a/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Data.Functor.purs
+++ b/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Data.Functor.purs
@@ -1,0 +1,4 @@
+module Data.Functor where
+
+class Functor f where
+  map :: forall a b. (a -> b) -> f a -> f b

--- a/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.purs
+++ b/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Data.Functor (class Functor)
+
+newtype Continuation r a = Continuation ((a -> r) -> r)
+
+instance Functor (Continuation r) where
+  map function (Continuation program) =
+    Continuation \return ->
+      program \a ->
+--    $
+        return (function a)
+--      $       $

--- a/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
+++ b/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
@@ -11,7 +11,7 @@ Hover at Position { line: 9, character: 6 }
 ```
 
 ```purescript
-((t :: Type) -> (t1 :: Type)) -> (t1 :: Type)
+((a :: Type) -> (r :: Type)) -> (r :: Type)
 ```
 
 
@@ -23,7 +23,7 @@ Hover at Position { line: 11, character: 8 }
 ```
 
 ```purescript
-(t :: Type) -> (t1 :: Type)
+(b :: Type) -> (r :: Type)
 ```
 
 
@@ -35,5 +35,5 @@ Hover at Position { line: 11, character: 16 }
 ```
 
 ```purescript
-(t :: Type) -> (t1 :: Type)
+(a :: Type) -> (b :: Type)
 ```

--- a/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
+++ b/tests-integration/fixtures/lsp/1785371460_instance_member_type_variable_names/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 9, character: 6 }
+
+```
+      program \a ->
+--    $
+```
+
+```purescript
+((t :: Type) -> (t1 :: Type)) -> (t1 :: Type)
+```
+
+
+Hover at Position { line: 11, character: 8 }
+
+```
+        return (function a)
+--      $       $
+```
+
+```purescript
+(t :: Type) -> (t1 :: Type)
+```
+
+
+Hover at Position { line: 11, character: 16 }
+
+```
+        return (function a)
+--      $       $
+```
+
+```purescript
+(t :: Type) -> (t1 :: Type)
+```

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -16,7 +16,7 @@ dictionary eqIdentity :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Mai
 
 dictionary eq1Identity :: Data.Eq.Eq1 Main.Identity where
   eq1 :: forall (t :: Prim.Type). Data.Eq.Eq t => Main.Identity t -> Main.Identity t -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Identity t) {eqIdentity {eqDict}}
+  eq1 = \{eqDict} -> eq @(Main.Identity a) {eqIdentity {eqDict}}
 
 dictionary ordIdentity :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.Identity t)
   where
@@ -33,4 +33,4 @@ dictionary ord1Identity :: Data.Ord.Ord1 Main.Identity where
   superclass eq1Dict = eq1Identity
   compare1 :: forall (t :: Prim.Type).
   Data.Ord.Ord t => Main.Identity t -> Main.Identity t -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Identity t) {ordIdentity {ordDict}}
+  compare1 = \{ordDict} -> compare @(Main.Identity a) {ordIdentity {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -23,7 +23,7 @@ dictionary eq1Wrap :: forall t. { eq1Dict :: Data.Eq.Eq1 t } => Data.Eq.Eq1 (Mai
   where
   eq1 :: forall (t1 :: Prim.Type).
   Data.Eq.Eq t1 => Main.Wrap @Prim.Type t t1 -> Main.Wrap @Prim.Type t t1 -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type t t1) {eqWrap {eq1Dict} {eqDict}}
+  eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type t a) {eqWrap {eq1Dict} {eqDict}}
 
 dictionary ordWrap ::
   forall t t1.
@@ -49,4 +49,4 @@ dictionary ord1Wrap ::
   compare1 :: forall (t1 :: Prim.Type).
   Data.Ord.Ord t1 =>
   Main.Wrap @Prim.Type t t1 -> Main.Wrap @Prim.Type t t1 -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type t t1) {ordWrap {ord1Dict} {ordDict}}
+  compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type t a) {ordWrap {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
@@ -27,7 +27,7 @@ dictionary eqList :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Li
 
 dictionary eq1List :: Data.Eq.Eq1 Main.List where
   eq1 :: forall (t :: Prim.Type). Data.Eq.Eq t => Main.List t -> Main.List t -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.List t) {eqList {eqDict}}
+  eq1 = \{eqDict} -> eq @(Main.List a) {eqList {eqDict}}
 
 dictionary ordList :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.List t) where
   superclass eqDict = eqList {ordDict.eqDict}
@@ -48,7 +48,7 @@ dictionary ordList :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (M
 dictionary ord1List :: Data.Ord.Ord1 Main.List where
   superclass eq1Dict = eq1List
   compare1 :: forall (t :: Prim.Type). Data.Ord.Ord t => Main.List t -> Main.List t -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.List t) {ordList {ordDict}}
+  compare1 = \{ordDict} -> compare @(Main.List a) {ordList {ordDict}}
 
 dictionary eqTree :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Tree t) where
   eq :: Main.Tree t -> Main.Tree t -> Prim.Boolean
@@ -65,7 +65,7 @@ dictionary eqTree :: forall t. { eqDict :: Data.Eq.Eq t } => Data.Eq.Eq (Main.Tr
 
 dictionary eq1Tree :: Data.Eq.Eq1 Main.Tree where
   eq1 :: forall (t :: Prim.Type). Data.Eq.Eq t => Main.Tree t -> Main.Tree t -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Tree t) {eqTree {eqDict}}
+  eq1 = \{eqDict} -> eq @(Main.Tree a) {eqTree {eqDict}}
 
 dictionary ordTree :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (Main.Tree t) where
   superclass eqDict = eqTree {ordDict.eqDict}
@@ -89,4 +89,4 @@ dictionary ordTree :: forall t. { ordDict :: Data.Ord.Ord t } => Data.Ord.Ord (M
 dictionary ord1Tree :: Data.Ord.Ord1 Main.Tree where
   superclass eq1Dict = eq1Tree
   compare1 :: forall (t :: Prim.Type). Data.Ord.Ord t => Main.Tree t -> Main.Tree t -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Tree t) {ordTree {ordDict}}
+  compare1 = \{ordDict} -> compare @(Main.Tree a) {ordTree {ordDict}}


### PR DESCRIPTION
## Intent

Instance members without explicit signatures are checked against their class member declarations, but the checker currently drops the source names of those inherited type variables. Local hovers then assign unrelated fallback names such as `t` and `t1` to each type independently, obscuring how values in the implementation relate to one another. Instance-head variables lose their source names for the same reason while their rigids are freshened.

Instance member bodies should preserve names from both the class declaration and the instance head so editor-facing types communicate the checked relationships accurately.

## Changes

- Add an LSP regression fixture that first records the incorrect hover names for a `Functor (Continuation r)` implementation.
- Resolve forall binder names from the checked module that defines them when skolemising inherited class member signatures.
- Retain optional source text for implicitly quantified variables through binding substitutions and instance-rigid freshening.
- Update LSP, checking diagnostic, and semantic snapshots where the preserved names become observable.

The resulting hovers report `function :: a -> b`, `program :: (a -> r) -> r`, and `return :: b -> r` without requiring an explicit instance member signature.

## Verification

- `cargo check -p checking --tests`
- `cargo check -p analyzer --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`
- `just t lsp`
- `just format`
- `git diff --check`