### PR TITLE
[cli] Restore default LSP invocation

### DIFF
--- a/compiler-bin/src/cli.rs
+++ b/compiler-bin/src/cli.rs
@@ -23,8 +23,16 @@ pub struct Cli {
     /// Print log path.
     #[arg(long)]
     pub log_file: bool,
+    #[command(flatten)]
+    pub lsp: LspOptions,
     #[command(subcommand)]
     pub command: Option<Command>,
+}
+
+impl Cli {
+    pub fn command(self) -> Command {
+        self.command.unwrap_or(Command::Lsp(self.lsp))
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -144,6 +152,16 @@ mod tests {
     use clap::error::ErrorKind;
     use std::path::Path;
 
+    fn lsp(args: &[&str]) -> LspOptions {
+        let mut argv = vec!["alexandrite"];
+        argv.extend(args);
+        let cli = Cli::parse_from(argv);
+        match cli.command() {
+            Command::Lsp(options) => options,
+            _ => unreachable!("parsed command was not `lsp`"),
+        }
+    }
+
     fn docs(args: &[&str]) -> DocsOptions {
         let mut argv = vec!["alexandrite", "docs"];
         argv.extend(args);
@@ -173,6 +191,14 @@ mod tests {
 
     fn current_directory_path(path: impl AsRef<Path>) -> PathBuf {
         current_directory().join(path)
+    }
+
+    #[test]
+    fn lsp_is_the_default_command() {
+        let options = lsp(&["--stdio", "--diagnostics-on-change"]);
+
+        assert!(options.stdio);
+        assert!(options.diagnostics_on_change);
     }
 
     #[test]

--- a/compiler-bin/src/lib.rs
+++ b/compiler-bin/src/lib.rs
@@ -14,10 +14,7 @@ pub fn run() {
         eprintln!("Log file: {:?}", logging::temporary_log_file());
     }
 
-    let command = cli.command.unwrap_or_else(|| {
-        let options = cli::LspOptions::default();
-        cli::Command::Lsp(options)
-    });
+    let command = cli.command();
 
     match command {
         cli::Command::Lsp(options) => {


### PR DESCRIPTION
## Problem

Language clients historically launched Alexandrite without an explicit `lsp` subcommand, often passing LSP options such as `--stdio` directly. The command dispatcher still selected LSP when no subcommand was present, but Clap rejected those root-level LSP options before dispatch, breaking existing client launch configurations.

## Change

- Flatten the LSP options into the root CLI parser while retaining the explicit `lsp` and `docs` subcommands.
- Resolve an omitted subcommand to LSP through the CLI command API.
- Add a regression test that parses root-level LSP options without an `lsp` subcommand.

## Verification

- `cargo nextest run -p purescript-alexandrite cli::tests`
- `cargo check -p purescript-alexandrite --tests`
- `just format`
- `git diff --check`