### PR TITLE
[checking] Preserve instance variable names in semantic trees

### DIFF
--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -589,6 +589,9 @@ where
     for implicit_unification in implicits_unifications {
         match implicit_unification {
             ImplicitOrUnification::Implicit(name, kind) => {
+                if let Some(text) = state.bindings.lookup_implicit_text(name) {
+                    state.checked.names.insert(name, text);
+                }
                 binders.push(ForallBinder { visible: false, name, kind })
             }
             ImplicitOrUnification::Unification(id, kind) => {

--- a/compiler-core/checking/src/core/pretty.rs
+++ b/compiler-core/checking/src/core/pretty.rs
@@ -272,6 +272,11 @@ where
         self.names.assign_display_name(name, display);
     }
 
+    pub(crate) fn allocate_display_name(&mut self, name: Name, base: SmolStr) {
+        let display = self.names.allocate_display_name(base);
+        self.names.assign_display_name(name, display);
+    }
+
     pub fn render(&mut self, id: TypeId) -> SmolStr {
         self.names.set_default_name("t");
         self.render_with_signature(None, id, Precedence::Top)

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -583,6 +583,12 @@ where
     ) -> QueryResult<Doc<'arena>> {
         let mut type_pretty = self.type_pretty.state();
 
+        for (rigid, display) in rigid_names {
+            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
+                type_pretty.assign_display_name(name, SmolStr::clone(display));
+            }
+        }
+
         let mut remaining_type = member.implementation_type;
         while let Type::Forall(binder, inner) = self.queries.lookup_type(remaining_type) {
             let binder = self.queries.lookup_forall_binder(binder);
@@ -593,15 +599,9 @@ where
             };
             if let Some(text) = text {
                 let text = self.queries.lookup_smol_str(text);
-                type_pretty.assign_display_name(binder.name, text);
+                type_pretty.allocate_display_name(binder.name, text);
             }
             remaining_type = inner;
-        }
-
-        for (rigid, display) in rigid_names {
-            if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
-                type_pretty.assign_display_name(name, SmolStr::clone(display));
-            }
         }
 
         let type_id = type_pretty.render(member.implementation_type);

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -23,9 +23,9 @@ use crate::evidence::{
 use crate::tree::{
     BinderId, BinderKind, BinderSource, CaseAlternative, Equation, ExpressionId, ExpressionKind,
     GuardedAlternative, GuardedExpression, InstanceDeclaration, InstanceImplementation,
-    LetBindingChunk, LetBindings, LocalDeclarationId, PatternGuard, RecordBinderField,
-    RecordExpressionField, RecordExpressionUpdate, TermDeclarationKind, TypeDeclarationKind,
-    VariableResolution, WhereExpression,
+    InstanceMember, LetBindingChunk, LetBindings, LocalDeclarationId, PatternGuard,
+    RecordBinderField, RecordExpressionField, RecordExpressionUpdate, TermDeclarationKind,
+    TypeDeclarationKind, VariableResolution, WhereExpression,
 };
 
 type Doc<'a> = DocBuilder<'a, Arena<'a>, ()>;
@@ -554,11 +554,8 @@ where
                         continue;
                     };
 
-                    let signature = self.instance_member_signature(
-                        &member_name,
-                        member.implementation_type,
-                        &rigid_names,
-                    );
+                    let signature =
+                        self.instance_member_signature(member, &member_name, &rigid_names)?;
                     fields.push(signature.append(self.arena.hardline()).append(equations));
                 }
             }
@@ -580,19 +577,35 @@ where
 
     fn instance_member_signature(
         &self,
+        member: &InstanceMember,
         name: &str,
-        type_id: crate::TypeId,
         rigid_names: &[(crate::TypeId, SmolStr)],
-    ) -> Doc<'arena> {
+    ) -> QueryResult<Doc<'arena>> {
         let mut type_pretty = self.type_pretty.state();
+
+        let mut remaining_type = member.implementation_type;
+        while let Type::Forall(binder, inner) = self.queries.lookup_type(remaining_type) {
+            let binder = self.queries.lookup_forall_binder(binder);
+            let text = if member.resolution.0 == self.file_id {
+                self.checked.lookup_name(binder.name)
+            } else {
+                self.queries.checked(member.resolution.0)?.lookup_name(binder.name)
+            };
+            if let Some(text) = text {
+                let text = self.queries.lookup_smol_str(text);
+                type_pretty.assign_display_name(binder.name, text);
+            }
+            remaining_type = inner;
+        }
+
         for (rigid, display) in rigid_names {
             if let Type::Rigid(name, _, _) = self.queries.lookup_type(*rigid) {
                 type_pretty.assign_display_name(name, SmolStr::clone(display));
             }
         }
 
-        let type_id = type_pretty.render(type_id);
-        self.arena.text(format!("  {name} :: {type_id}"))
+        let type_id = type_pretty.render(member.implementation_type);
+        Ok(self.arena.text(format!("  {name} :: {type_id}")))
     }
 
     fn dictionary_signature(

--- a/tests-integration/fixtures/checking/1772140680_instance_check/Main.snap
+++ b/tests-integration/fixtures/checking/1772140680_instance_check/Main.snap
@@ -14,6 +14,6 @@ class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
 class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEq @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type). Main.Eq (t0 :: Prim.Type) => Main.Eq (Prim.Array (t0 :: Prim.Type))
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.TypeEq @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t1 :: (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) => Main.Eq (Prim.Array (a :: Prim.Type))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.TypeEq @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (a :: (t0 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301720_instance_constraint_solving/Main.snap
+++ b/tests-integration/fixtures/checking/1772301720_instance_constraint_solving/Main.snap
@@ -24,4 +24,4 @@ class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
 
 Instances
 instance Main.Eq Prim.Int
-instance forall (t0 :: Prim.Type). Main.Eq (t0 :: Prim.Type) => Main.Eq (Prim.Array (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) => Main.Eq (Prim.Array (a :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301780_instance_functional_dependency/Main.snap
+++ b/tests-integration/fixtures/checking/1772301780_instance_functional_dependency/Main.snap
@@ -22,5 +22,5 @@ class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). M
 
 Instances
 instance Main.Convert Prim.Int Prim.String
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.TypeEq @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t1 :: (t0 :: Prim.Type))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.TypeEq @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (a :: (t0 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772301840_instance_given_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1772301840_instance_given_constraint/Main.snap
@@ -20,4 +20,4 @@ class forall (a :: Prim.Type). Main.Eq (a :: Prim.Type)
 
 Instances
 instance Main.Eq Prim.Int
-instance forall (t0 :: Prim.Type). Main.Eq (t0 :: Prim.Type) => Main.Eq (Prim.Array (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.Eq (a :: Prim.Type) => Main.Eq (Prim.Array (a :: Prim.Type))

--- a/tests-integration/fixtures/checking/1772475780_instance_member_signature_head_variable/Main.snap
+++ b/tests-integration/fixtures/checking/1772475780_instance_member_signature_head_variable/Main.snap
@@ -16,7 +16,7 @@ class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
   show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Instances
-instance forall (t0 :: Prim.Type). Main.Show (t0 :: Prim.Type) => Main.Show (Main.Box (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.Show (a :: Prim.Type) => Main.Show (Main.Box (a :: Prim.Type))
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
+++ b/tests-integration/fixtures/checking/1772475840_instance_member_missing_constraint/Main.snap
@@ -16,7 +16,7 @@ class forall (a :: Prim.Type). Main.Show (a :: Prim.Type)
   show :: forall (@a :: Prim.Type). Main.Show (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
 
 Instances
-instance forall (t0 :: Prim.Type). Main.Show (Main.Box (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.Show (Main.Box (a :: Prim.Type))
 
 Roles
 Box = [Representational]

--- a/tests-integration/fixtures/checking/1772475960_instance_member_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772475960_instance_member_higher_kinded/Main.snap
@@ -37,9 +37,9 @@ class forall (f :: Prim.Type -> Prim.Type). Main.Functor (f :: Prim.Type -> Prim
       (f :: Prim.Type -> Prim.Type) (b :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Main.Functor (t0 :: Prim.Type -> Prim.Type) =>
-  Main.Functor (Main.Wrap @Prim.Type (t1 :: Prim.Type) (t0 :: Prim.Type -> Prim.Type))
+instance forall (w :: Prim.Type -> Prim.Type) (e :: Prim.Type).
+  Main.Functor (w :: Prim.Type -> Prim.Type) =>
+  Main.Functor (Main.Wrap @Prim.Type (e :: Prim.Type) (w :: Prim.Type -> Prim.Type))
 
 Roles
 Wrap = [Phantom, Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772564640_derive_ord_1_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772564640_derive_ord_1_higher_kinded/Main.snap
@@ -21,38 +21,38 @@ WrapNoOrd1 ::
   forall (t0 :: Prim.Type). ((t0 :: Prim.Type) -> Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (t1 :: Prim.Type) =>
-  Data.Eq.Eq (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord (t1 :: Prim.Type) =>
-  Data.Ord.Ord (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (t1 :: Prim.Type) =>
-  Data.Eq.Eq (Main.WrapNoOrd1 @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Ord.Ord (t0 :: Prim.Type) =>
-  Data.Ord.Ord (Main.WrapNoOrd1 @Prim.Type (t1 :: Prim.Type -> Prim.Type) (t0 :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (a :: Prim.Type) =>
+  Data.Ord.Ord (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.WrapNoOrd1 @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (a :: Prim.Type) (f :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord (a :: Prim.Type) =>
+  Data.Ord.Ord (Main.WrapNoOrd1 @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]
 WrapNoOrd1 = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Ord1 (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Ord1 (f :: Type -> Type)
   --> 14:1..14:46
    |
 14 | derive instance Ord a => Ord (WrapNoOrd1 f a)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t1 :: Type) is in scope
-  trivia: Eq (t1 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq1 (t0 :: Type -> Type)
+  trivia: Ord (a :: Type) is in scope
+  trivia: Eq (a :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Eq1 (f :: Type -> Type)
   --> 14:1..14:46
    |
 14 | derive instance Ord a => Ord (WrapNoOrd1 f a)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t1 :: Type) is in scope
-  trivia: Eq (t1 :: Type) is in scope
+  trivia: Ord (a :: Type) is in scope
+  trivia: Eq (a :: Type) is in scope

--- a/tests-integration/fixtures/checking/1772564700_derive_eq_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772564700_derive_eq_simple/Main.snap
@@ -16,8 +16,8 @@ NoEq :: Prim.Type
 ContainsNoEq :: Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Data.Eq.Eq (Main.Proxy @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)))
+derive forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Data.Eq.Eq (Main.Proxy @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)))
 derive Data.Eq.Eq Main.ContainsNoEq
 
 Roles

--- a/tests-integration/fixtures/checking/1772564760_derive_eq_parameterized/Main.snap
+++ b/tests-integration/fixtures/checking/1772564760_derive_eq_parameterized/Main.snap
@@ -11,7 +11,7 @@ Types
 Maybe :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Maybe (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Maybe (a :: Prim.Type))
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1772564880_derive_eq_1/Main.snap
+++ b/tests-integration/fixtures/checking/1772564880_derive_eq_1/Main.snap
@@ -45,38 +45,35 @@ Either' :: Prim.Type -> Prim.Type
 NoEq :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Id (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Id (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.Id
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Pair (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Pair (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.Pair
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Mixed (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Mixed (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.Mixed
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Rec (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Rec (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.Rec
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (t1 :: Prim.Type) =>
-  Data.Eq.Eq (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq1 (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type) -> Prim.Type)
-  (t3 :: (t1 :: Prim.Type)).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq ((t2 :: (t1 :: Prim.Type) -> Prim.Type) (t3 :: (t1 :: Prim.Type))) =>
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1 (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (t0 :: Prim.Type) (g :: (t0 :: Prim.Type) -> Prim.Type)
+  (a :: (t0 :: Prim.Type)).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq ((g :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type))) =>
   Data.Eq.Eq
-    (Main.Compose @Prim.Type @(t1 :: Prim.Type)
-      (t0 :: Prim.Type -> Prim.Type)
-      (t2 :: (t1 :: Prim.Type) -> Prim.Type)
-      (t3 :: (t1 :: Prim.Type)))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
+    (Main.Compose @Prim.Type @(t0 :: Prim.Type)
+      (f :: Prim.Type -> Prim.Type)
+      (g :: (t0 :: Prim.Type) -> Prim.Type)
+      (a :: (t0 :: Prim.Type)))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
   Data.Eq.Eq1
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type).
-  Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Either' (t0 :: Prim.Type))
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Either' (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.Either'
 derive Data.Eq.Eq1 Main.NoEq
 
@@ -91,16 +88,16 @@ Either' = [Representational]
 NoEq = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq ((t0 :: Type -> Type) (t1 :: Type))
+error[NoInstanceFound]: No instance found for: Eq ((g :: Type -> Type) (t0 :: Type))
   --> 34:1..34:43
    |
 34 | derive instance Eq1 f => Eq1 (Compose f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (t2 :: Type -> Type) is in scope
-  trivia: Eq (t1 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq (NoEq (t3 :: Type))
+  trivia: Eq1 (f :: Type -> Type) is in scope
+  trivia: Eq (t0 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Eq (NoEq (t1 :: Type))
   --> 43:1..43:25
    |
 43 | derive instance Eq1 NoEq
    | ^~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq (t3 :: Type) is in scope
+  trivia: Eq (t1 :: Type) is in scope

--- a/tests-integration/fixtures/checking/1772564940_derive_ord_1/Main.snap
+++ b/tests-integration/fixtures/checking/1772564940_derive_ord_1/Main.snap
@@ -32,55 +32,51 @@ Compose ::
 NoOrd :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Id (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Id (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.Id
-derive forall (t0 :: Prim.Type). Data.Ord.Ord (t0 :: Prim.Type) => Data.Ord.Ord (Main.Id (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Ord.Ord (a :: Prim.Type) => Data.Ord.Ord (Main.Id (a :: Prim.Type))
 derive Data.Ord.Ord1 Main.Id
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (t1 :: Prim.Type) =>
-  Data.Eq.Eq (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq1 (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord (t1 :: Prim.Type) =>
-  Data.Ord.Ord (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord1 (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type) -> Prim.Type)
-  (t3 :: (t1 :: Prim.Type)).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq ((t2 :: (t1 :: Prim.Type) -> Prim.Type) (t3 :: (t1 :: Prim.Type))) =>
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1 (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (a :: Prim.Type) =>
+  Data.Ord.Ord (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord1 (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (t0 :: Prim.Type) (g :: (t0 :: Prim.Type) -> Prim.Type)
+  (a :: (t0 :: Prim.Type)).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq ((g :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type))) =>
   Data.Eq.Eq
-    (Main.Compose @Prim.Type @(t1 :: Prim.Type)
-      (t0 :: Prim.Type -> Prim.Type)
-      (t2 :: (t1 :: Prim.Type) -> Prim.Type)
-      (t3 :: (t1 :: Prim.Type)))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type) (t2 :: (t1 :: Prim.Type) -> Prim.Type)
-  (t3 :: (t1 :: Prim.Type)).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord ((t2 :: (t1 :: Prim.Type) -> Prim.Type) (t3 :: (t1 :: Prim.Type))) =>
+    (Main.Compose @Prim.Type @(t0 :: Prim.Type)
+      (f :: Prim.Type -> Prim.Type)
+      (g :: (t0 :: Prim.Type) -> Prim.Type)
+      (a :: (t0 :: Prim.Type)))
+derive forall (f :: Prim.Type -> Prim.Type) (t0 :: Prim.Type) (g :: (t0 :: Prim.Type) -> Prim.Type)
+  (a :: (t0 :: Prim.Type)).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord ((g :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type))) =>
   Data.Ord.Ord
-    (Main.Compose @Prim.Type @(t1 :: Prim.Type)
-      (t0 :: Prim.Type -> Prim.Type)
-      (t2 :: (t1 :: Prim.Type) -> Prim.Type)
-      (t3 :: (t1 :: Prim.Type)))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
+    (Main.Compose @Prim.Type @(t0 :: Prim.Type)
+      (f :: Prim.Type -> Prim.Type)
+      (g :: (t0 :: Prim.Type) -> Prim.Type)
+      (a :: (t0 :: Prim.Type)))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
   Data.Eq.Eq1
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
   Data.Ord.Ord1
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.NoOrd (t0 :: Prim.Type))
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.NoOrd (a :: Prim.Type))
 derive Data.Eq.Eq1 Main.NoOrd
 derive Data.Ord.Ord1 Main.NoOrd
 
@@ -91,26 +87,26 @@ Compose = [Representational, Representational, Nominal]
 NoOrd = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq ((t0 :: Type -> Type) (t1 :: Type))
+error[NoInstanceFound]: No instance found for: Eq ((g :: Type -> Type) (t0 :: Type))
   --> 25:1..25:43
    |
 25 | derive instance Eq1 f => Eq1 (Compose f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (t2 :: Type -> Type) is in scope
-  trivia: Eq (t1 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord ((t3 :: Type -> Type) (t4 :: Type))
+  trivia: Eq1 (f :: Type -> Type) is in scope
+  trivia: Eq (t0 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Ord ((g1 :: Type -> Type) (t1 :: Type))
   --> 26:1..26:45
    |
 26 | derive instance Ord1 f => Ord1 (Compose f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord1 (t5 :: Type -> Type) is in scope
-  trivia: Ord (t4 :: Type) is in scope
-  trivia: Eq1 (t5 :: Type -> Type) is in scope
-  trivia: Eq (t4 :: Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord (NoOrd (t6 :: Type))
+  trivia: Ord1 (f1 :: Type -> Type) is in scope
+  trivia: Ord (t1 :: Type) is in scope
+  trivia: Eq1 (f1 :: Type -> Type) is in scope
+  trivia: Eq (t1 :: Type) is in scope
+error[NoInstanceFound]: No instance found for: Ord (NoOrd (t2 :: Type))
   --> 32:1..32:27
    |
 32 | derive instance Ord1 NoOrd
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord (t6 :: Type) is in scope
-  trivia: Eq (t6 :: Type) is in scope
+  trivia: Ord (t2 :: Type) is in scope
+  trivia: Eq (t2 :: Type) is in scope

--- a/tests-integration/fixtures/checking/1772565000_derive_functor_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565000_derive_functor_simple/Main.snap
@@ -18,7 +18,7 @@ Maybe :: Prim.Type -> Prim.Type
 
 Derived
 derive Data.Functor.Functor Main.Identity
-derive forall (t0 :: Prim.Type). Data.Functor.Functor (Main.Const @Prim.Type (t0 :: Prim.Type))
+derive forall (e :: Prim.Type). Data.Functor.Functor (Main.Const @Prim.Type (e :: Prim.Type))
 derive Data.Functor.Functor Main.Maybe
 
 Roles

--- a/tests-integration/fixtures/checking/1772565060_derive_functor_contravariant_error/Main.snap
+++ b/tests-integration/fixtures/checking/1772565060_derive_functor_contravariant_error/Main.snap
@@ -21,8 +21,8 @@ Cont :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
 derive Data.Functor.Functor Main.Predicate
-derive forall (t0 :: Prim.Type). Data.Functor.Functor (Main.Reader (t0 :: Prim.Type))
-derive forall (t0 :: Prim.Type). Data.Functor.Functor (Main.Cont (t0 :: Prim.Type))
+derive forall (r :: Prim.Type). Data.Functor.Functor (Main.Reader (r :: Prim.Type))
+derive forall (r :: Prim.Type). Data.Functor.Functor (Main.Cont (r :: Prim.Type))
 
 Roles
 Predicate = [Representational]

--- a/tests-integration/fixtures/checking/1772565180_derive_bifunctor_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565180_derive_bifunctor_simple/Main.snap
@@ -32,8 +32,8 @@ Const2 ::
 Derived
 derive Data.Bifunctor.Bifunctor Main.Either
 derive Data.Bifunctor.Bifunctor Main.Pair
-derive forall (t0 :: Prim.Type).
-  Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type (t0 :: Prim.Type))
+derive forall (e :: Prim.Type).
+  Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type (e :: Prim.Type))
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
+++ b/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
@@ -25,22 +25,22 @@ WrapBoth ::
     Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
   Data.Bifunctor.Bifunctor
     (Main.WrapBoth @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
   --> 6:1..6:41
   |
 6 | derive instance Bifunctor (WrapBoth f g)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Functor (t1 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Functor (g :: Type -> Type)
   --> 6:1..6:41
   |
 6 | derive instance Bifunctor (WrapBoth f g)

--- a/tests-integration/fixtures/checking/1772565360_derive_traversable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565360_derive_traversable_simple/Main.snap
@@ -23,9 +23,9 @@ derive Data.Traversable.Traversable Main.Identity
 derive Data.Functor.Functor Main.Maybe
 derive Data.Foldable.Foldable Main.Maybe
 derive Data.Traversable.Traversable Main.Maybe
-derive forall (t0 :: Prim.Type). Data.Functor.Functor (Main.Const @Prim.Type (t0 :: Prim.Type))
-derive forall (t0 :: Prim.Type). Data.Foldable.Foldable (Main.Const @Prim.Type (t0 :: Prim.Type))
-derive forall (t0 :: Prim.Type). Data.Traversable.Traversable (Main.Const @Prim.Type (t0 :: Prim.Type))
+derive forall (e :: Prim.Type). Data.Functor.Functor (Main.Const @Prim.Type (e :: Prim.Type))
+derive forall (e :: Prim.Type). Data.Foldable.Foldable (Main.Const @Prim.Type (e :: Prim.Type))
+derive forall (e :: Prim.Type). Data.Traversable.Traversable (Main.Const @Prim.Type (e :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772565420_derive_traversable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772565420_derive_traversable_higher_kinded/Main.snap
@@ -23,27 +23,21 @@ Compose ::
     Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Functor.Functor (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Functor.Functor (t1 :: Prim.Type -> Prim.Type) =>
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (f :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (g :: Prim.Type -> Prim.Type) =>
   Data.Functor.Functor
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Foldable.Foldable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Foldable.Foldable (t1 :: Prim.Type -> Prim.Type) =>
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (f :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (g :: Prim.Type -> Prim.Type) =>
   Data.Foldable.Foldable
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Traversable.Traversable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Traversable.Traversable (t1 :: Prim.Type -> Prim.Type) =>
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Traversable.Traversable (f :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable (g :: Prim.Type -> Prim.Type) =>
   Data.Traversable.Traversable
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
 
 Roles
 Compose = [Representational, Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772565480_derive_traversable_missing_superclass/Main.snap
+++ b/tests-integration/fixtures/checking/1772565480_derive_traversable_missing_superclass/Main.snap
@@ -23,37 +23,35 @@ Compose ::
     Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Traversable.Traversable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Traversable.Traversable (t1 :: Prim.Type -> Prim.Type) =>
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Traversable.Traversable (f :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable (g :: Prim.Type -> Prim.Type) =>
   Data.Traversable.Traversable
-    (Main.Compose @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
+    (Main.Compose @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
 
 Roles
 Compose = [Representational, Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (Compose @Type @Type (t0 :: Type -> Type) (t1 :: Type -> Type))
+error[NoInstanceFound]: No instance found for: Functor (Compose @Type @Type (f :: Type -> Type) (g :: Type -> Type))
   --> 6:1..6:76
   |
 6 | derive instance (Traversable f, Traversable g) => Traversable (Compose f g)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Traversable (t0 :: Type -> Type) is in scope
-  trivia: Traversable (t1 :: Type -> Type) is in scope
-  trivia: Functor (t0 :: Type -> Type) is in scope
-  trivia: Foldable (t0 :: Type -> Type) is in scope
-  trivia: Functor (t1 :: Type -> Type) is in scope
-  trivia: Foldable (t1 :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Foldable (Compose @Type @Type (t0 :: Type -> Type) (t1 :: Type -> Type))
+  trivia: Traversable (f :: Type -> Type) is in scope
+  trivia: Traversable (g :: Type -> Type) is in scope
+  trivia: Functor (f :: Type -> Type) is in scope
+  trivia: Foldable (f :: Type -> Type) is in scope
+  trivia: Functor (g :: Type -> Type) is in scope
+  trivia: Foldable (g :: Type -> Type) is in scope
+error[NoInstanceFound]: No instance found for: Foldable (Compose @Type @Type (f :: Type -> Type) (g :: Type -> Type))
   --> 6:1..6:76
   |
 6 | derive instance (Traversable f, Traversable g) => Traversable (Compose f g)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Traversable (t0 :: Type -> Type) is in scope
-  trivia: Traversable (t1 :: Type -> Type) is in scope
-  trivia: Functor (t0 :: Type -> Type) is in scope
-  trivia: Foldable (t0 :: Type -> Type) is in scope
-  trivia: Functor (t1 :: Type -> Type) is in scope
-  trivia: Foldable (t1 :: Type -> Type) is in scope
+  trivia: Traversable (f :: Type -> Type) is in scope
+  trivia: Traversable (g :: Type -> Type) is in scope
+  trivia: Functor (f :: Type -> Type) is in scope
+  trivia: Foldable (f :: Type -> Type) is in scope
+  trivia: Functor (g :: Type -> Type) is in scope
+  trivia: Foldable (g :: Type -> Type) is in scope

--- a/tests-integration/fixtures/checking/1772565720_derive_profunctor_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565720_derive_profunctor_simple/Main.snap
@@ -25,7 +25,7 @@ Choice :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
 derive Data.Profunctor.Profunctor Main.Fn
-derive forall (t0 :: Prim.Type). Data.Profunctor.Profunctor (Main.ConstR @Prim.Type (t0 :: Prim.Type))
+derive forall (r :: Prim.Type). Data.Profunctor.Profunctor (Main.ConstR @Prim.Type (r :: Prim.Type))
 derive Data.Profunctor.Profunctor Main.Choice
 
 Roles

--- a/tests-integration/fixtures/checking/1772565840_derive_contravariant_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565840_derive_contravariant_simple/Main.snap
@@ -21,7 +21,7 @@ Op :: Prim.Type -> Prim.Type -> Prim.Type
 Derived
 derive Data.Functor.Contravariant.Contravariant Main.Predicate
 derive Data.Functor.Contravariant.Contravariant Main.Comparison
-derive forall (t0 :: Prim.Type). Data.Functor.Contravariant.Contravariant (Main.Op (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Functor.Contravariant.Contravariant (Main.Op (a :: Prim.Type))
 
 Roles
 Predicate = [Representational]

--- a/tests-integration/fixtures/checking/1772565960_derive_foldable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772565960_derive_foldable_simple/Main.snap
@@ -19,7 +19,7 @@ Const :: forall (t0 :: Prim.Type). Prim.Type -> (t0 :: Prim.Type) -> Prim.Type
 Derived
 derive Data.Foldable.Foldable Main.Identity
 derive Data.Foldable.Foldable Main.Maybe
-derive forall (t0 :: Prim.Type). Data.Foldable.Foldable (Main.Const @Prim.Type (t0 :: Prim.Type))
+derive forall (e :: Prim.Type). Data.Foldable.Foldable (Main.Const @Prim.Type (e :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772566020_derive_foldable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566020_derive_foldable_higher_kinded/Main.snap
@@ -21,18 +21,18 @@ WrapNoFoldable ::
   forall (t0 :: Prim.Type). ((t0 :: Prim.Type) -> Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Foldable.Foldable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Foldable.Foldable (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Foldable.Foldable (Main.WrapNoFoldable @Prim.Type (t0 :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (f :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (Main.WrapNoFoldable @Prim.Type (f :: Prim.Type -> Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]
 WrapNoFoldable = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Foldable (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Foldable (f :: Type -> Type)
   --> 9:1..9:44
   |
 9 | derive instance Foldable (WrapNoFoldable f)

--- a/tests-integration/fixtures/checking/1772566140_derive_bitraversable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566140_derive_bitraversable_higher_kinded/Main.snap
@@ -25,27 +25,27 @@ WrapBoth ::
     Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Functor.Functor (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Functor.Functor (t1 :: Prim.Type -> Prim.Type) =>
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (f :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (g :: Prim.Type -> Prim.Type) =>
   Data.Bifunctor.Bifunctor
     (Main.WrapBoth @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Foldable.Foldable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Foldable.Foldable (t1 :: Prim.Type -> Prim.Type) =>
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (f :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (g :: Prim.Type -> Prim.Type) =>
   Data.Bifoldable.Bifoldable
     (Main.WrapBoth @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Traversable.Traversable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Traversable.Traversable (t1 :: Prim.Type -> Prim.Type) =>
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Traversable.Traversable (f :: Prim.Type -> Prim.Type) =>
+  Data.Traversable.Traversable (g :: Prim.Type -> Prim.Type) =>
   Data.Bitraversable.Bitraversable
     (Main.WrapBoth @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]

--- a/tests-integration/fixtures/checking/1772566200_derive_bifoldable_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772566200_derive_bifoldable_simple/Main.snap
@@ -32,8 +32,8 @@ Const2 ::
 Derived
 derive Data.Bifoldable.Bifoldable Main.Either
 derive Data.Bifoldable.Bifoldable Main.Pair
-derive forall (t0 :: Prim.Type).
-  Data.Bifoldable.Bifoldable (Main.Const2 @Prim.Type @Prim.Type (t0 :: Prim.Type))
+derive forall (e :: Prim.Type).
+  Data.Bifoldable.Bifoldable (Main.Const2 @Prim.Type @Prim.Type (e :: Prim.Type))
 
 Roles
 Either = [Representational, Representational]

--- a/tests-integration/fixtures/checking/1772566260_derive_bifoldable_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772566260_derive_bifoldable_higher_kinded/Main.snap
@@ -42,30 +42,30 @@ WrapBothNoConstraint ::
     Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Foldable.Foldable (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Foldable.Foldable (t1 :: Prim.Type -> Prim.Type) =>
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Foldable.Foldable (f :: Prim.Type -> Prim.Type) =>
+  Data.Foldable.Foldable (g :: Prim.Type -> Prim.Type) =>
   Data.Bifoldable.Bifoldable
     (Main.WrapBoth @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
   Data.Bifoldable.Bifoldable
     (Main.WrapBothNoConstraint @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]
 WrapBothNoConstraint = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Foldable (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Foldable (f :: Type -> Type)
   --> 10:1..10:54
    |
 10 | derive instance Bifoldable (WrapBothNoConstraint f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Foldable (t1 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Foldable (g :: Type -> Type)
   --> 10:1..10:54
    |
 10 | derive instance Bifoldable (WrapBothNoConstraint f g)

--- a/tests-integration/fixtures/checking/1772566380_derive_newtype_class_parameterized/Main.snap
+++ b/tests-integration/fixtures/checking/1772566380_derive_newtype_class_parameterized/Main.snap
@@ -10,8 +10,8 @@ Types
 Wrapper :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type).
-  Data.Newtype.Newtype @Prim.Type (Main.Wrapper (t0 :: Prim.Type)) (t0 :: Prim.Type)
+derive forall (a :: Prim.Type).
+  Data.Newtype.Newtype @Prim.Type (Main.Wrapper (a :: Prim.Type)) (a :: Prim.Type)
 
 Roles
 Wrapper = [Representational]

--- a/tests-integration/fixtures/checking/1772566500_derive_generic_simple/Main.snap
+++ b/tests-integration/fixtures/checking/1772566500_derive_generic_simple/Main.snap
@@ -83,28 +83,28 @@ derive Data.Generic.Rep.Generic Main.Void Data.Generic.Rep.NoConstructors
 derive Data.Generic.Rep.Generic
   Main.MyUnit
   (Data.Generic.Rep.Constructor "MyUnit" Data.Generic.Rep.NoArguments)
-derive forall (t0 :: Prim.Type).
+derive forall (a :: Prim.Type).
   Data.Generic.Rep.Generic
-    (Main.Identity (t0 :: Prim.Type))
-    (Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument (t0 :: Prim.Type)))
-derive forall (t0 :: Prim.Type) (t1 :: Prim.Type).
+    (Main.Identity (a :: Prim.Type))
+    (Data.Generic.Rep.Constructor "Identity" (Data.Generic.Rep.Argument (a :: Prim.Type)))
+derive forall (a :: Prim.Type) (b :: Prim.Type).
   Data.Generic.Rep.Generic
-    (Main.Either (t0 :: Prim.Type) (t1 :: Prim.Type))
+    (Main.Either (a :: Prim.Type) (b :: Prim.Type))
     (Data.Generic.Rep.Sum
-      (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument (t0 :: Prim.Type)))
-      (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument (t1 :: Prim.Type))))
-derive forall (t0 :: Prim.Type) (t1 :: Prim.Type).
+      (Data.Generic.Rep.Constructor "Left" (Data.Generic.Rep.Argument (a :: Prim.Type)))
+      (Data.Generic.Rep.Constructor "Right" (Data.Generic.Rep.Argument (b :: Prim.Type))))
+derive forall (a :: Prim.Type) (b :: Prim.Type).
   Data.Generic.Rep.Generic
-    (Main.Tuple (t0 :: Prim.Type) (t1 :: Prim.Type))
+    (Main.Tuple (a :: Prim.Type) (b :: Prim.Type))
     (Data.Generic.Rep.Constructor
       "Tuple"
       (Data.Generic.Rep.Product
-        (Data.Generic.Rep.Argument (t0 :: Prim.Type))
-        (Data.Generic.Rep.Argument (t1 :: Prim.Type))))
-derive forall (t0 :: Prim.Type).
+        (Data.Generic.Rep.Argument (a :: Prim.Type))
+        (Data.Generic.Rep.Argument (b :: Prim.Type))))
+derive forall (a :: Prim.Type).
   Data.Generic.Rep.Generic
-    (Main.Wrapper (t0 :: Prim.Type))
-    (Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument (t0 :: Prim.Type)))
+    (Main.Wrapper (a :: Prim.Type))
+    (Data.Generic.Rep.Constructor "Wrapper" (Data.Generic.Rep.Argument (a :: Prim.Type)))
 
 Roles
 Void = []

--- a/tests-integration/fixtures/checking/1772566860_derive_newtype_class_coercible/Main.snap
+++ b/tests-integration/fixtures/checking/1772566860_derive_newtype_class_coercible/Main.snap
@@ -17,8 +17,8 @@ Wrapper :: Prim.Type -> Prim.Type
 
 Derived
 derive Data.Newtype.Newtype @Prim.Type Main.UserId Prim.Int
-derive forall (t0 :: Prim.Type).
-  Data.Newtype.Newtype @Prim.Type (Main.Wrapper (t0 :: Prim.Type)) (t0 :: Prim.Type)
+derive forall (a :: Prim.Type).
+  Data.Newtype.Newtype @Prim.Type (Main.Wrapper (a :: Prim.Type)) (a :: Prim.Type)
 
 Roles
 UserId = []

--- a/tests-integration/fixtures/checking/1772566920_derive_newtype_with_given/Main.snap
+++ b/tests-integration/fixtures/checking/1772566920_derive_newtype_with_given/Main.snap
@@ -10,8 +10,8 @@ Types
 Identity :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type).
-  Data.Show.Show (t0 :: Prim.Type) => Data.Show.Show (Main.Identity (t0 :: Prim.Type))
+derive forall (a :: Prim.Type).
+  Data.Show.Show (a :: Prim.Type) => Data.Show.Show (Main.Identity (a :: Prim.Type))
 
 Roles
 Identity = [Representational]

--- a/tests-integration/fixtures/checking/1772567040_derive_newtype_missing_given/Main.snap
+++ b/tests-integration/fixtures/checking/1772567040_derive_newtype_missing_given/Main.snap
@@ -10,13 +10,13 @@ Types
 Identity :: Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type). Data.Show.Show (Main.Identity (t0 :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Show.Show (Main.Identity (a :: Prim.Type))
 
 Roles
 Identity = [Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Show (t0 :: Type)
+error[NoInstanceFound]: No instance found for: Show (a :: Type)
   --> 7:1..7:42
   |
 7 | derive newtype instance Show (Identity a)

--- a/tests-integration/fixtures/checking/1772567340_derive_eq_1_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567340_derive_eq_1_higher_kinded/Main.snap
@@ -19,22 +19,22 @@ WrapNoEq1 ::
   forall (t0 :: Prim.Type). ((t0 :: Prim.Type) -> Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (t1 :: Prim.Type) =>
-  Data.Eq.Eq (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq (t0 :: Prim.Type) =>
-  Data.Eq.Eq (Main.WrapNoEq1 @Prim.Type (t1 :: Prim.Type -> Prim.Type) (t0 :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (a :: Prim.Type) (f :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.WrapNoEq1 @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]
 WrapNoEq1 = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq1 (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Eq1 (f :: Type -> Type)
   --> 11:1..11:43
    |
 11 | derive instance Eq a => Eq (WrapNoEq1 f a)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq (t1 :: Type) is in scope
+  trivia: Eq (a :: Type) is in scope

--- a/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
+++ b/tests-integration/fixtures/checking/1772567400_derive_eq_partial/Main.snap
@@ -15,22 +15,22 @@ Types
 Either :: Prim.Type -> Prim.Type -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type).
-  Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Either Prim.Int (t0 :: Prim.Type))
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (Main.Either Prim.Int (t0 :: Prim.Type))
+derive forall (b :: Prim.Type).
+  Data.Eq.Eq (b :: Prim.Type) => Data.Eq.Eq (Main.Either Prim.Int (b :: Prim.Type))
+derive forall (b :: Prim.Type). Data.Eq.Eq (Main.Either Prim.Int (b :: Prim.Type))
 
 Roles
 Either = [Representational, Representational]
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Eq (Either Int (t0 :: Type))
+error[OverlappingInstances]: Overlapping type class instances found for: Eq (Either Int (b :: Type))
   --> 9:1..9:34
   |
 9 | derive instance Eq (Either Int b)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall (t1 :: Type). Eq (t1 :: Type) => Eq (Either Int (t1 :: Type)) is matching
-  trivia: forall (t0 :: Type). Eq (Either Int (t0 :: Type)) is matching
-error[NoInstanceFound]: No instance found for: Eq (t0 :: Type)
+  trivia: forall (b1 :: Type). Eq (b1 :: Type) => Eq (Either Int (b1 :: Type)) is matching
+  trivia: forall (b :: Type). Eq (Either Int (b :: Type)) is matching
+error[NoInstanceFound]: No instance found for: Eq (b :: Type)
   --> 9:1..9:34
   |
 9 | derive instance Eq (Either Int b)

--- a/tests-integration/fixtures/checking/1772567460_derive_eq_ord_nested_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567460_derive_eq_ord_nested_higher_kinded/Main.snap
@@ -35,26 +35,24 @@ V ::
     ((t0 :: Prim.Type) -> Prim.Type) -> (Prim.Int -> (t0 :: Prim.Type)) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (Main.T @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord (Main.T @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Maybe (t0 :: Prim.Type))
-derive forall (t0 :: Prim.Type).
-  Data.Ord.Ord (t0 :: Prim.Type) => Data.Ord.Ord (Main.Maybe (t0 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) => Data.Eq.Eq (Main.U (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord (Main.U (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (Main.V @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord (Main.V @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Int -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (Main.T @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (Main.T @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type))
+derive forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Maybe (a :: Prim.Type))
+derive forall (a :: Prim.Type). Data.Ord.Ord (a :: Prim.Type) => Data.Ord.Ord (Main.Maybe (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) => Data.Eq.Eq (Main.U (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) => Data.Ord.Ord (Main.U (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Int -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (Main.V @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Int -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Int -> Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (Main.V @Prim.Type (f :: Prim.Type -> Prim.Type) (g :: Prim.Int -> Prim.Type))
 
 Roles
 T = [Representational, Representational]
@@ -63,29 +61,29 @@ U = [Representational]
 V = [Representational, Representational]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Eq ((t0 :: Type -> Type) Int)
+error[NoInstanceFound]: No instance found for: Eq ((g :: Type -> Type) Int)
   --> 8:1..8:36
   |
 8 | derive instance Eq1 f => Eq (T f g)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (t1 :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord ((t2 :: Type -> Type) Int)
+  trivia: Eq1 (f :: Type -> Type) is in scope
+error[NoInstanceFound]: No instance found for: Ord ((g1 :: Type -> Type) Int)
   --> 9:1..9:38
   |
 9 | derive instance Ord1 f => Ord (T f g)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord1 (t3 :: Type -> Type) is in scope
-  trivia: Eq1 (t3 :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Eq ((t4 :: Int -> Type) 42)
+  trivia: Ord1 (f1 :: Type -> Type) is in scope
+  trivia: Eq1 (f1 :: Type -> Type) is in scope
+error[NoInstanceFound]: No instance found for: Eq ((g2 :: Int -> Type) 42)
   --> 23:1..23:36
    |
 23 | derive instance Eq1 f => Eq (V f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Eq1 (t5 :: Type -> Type) is in scope
-error[NoInstanceFound]: No instance found for: Ord ((t6 :: Int -> Type) 42)
+  trivia: Eq1 (f2 :: Type -> Type) is in scope
+error[NoInstanceFound]: No instance found for: Ord ((g3 :: Int -> Type) 42)
   --> 24:1..24:38
    |
 24 | derive instance Ord1 f => Ord (V f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: Ord1 (t7 :: Type -> Type) is in scope
-  trivia: Eq1 (t7 :: Type -> Type) is in scope
+  trivia: Ord1 (f3 :: Type -> Type) is in scope
+  trivia: Eq1 (f3 :: Type -> Type) is in scope

--- a/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
@@ -21,18 +21,18 @@ WrapNoFunctor ::
   forall (t0 :: Prim.Type). ((t0 :: Prim.Type) -> Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Functor.Functor (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Functor.Functor (Main.Wrap @Prim.Type (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Functor.Functor (Main.WrapNoFunctor @Prim.Type (t0 :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (f :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (Main.Wrap @Prim.Type (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (Main.WrapNoFunctor @Prim.Type (f :: Prim.Type -> Prim.Type))
 
 Roles
 Wrap = [Representational, Nominal]
 WrapNoFunctor = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
   --> 9:1..9:42
   |
 9 | derive instance Functor (WrapNoFunctor f)

--- a/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
@@ -42,30 +42,30 @@ WrapBothNoConstraint ::
     Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Data.Functor.Functor (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Functor.Functor (t1 :: Prim.Type -> Prim.Type) =>
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
+  Data.Functor.Functor (f :: Prim.Type -> Prim.Type) =>
+  Data.Functor.Functor (g :: Prim.Type -> Prim.Type) =>
   Data.Bifunctor.Bifunctor
     (Main.WrapBoth @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (g :: Prim.Type -> Prim.Type).
   Data.Bifunctor.Bifunctor
     (Main.WrapBothNoConstraint @Prim.Type @Prim.Type
-      (t0 :: Prim.Type -> Prim.Type)
-      (t1 :: Prim.Type -> Prim.Type))
+      (f :: Prim.Type -> Prim.Type)
+      (g :: Prim.Type -> Prim.Type))
 
 Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]
 WrapBothNoConstraint = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (t0 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
   --> 10:1..10:53
    |
 10 | derive instance Bifunctor (WrapBothNoConstraint f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Functor (t1 :: Type -> Type)
+error[NoInstanceFound]: No instance found for: Functor (g :: Type -> Type)
   --> 10:1..10:53
    |
 10 | derive instance Bifunctor (WrapBothNoConstraint f g)

--- a/tests-integration/fixtures/checking/1772823120_instance_record_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1772823120_instance_record_matching/Main.snap
@@ -28,7 +28,7 @@ class forall (a :: Prim.Type) (b :: Prim.Type). Main.Convert (a :: Prim.Type) (b
     Main.Convert (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Row Prim.Type).
-  Main.Make {| (t0 :: Prim.Row Prim.Type) } {| (t0 :: Prim.Row Prim.Type) }
-instance forall (t0 :: Prim.Row Prim.Type).
-  Main.Convert {| (t0 :: Prim.Row Prim.Type) } { converted :: {| (t0 :: Prim.Row Prim.Type) } }
+instance forall (r :: Prim.Row Prim.Type).
+  Main.Make {| (r :: Prim.Row Prim.Type) } {| (r :: Prim.Row Prim.Type) }
+instance forall (r :: Prim.Row Prim.Type).
+  Main.Convert {| (r :: Prim.Row Prim.Type) } { converted :: {| (r :: Prim.Row Prim.Type) } }

--- a/tests-integration/fixtures/checking/1772823180_instance_record_open_row/Main.snap
+++ b/tests-integration/fixtures/checking/1772823180_instance_record_open_row/Main.snap
@@ -31,9 +31,9 @@ class forall (a :: Prim.Type) (b :: Prim.Type). Main.Nest (a :: Prim.Type) (b ::
     Main.Nest (a :: Prim.Type) (b :: Prim.Type) => (a :: Prim.Type) -> (b :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Row Prim.Type).
-  Main.Clone {| (t0 :: Prim.Row Prim.Type) } {| (t0 :: Prim.Row Prim.Type) }
-instance forall (t0 :: Prim.Row Prim.Type).
+instance forall (r :: Prim.Row Prim.Type).
+  Main.Clone {| (r :: Prim.Row Prim.Type) } {| (r :: Prim.Row Prim.Type) }
+instance forall (r :: Prim.Row Prim.Type).
   Main.Nest
-    {| (t0 :: Prim.Row Prim.Type) }
-    { inner :: {| (t0 :: Prim.Row Prim.Type) }, outer :: Prim.Int }
+    {| (r :: Prim.Row Prim.Type) }
+    { inner :: {| (r :: Prim.Row Prim.Type) }, outer :: Prim.Int }

--- a/tests-integration/fixtures/checking/1772823300_instance_kind_application_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1772823300_instance_kind_application_matching/Main.snap
@@ -23,15 +23,15 @@ Endo ::
     ((k :: Prim.Type) -> (k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type)
-  (t2 :: (t0 :: Prim.Type)).
+instance forall (t0 :: Prim.Type) (c :: (t0 :: Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type)
+  (a :: (t0 :: Prim.Type)).
   Data.Newtype.Newtype @Prim.Type
     (Main.Endo @(t0 :: Prim.Type)
-      (t1 :: (t0 :: Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type)
-      (t2 :: (t0 :: Prim.Type)))
-    ((t1 :: (t0 :: Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type)
-      (t2 :: (t0 :: Prim.Type))
-      (t2 :: (t0 :: Prim.Type)))
+      (c :: (t0 :: Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type)
+      (a :: (t0 :: Prim.Type)))
+    ((c :: (t0 :: Prim.Type) -> (t0 :: Prim.Type) -> Prim.Type)
+      (a :: (t0 :: Prim.Type))
+      (a :: (t0 :: Prim.Type)))
 
 Roles
 Endo = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1772823480_application_function_decomposition/Main.snap
+++ b/tests-integration/fixtures/checking/1772823480_application_function_decomposition/Main.snap
@@ -83,14 +83,12 @@ class forall (i :: Prim.Type) (f :: Prim.Type -> Prim.Type). Main.Foldable (f ::
       (b1 :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type -> Prim.Type).
-  Main.Foldable (t0 :: Prim.Type -> Prim.Type) =>
-  Main.Foldable (Main.NonEmpty (t0 :: Prim.Type -> Prim.Type))
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
-  Main.FoldableWithIndex (t0 :: Prim.Type) (t1 :: Prim.Type -> Prim.Type) =>
-  Main.FoldableWithIndex
-    (Main.Maybe (t0 :: Prim.Type))
-    (Main.NonEmpty (t1 :: Prim.Type -> Prim.Type))
+instance forall (f :: Prim.Type -> Prim.Type).
+  Main.Foldable (f :: Prim.Type -> Prim.Type) =>
+  Main.Foldable (Main.NonEmpty (f :: Prim.Type -> Prim.Type))
+instance forall (i :: Prim.Type) (f :: Prim.Type -> Prim.Type).
+  Main.FoldableWithIndex (i :: Prim.Type) (f :: Prim.Type -> Prim.Type) =>
+  Main.FoldableWithIndex (Main.Maybe (i :: Prim.Type)) (Main.NonEmpty (f :: Prim.Type -> Prim.Type))
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1773152280_derive_newtype_invalid_skolem_layout/Main.snap
+++ b/tests-integration/fixtures/checking/1773152280_derive_newtype_invalid_skolem_layout/Main.snap
@@ -31,8 +31,8 @@ Instances
 instance Main.Empty Prim.Array
 
 Derived
-derive forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.Empty (Main.Vector @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)))
+derive forall (t0 :: Prim.Type) (n :: (t0 :: Prim.Type)).
+  Main.Empty (Main.Vector @(t0 :: Prim.Type) (n :: (t0 :: Prim.Type)))
 derive Main.Empty (Main.InvalidVector @Prim.Type Prim.Int)
 
 Roles

--- a/tests-integration/fixtures/checking/1773174840_instance_implicit_variable_freshening/Main.snap
+++ b/tests-integration/fixtures/checking/1773174840_instance_implicit_variable_freshening/Main.snap
@@ -18,8 +18,8 @@ class forall (a :: Prim.Type). Main.Top (a :: Prim.Type)
   top :: forall (@a :: Prim.Type). Main.Top (a :: Prim.Type) => (a :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.Top (Main.Proxy @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.Top (Main.Proxy @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)))
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1773501960_derive_eq_ord_1_kind_arguments/Main.snap
+++ b/tests-integration/fixtures/checking/1773501960_derive_eq_ord_1_kind_arguments/Main.snap
@@ -13,24 +13,24 @@ Types
 App :: forall (k :: Prim.Type). ((k :: Prim.Type) -> Prim.Type) -> (k :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type) -> Prim.Type) (t2 :: (t0 :: Prim.Type)).
+derive forall (t0 :: Prim.Type) (f :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)).
   Data.Newtype.Newtype @Prim.Type
-    (Main.App @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type) -> Prim.Type) (t2 :: (t0 :: Prim.Type)))
-    ((t1 :: (t0 :: Prim.Type) -> Prim.Type) (t2 :: (t0 :: Prim.Type)))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq (t1 :: Prim.Type) =>
-  Data.Eq.Eq (Main.App @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Eq.Eq1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Eq.Eq1 (Main.App @Prim.Type (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord (t1 :: Prim.Type) =>
-  Data.Ord.Ord (Main.App @Prim.Type (t0 :: Prim.Type -> Prim.Type) (t1 :: Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Ord.Ord1 (t0 :: Prim.Type -> Prim.Type) =>
-  Data.Ord.Ord1 (Main.App @Prim.Type (t0 :: Prim.Type -> Prim.Type))
+    (Main.App @(t0 :: Prim.Type) (f :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)))
+    ((f :: (t0 :: Prim.Type) -> Prim.Type) (a :: (t0 :: Prim.Type)))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq (a :: Prim.Type) =>
+  Data.Eq.Eq (Main.App @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Eq.Eq1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Eq.Eq1 (Main.App @Prim.Type (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord (a :: Prim.Type) =>
+  Data.Ord.Ord (Main.App @Prim.Type (f :: Prim.Type -> Prim.Type) (a :: Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Ord.Ord1 (f :: Prim.Type -> Prim.Type) =>
+  Data.Ord.Ord1 (Main.App @Prim.Type (f :: Prim.Type -> Prim.Type))
 
 Roles
 App = [Representational, Nominal]

--- a/tests-integration/fixtures/checking/1773841860_instance_kind_substitution/Main.snap
+++ b/tests-integration/fixtures/checking/1773841860_instance_kind_substitution/Main.snap
@@ -25,11 +25,11 @@ class forall (k :: Prim.Type) (a :: (k :: Prim.Type)). Main.Use @(k :: Prim.Type
     Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t2 :: Prim.RowList.RowList (t0 :: Prim.Type)).
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (xs :: Prim.RowList.RowList (t0 :: Prim.Type)).
   Prim.RowList.RowToList @(t0 :: Prim.Type)
-    ( x :: (t1 :: (t0 :: Prim.Type)) )
-    (t2 :: Prim.RowList.RowList (t0 :: Prim.Type)) =>
-  Main.Use @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type))
+    ( x :: (a :: (t0 :: Prim.Type)) )
+    (xs :: Prim.RowList.RowList (t0 :: Prim.Type)) =>
+  Main.Use @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type))
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1774448280_given_synonym_expansion/Main.snap
+++ b/tests-integration/fixtures/checking/1774448280_given_synonym_expansion/Main.snap
@@ -45,5 +45,5 @@ Classes
 class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). Main.TypeEquals @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.TypeEquals @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t1 :: (t0 :: Prim.Type))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.TypeEquals @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (a :: (t0 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1774553700_instance_chain_stuck_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1774553700_instance_chain_stuck_matching/Main.snap
@@ -24,12 +24,12 @@ Classes
 class forall (t :: Prim.Type) (m :: Prim.Type -> Prim.Type). Main.Convert (t :: Prim.Type) (m :: Prim.Type -> Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type -> Prim.Type).
+instance forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Main.Convert
-    ((t0 :: Prim.Type) -> (t1 :: Prim.Type -> Prim.Type) Main.Unit)
-    (t1 :: Prim.Type -> Prim.Type)
-instance forall (t0 :: Prim.Type -> Prim.Type).
-  Main.Convert ((t0 :: Prim.Type -> Prim.Type) Main.Unit) (t0 :: Prim.Type -> Prim.Type)
+    ((a :: Prim.Type) -> (m :: Prim.Type -> Prim.Type) Main.Unit)
+    (m :: Prim.Type -> Prim.Type)
+instance forall (m :: Prim.Type -> Prim.Type).
+  Main.Convert ((m :: Prim.Type -> Prim.Type) Main.Unit) (m :: Prim.Type -> Prim.Type)
 
 Roles
 Unit = []

--- a/tests-integration/fixtures/checking/1774667040_given_stuck_match_collapse/Main.snap
+++ b/tests-integration/fixtures/checking/1774667040_given_stuck_match_collapse/Main.snap
@@ -34,13 +34,13 @@ class forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (f :: (t0 :: 
   (h :: (t2 :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.TypeEquals @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t1 :: (t0 :: Prim.Type))
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
-  Main.TypeEquals @Prim.Type (t0 :: Prim.Type) (Main.A -> Prim.String) =>
-  Main.TypeEquals @Prim.Type (t1 :: Prim.Type) (Main.B -> Prim.String) =>
-  Main.TypeEquals @Prim.Type (t2 :: Prim.Type) (Main.C -> Prim.String) =>
-  Main.Match3 @Prim.Type @Prim.Type @Prim.Type (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type)
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.TypeEquals @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (a :: (t0 :: Prim.Type))
+instance forall (f :: Prim.Type) (g :: Prim.Type) (h :: Prim.Type).
+  Main.TypeEquals @Prim.Type (f :: Prim.Type) (Main.A -> Prim.String) =>
+  Main.TypeEquals @Prim.Type (g :: Prim.Type) (Main.B -> Prim.String) =>
+  Main.TypeEquals @Prim.Type (h :: Prim.Type) (Main.C -> Prim.String) =>
+  Main.Match3 @Prim.Type @Prim.Type @Prim.Type (f :: Prim.Type) (g :: Prim.Type) (h :: Prim.Type)
 
 Roles
 A = []

--- a/tests-integration/fixtures/checking/1777130640_instance_given_is_not_blocking/Main.snap
+++ b/tests-integration/fixtures/checking/1777130640_instance_given_is_not_blocking/Main.snap
@@ -30,5 +30,5 @@ class forall (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type). Main.Bu
     {| (subrow :: Prim.Row Prim.Type) }
 
 Instances
-instance forall (t0 :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type).
-  Main.BuildRecord (t0 :: Prim.Row Prim.Type) (t1 :: Prim.Row Prim.Type)
+instance forall (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type).
+  Main.BuildRecord (row :: Prim.Row Prim.Type) (subrow :: Prim.Row Prim.Type)

--- a/tests-integration/fixtures/checking/1777463820_stress_test_row/Main.snap
+++ b/tests-integration/fixtures/checking/1777463820_stress_test_row/Main.snap
@@ -10029,18 +10029,23 @@ class forall (t0 :: Prim.Type) (t1 :: Prim.Type) (n :: (t0 :: Prim.Type)) (r :: 
 
 Instances
 instance forall (t0 :: Prim.Type). Main.Build @Prim.Int @(Prim.Row (t0 :: Prim.Type)) 0 ()
-instance forall (t0 :: Prim.Int) (t1 :: Prim.Int) (t2 :: Prim.Symbol) (t3 :: Prim.Symbol)
-  (t4 :: Prim.Row Prim.Int) (t5 :: Prim.Row Prim.Int).
-  Prim.Int.Add (t0 :: Prim.Int) 1 (t1 :: Prim.Int) =>
-  Prim.Int.ToString (t1 :: Prim.Int) (t2 :: Prim.Symbol) =>
-  Prim.Symbol.Append "n" (t2 :: Prim.Symbol) (t3 :: Prim.Symbol) =>
-  Main.Build @Prim.Int @(Prim.Row Prim.Int) (t0 :: Prim.Int) (t4 :: Prim.Row Prim.Int) =>
+instance forall (minusOne :: Prim.Int) (currentId :: Prim.Int) (labelId :: Prim.Symbol)
+  (actualLabel :: Prim.Symbol) (minusOneResult :: Prim.Row Prim.Int)
+  (finalResult :: Prim.Row Prim.Int).
+  Prim.Int.Add (minusOne :: Prim.Int) 1 (currentId :: Prim.Int) =>
+  Prim.Int.ToString (currentId :: Prim.Int) (labelId :: Prim.Symbol) =>
+  Prim.Symbol.Append "n" (labelId :: Prim.Symbol) (actualLabel :: Prim.Symbol) =>
+  Main.Build @Prim.Int @(Prim.Row Prim.Int)
+    (minusOne :: Prim.Int)
+    (minusOneResult :: Prim.Row Prim.Int) =>
   Prim.Row.Cons @Prim.Int
-    (t3 :: Prim.Symbol)
-    (t1 :: Prim.Int)
-    (t4 :: Prim.Row Prim.Int)
-    (t5 :: Prim.Row Prim.Int) =>
-  Main.Build @Prim.Int @(Prim.Row Prim.Int) (t1 :: Prim.Int) (t5 :: Prim.Row Prim.Int)
+    (actualLabel :: Prim.Symbol)
+    (currentId :: Prim.Int)
+    (minusOneResult :: Prim.Row Prim.Int)
+    (finalResult :: Prim.Row Prim.Int) =>
+  Main.Build @Prim.Int @(Prim.Row Prim.Int)
+    (currentId :: Prim.Int)
+    (finalResult :: Prim.Row Prim.Int)
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1777725840_derive_newtype_recursive_record/Main.snap
+++ b/tests-integration/fixtures/checking/1777725840_derive_newtype_recursive_record/Main.snap
@@ -18,11 +18,11 @@ Maybe :: Prim.Type -> Prim.Type
 List :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
 
 Instances
-instance forall (t0 :: Prim.Type). Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.Maybe (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.Maybe (a :: Prim.Type))
 
 Derived
-derive forall (t0 :: Prim.Type).
-  Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Main.List @Prim.Type (t0 :: Prim.Type))
+derive forall (a :: Prim.Type).
+  Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Main.List @Prim.Type (a :: Prim.Type))
 
 Roles
 Maybe = [Representational]

--- a/tests-integration/fixtures/checking/1777825620_instance_chain_skolem/Main.snap
+++ b/tests-integration/fixtures/checking/1777825620_instance_chain_skolem/Main.snap
@@ -40,10 +40,10 @@ class forall (f :: Prim.Type) (a :: Prim.Type) (r :: Prim.Type). Main.Walk (f ::
     (f :: Prim.Type) -> (a :: Prim.Type) -> (r :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type).
-  Main.Step (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) =>
-  Main.Walk (t0 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type) =>
-  Main.Walk (t0 :: Prim.Type) (t1 :: Prim.Type) ((t2 :: Prim.Type) -> (t4 :: Prim.Type))
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
-  Main.Done (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) =>
-  Main.Walk (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type)
+instance forall (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) (a' :: Prim.Type) (xs :: Prim.Type).
+  Main.Step (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) (a' :: Prim.Type) =>
+  Main.Walk (f :: Prim.Type) (a' :: Prim.Type) (xs :: Prim.Type) =>
+  Main.Walk (f :: Prim.Type) (a :: Prim.Type) ((x :: Prim.Type) -> (xs :: Prim.Type))
+instance forall (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type).
+  Main.Done (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type) =>
+  Main.Walk (f :: Prim.Type) (a :: Prim.Type) (x :: Prim.Type)

--- a/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
+++ b/tests-integration/fixtures/checking/1778051580_match_type_semantics/Main.snap
@@ -45,13 +45,12 @@ class forall (k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)). M
     Main.RowSame @(k :: Prim.Type) (a :: (k :: Prim.Type)) (b :: (k :: Prim.Type)) => Main.Unit
 
 Instances
-instance forall (t0 :: Prim.Type). Main.IsEq (t0 :: Prim.Type) (t0 :: Prim.Type) Main.Output
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type).
-  Main.IsEq (t0 :: Prim.Type) (t1 :: Prim.Type) Main.Output
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.TypeEquals @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t1 :: (t0 :: Prim.Type))
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.RowSame @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) (t1 :: (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.IsEq (a :: Prim.Type) (a :: Prim.Type) Main.Output
+instance forall (a :: Prim.Type) (b :: Prim.Type). Main.IsEq (a :: Prim.Type) (b :: Prim.Type) Main.Output
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.TypeEquals @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (a :: (t0 :: Prim.Type))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.RowSame @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type)) (a :: (t0 :: Prim.Type))
 
 Roles
 Unit = []

--- a/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
+++ b/tests-integration/fixtures/checking/1778051640_open_row_instance_chain_apart/Main.snap
@@ -34,8 +34,8 @@ class forall (key :: Prim.Type) (row :: Prim.Row Prim.Type). Main.C (key :: Prim
 
 Instances
 instance Main.C Main.K1 ( a :: Prim.Int, b :: Prim.Boolean )
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Row Prim.Type).
-  Main.C (t0 :: Prim.Type) ( a :: Prim.String, b :: Prim.Boolean | (t1 :: Prim.Row Prim.Type) )
+instance forall (key :: Prim.Type) (r :: Prim.Row Prim.Type).
+  Main.C (key :: Prim.Type) ( a :: Prim.String, b :: Prim.Boolean | (r :: Prim.Row Prim.Type) )
 
 Roles
 Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1778758320_function_application_instance_matching/Main.snap
+++ b/tests-integration/fixtures/checking/1778758320_function_application_instance_matching/Main.snap
@@ -23,6 +23,5 @@ class forall (a :: Prim.Type). Main.HeytingAlgebra (a :: Prim.Type)
 
 Instances
 instance Main.HeytingAlgebra Prim.Boolean
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type).
-  Main.HeytingAlgebra (t0 :: Prim.Type) =>
-  Main.HeytingAlgebra ((t1 :: Prim.Type) -> (t0 :: Prim.Type))
+instance forall (b :: Prim.Type) (a :: Prim.Type).
+  Main.HeytingAlgebra (b :: Prim.Type) => Main.HeytingAlgebra ((a :: Prim.Type) -> (b :: Prim.Type))

--- a/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
+++ b/tests-integration/fixtures/checking/1778857680_kind_polymorphic_row_synonym_tails/Main.snap
@@ -24,8 +24,8 @@ class forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (defaults :: 
   (all :: (t2 :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Row Prim.Type).
+instance forall (provided :: Prim.Row Prim.Type).
   Main.ConvertOptions @Prim.Type @Prim.Type @Prim.Type
     {| Main.Optional @Prim.Type }
-    {| (t0 :: Prim.Row Prim.Type) }
+    {| (provided :: Prim.Row Prim.Type) }
     {| Main.All }

--- a/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
+++ b/tests-integration/fixtures/checking/1779291540_constrained_record_field_subtyping/Main.snap
@@ -62,6 +62,6 @@ class forall (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.T
     Prim.String
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type).
-  Main.RecordDefRowList (t0 :: Prim.Type) (t1 :: Prim.Row Prim.Type) (t2 :: Prim.Type) =>
-  Main.RecordDef (t0 :: Prim.Type) (t1 :: Prim.Row Prim.Type)
+instance forall (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.Type).
+  Main.RecordDefRowList (token :: Prim.Type) (row :: Prim.Row Prim.Type) (rowList :: Prim.Type) =>
+  Main.RecordDef (token :: Prim.Type) (row :: Prim.Row Prim.Type)

--- a/tests-integration/fixtures/checking/1779694800_constraint_solving_priority/Main.snap
+++ b/tests-integration/fixtures/checking/1779694800_constraint_solving_priority/Main.snap
@@ -72,13 +72,17 @@ class forall (context :: Prim.Row Prim.Type) (input :: Prim.Row Prim.Type) (outp
     {| (output :: Prim.Row Prim.Type) }
 
 Instances
-instance forall (t0 :: Prim.Row Prim.Type).
-  Main.Ask (t0 :: Prim.Row Prim.Type) (Main.M (t0 :: Prim.Row Prim.Type))
-instance forall (t0 :: Prim.Row Prim.Type) (t1 :: Prim.RowList.RowList Prim.Type) (t2 :: Prim.Row Prim.Type).
+instance forall (context :: Prim.Row Prim.Type).
+  Main.Ask (context :: Prim.Row Prim.Type) (Main.M (context :: Prim.Row Prim.Type))
+instance forall (input :: Prim.Row Prim.Type) (inputList :: Prim.RowList.RowList Prim.Type)
+  (context :: Prim.Row Prim.Type).
   Prim.RowList.RowToList @Prim.Type
-    (t0 :: Prim.Row Prim.Type)
-    (t1 :: Prim.RowList.RowList Prim.Type) =>
-  Main.Produce (t2 :: Prim.Row Prim.Type) (t0 :: Prim.Row Prim.Type) (t0 :: Prim.Row Prim.Type)
+    (input :: Prim.Row Prim.Type)
+    (inputList :: Prim.RowList.RowList Prim.Type) =>
+  Main.Produce
+    (context :: Prim.Row Prim.Type)
+    (input :: Prim.Row Prim.Type)
+    (input :: Prim.Row Prim.Type)
 
 Roles
 M = [Phantom, Representational]

--- a/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping/Main.snap
@@ -15,7 +15,7 @@ class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
   test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type). Main.Test (t0 :: Prim.Type)
+instance forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
 instance Main.Test Prim.Int
 
 Diagnostics
@@ -24,5 +24,5 @@ error[OverlappingInstances]: Overlapping type class instances found for: Test In
   |
 9 | instance testInt :: Test Int where
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall (t0 :: Type). Test (t0 :: Type) is matching
+  trivia: forall (a :: Type). Test (a :: Type) is matching
   trivia: Test Int is matching

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_chain/Main.snap
@@ -16,4 +16,4 @@ class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
 
 Instances
 instance Main.Test Prim.Int
-instance forall (t0 :: Prim.Type). Main.Test (t0 :: Prim.Type)
+instance forall (a :: Prim.Type). Main.Test (a :: Prim.Type)

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_no_use/Main.snap
@@ -14,7 +14,7 @@ class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
   test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> (a :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type). Main.Test (t0 :: Prim.Type)
+instance forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
 instance Main.Test Prim.Int
 
 Diagnostics
@@ -23,5 +23,5 @@ error[OverlappingInstances]: Overlapping type class instances found for: Test In
   |
 9 | instance testInt :: Test Int where
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall (t0 :: Type). Test (t0 :: Type) is matching
+  trivia: forall (a :: Type). Test (a :: Type) is matching
   trivia: Test Int is matching

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_polymorphic/Main.snap
@@ -25,19 +25,19 @@ class forall (k :: Prim.Type) (a :: (k :: Prim.Type)). Main.ShowP @(k :: Prim.Ty
     Main.Proxy @(k :: Prim.Type) (a :: (k :: Prim.Type)) -> Prim.String
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.ShowP @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type))
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.ShowP @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.ShowP @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type))
+instance forall (t0 :: Prim.Type) (a :: (t0 :: Prim.Type)).
+  Main.ShowP @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type))
 
 Roles
 Proxy = [Phantom]
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: ShowP @(t0 :: Type) (t1 :: (t0 :: Type))
+error[OverlappingInstances]: Overlapping type class instances found for: ShowP @(t0 :: Type) (a :: (t0 :: Type))
   --> 13:1..14:21
    |
 13 | instance showPSecond :: ShowP a where
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall (t2 :: Type) (t3 :: (t2 :: Type)). ShowP @(t2 :: Type) (t3 :: (t2 :: Type)) is matching
-  trivia: forall (t0 :: Type) (t1 :: (t0 :: Type)). ShowP @(t0 :: Type) (t1 :: (t0 :: Type)) is matching
+  trivia: forall (t1 :: Type) (a1 :: (t1 :: Type)). ShowP @(t1 :: Type) (a1 :: (t1 :: Type)) is matching
+  trivia: forall (t0 :: Type) (a :: (t0 :: Type)). ShowP @(t0 :: Type) (a :: (t0 :: Type)) is matching

--- a/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
+++ b/tests-integration/fixtures/checking/1779972240_overlapping_instances_partial_no_use/Main.snap
@@ -18,17 +18,17 @@ class forall (a :: Prim.Type). Main.Test (a :: Prim.Type)
   test :: forall (@a :: Prim.Type). Main.Test (a :: Prim.Type) => (a :: Prim.Type) -> Prim.Int
 
 Instances
-instance forall (t0 :: Prim.Type). Main.Test (Main.Pair (t0 :: Prim.Type) Prim.Int)
-instance forall (t0 :: Prim.Type). Main.Test (Main.Pair Prim.String (t0 :: Prim.Type))
+instance forall (a :: Prim.Type). Main.Test (Main.Pair (a :: Prim.Type) Prim.Int)
+instance forall (b :: Prim.Type). Main.Test (Main.Pair Prim.String (b :: Prim.Type))
 
 Roles
 Pair = [Representational, Representational]
 
 Diagnostics
-error[OverlappingInstances]: Overlapping type class instances found for: Test (Pair String (t0 :: Type))
+error[OverlappingInstances]: Overlapping type class instances found for: Test (Pair String (b :: Type))
   --> 11:1..12:13
    |
 11 | instance testRight :: Test (Pair String b) where
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  trivia: forall (t1 :: Type). Test (Pair (t1 :: Type) Int) is matching
-  trivia: forall (t0 :: Type). Test (Pair String (t0 :: Type)) is matching
+  trivia: forall (a :: Type). Test (Pair (a :: Type) Int) is matching
+  trivia: forall (b :: Type). Test (Pair String (b :: Type)) is matching

--- a/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
+++ b/tests-integration/fixtures/checking/1781171580_typed_holes/Main.snap
@@ -26,7 +26,7 @@ class forall (implicit :: Prim.Type). Main.InstanceTypeHole (implicit :: Prim.Ty
     (implicit :: Prim.Type) -> (implicit :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type). Main.InstanceTypeHole (t0 :: Prim.Type)
+instance forall (implicit :: Prim.Type). Main.InstanceTypeHole (implicit :: Prim.Type)
 
 Diagnostics
 error[TypeHole]: Type hole '?type' has inferred type: ?3 :: Type

--- a/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
+++ b/tests-integration/fixtures/checking/1781629500_instance_matching_kind_unification/Main.snap
@@ -28,14 +28,14 @@ class forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (a :: (t0 :: 
   (result :: (t2 :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Int).
-  Prim.Int.Compare (t0 :: Prim.Int) (t0 :: Prim.Int) Prim.Ordering.EQ =>
-  Main.Pick @Prim.Int @Prim.Int @Prim.Int (t0 :: Prim.Int) (t0 :: Prim.Int) (t0 :: Prim.Int)
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: (t0 :: Prim.Type)) (t3 :: (t1 :: Prim.Type)).
+instance forall (a :: Prim.Int).
+  Prim.Int.Compare (a :: Prim.Int) (a :: Prim.Int) Prim.Ordering.EQ =>
+  Main.Pick @Prim.Int @Prim.Int @Prim.Int (a :: Prim.Int) (a :: Prim.Int) (a :: Prim.Int)
+instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (a :: (t0 :: Prim.Type)) (b :: (t1 :: Prim.Type)).
   Main.Pick @(t0 :: Prim.Type) @(t1 :: Prim.Type) @(t1 :: Prim.Type)
-    (t2 :: (t0 :: Prim.Type))
-    (t3 :: (t1 :: Prim.Type))
-    (t3 :: (t1 :: Prim.Type))
+    (a :: (t0 :: Prim.Type))
+    (b :: (t1 :: Prim.Type))
+    (b :: (t1 :: Prim.Type))
 
 Diagnostics
 error[CannotUnify]: Cannot unify 'Type' with 'Int'

--- a/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.snap
+++ b/tests-integration/fixtures/checking/1781896800_kind_argument_overlap_apartness/Main.snap
@@ -20,20 +20,20 @@ Classes
 class forall (input :: Prim.Type) (input1 :: (input :: Prim.Type)) (output :: Prim.Type). Main.Test @(input :: Prim.Type) (input1 :: (input :: Prim.Type)) (output :: Prim.Type)
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: (t0 :: Prim.Type)) (t3 :: (t1 :: Prim.Type)).
+instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (left :: (t0 :: Prim.Type)) (right :: (t1 :: Prim.Type)).
   Main.Test @Prim.Type
     (Main.Outer @(t0 :: Prim.Type) @(t1 :: Prim.Type)
-      (t2 :: (t0 :: Prim.Type))
-      (t3 :: (t1 :: Prim.Type)))
+      (left :: (t0 :: Prim.Type))
+      (right :: (t1 :: Prim.Type)))
     Main.ResultA
-instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: (t1 :: Prim.Type))
-  (t4 :: (t2 :: Prim.Type)) (t5 :: (t0 :: Prim.Type)).
+instance forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (left :: (t1 :: Prim.Type))
+  (right :: (t2 :: Prim.Type)) (other :: (t0 :: Prim.Type)).
   Main.Test @Prim.Type
     (Main.Outer @Prim.Type @(t0 :: Prim.Type)
       (Main.Inner @(t1 :: Prim.Type) @(t2 :: Prim.Type)
-        (t3 :: (t1 :: Prim.Type))
-        (t4 :: (t2 :: Prim.Type)))
-      (t5 :: (t0 :: Prim.Type)))
+        (left :: (t1 :: Prim.Type))
+        (right :: (t2 :: Prim.Type)))
+      (other :: (t0 :: Prim.Type)))
     Main.ResultB
 
 Roles

--- a/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.snap
+++ b/tests-integration/fixtures/checking/1784740680_instance_superclass_given/Main.snap
@@ -14,6 +14,6 @@ class forall (k :: Prim.Type) (value :: (k :: Prim.Type)). Main.Parent @(k :: Pr
 class forall (k :: Prim.Type) (value :: (k :: Prim.Type)). Main.Parent @(k :: Prim.Type) (value :: (k :: Prim.Type)) <= Main.Child @(k :: Prim.Type) (value :: (k :: Prim.Type))
 
 Instances
-instance forall (t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)).
-  Main.Parent @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type)) =>
-  Main.Child @(t0 :: Prim.Type) (t1 :: (t0 :: Prim.Type))
+instance forall (t0 :: Prim.Type) (value :: (t0 :: Prim.Type)).
+  Main.Parent @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type)) =>
+  Main.Child @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))

--- a/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
+++ b/tests-integration/fixtures/checking/1785144540_reject_known_deriving_for_nonlocal_data/Main.snap
@@ -11,11 +11,11 @@ Opaque1 :: Prim.Type -> Prim.Type
 Derived
 derive Data.Eq.Eq1 Main.Opaque1
 derive Data.Ord.Ord1 Main.Opaque1
-derive forall (t0 :: Prim.Type).
-  Data.Eq.Eq (t0 :: Prim.Type) => Data.Eq.Eq (Library.Imported (t0 :: Prim.Type))
+derive forall (a :: Prim.Type).
+  Data.Eq.Eq (a :: Prim.Type) => Data.Eq.Eq (Library.Imported (a :: Prim.Type))
 derive Data.Eq.Eq1 Library.Imported
-derive forall (t0 :: Prim.Type).
-  Data.Ord.Ord (t0 :: Prim.Type) => Data.Ord.Ord (Library.Imported (t0 :: Prim.Type))
+derive forall (a :: Prim.Type).
+  Data.Ord.Ord (a :: Prim.Type) => Data.Ord.Ord (Library.Imported (a :: Prim.Type))
 derive Data.Ord.Ord1 Library.Imported
 
 Roles
@@ -32,7 +32,7 @@ error[CannotDeriveForType]: Cannot derive for type: Opaque1
    |
 10 | derive instance Ord1 Opaque1
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Imported (t0 :: Type)
+error[CannotDeriveForType]: Cannot derive for type: Imported (a :: Type)
   --> 12:1..12:40
    |
 12 | derive instance Eq a => Eq (Imported a)
@@ -42,7 +42,7 @@ error[CannotDeriveForType]: Cannot derive for type: Imported
    |
 13 | derive instance Eq1 Imported
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Imported (t1 :: Type)
+error[CannotDeriveForType]: Cannot derive for type: Imported (a1 :: Type)
   --> 14:1..14:42
    |
 14 | derive instance Ord a => Ord (Imported a)

--- a/tests-integration/fixtures/checking/1785319980_preserve_unary_variance_application_checks/Main.snap
+++ b/tests-integration/fixtures/checking/1785319980_preserve_unary_variance_application_checks/Main.snap
@@ -24,27 +24,27 @@ Wrong ::
     ((t0 :: Prim.Type) -> Prim.Type) -> (t0 :: Prim.Type) -> (t1 :: Prim.Type) -> Prim.Type
 
 Derived
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Functor.Contravariant.Contravariant (Main.Wrapped (t0 :: Prim.Type -> Prim.Type))
-derive forall (t0 :: Prim.Type -> Prim.Type).
-  Data.Profunctor.Profunctor (Main.Wrong @Prim.Type @Prim.Type (t0 :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Functor.Contravariant.Contravariant (Main.Wrapped (f :: Prim.Type -> Prim.Type))
+derive forall (f :: Prim.Type -> Prim.Type).
+  Data.Profunctor.Profunctor (Main.Wrong @Prim.Type @Prim.Type (f :: Prim.Type -> Prim.Type))
 
 Roles
 Wrapped = [Representational, Representational]
 Wrong = [Representational, Nominal, Phantom]
 
 Diagnostics
-error[CovariantOccurrence]: Type variable occurs in covariant position: (t0 :: Type -> Type) ((t1 :: Type) -> Int)
+error[CovariantOccurrence]: Type variable occurs in covariant position: (f :: Type -> Type) ((t0 :: Type) -> Int)
   --> 7:1..7:42
   |
 7 | derive instance Contravariant (Wrapped f)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CovariantOccurrence]: Type variable occurs in covariant position: (t2 :: Type -> Type) (t3 :: Type)
+error[CovariantOccurrence]: Type variable occurs in covariant position: (f1 :: Type -> Type) (t1 :: Type)
   --> 10:1..10:37
    |
 10 | derive instance Profunctor (Wrong f)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CovariantOccurrence]: Type variable occurs in covariant position: (t3 :: Type)
+error[CovariantOccurrence]: Type variable occurs in covariant position: (t1 :: Type)
   --> 10:1..10:37
    |
 10 | derive instance Profunctor (Wrong f)

--- a/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
+++ b/tests-integration/fixtures/semantic/1784741400_instance_dictionary_constraints/Main.snap
@@ -19,10 +19,10 @@ implementation = \{secondDict} -> \_ -> \_ -> boolean
 foreign import boolean :: Prim.Boolean
 
 dictionary exampleAB ::
-  forall t0 t1.
-  { firstDict :: Main.First t0 } =>
-  { secondDict :: Main.Second t1 } =>
-  Main.Example t0 t1
+  forall a b.
+  { firstDict :: Main.First a } =>
+  { secondDict :: Main.Second b } =>
+  Main.Example a b
   where
-  example :: t0 -> t1 -> Prim.Boolean
-  example = implementation @t1 @t0 {secondDict}
+  example :: a -> b -> Prim.Boolean
+  example = implementation @b @a {secondDict}

--- a/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_ado_expressions/Main.snap
@@ -10,7 +10,7 @@ dictionary onZero :: Main.OnStep 0
 
 dictionary onTwo :: Main.OnStep 2
 
-dictionary onDefault :: forall t0. Main.OnStep t0
+dictionary onDefault :: forall step. Main.OnStep step
 
 foreign import map :: forall step.
   Main.OnStep step =>

--- a/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784881320_indexed_do_expressions/Main.snap
@@ -10,7 +10,7 @@ dictionary onZero :: Main.OnStep 0
 
 dictionary onTwo :: Main.OnStep 2
 
-dictionary onDefault :: forall t0. Main.OnStep t0
+dictionary onDefault :: forall step. Main.OnStep step
 
 foreign import bind :: forall step.
   Main.OnStep step =>

--- a/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785087180_derive_eq_maybe_body/Main.snap
@@ -8,11 +8,11 @@ data Maybe @a
   | Nothing :: Main.Maybe a
   | Just :: a -> Main.Maybe a
 
-dictionary eqMaybe :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.Maybe t0) where
-  eq :: Main.Maybe t0 -> Main.Maybe t0 -> Prim.Boolean
+dictionary eqMaybe :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Maybe a) where
+  eq :: Main.Maybe a -> Main.Maybe a -> Prim.Boolean
   eq = \left right ->
     case left, right of
       Nothing, Nothing -> true
       (Just left0), (Just right0) ->
-        if eq @t0 {eqDict} left0 right0 then true else false
+        if eq @a {eqDict} left0 right0 then true else false
       _, _ -> false

--- a/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785088320_derive_ord_maybe_body/Main.snap
@@ -8,25 +8,24 @@ data Maybe @a
   | Nothing :: Main.Maybe a
   | Just :: a -> Main.Maybe a
 
-dictionary eqMaybe :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.Maybe t0) where
-  eq :: Main.Maybe t0 -> Main.Maybe t0 -> Prim.Boolean
+dictionary eqMaybe :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Maybe a) where
+  eq :: Main.Maybe a -> Main.Maybe a -> Prim.Boolean
   eq = \left right ->
     case left, right of
       Nothing, Nothing -> true
       (Just left0), (Just right0) ->
-        if eq @t0 {eqDict} left0 right0 then true else false
+        if eq @a {eqDict} left0 right0 then true else false
       _, _ -> false
 
-dictionary ordMaybe :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord (Main.Maybe t0)
-  where
+dictionary ordMaybe :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Maybe a) where
   superclass eqDict = eqMaybe {ordDict.eqDict}
-  compare :: Main.Maybe t0 -> Main.Maybe t0 -> Data.Ordering.Ordering
+  compare :: Main.Maybe a -> Main.Maybe a -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       Nothing, Nothing -> EQ
       Nothing, _ -> LT
       _, Nothing -> GT
       (Just left0), (Just right0) ->
-        case compare @t0 {ordDict} left0 right0 of
+        case compare @a {ordDict} left0 right0 of
           EQ -> EQ
           ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785131880_derive_eq_ord_tuple_body/Main.snap
@@ -8,34 +8,34 @@ data Tuple @a @b
   | Tuple :: a -> b -> Main.Tuple a b
 
 dictionary eqTuple ::
-  forall t0 t1.
-  { eqDict :: Data.Eq.Eq t0 } =>
-  { eqDict1 :: Data.Eq.Eq t1 } =>
-  Data.Eq.Eq (Main.Tuple t0 t1)
+  forall a b.
+  { eqDict :: Data.Eq.Eq a } =>
+  { eqDict1 :: Data.Eq.Eq b } =>
+  Data.Eq.Eq (Main.Tuple a b)
   where
-  eq :: Main.Tuple t0 t1 -> Main.Tuple t0 t1 -> Prim.Boolean
+  eq :: Main.Tuple a b -> Main.Tuple a b -> Prim.Boolean
   eq = \left right ->
     case left, right of
       (Tuple left0 left1), (Tuple right0 right1) ->
-        if eq @t0 {eqDict} left0 right0 then
-          if eq @t1 {eqDict1} left1 right1 then true else false
+        if eq @a {eqDict} left0 right0 then
+          if eq @b {eqDict1} left1 right1 then true else false
         else
           false
 
 dictionary ordTuple ::
-  forall t0 t1.
-  { ordDict :: Data.Ord.Ord t0 } =>
-  { ordDict1 :: Data.Ord.Ord t1 } =>
-  Data.Ord.Ord (Main.Tuple t0 t1)
+  forall a b.
+  { ordDict :: Data.Ord.Ord a } =>
+  { ordDict1 :: Data.Ord.Ord b } =>
+  Data.Ord.Ord (Main.Tuple a b)
   where
   superclass eqDict = eqTuple {ordDict.eqDict} {ordDict1.eqDict}
-  compare :: Main.Tuple t0 t1 -> Main.Tuple t0 t1 -> Data.Ordering.Ordering
+  compare :: Main.Tuple a b -> Main.Tuple a b -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       (Tuple left0 left1), (Tuple right0 right1) ->
-        case compare @t0 {ordDict} left0 right0 of
+        case compare @a {ordDict} left0 right0 of
           EQ ->
-            case compare @t1 {ordDict1} left1 right1 of
+            case compare @b {ordDict1} left1 right1 of
               EQ -> EQ
               ordering -> ordering
           ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -7,29 +7,25 @@ data Identity :: Prim.Type -> Prim.Type
 data Identity @a
   | Identity :: a -> Main.Identity a
 
-dictionary eqIdentity :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.Identity t0)
-  where
-  eq :: Main.Identity t0 -> Main.Identity t0 -> Prim.Boolean
+dictionary eqIdentity :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Identity a) where
+  eq :: Main.Identity a -> Main.Identity a -> Prim.Boolean
   eq = \left right ->
     case left, right of
       (Identity left0), (Identity right0) ->
-        if eq @t0 {eqDict} left0 right0 then true else false
+        if eq @a {eqDict} left0 right0 then true else false
 
 dictionary eq1Identity :: Data.Eq.Eq1 Main.Identity where
   eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Identity a -> Main.Identity a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.Identity a) {eqIdentity {eqDict}}
 
-dictionary ordIdentity ::
-  forall t0.
-  { ordDict :: Data.Ord.Ord t0 } =>
-  Data.Ord.Ord (Main.Identity t0)
+dictionary ordIdentity :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Identity a)
   where
   superclass eqDict = eqIdentity {ordDict.eqDict}
-  compare :: Main.Identity t0 -> Main.Identity t0 -> Data.Ordering.Ordering
+  compare :: Main.Identity a -> Main.Identity a -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       (Identity left0), (Identity right0) ->
-        case compare @t0 {ordDict} left0 right0 of
+        case compare @a {ordDict} left0 right0 of
           EQ -> EQ
           ordering -> ordering
 

--- a/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133260_derive_eq1_ord1_identity_bodies/Main.snap
@@ -16,7 +16,7 @@ dictionary eqIdentity :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (M
         if eq @t0 {eqDict} left0 right0 then true else false
 
 dictionary eq1Identity :: Data.Eq.Eq1 Main.Identity where
-  eq1 :: forall (t0 :: Prim.Type). Data.Eq.Eq t0 => Main.Identity t0 -> Main.Identity t0 -> Prim.Boolean
+  eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Identity a -> Main.Identity a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.Identity a) {eqIdentity {eqDict}}
 
 dictionary ordIdentity ::
@@ -35,6 +35,6 @@ dictionary ordIdentity ::
 
 dictionary ord1Identity :: Data.Ord.Ord1 Main.Identity where
   superclass eq1Dict = eq1Identity
-  compare1 :: forall (t0 :: Prim.Type).
-  Data.Ord.Ord t0 => Main.Identity t0 -> Main.Identity t0 -> Data.Ordering.Ordering
+  compare1 :: forall (a :: Prim.Type).
+  Data.Ord.Ord a => Main.Identity a -> Main.Identity a -> Data.Ordering.Ordering
   compare1 = \{ordDict} -> compare @(Main.Identity a) {ordIdentity {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -24,8 +24,8 @@ dictionary eq1Wrap ::
   { eq1Dict :: Data.Eq.Eq1 t0 } =>
   Data.Eq.Eq1 (Main.Wrap @Prim.Type t0)
   where
-  eq1 :: forall (t1 :: Prim.Type).
-  Data.Eq.Eq t1 => Main.Wrap @Prim.Type t0 t1 -> Main.Wrap @Prim.Type t0 t1 -> Prim.Boolean
+  eq1 :: forall (a :: Prim.Type).
+  Data.Eq.Eq a => Main.Wrap @Prim.Type t0 a -> Main.Wrap @Prim.Type t0 a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type t0 a) {eqWrap {eq1Dict} {eqDict}}
 
 dictionary ordWrap ::
@@ -49,7 +49,6 @@ dictionary ord1Wrap ::
   Data.Ord.Ord1 (Main.Wrap @Prim.Type t0)
   where
   superclass eq1Dict = eq1Wrap {ord1Dict.eq1Dict}
-  compare1 :: forall (t1 :: Prim.Type).
-  Data.Ord.Ord t1 =>
-  Main.Wrap @Prim.Type t0 t1 -> Main.Wrap @Prim.Type t0 t1 -> Data.Ordering.Ordering
+  compare1 :: forall (a :: Prim.Type).
+  Data.Ord.Ord a => Main.Wrap @Prim.Type t0 a -> Main.Wrap @Prim.Type t0 a -> Data.Ordering.Ordering
   compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type t0 a) {ordWrap {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785133320_derive_eq1_ord1_wrap_bodies/Main.snap
@@ -8,47 +8,44 @@ data Wrap @f @a
   | Wrap :: f a -> Main.Wrap f a
 
 dictionary eqWrap ::
-  forall t0 t1.
-  { eq1Dict :: Data.Eq.Eq1 t0 } =>
-  { eqDict :: Data.Eq.Eq t1 } =>
-  Data.Eq.Eq (Main.Wrap @Prim.Type t0 t1)
+  forall f a.
+  { eq1Dict :: Data.Eq.Eq1 f } =>
+  { eqDict :: Data.Eq.Eq a } =>
+  Data.Eq.Eq (Main.Wrap @Prim.Type f a)
   where
-  eq :: Main.Wrap @Prim.Type t0 t1 -> Main.Wrap @Prim.Type t0 t1 -> Prim.Boolean
+  eq :: Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Prim.Boolean
   eq = \left right ->
     case left, right of
       (Wrap left0), (Wrap right0) ->
-        if eq1 @t0 {eq1Dict} @t1 {eqDict} left0 right0 then true else false
+        if eq1 @f {eq1Dict} @a {eqDict} left0 right0 then true else false
 
-dictionary eq1Wrap ::
-  forall t0.
-  { eq1Dict :: Data.Eq.Eq1 t0 } =>
-  Data.Eq.Eq1 (Main.Wrap @Prim.Type t0)
+dictionary eq1Wrap :: forall f. { eq1Dict :: Data.Eq.Eq1 f } => Data.Eq.Eq1 (Main.Wrap @Prim.Type f)
   where
   eq1 :: forall (a :: Prim.Type).
-  Data.Eq.Eq a => Main.Wrap @Prim.Type t0 a -> Main.Wrap @Prim.Type t0 a -> Prim.Boolean
-  eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type t0 a) {eqWrap {eq1Dict} {eqDict}}
+  Data.Eq.Eq a => Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Prim.Boolean
+  eq1 = \{eqDict} -> eq @(Main.Wrap @Prim.Type f a) {eqWrap {eq1Dict} {eqDict}}
 
 dictionary ordWrap ::
-  forall t0 t1.
-  { ord1Dict :: Data.Ord.Ord1 t0 } =>
-  { ordDict :: Data.Ord.Ord t1 } =>
-  Data.Ord.Ord (Main.Wrap @Prim.Type t0 t1)
+  forall f a.
+  { ord1Dict :: Data.Ord.Ord1 f } =>
+  { ordDict :: Data.Ord.Ord a } =>
+  Data.Ord.Ord (Main.Wrap @Prim.Type f a)
   where
   superclass eqDict = eqWrap {ord1Dict.eq1Dict} {ordDict.eqDict}
-  compare :: Main.Wrap @Prim.Type t0 t1 -> Main.Wrap @Prim.Type t0 t1 -> Data.Ordering.Ordering
+  compare :: Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       (Wrap left0), (Wrap right0) ->
-        case compare1 @t0 {ord1Dict} @t1 {ordDict} left0 right0 of
+        case compare1 @f {ord1Dict} @a {ordDict} left0 right0 of
           EQ -> EQ
           ordering -> ordering
 
 dictionary ord1Wrap ::
-  forall t0.
-  { ord1Dict :: Data.Ord.Ord1 t0 } =>
-  Data.Ord.Ord1 (Main.Wrap @Prim.Type t0)
+  forall f.
+  { ord1Dict :: Data.Ord.Ord1 f } =>
+  Data.Ord.Ord1 (Main.Wrap @Prim.Type f)
   where
   superclass eq1Dict = eq1Wrap {ord1Dict.eq1Dict}
   compare1 :: forall (a :: Prim.Type).
-  Data.Ord.Ord a => Main.Wrap @Prim.Type t0 a -> Main.Wrap @Prim.Type t0 a -> Data.Ordering.Ordering
-  compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type t0 a) {ordWrap {ord1Dict} {ordDict}}
+  Data.Ord.Ord a => Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f a -> Data.Ordering.Ordering
+  compare1 = \{ordDict} -> compare @(Main.Wrap @Prim.Type f a) {ordWrap {ord1Dict} {ordDict}}

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
@@ -26,7 +26,7 @@ dictionary eqList :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.
       _, _ -> false
 
 dictionary eq1List :: Data.Eq.Eq1 Main.List where
-  eq1 :: forall (t0 :: Prim.Type). Data.Eq.Eq t0 => Main.List t0 -> Main.List t0 -> Prim.Boolean
+  eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.List a -> Main.List a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.List a) {eqList {eqDict}}
 
 dictionary ordList :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord (Main.List t0) where
@@ -47,7 +47,7 @@ dictionary ordList :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord 
 
 dictionary ord1List :: Data.Ord.Ord1 Main.List where
   superclass eq1Dict = eq1List
-  compare1 :: forall (t0 :: Prim.Type). Data.Ord.Ord t0 => Main.List t0 -> Main.List t0 -> Data.Ordering.Ordering
+  compare1 :: forall (a :: Prim.Type). Data.Ord.Ord a => Main.List a -> Main.List a -> Data.Ordering.Ordering
   compare1 = \{ordDict} -> compare @(Main.List a) {ordList {ordDict}}
 
 dictionary eqTree :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.Tree t0) where
@@ -64,7 +64,7 @@ dictionary eqTree :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.
       _, _ -> false
 
 dictionary eq1Tree :: Data.Eq.Eq1 Main.Tree where
-  eq1 :: forall (t0 :: Prim.Type). Data.Eq.Eq t0 => Main.Tree t0 -> Main.Tree t0 -> Prim.Boolean
+  eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Tree a -> Main.Tree a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.Tree a) {eqTree {eqDict}}
 
 dictionary ordTree :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord (Main.Tree t0) where
@@ -88,5 +88,5 @@ dictionary ordTree :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord 
 
 dictionary ord1Tree :: Data.Ord.Ord1 Main.Tree where
   superclass eq1Dict = eq1Tree
-  compare1 :: forall (t0 :: Prim.Type). Data.Ord.Ord t0 => Main.Tree t0 -> Main.Tree t0 -> Data.Ordering.Ordering
+  compare1 :: forall (a :: Prim.Type). Data.Ord.Ord a => Main.Tree a -> Main.Tree a -> Data.Ordering.Ordering
   compare1 = \{ordDict} -> compare @(Main.Tree a) {ordTree {ordDict}}

--- a/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785138420_derive_eq1_ord1_recursive_data/Main.snap
@@ -13,14 +13,14 @@ data Tree @a
   | Leaf :: a -> Main.Tree a
   | Branch :: Main.Tree a -> Main.Tree a -> Main.Tree a
 
-dictionary eqList :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.List t0) where
-  eq :: Main.List t0 -> Main.List t0 -> Prim.Boolean
+dictionary eqList :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.List a) where
+  eq :: Main.List a -> Main.List a -> Prim.Boolean
   eq = \left right ->
     case left, right of
       Nil, Nil -> true
       (Cons left0 left1), (Cons right0 right1) ->
-        if eq @t0 {eqDict} left0 right0 then
-          if eq @(Main.List t0) {eqList {eqDict}} left1 right1 then true else false
+        if eq @a {eqDict} left0 right0 then
+          if eq @(Main.List a) {eqList {eqDict}} left1 right1 then true else false
         else
           false
       _, _ -> false
@@ -29,18 +29,18 @@ dictionary eq1List :: Data.Eq.Eq1 Main.List where
   eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.List a -> Main.List a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.List a) {eqList {eqDict}}
 
-dictionary ordList :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord (Main.List t0) where
+dictionary ordList :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.List a) where
   superclass eqDict = eqList {ordDict.eqDict}
-  compare :: Main.List t0 -> Main.List t0 -> Data.Ordering.Ordering
+  compare :: Main.List a -> Main.List a -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       Nil, Nil -> EQ
       Nil, _ -> LT
       _, Nil -> GT
       (Cons left0 left1), (Cons right0 right1) ->
-        case compare @t0 {ordDict} left0 right0 of
+        case compare @a {ordDict} left0 right0 of
           EQ ->
-            case compare @(Main.List t0) {ordList {ordDict}} left1 right1 of
+            case compare @(Main.List a) {ordList {ordDict}} left1 right1 of
               EQ -> EQ
               ordering -> ordering
           ordering -> ordering
@@ -50,15 +50,15 @@ dictionary ord1List :: Data.Ord.Ord1 Main.List where
   compare1 :: forall (a :: Prim.Type). Data.Ord.Ord a => Main.List a -> Main.List a -> Data.Ordering.Ordering
   compare1 = \{ordDict} -> compare @(Main.List a) {ordList {ordDict}}
 
-dictionary eqTree :: forall t0. { eqDict :: Data.Eq.Eq t0 } => Data.Eq.Eq (Main.Tree t0) where
-  eq :: Main.Tree t0 -> Main.Tree t0 -> Prim.Boolean
+dictionary eqTree :: forall a. { eqDict :: Data.Eq.Eq a } => Data.Eq.Eq (Main.Tree a) where
+  eq :: Main.Tree a -> Main.Tree a -> Prim.Boolean
   eq = \left right ->
     case left, right of
       (Leaf left0), (Leaf right0) ->
-        if eq @t0 {eqDict} left0 right0 then true else false
+        if eq @a {eqDict} left0 right0 then true else false
       (Branch left0 left1), (Branch right0 right1) ->
-        if eq @(Main.Tree t0) {eqTree {eqDict}} left0 right0 then
-          if eq @(Main.Tree t0) {eqTree {eqDict}} left1 right1 then true else false
+        if eq @(Main.Tree a) {eqTree {eqDict}} left0 right0 then
+          if eq @(Main.Tree a) {eqTree {eqDict}} left1 right1 then true else false
         else
           false
       _, _ -> false
@@ -67,21 +67,21 @@ dictionary eq1Tree :: Data.Eq.Eq1 Main.Tree where
   eq1 :: forall (a :: Prim.Type). Data.Eq.Eq a => Main.Tree a -> Main.Tree a -> Prim.Boolean
   eq1 = \{eqDict} -> eq @(Main.Tree a) {eqTree {eqDict}}
 
-dictionary ordTree :: forall t0. { ordDict :: Data.Ord.Ord t0 } => Data.Ord.Ord (Main.Tree t0) where
+dictionary ordTree :: forall a. { ordDict :: Data.Ord.Ord a } => Data.Ord.Ord (Main.Tree a) where
   superclass eqDict = eqTree {ordDict.eqDict}
-  compare :: Main.Tree t0 -> Main.Tree t0 -> Data.Ordering.Ordering
+  compare :: Main.Tree a -> Main.Tree a -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       (Leaf left0), (Leaf right0) ->
-        case compare @t0 {ordDict} left0 right0 of
+        case compare @a {ordDict} left0 right0 of
           EQ -> EQ
           ordering -> ordering
       (Leaf _), _ -> LT
       _, (Leaf _) -> GT
       (Branch left0 left1), (Branch right0 right1) ->
-        case compare @(Main.Tree t0) {ordTree {ordDict}} left0 right0 of
+        case compare @(Main.Tree a) {ordTree {ordDict}} left0 right0 of
           EQ ->
-            case compare @(Main.Tree t0) {ordTree {ordDict}} left1 right1 of
+            case compare @(Main.Tree a) {ordTree {ordDict}} left1 right1 of
               EQ -> EQ
               ordering -> ordering
           ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.snap
+++ b/tests-integration/fixtures/semantic/1785144720_derive_eq_ord_lifted_recursive_data/Main.snap
@@ -7,19 +7,19 @@ newtype Mu :: (Prim.Type -> Prim.Type) -> Prim.Type
 newtype Mu @f
   | In :: f (Main.Mu f) -> Main.Mu f
 
-dictionary eqMu :: forall t0. { eq1Dict :: Data.Eq.Eq1 t0 } => Data.Eq.Eq (Main.Mu t0) where
-  eq :: Main.Mu t0 -> Main.Mu t0 -> Prim.Boolean
+dictionary eqMu :: forall f. { eq1Dict :: Data.Eq.Eq1 f } => Data.Eq.Eq (Main.Mu f) where
+  eq :: Main.Mu f -> Main.Mu f -> Prim.Boolean
   eq = \left right ->
     case left, right of
       (In left0), (In right0) ->
-        if eq1 @t0 {eq1Dict} @(Main.Mu t0) {eqMu {eq1Dict}} left0 right0 then true else false
+        if eq1 @f {eq1Dict} @(Main.Mu f) {eqMu {eq1Dict}} left0 right0 then true else false
 
-dictionary ordMu :: forall t0. { ord1Dict :: Data.Ord.Ord1 t0 } => Data.Ord.Ord (Main.Mu t0) where
+dictionary ordMu :: forall f. { ord1Dict :: Data.Ord.Ord1 f } => Data.Ord.Ord (Main.Mu f) where
   superclass eqDict = eqMu {ord1Dict.eq1Dict}
-  compare :: Main.Mu t0 -> Main.Mu t0 -> Data.Ordering.Ordering
+  compare :: Main.Mu f -> Main.Mu f -> Data.Ordering.Ordering
   compare = \left right ->
     case left, right of
       (In left0), (In right0) ->
-        case compare1 @t0 {ord1Dict} @(Main.Mu t0) {ordMu {ord1Dict}} left0 right0 of
+        case compare1 @f {ord1Dict} @(Main.Mu f) {ordMu {ord1Dict}} left0 right0 of
           EQ -> EQ
           ordering -> ordering

--- a/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785249840_derive_newtype_delegate_implementation/Main.snap
@@ -8,6 +8,6 @@ newtype Identity @a
   | Identity :: a -> Main.Identity a
 
 dictionary showIdentity ::
-  forall t0.
-  { showDict :: Data.Show.Show t0 } =>
-  Data.Show.Show (Main.Identity t0) = showDict
+  forall a.
+  { showDict :: Data.Show.Show a } =>
+  Data.Show.Show (Main.Identity a) = showDict

--- a/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.snap
+++ b/tests-integration/fixtures/semantic/1785250560_derive_newtype_delegate_applied_representation/Main.snap
@@ -8,6 +8,6 @@ newtype NonEmpty @a
   | NonEmpty :: Prim.Array a -> Main.NonEmpty a
 
 dictionary showNonEmpty ::
-  forall t0.
-  { showDict :: Data.Show.Show t0 } =>
-  Data.Show.Show (Main.NonEmpty t0) = showArray {showDict}
+  forall a.
+  { showDict :: Data.Show.Show a } =>
+  Data.Show.Show (Main.NonEmpty a) = showArray {showDict}

--- a/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
@@ -51,12 +51,12 @@ dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
     case value of
       (Identity field0) -> Identity @b (function field0)
 
-dictionary functorConst :: forall t0. Data.Functor.Functor (Main.Const @Prim.Type t0) where
+dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
-  (a -> b) -> Main.Const @Prim.Type t0 a -> Main.Const @Prim.Type t0 b
+  (a -> b) -> Main.Const @Prim.Type e a -> Main.Const @Prim.Type e b
   map = \function value ->
     case value of
-      (Const field0) -> Const @Prim.Type @t0 @b field0
+      (Const field0) -> Const @Prim.Type @e @b field0
 
 dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Maybe a -> Main.Maybe b
@@ -66,53 +66,51 @@ dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
       (Just field0) -> Just @b (function field0)
 
 dictionary functorWrap ::
-  forall t0.
-  { functorDict :: Data.Functor.Functor t0 } =>
-  Data.Functor.Functor (Main.Wrap @Prim.Type t0)
+  forall f.
+  { functorDict :: Data.Functor.Functor f } =>
+  Data.Functor.Functor (Main.Wrap @Prim.Type f)
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
-  (a -> b) -> Main.Wrap @Prim.Type t0 a -> Main.Wrap @Prim.Type t0 b
+  (a -> b) -> Main.Wrap @Prim.Type f a -> Main.Wrap @Prim.Type f b
   map = \function value ->
     case value of
-      (Wrap field0) -> Wrap @Prim.Type @t0 @b
-        (map @t0 {functorDict} @a @b (\element -> function element) field0)
+      (Wrap field0) -> Wrap @Prim.Type @f @b
+        (map @f {functorDict} @a @b (\element -> function element) field0)
 
 dictionary functorCompose ::
-  forall t0 t1.
-  { functorDict :: Data.Functor.Functor t0 } =>
-  { functorDict1 :: Data.Functor.Functor t1 } =>
-  Data.Functor.Functor (Main.Compose @Prim.Type @Prim.Type t0 t1)
+  forall f g.
+  { functorDict :: Data.Functor.Functor f } =>
+  { functorDict1 :: Data.Functor.Functor g } =>
+  Data.Functor.Functor (Main.Compose @Prim.Type @Prim.Type f g)
   where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
-  (a -> b) ->
-  Main.Compose @Prim.Type @Prim.Type t0 t1 a ->
-  Main.Compose @Prim.Type @Prim.Type t0 t1 b
+  (a -> b) -> Main.Compose @Prim.Type @Prim.Type f g a -> Main.Compose @Prim.Type @Prim.Type f g b
   map = \function value ->
     case value of
-      (Compose field0) -> Compose @Prim.Type @Prim.Type @t0 @t1 @b
-        (map @t0 {functorDict} @(t1 a) @(t1 b)
-          (\element -> map @t1 {functorDict1} @a @b (\element -> function element) element)
+      (Compose field0) -> Compose @Prim.Type @Prim.Type @f @g @b
+        (map @f {functorDict} @(g a) @(g b)
+          (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
           field0)
 
-dictionary functorReader :: forall t0. Data.Functor.Functor (Main.Reader t0) where
-  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Reader t0 a -> Main.Reader t0 b
+dictionary functorReader :: forall r. Data.Functor.Functor (Main.Reader r) where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Reader r a -> Main.Reader r b
   map = \function value ->
     case value of
-      (Reader field0) -> Reader @t0 @b \argument -> function (field0 argument)
+      (Reader field0) -> Reader @r @b \argument -> function (field0 argument)
 
-dictionary functorNestedReader :: forall t0 t1. Data.Functor.Functor (Main.NestedReader t0 t1) where
+dictionary functorNestedReader :: forall r s. Data.Functor.Functor (Main.NestedReader r s) where
   map :: forall (a :: Prim.Type) (b :: Prim.Type).
-  (a -> b) -> Main.NestedReader t0 t1 a -> Main.NestedReader t0 t1 b
+  (a -> b) -> Main.NestedReader r s a -> Main.NestedReader r s b
   map = \function value ->
     case value of
-      (NestedReader field0) -> NestedReader @t0 @t1 @b \argument ->
+      (NestedReader field0) -> NestedReader @r @s @b \argument ->
         \argument1 -> function (field0 argument argument1)
 
-dictionary functorCont :: forall t0. Data.Functor.Functor (Main.Cont t0) where
-  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Cont t0 a -> Main.Cont t0 b
+dictionary functorCont :: forall r. Data.Functor.Functor (Main.Cont r) where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Cont r a -> Main.Cont r b
   map = \function value ->
     case value of
-      (Cont field0) -> Cont @t0 @b \argument -> field0 \argument1 -> argument (function argument1)
+      (Cont field0) -> Cont @r @b \argument -> field0 \argument1 -> argument (function argument1)
 
 dictionary functorRecord :: Data.Functor.Functor Main.Record where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Record a -> Main.Record b
@@ -120,8 +118,8 @@ dictionary functorRecord :: Data.Functor.Functor Main.Record where
     case value of
       (Record field0) -> Record @b field0 { changed = function field0.changed }
 
-dictionary functorOpenRecord :: forall t0. Data.Functor.Functor (Main.OpenRecord t0) where
-  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.OpenRecord t0 a -> Main.OpenRecord t0 b
+dictionary functorOpenRecord :: forall r. Data.Functor.Functor (Main.OpenRecord r) where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.OpenRecord r a -> Main.OpenRecord r b
   map = \function value ->
     case value of
-      (OpenRecord field0) -> OpenRecord @t0 @b field0 { changed = function field0.changed }
+      (OpenRecord field0) -> OpenRecord @r @b field0 { changed = function field0.changed }

--- a/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785263040_derive_functor_generated_bodies/Main.snap
@@ -46,20 +46,20 @@ data OpenRecord @r @a
   | OpenRecord :: { changed :: a | r } -> Main.OpenRecord r a
 
 dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
-  map :: forall (t0 :: Prim.Type) (t1 :: Prim.Type). (t0 -> t1) -> Main.Identity t0 -> Main.Identity t1
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Identity a -> Main.Identity b
   map = \function value ->
     case value of
       (Identity field0) -> Identity @b (function field0)
 
 dictionary functorConst :: forall t0. Data.Functor.Functor (Main.Const @Prim.Type t0) where
-  map :: forall (t1 :: Prim.Type) (t2 :: Prim.Type).
-  (t1 -> t2) -> Main.Const @Prim.Type t0 t1 -> Main.Const @Prim.Type t0 t2
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.Const @Prim.Type t0 a -> Main.Const @Prim.Type t0 b
   map = \function value ->
     case value of
       (Const field0) -> Const @Prim.Type @t0 @b field0
 
 dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
-  map :: forall (t0 :: Prim.Type) (t1 :: Prim.Type). (t0 -> t1) -> Main.Maybe t0 -> Main.Maybe t1
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Maybe a -> Main.Maybe b
   map = \function value ->
     case value of
       Nothing -> Nothing @b
@@ -70,8 +70,8 @@ dictionary functorWrap ::
   { functorDict :: Data.Functor.Functor t0 } =>
   Data.Functor.Functor (Main.Wrap @Prim.Type t0)
   where
-  map :: forall (t1 :: Prim.Type) (t2 :: Prim.Type).
-  (t1 -> t2) -> Main.Wrap @Prim.Type t0 t1 -> Main.Wrap @Prim.Type t0 t2
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.Wrap @Prim.Type t0 a -> Main.Wrap @Prim.Type t0 b
   map = \function value ->
     case value of
       (Wrap field0) -> Wrap @Prim.Type @t0 @b
@@ -83,10 +83,10 @@ dictionary functorCompose ::
   { functorDict1 :: Data.Functor.Functor t1 } =>
   Data.Functor.Functor (Main.Compose @Prim.Type @Prim.Type t0 t1)
   where
-  map :: forall (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t2 -> t3) ->
-  Main.Compose @Prim.Type @Prim.Type t0 t1 t2 ->
-  Main.Compose @Prim.Type @Prim.Type t0 t1 t3
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) ->
+  Main.Compose @Prim.Type @Prim.Type t0 t1 a ->
+  Main.Compose @Prim.Type @Prim.Type t0 t1 b
   map = \function value ->
     case value of
       (Compose field0) -> Compose @Prim.Type @Prim.Type @t0 @t1 @b
@@ -95,34 +95,33 @@ dictionary functorCompose ::
           field0)
 
 dictionary functorReader :: forall t0. Data.Functor.Functor (Main.Reader t0) where
-  map :: forall (t1 :: Prim.Type) (t2 :: Prim.Type). (t1 -> t2) -> Main.Reader t0 t1 -> Main.Reader t0 t2
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Reader t0 a -> Main.Reader t0 b
   map = \function value ->
     case value of
       (Reader field0) -> Reader @t0 @b \argument -> function (field0 argument)
 
 dictionary functorNestedReader :: forall t0 t1. Data.Functor.Functor (Main.NestedReader t0 t1) where
-  map :: forall (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t2 -> t3) -> Main.NestedReader t0 t1 t2 -> Main.NestedReader t0 t1 t3
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.NestedReader t0 t1 a -> Main.NestedReader t0 t1 b
   map = \function value ->
     case value of
       (NestedReader field0) -> NestedReader @t0 @t1 @b \argument ->
         \argument1 -> function (field0 argument argument1)
 
 dictionary functorCont :: forall t0. Data.Functor.Functor (Main.Cont t0) where
-  map :: forall (t1 :: Prim.Type) (t2 :: Prim.Type). (t1 -> t2) -> Main.Cont t0 t1 -> Main.Cont t0 t2
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Cont t0 a -> Main.Cont t0 b
   map = \function value ->
     case value of
       (Cont field0) -> Cont @t0 @b \argument -> field0 \argument1 -> argument (function argument1)
 
 dictionary functorRecord :: Data.Functor.Functor Main.Record where
-  map :: forall (t0 :: Prim.Type) (t1 :: Prim.Type). (t0 -> t1) -> Main.Record t0 -> Main.Record t1
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Record a -> Main.Record b
   map = \function value ->
     case value of
       (Record field0) -> Record @b field0 { changed = function field0.changed }
 
 dictionary functorOpenRecord :: forall t0. Data.Functor.Functor (Main.OpenRecord t0) where
-  map :: forall (t1 :: Prim.Type) (t2 :: Prim.Type).
-  (t1 -> t2) -> Main.OpenRecord t0 t1 -> Main.OpenRecord t0 t2
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.OpenRecord t0 a -> Main.OpenRecord t0 b
   map = \function value ->
     case value of
       (OpenRecord field0) -> OpenRecord @t0 @b field0 { changed = function field0.changed }

--- a/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
@@ -79,34 +79,34 @@ dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
       (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
 
 dictionary bifunctorConst2 ::
-  forall t0.
-  Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type t0)
+  forall value.
+  Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type value)
   where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) ->
   (c -> d) ->
-  Main.Const2 @Prim.Type @Prim.Type t0 a c ->
-  Main.Const2 @Prim.Type @Prim.Type t0 b d
+  Main.Const2 @Prim.Type @Prim.Type value a c ->
+  Main.Const2 @Prim.Type @Prim.Type value b d
   bimap = \firstFunction secondFunction value ->
     case value of
-      (Const2 field0) -> Const2 @Prim.Type @Prim.Type @t0 @b @d field0
+      (Const2 field0) -> Const2 @Prim.Type @Prim.Type @value @b @d field0
 
 dictionary bifunctorWrapBoth ::
-  forall t0 t1.
-  { functorDict :: Data.Functor.Functor t0 } =>
-  { functorDict1 :: Data.Functor.Functor t1 } =>
-  Data.Bifunctor.Bifunctor (Main.WrapBoth @Prim.Type @Prim.Type t0 t1)
+  forall f g.
+  { functorDict :: Data.Functor.Functor f } =>
+  { functorDict1 :: Data.Functor.Functor g } =>
+  Data.Bifunctor.Bifunctor (Main.WrapBoth @Prim.Type @Prim.Type f g)
   where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
   (a -> b) ->
   (c -> d) ->
-  Main.WrapBoth @Prim.Type @Prim.Type t0 t1 a c ->
-  Main.WrapBoth @Prim.Type @Prim.Type t0 t1 b d
+  Main.WrapBoth @Prim.Type @Prim.Type f g a c ->
+  Main.WrapBoth @Prim.Type @Prim.Type f g b d
   bimap = \firstFunction secondFunction value ->
     case value of
-      (WrapBoth field0 field1) -> WrapBoth @Prim.Type @Prim.Type @t0 @t1 @b @d
-        (map @t0 {functorDict} @a @b (\element -> firstFunction element) field0)
-        (map @t1 {functorDict1} @c @d (\element -> secondFunction element) field1)
+      (WrapBoth field0 field1) -> WrapBoth @Prim.Type @Prim.Type @f @g @b @d
+        (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
+        (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
 
 dictionary bifunctorTuple :: Data.Bifunctor.Bifunctor Main.Tuple where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
@@ -115,11 +115,11 @@ dictionary bifunctorTuple :: Data.Bifunctor.Bifunctor Main.Tuple where
     case value of
       (Tuple field0 field1) -> Tuple @b @d (firstFunction field0) (secondFunction field1)
 
-dictionary functorTuple :: forall t0. Data.Functor.Functor (Main.Tuple t0) where
-  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Tuple t0 a -> Main.Tuple t0 b
+dictionary functorTuple :: forall a. Data.Functor.Functor (Main.Tuple a) where
+  map :: forall (a1 :: Prim.Type) (b :: Prim.Type). (a1 -> b) -> Main.Tuple a a1 -> Main.Tuple a b
   map = \function value ->
     case value of
-      (Tuple field0 field1) -> Tuple @t0 @b field0 (function field1)
+      (Tuple field0 field1) -> Tuple @a @b field0 (function field1)
 
 dictionary bifunctorBoth :: Data.Bifunctor.Bifunctor Main.Both where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
@@ -164,19 +164,20 @@ dictionary bifunctorNested :: Data.Bifunctor.Bifunctor Main.Nested where
               element)
           field0)
 
-dictionary bifunctorTriple :: forall t0. Data.Bifunctor.Bifunctor (Main.Triple t0) where
+dictionary bifunctorTriple :: forall fixed. Data.Bifunctor.Bifunctor (Main.Triple fixed) where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
-  (a -> b) -> (c -> d) -> Main.Triple t0 a c -> Main.Triple t0 b d
+  (a -> b) -> (c -> d) -> Main.Triple fixed a c -> Main.Triple fixed b d
   bimap = \firstFunction secondFunction value ->
     case value of
-      (Triple field0 field1 field2) -> Triple @t0 @b @d field0 (firstFunction field1)
+      (Triple field0 field1 field2) -> Triple @fixed @b @d field0 (firstFunction field1)
         (secondFunction field2)
 
-dictionary functorTriple :: forall t0 t1. Data.Functor.Functor (Main.Triple t0 t1) where
-  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Triple t0 t1 a -> Main.Triple t0 t1 b
+dictionary functorTriple :: forall fixed a. Data.Functor.Functor (Main.Triple fixed a) where
+  map :: forall (a1 :: Prim.Type) (b :: Prim.Type).
+  (a1 -> b) -> Main.Triple fixed a a1 -> Main.Triple fixed a b
   map = \function value ->
     case value of
-      (Triple field0 field1 field2) -> Triple @t0 @t1 @b field0 field1 (function field2)
+      (Triple field0 field1 field2) -> Triple @fixed @a @b field0 field1 (function field2)
 
 dictionary bifunctorNestedTriple :: Data.Bifunctor.Bifunctor Main.NestedTriple where
   bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).

--- a/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
+++ b/tests-integration/fixtures/semantic/1785318540_derive_bifunctor_generated_bodies/Main.snap
@@ -64,16 +64,16 @@ data RecordPair @a @b
   | RecordPair :: { first :: a, fixed :: Prim.Int, second :: b } -> Main.RecordPair a b
 
 dictionary bifunctorEither :: Data.Bifunctor.Bifunctor Main.Either where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.Either t0 t2 -> Main.Either t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Either a c -> Main.Either b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Left field0) -> Left @b @d (firstFunction field0)
       (Right field0) -> Right @b @d (secondFunction field0)
 
 dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.Pair t0 t2 -> Main.Pair t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
@@ -82,11 +82,11 @@ dictionary bifunctorConst2 ::
   forall t0.
   Data.Bifunctor.Bifunctor (Main.Const2 @Prim.Type @Prim.Type t0)
   where
-  bimap :: forall (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type).
-  (t1 -> t2) ->
-  (t3 -> t4) ->
-  Main.Const2 @Prim.Type @Prim.Type t0 t1 t3 ->
-  Main.Const2 @Prim.Type @Prim.Type t0 t2 t4
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) ->
+  (c -> d) ->
+  Main.Const2 @Prim.Type @Prim.Type t0 a c ->
+  Main.Const2 @Prim.Type @Prim.Type t0 b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Const2 field0) -> Const2 @Prim.Type @Prim.Type @t0 @b @d field0
@@ -97,11 +97,11 @@ dictionary bifunctorWrapBoth ::
   { functorDict1 :: Data.Functor.Functor t1 } =>
   Data.Bifunctor.Bifunctor (Main.WrapBoth @Prim.Type @Prim.Type t0 t1)
   where
-  bimap :: forall (t2 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type) (t5 :: Prim.Type).
-  (t2 -> t3) ->
-  (t4 -> t5) ->
-  Main.WrapBoth @Prim.Type @Prim.Type t0 t1 t2 t4 ->
-  Main.WrapBoth @Prim.Type @Prim.Type t0 t1 t3 t5
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) ->
+  (c -> d) ->
+  Main.WrapBoth @Prim.Type @Prim.Type t0 t1 a c ->
+  Main.WrapBoth @Prim.Type @Prim.Type t0 t1 b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (WrapBoth field0 field1) -> WrapBoth @Prim.Type @Prim.Type @t0 @t1 @b @d
@@ -109,21 +109,21 @@ dictionary bifunctorWrapBoth ::
         (map @t1 {functorDict1} @c @d (\element -> secondFunction element) field1)
 
 dictionary bifunctorTuple :: Data.Bifunctor.Bifunctor Main.Tuple where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.Tuple t0 t2 -> Main.Tuple t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Tuple a c -> Main.Tuple b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Tuple field0 field1) -> Tuple @b @d (firstFunction field0) (secondFunction field1)
 
 dictionary functorTuple :: forall t0. Data.Functor.Functor (Main.Tuple t0) where
-  map :: forall (t1 :: Prim.Type) (t2 :: Prim.Type). (t1 -> t2) -> Main.Tuple t0 t1 -> Main.Tuple t0 t2
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Tuple t0 a -> Main.Tuple t0 b
   map = \function value ->
     case value of
       (Tuple field0 field1) -> Tuple @t0 @b field0 (function field1)
 
 dictionary bifunctorBoth :: Data.Bifunctor.Bifunctor Main.Both where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.Both t0 t2 -> Main.Both t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Both a c -> Main.Both b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Both field0) -> Both @b @d
@@ -132,8 +132,8 @@ dictionary bifunctorBoth :: Data.Bifunctor.Bifunctor Main.Both where
           field0)
 
 dictionary bifunctorOneSided :: Data.Bifunctor.Bifunctor Main.OneSided where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.OneSided t0 t2 -> Main.OneSided t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.OneSided a c -> Main.OneSided b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (OneSidedFirst field0) -> OneSidedFirst @b @d
@@ -146,14 +146,14 @@ dictionary bifunctorOneSided :: Data.Bifunctor.Bifunctor Main.OneSided where
           field0)
 
 dictionary functorBox :: Data.Functor.Functor Main.Box where
-  map :: forall (t0 :: Prim.Type) (t1 :: Prim.Type). (t0 -> t1) -> Main.Box t0 -> Main.Box t1
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Box a -> Main.Box b
   map = \function value ->
     case value of
       (Box field0) -> Box @b (function field0)
 
 dictionary bifunctorNested :: Data.Bifunctor.Bifunctor Main.Nested where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.Nested t0 t2 -> Main.Nested t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Nested a c -> Main.Nested b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Nested field0) -> Nested @b @d
@@ -165,23 +165,22 @@ dictionary bifunctorNested :: Data.Bifunctor.Bifunctor Main.Nested where
           field0)
 
 dictionary bifunctorTriple :: forall t0. Data.Bifunctor.Bifunctor (Main.Triple t0) where
-  bimap :: forall (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type) (t4 :: Prim.Type).
-  (t1 -> t2) -> (t3 -> t4) -> Main.Triple t0 t1 t3 -> Main.Triple t0 t2 t4
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Triple t0 a c -> Main.Triple t0 b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (Triple field0 field1 field2) -> Triple @t0 @b @d field0 (firstFunction field1)
         (secondFunction field2)
 
 dictionary functorTriple :: forall t0 t1. Data.Functor.Functor (Main.Triple t0 t1) where
-  map :: forall (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t2 -> t3) -> Main.Triple t0 t1 t2 -> Main.Triple t0 t1 t3
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Triple t0 t1 a -> Main.Triple t0 t1 b
   map = \function value ->
     case value of
       (Triple field0 field1 field2) -> Triple @t0 @t1 @b field0 field1 (function field2)
 
 dictionary bifunctorNestedTriple :: Data.Bifunctor.Bifunctor Main.NestedTriple where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.NestedTriple t0 t2 -> Main.NestedTriple t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.NestedTriple a c -> Main.NestedTriple b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (NestedTriple field0) -> NestedTriple @b @d
@@ -192,11 +191,11 @@ dictionary bifunctorNestedTriple :: Data.Bifunctor.Bifunctor Main.NestedTriple w
 
 dictionary bifunctorNestedTripleLast :: Data.Bifunctor.Bifunctor (Main.NestedTripleLast @Prim.Type)
   where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) ->
-  (t2 -> t3) ->
-  Main.NestedTripleLast @Prim.Type t0 t2 ->
-  Main.NestedTripleLast @Prim.Type t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) ->
+  (c -> d) ->
+  Main.NestedTripleLast @Prim.Type a c ->
+  Main.NestedTripleLast @Prim.Type b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (NestedTripleLast field0) -> NestedTripleLast @Prim.Type @b @d
@@ -205,8 +204,8 @@ dictionary bifunctorNestedTripleLast :: Data.Bifunctor.Bifunctor (Main.NestedTri
           field0)
 
 dictionary bifunctorReaderPair :: Data.Bifunctor.Bifunctor Main.ReaderPair where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.ReaderPair t0 t2 -> Main.ReaderPair t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.ReaderPair a c -> Main.ReaderPair b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (ReaderPair field0) -> ReaderPair @b @d \argument ->
@@ -215,8 +214,8 @@ dictionary bifunctorReaderPair :: Data.Bifunctor.Bifunctor Main.ReaderPair where
           (field0 argument)
 
 dictionary bifunctorRecordPair :: Data.Bifunctor.Bifunctor Main.RecordPair where
-  bimap :: forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (t3 :: Prim.Type).
-  (t0 -> t1) -> (t2 -> t3) -> Main.RecordPair t0 t2 -> Main.RecordPair t1 t3
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.RecordPair a c -> Main.RecordPair b d
   bimap = \firstFunction secondFunction value ->
     case value of
       (RecordPair field0) -> RecordPair @b @d


### PR DESCRIPTION
## Intent

Keep source-level type variable names visible throughout checked output. Imported class members should retain their declared binder names, and implicit variables in instance heads should retain names such as `e`, `f`, and `r` instead of being printed as generated `t0` names.

## Changes

- preserve imported class-member binder text when rendering instance member signatures
- retain implicit binder text when instance signatures are generalised
- allocate collision-free member-local names when an instance binder uses the same text
- update checking and semantic snapshots for ordinary, derived, and delegated instances

## Verification

- `just t checking`
- `just t semantic`
- `just t lowering`
- `just t resolving`
- `just t lsp`
- `just t docs`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `git diff --check`