### PR TITLE
[checking] Simplify source type variable bindings

### DIFF
--- a/compiler-core/checking/src/core/generalise.rs
+++ b/compiler-core/checking/src/core/generalise.rs
@@ -589,9 +589,6 @@ where
     for implicit_unification in implicits_unifications {
         match implicit_unification {
             ImplicitOrUnification::Implicit(name, kind) => {
-                if let Some(text) = state.bindings.lookup_implicit_text(name) {
-                    state.checked.names.insert(name, text);
-                }
                 binders.push(ForallBinder { visible: false, name, kind })
             }
             ImplicitOrUnification::Unification(id, kind) => {

--- a/compiler-core/checking/src/core/signature.rs
+++ b/compiler-core/checking/src/core/signature.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use itertools::Itertools;
 use lowering::TypeVariableBinding;
 
 use crate::context::CheckContext;
-use crate::core::substitute::{NameToType, SubstituteName};
+use crate::core::substitute::RigidRenaming;
 use crate::core::{ForallBinder, Type, TypeId, normalise, toolkit, unification};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
@@ -17,7 +19,7 @@ pub struct DecomposedSignature {
 }
 
 pub struct SkolemisedSignature {
-    pub substitution: NameToType,
+    pub renaming: Arc<RigidRenaming>,
     pub constraints: Vec<TypeId>,
     pub arguments: Vec<TypeId>,
     pub result: TypeId,
@@ -143,7 +145,7 @@ where
     let signature =
         decompose_signature(state, context, signature_type, DecomposeSignatureMode::Full)?;
 
-    let SkolemisedSignature { substitution, constraints, arguments, result } =
+    let SkolemisedSignature { renaming, constraints, arguments, result } =
         skolemise_decomposed_signature(state, context, signature)?;
 
     let mut remaining = arguments.into_iter();
@@ -152,7 +154,7 @@ where
     let mut result = context.intern_function_iter(remaining, result);
     synthesise_functions(state, context, &mut arguments, &mut result, required)?;
 
-    Ok(SkolemisedSignature { substitution, constraints, arguments, result })
+    Ok(SkolemisedSignature { renaming, constraints, arguments, result })
 }
 
 fn synthesise_functions<Q>(
@@ -195,28 +197,29 @@ fn skolemise_decomposed_signature<Q>(
 where
     Q: ExternalQueries,
 {
-    let mut substitution = NameToType::default();
+    let mut renaming = RigidRenaming::default();
 
     for binder in &signature.binders {
-        let kind = SubstituteName::many(state, context, &substitution, binder.kind)?;
+        let kind = renaming.substitute(state, context, binder.kind)?;
         let text = toolkit::lookup_name(state, context, binder.name)?;
         let rigid = state.fresh_rigid_named(context.queries, kind, text);
-        substitution.insert(binder.name, rigid);
+        renaming.insert(context, binder.name, rigid);
     }
 
     let constraints = signature
         .constraints
         .iter()
-        .map(|&constraint| SubstituteName::many(state, context, &substitution, constraint))
+        .map(|&constraint| renaming.substitute(state, context, constraint))
         .collect::<QueryResult<Vec<_>>>()?;
 
     let arguments = signature
         .arguments
         .iter()
-        .map(|&argument| SubstituteName::many(state, context, &substitution, argument))
+        .map(|&argument| renaming.substitute(state, context, argument))
         .collect::<QueryResult<Vec<_>>>()?;
 
-    let result = SubstituteName::many(state, context, &substitution, signature.result)?;
+    let result = renaming.substitute(state, context, signature.result)?;
+    let renaming = Arc::new(renaming);
 
-    Ok(SkolemisedSignature { substitution, constraints, arguments, result })
+    Ok(SkolemisedSignature { renaming, constraints, arguments, result })
 }

--- a/compiler-core/checking/src/core/substitute.rs
+++ b/compiler-core/checking/src/core/substitute.rs
@@ -12,6 +12,50 @@ use crate::state::CheckState;
 
 pub type NameToType = FxHashMap<Name, TypeId>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RigidReplacement {
+    name: Name,
+    type_id: TypeId,
+}
+
+/// A name-based replacement of rigid variables with fresh rigid variables.
+///
+/// Unlike [`NameToType`], this representation cannot contain non-rigid
+/// replacement types.
+#[derive(Debug, Default)]
+pub struct RigidRenaming {
+    replacements: FxHashMap<Name, RigidReplacement>,
+}
+
+impl RigidRenaming {
+    pub fn insert<Q>(&mut self, context: &CheckContext<Q>, original: Name, replacement: TypeId)
+    where
+        Q: ExternalQueries,
+    {
+        let Type::Rigid(name, _, _) = context.lookup_type(replacement) else {
+            unreachable!("invariant violated: expected a rigid variable");
+        };
+        let replacement = RigidReplacement { name, type_id: replacement };
+        self.replacements.insert(original, replacement);
+    }
+
+    pub fn substitute<Q>(
+        &self,
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        in_type: TypeId,
+    ) -> QueryResult<TypeId>
+    where
+        Q: ExternalQueries,
+    {
+        fold_type(state, context, in_type, &mut SubstituteRigidName { renaming: self })
+    }
+
+    pub(crate) fn replacement_name(&self, original: Name) -> Option<Name> {
+        self.replacements.get(&original).map(|replacement| replacement.name)
+    }
+}
+
 /// Implements [`Name`]-based substitution for [`Type::Rigid`] variables.
 ///
 /// Names are globally unique, removing the need for scope tracking and
@@ -64,6 +108,31 @@ impl TypeFold for SubstituteName<'_> {
             && let Some(id) = self.bindings.get(name)
         {
             Ok(FoldAction::Replace(*id))
+        } else {
+            Ok(FoldAction::Continue)
+        }
+    }
+}
+
+struct SubstituteRigidName<'a> {
+    renaming: &'a RigidRenaming,
+}
+
+impl TypeFold for SubstituteRigidName<'_> {
+    fn transform<Q>(
+        &mut self,
+        _state: &mut CheckState,
+        _context: &CheckContext<Q>,
+        _id: TypeId,
+        t: &Type,
+    ) -> QueryResult<FoldAction>
+    where
+        Q: ExternalQueries,
+    {
+        if let Type::Rigid(name, _, _) = t
+            && let Some(replacement) = self.renaming.replacements.get(name)
+        {
+            Ok(FoldAction::Replace(replacement.type_id))
         } else {
             Ok(FoldAction::Continue)
         }

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::substitute::SubstituteName;
 use crate::core::{KindOrType, TypeId, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
@@ -67,7 +66,7 @@ where
     };
 
     let freshened = freshen_instance_rigids(state, context, &instance)?;
-    state.with_implicit(context, &freshened.substitution, |state| {
+    state.with_source_type_renaming(&freshened.renaming, |state| {
         let mut evidences = Vec::with_capacity(freshened.constraints.len());
         for (&constraint, &signature_constraint) in
             std::iter::zip(&freshened.constraints, &instance.constraints)
@@ -85,7 +84,7 @@ where
         )?;
 
         let delegate_constraint =
-            SubstituteName::many(state, context, &freshened.substitution, delegate_constraint)?;
+            freshened.renaming.substitute(state, context, delegate_constraint)?;
         let evidence = state.push_wanted(delegate_constraint);
 
         let instance = tree::InstanceDeclaration {
@@ -127,7 +126,7 @@ where
     };
 
     let freshened = freshen_instance_rigids(state, context, &instance)?;
-    state.with_implicit(context, &freshened.substitution, |state| {
+    state.with_source_type_renaming(&freshened.renaming, |state| {
         let mut evidences = Vec::with_capacity(freshened.constraints.len());
         for (&constraint, &signature_constraint) in
             std::iter::zip(&freshened.constraints, &instance.constraints)
@@ -265,7 +264,7 @@ where
             return Ok(None);
         };
 
-        let signature::SkolemisedSignature { substitution, constraints, result: body_type, .. } =
+        let signature::SkolemisedSignature { renaming, constraints, result: body_type, .. } =
             signature::expect_term_signature(state, context, member.implementation_type, 0)?;
 
         let mut evidences = Vec::with_capacity(constraints.len());
@@ -274,7 +273,7 @@ where
             evidences.push(evidence);
         }
 
-        let body = state.with_implicit(context, &substitution, |state| {
+        let body = state.with_source_type_renaming(&renaming, |state| {
             let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
             let body = builder.term_reference(operation)?;
             builder.subtype(body, body_type)

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use building_types::QueryResult;
 use itertools::izip;
 use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
-use crate::core::substitute::NameToType;
+use crate::core::substitute::RigidRenaming;
 use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
@@ -47,7 +49,7 @@ impl Mappings<ElaboratedExpression> {
 
 struct DecodedTraversalMember {
     member: ResolvedMember,
-    substitution: NameToType,
+    renaming: Arc<RigidRenaming>,
     constraints: Vec<TypeId>,
     implementation_type: TypeId,
     function_type: TypeId,
@@ -72,7 +74,7 @@ impl DecodedTraversalMember {
             TraversalKind::Functor => 2,
             TraversalKind::Bifunctor => 3,
         };
-        let signature::SkolemisedSignature { substitution, constraints, arguments, result } =
+        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
             signature::expect_term_signature(
                 state,
                 context,
@@ -96,7 +98,7 @@ impl DecodedTraversalMember {
         Ok(Some(DecodedTraversalMember {
             implementation_type: member.implementation_type,
             member,
-            substitution,
+            renaming,
             constraints,
             function_type,
             mappings,
@@ -143,7 +145,7 @@ where
             evidences.push(Evidence::Given(state.push_given(constraint)));
         }
 
-        let body = state.with_implicit(context, &member.substitution, |state| {
+        let body = state.with_source_type_renaming(&member.renaming, |state| {
             emit_variance_traversal(state, context, result.derive_id, &member, recipe)
         })?;
         let Some(body) = body else { return Ok(None) };

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 
 use crate::context::CheckContext;
 use crate::core::constraint::ConstraintInScope;
-use crate::core::substitute::{NameToType, SubstituteName};
+use crate::core::substitute::{NameToType, RigidRenaming, SubstituteName};
 use crate::core::{
     CheckedInstance, KindOrType, Type, TypeId, constraint, exhaustive, generalise, normalise,
     signature, toolkit, unification, zonk,
@@ -277,11 +277,11 @@ where
             let FreshenedInstanceRigids {
                 constraints: instance_constraints,
                 arguments: instance_arguments,
-                substitution,
+                renaming,
                 rigids,
             } = freshen_instance_rigids(state, context, instance)?;
 
-            state.with_implicit(context, &substitution, |state| {
+            state.with_source_type_renaming(&renaming, |state| {
                 debug_assert_eq!(instance_constraints.len(), instance.constraints.len());
                 let mut instance_evidences = vec![];
                 for (&constraint, &signature_constraint) in
@@ -467,7 +467,7 @@ fn record_instance_member(
 pub(crate) struct FreshenedInstanceRigids {
     pub(crate) constraints: Vec<TypeId>,
     pub(crate) arguments: Vec<KindOrType>,
-    pub(crate) substitution: NameToType,
+    pub(crate) renaming: Arc<RigidRenaming>,
     pub(crate) rigids: Vec<TypeId>,
 }
 
@@ -479,31 +479,31 @@ pub(crate) fn freshen_instance_rigids<Q>(
 where
     Q: ExternalQueries,
 {
-    let mut substitution = NameToType::default();
+    let mut renaming = RigidRenaming::default();
     let mut rigids = Vec::with_capacity(instance.binders.len());
 
     for binder in &instance.binders {
-        let kind = SubstituteName::many(state, context, &substitution, binder.kind)?;
-        let text = toolkit::lookup_name(state, context, binder.name)?
-            .or_else(|| state.bindings.lookup_implicit_text(binder.name));
+        let kind = renaming.substitute(state, context, binder.kind)?;
+        let text = toolkit::lookup_name(state, context, binder.name)?;
         let rigid = state.fresh_rigid_named(context.queries, kind, text);
-        substitution.insert(binder.name, rigid);
+        renaming.insert(context, binder.name, rigid);
         rigids.push(rigid);
     }
 
     let constraints = instance
         .constraints
         .iter()
-        .map(|&constraint| SubstituteName::many(state, context, &substitution, constraint))
+        .map(|&constraint| renaming.substitute(state, context, constraint))
         .collect::<QueryResult<Vec<_>>>()?;
 
     let arguments = instance
         .arguments
         .iter()
-        .map(|&argument| substitute_kind_or_type(state, context, &substitution, argument))
+        .map(|&argument| substitute_kind_or_type(state, context, &renaming, argument))
         .collect::<QueryResult<Vec<_>>>()?;
 
-    Ok(FreshenedInstanceRigids { constraints, arguments, substitution, rigids })
+    let renaming = Arc::new(renaming);
+    Ok(FreshenedInstanceRigids { constraints, arguments, renaming, rigids })
 }
 
 pub(crate) fn emit_instance_superclass_constraints<Q>(
@@ -593,7 +593,7 @@ where
 fn substitute_kind_or_type<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
-    bindings: &NameToType,
+    renaming: &RigidRenaming,
     argument: KindOrType,
 ) -> QueryResult<KindOrType>
 where
@@ -601,10 +601,10 @@ where
 {
     Ok(match argument {
         KindOrType::Kind(argument) => {
-            KindOrType::Kind(SubstituteName::many(state, context, bindings, argument)?)
+            KindOrType::Kind(renaming.substitute(state, context, argument)?)
         }
         KindOrType::Type(argument) => {
-            KindOrType::Type(SubstituteName::many(state, context, bindings, argument)?)
+            KindOrType::Type(renaming.substitute(state, context, argument)?)
         }
     })
 }

--- a/compiler-core/checking/src/source/terms/equations.rs
+++ b/compiler-core/checking/src/source/terms/equations.rs
@@ -72,7 +72,7 @@ where
 {
     let required = equations.iter().map(|equation| equation.binders.len()).max().unwrap_or(0);
 
-    let signature::SkolemisedSignature { substitution, constraints, arguments, result } =
+    let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
         signature::expect_term_signature(state, context, expected_type, required)?;
 
     let mut evidences = vec![];
@@ -87,7 +87,7 @@ where
     let mut arguments = ValueEquationPatterns::clone(&signature.arguments);
     instantiate_pattern_arguments(state, context, &mut arguments, equations)?;
 
-    let equations = state.with_implicit(context, &substitution, |state| {
+    let equations = state.with_source_type_renaming(&renaming, |state| {
         check_equations(state, context, origin, &signature, &arguments, equations)
     })?;
 

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -16,7 +16,7 @@ use crate::core::{ForallBinder, RowField, Type, TypeId, normalise, toolkit, unif
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::holes::{HoleBinding, TypeHole};
 use crate::source::{operator, synonym};
-use crate::state::CheckState;
+use crate::state::{CheckState, SourceTypeVariableKey};
 use crate::{ExternalQueries, safe_loop};
 
 const MISSING_NAME: SmolStr = SmolStr::new_static("<MissingName>");
@@ -257,38 +257,41 @@ where
 
         lowering::TypeKind::Variable { name, resolution } => match resolution {
             Some(lowering::TypeVariableResolution::Forall(forall)) => {
-                let (n, k) = state
-                    .bindings
-                    .lookup_forall(*forall)
+                let variable = state
+                    .lookup_source_type_variable(context, SourceTypeVariableKey::Forall(*forall))?
                     .expect("invariant violated: KindScope::bind_forall");
 
-                let t = context.intern_rigid(n, state.depth, k);
+                let t = context.intern_rigid(variable.name, state.depth, variable.kind);
 
-                Ok((t, k))
+                Ok((t, variable.kind))
             }
 
             Some(lowering::TypeVariableResolution::Implicit(implicit)) => {
+                let key = SourceTypeVariableKey::Implicit { node: implicit.node, id: implicit.id };
                 if implicit.binding {
                     let n = state.names.fresh();
                     let k = state.fresh_unification(context.queries, context.prim.t);
 
-                    let text = name.clone().map(|text| context.queries.intern_smol_str(text));
+                    if let Some(text) = name {
+                        let text = SmolStr::clone(text);
+                        let text = context.queries.intern_smol_str(text);
+                        state.checked.names.insert(n, text);
+                    }
 
-                    state.bindings.bind_implicit(implicit.node, implicit.id, n, k, text);
+                    state.bindings.bind_implicit(implicit.node, implicit.id, n, k);
                     state.checked.nodes.implicit_bindings.insert((implicit.node, implicit.id), k);
 
                     let t = context.intern_rigid(n, state.depth, k);
 
                     Ok((t, k))
                 } else {
-                    let (n, k) = state
-                        .bindings
-                        .lookup_implicit(implicit.node, implicit.id)
+                    let variable = state
+                        .lookup_source_type_variable(context, key)?
                         .expect("invariant violated: KindScope::bind_implicit");
 
-                    let t = context.intern_rigid(n, state.depth, k);
+                    let t = context.intern_rigid(variable.name, state.depth, variable.kind);
 
-                    Ok((t, k))
+                    Ok((t, variable.kind))
                 }
             }
 
@@ -391,12 +394,10 @@ fn collect_forall_binding<'a>(
     seen: &mut FxHashSet<&'a SmolStr>,
     result: &mut Vec<HoleBinding>,
 ) {
-    let Some(type_id) = state
-        .checked
-        .nodes
-        .lookup_forall_binding(binding_id)
-        .or_else(|| state.bindings.lookup_forall(binding_id).map(|(_, kind)| kind))
-    else {
+    let Some(type_id) = state.checked.nodes.lookup_forall_binding(binding_id).or_else(|| {
+        let key = SourceTypeVariableKey::Forall(binding_id);
+        state.bindings.lookup(key).map(|variable| variable.kind)
+    }) else {
         return;
     };
 
@@ -413,11 +414,11 @@ fn collect_implicit_binding<'a>(
     seen: &mut FxHashSet<&'a SmolStr>,
     result: &mut Vec<HoleBinding>,
 ) {
-    let Some(type_id) = state
-        .checked
-        .nodes
-        .lookup_implicit_binding(node_id, binding_id)
-        .or_else(|| state.bindings.lookup_implicit(node_id, binding_id).map(|(_, kind)| kind))
+    let Some(type_id) =
+        state.checked.nodes.lookup_implicit_binding(node_id, binding_id).or_else(|| {
+            let key = SourceTypeVariableKey::Implicit { node: node_id, id: binding_id };
+            state.bindings.lookup(key).map(|variable| variable.kind)
+        })
     else {
         return;
     };

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -12,7 +12,7 @@ use crate::core::constraint::{CanonicalConstraintId, Canonicals, ConstraintInSco
 use crate::core::exhaustive::{
     ExhaustivenessReport, Pattern, PatternConstructor, PatternId, PatternInterner, PatternKind,
 };
-use crate::core::substitute::{NameToType, SubstituteName};
+use crate::core::substitute::RigidRenaming;
 use crate::core::{Depth, Name, SmolStrId, Type, TypeId, constraint};
 use crate::error::{CheckingError, ErrorCrumb, ErrorKind};
 use crate::evidence::{EvidenceBinderId, EvidenceVarId};
@@ -87,118 +87,48 @@ impl Unifications {
 /// Tracks type variable bindings during kind inference.
 #[derive(Default)]
 pub struct Bindings {
-    forall: Vec<ForallBinding>,
-    implicit: Vec<ImplicitBinding>,
+    variables: FxHashMap<SourceTypeVariableKey, SourceTypeVariable>,
+    renamings: Vec<Arc<RigidRenaming>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SourceTypeVariableKey {
+    Forall(lowering::TypeVariableBindingId),
+    Implicit { node: lowering::GraphNodeId, id: lowering::ImplicitBindingId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ForallBinding {
-    id: lowering::TypeVariableBindingId,
-    name: Name,
-    kind: TypeId,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ImplicitBinding {
-    node: lowering::GraphNodeId,
-    id: lowering::ImplicitBindingId,
-    name: Name,
-    kind: TypeId,
-    text: Option<SmolStrId>,
+pub(crate) struct SourceTypeVariable {
+    pub(crate) name: Name,
+    pub(crate) kind: TypeId,
 }
 
 impl Bindings {
-    pub fn bind_forall(&mut self, id: lowering::TypeVariableBindingId, name: Name, kind: TypeId) {
-        self.forall.push(ForallBinding { id, name, kind });
+    fn bind(&mut self, key: SourceTypeVariableKey, name: Name, kind: TypeId) {
+        self.variables.insert(key, SourceTypeVariable { name, kind });
     }
 
-    pub fn lookup_forall(&self, id: lowering::TypeVariableBindingId) -> Option<(Name, TypeId)> {
-        self.forall
-            .iter()
-            .rev()
-            .find(|binding| binding.id == id)
-            .map(|binding| (binding.name, binding.kind))
+    pub(crate) fn bind_forall(
+        &mut self,
+        id: lowering::TypeVariableBindingId,
+        name: Name,
+        kind: TypeId,
+    ) {
+        self.bind(SourceTypeVariableKey::Forall(id), name, kind);
     }
 
-    pub fn bind_implicit(
+    pub(crate) fn bind_implicit(
         &mut self,
         node: lowering::GraphNodeId,
         id: lowering::ImplicitBindingId,
         name: Name,
         kind: TypeId,
-        text: Option<SmolStrId>,
     ) {
-        self.implicit.push(ImplicitBinding { node, id, name, kind, text });
+        self.bind(SourceTypeVariableKey::Implicit { node, id }, name, kind);
     }
 
-    fn bind_implicit_substitution<Q>(
-        state: &mut CheckState,
-        context: &CheckContext<Q>,
-        substitution: &NameToType,
-    ) -> QueryResult<()>
-    where
-        Q: ExternalQueries,
-    {
-        let scope = state.bindings.implicit.len();
-
-        for binding in 0..scope {
-            let ImplicitBinding { node, id, name, kind, text } = state.bindings.implicit[binding];
-            let Some(&replacement) = substitution.get(&name) else { continue };
-
-            let Type::Rigid(name, _, _) = context.lookup_type(replacement) else {
-                unreachable!("invariant violated: expected a rigid variable");
-            };
-
-            let kind = SubstituteName::many(state, context, substitution, kind)?;
-            state.bindings.implicit.push(ImplicitBinding { node, id, name, kind, text });
-        }
-
-        Ok(())
-    }
-
-    fn bind_forall_substitution<Q>(
-        state: &mut CheckState,
-        context: &CheckContext<Q>,
-        substitution: &NameToType,
-    ) -> QueryResult<()>
-    where
-        Q: ExternalQueries,
-    {
-        let scope = state.bindings.forall.len();
-
-        for binding in 0..scope {
-            let ForallBinding { id, name, kind } = state.bindings.forall[binding];
-            let Some(&replacement) = substitution.get(&name) else { continue };
-
-            let Type::Rigid(name, _, _) = context.lookup_type(replacement) else {
-                unreachable!("invariant violated: expected a rigid variable");
-            };
-
-            let kind = SubstituteName::many(state, context, substitution, kind)?;
-            state.bindings.forall.push(ForallBinding { id, name, kind });
-        }
-
-        Ok(())
-    }
-
-    pub fn lookup_implicit(
-        &self,
-        node: lowering::GraphNodeId,
-        id: lowering::ImplicitBindingId,
-    ) -> Option<(Name, TypeId)> {
-        self.implicit
-            .iter()
-            .rev()
-            .find(|binding| binding.node == node && binding.id == id)
-            .map(|binding| (binding.name, binding.kind))
-    }
-
-    pub fn lookup_implicit_text(&self, name: Name) -> Option<SmolStrId> {
-        self.implicit
-            .iter()
-            .rev()
-            .find(|binding| binding.name == name)
-            .and_then(|binding| binding.text)
+    pub(crate) fn lookup(&self, key: SourceTypeVariableKey) -> Option<SourceTypeVariable> {
+        self.variables.get(&key).copied()
     }
 }
 
@@ -388,22 +318,38 @@ impl CheckState {
         result
     }
 
-    pub fn with_implicit<Q, T>(
+    pub(crate) fn lookup_source_type_variable<Q>(
         &mut self,
         context: &CheckContext<Q>,
-        substitution: &NameToType,
-        f: impl FnOnce(&mut CheckState) -> QueryResult<T>,
-    ) -> QueryResult<T>
+        key: SourceTypeVariableKey,
+    ) -> QueryResult<Option<SourceTypeVariable>>
     where
         Q: ExternalQueries,
     {
-        let forall_scope = self.bindings.forall.len();
-        Bindings::bind_forall_substitution(self, context, substitution)?;
-        let scope = self.bindings.implicit.len();
-        Bindings::bind_implicit_substitution(self, context, substitution)?;
+        let Some(mut variable) = self.bindings.lookup(key) else { return Ok(None) };
+
+        if self.bindings.renamings.is_empty() {
+            return Ok(Some(variable));
+        }
+
+        for renaming in Vec::clone(&self.bindings.renamings) {
+            variable.kind = renaming.substitute(self, context, variable.kind)?;
+            if let Some(name) = renaming.replacement_name(variable.name) {
+                variable.name = name;
+            }
+        }
+
+        Ok(Some(variable))
+    }
+
+    pub fn with_source_type_renaming<T>(
+        &mut self,
+        renaming: &Arc<RigidRenaming>,
+        f: impl FnOnce(&mut CheckState) -> QueryResult<T>,
+    ) -> QueryResult<T> {
+        self.bindings.renamings.push(Arc::clone(renaming));
         let result = f(self);
-        self.bindings.implicit.truncate(scope);
-        self.bindings.forall.truncate(forall_scope);
+        self.bindings.renamings.pop();
 
         result
     }

--- a/tests-integration/fixtures/checking/1785433380_source_type_variable_renaming/Main.purs
+++ b/tests-integration/fixtures/checking/1785433380_source_type_variable_renaming/Main.purs
@@ -1,0 +1,20 @@
+module Main where
+
+data Proxy :: forall k. k -> Type
+data Proxy value = Proxy
+
+identity :: forall @value. value -> value
+identity value = value
+
+class Grouped :: Type -> Type -> Constraint
+class Grouped left right where
+  grouped :: forall (value :: Type). Proxy value -> Proxy right -> Proxy value
+  ranked :: (forall (value :: Type). Proxy value -> Proxy value) -> Proxy right
+
+instance Grouped (function left) (function right) where
+  grouped :: forall (left :: Type). Proxy left -> Proxy (function right) -> Proxy left
+  grouped (value :: Proxy left) (_ :: Proxy (function right)) =
+    identity @(Proxy left) (value :: Proxy left)
+
+  ranked :: (forall (left :: Type). Proxy left -> Proxy left) -> Proxy (function right)
+  ranked (_ :: forall (left :: Type). Proxy left -> Proxy left) = Proxy

--- a/tests-integration/fixtures/checking/1785433380_source_type_variable_renaming/Main.snap
+++ b/tests-integration/fixtures/checking/1785433380_source_type_variable_renaming/Main.snap
@@ -1,0 +1,53 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Proxy ::
+  forall (k :: Prim.Type) (@value :: (k :: Prim.Type)).
+    Main.Proxy @(k :: Prim.Type) (value :: (k :: Prim.Type))
+identity :: forall (@value :: Prim.Type). (value :: Prim.Type) -> (value :: Prim.Type)
+grouped ::
+  forall (@left :: Prim.Type) (@right :: Prim.Type).
+    Main.Grouped (left :: Prim.Type) (right :: Prim.Type) =>
+    (forall (value :: Prim.Type).
+      Main.Proxy @Prim.Type (value :: Prim.Type) ->
+      Main.Proxy @Prim.Type (right :: Prim.Type) ->
+      Main.Proxy @Prim.Type (value :: Prim.Type))
+ranked ::
+  forall (@left :: Prim.Type) (@right :: Prim.Type).
+    Main.Grouped (left :: Prim.Type) (right :: Prim.Type) =>
+    (forall (value :: Prim.Type).
+      Main.Proxy @Prim.Type (value :: Prim.Type) -> Main.Proxy @Prim.Type (value :: Prim.Type)) ->
+    Main.Proxy @Prim.Type (right :: Prim.Type)
+
+Types
+Proxy :: forall (k :: Prim.Type). (k :: Prim.Type) -> Prim.Type
+Grouped :: Prim.Type -> Prim.Type -> Prim.Constraint
+
+Classes
+class forall (left :: Prim.Type) (right :: Prim.Type). Main.Grouped (left :: Prim.Type) (right :: Prim.Type)
+  grouped ::
+  forall (@left :: Prim.Type) (@right :: Prim.Type).
+    Main.Grouped (left :: Prim.Type) (right :: Prim.Type) =>
+    (forall (value :: Prim.Type).
+      Main.Proxy @Prim.Type (value :: Prim.Type) ->
+      Main.Proxy @Prim.Type (right :: Prim.Type) ->
+      Main.Proxy @Prim.Type (value :: Prim.Type))
+  ranked ::
+  forall (@left :: Prim.Type) (@right :: Prim.Type).
+    Main.Grouped (left :: Prim.Type) (right :: Prim.Type) =>
+    (forall (value1 :: Prim.Type).
+      Main.Proxy @Prim.Type (value1 :: Prim.Type) -> Main.Proxy @Prim.Type (value1 :: Prim.Type)) ->
+    Main.Proxy @Prim.Type (right :: Prim.Type)
+
+Instances
+instance forall (t0 :: Prim.Type) (function :: (t0 :: Prim.Type) -> Prim.Type) (left :: (t0 :: Prim.Type))
+  (right :: (t0 :: Prim.Type)).
+  Main.Grouped
+    ((function :: (t0 :: Prim.Type) -> Prim.Type) (left :: (t0 :: Prim.Type)))
+    ((function :: (t0 :: Prim.Type) -> Prim.Type) (right :: (t0 :: Prim.Type)))
+
+Roles
+Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1785435780_dependent_kind_source_type_variable_renaming/Main.purs
+++ b/tests-integration/fixtures/checking/1785435780_dependent_kind_source_type_variable_renaming/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+data Proxy :: forall kind. kind -> Type
+data Proxy value = Proxy
+
+class Dependent :: forall kind. kind -> Constraint
+class Dependent value where
+  dependent :: Proxy value
+
+instance Dependent value where
+  dependent :: Proxy value
+  dependent = Proxy :: Proxy value

--- a/tests-integration/fixtures/checking/1785435780_dependent_kind_source_type_variable_renaming/Main.snap
+++ b/tests-integration/fixtures/checking/1785435780_dependent_kind_source_type_variable_renaming/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Proxy ::
+  forall (kind :: Prim.Type) (@value :: (kind :: Prim.Type)).
+    Main.Proxy @(kind :: Prim.Type) (value :: (kind :: Prim.Type))
+dependent ::
+  forall (kind :: Prim.Type) (@value :: (kind :: Prim.Type)).
+    Main.Dependent @(kind :: Prim.Type) (value :: (kind :: Prim.Type)) =>
+    Main.Proxy @(kind :: Prim.Type) (value :: (kind :: Prim.Type))
+
+Types
+Proxy :: forall (kind :: Prim.Type). (kind :: Prim.Type) -> Prim.Type
+Dependent :: forall (kind :: Prim.Type). (kind :: Prim.Type) -> Prim.Constraint
+
+Classes
+class forall (kind :: Prim.Type) (value :: (kind :: Prim.Type)). Main.Dependent @(kind :: Prim.Type) (value :: (kind :: Prim.Type))
+  dependent ::
+  forall (kind :: Prim.Type) (@value :: (kind :: Prim.Type)).
+    Main.Dependent @(kind :: Prim.Type) (value :: (kind :: Prim.Type)) =>
+    Main.Proxy @(kind :: Prim.Type) (value :: (kind :: Prim.Type))
+
+Instances
+instance forall (t0 :: Prim.Type) (value :: (t0 :: Prim.Type)).
+  Main.Dependent @(t0 :: Prim.Type) (value :: (t0 :: Prim.Type))
+
+Roles
+Proxy = [Phantom]

--- a/tests-integration/fixtures/checking/1785435780_nested_source_type_variable_renaming/Main.purs
+++ b/tests-integration/fixtures/checking/1785435780_nested_source_type_variable_renaming/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+data Proxy :: forall kind. kind -> Type
+data Proxy value = Proxy
+
+class Grouped :: Type -> Type -> Constraint
+class Grouped left right where
+  grouped :: forall (value :: Type). Proxy value -> Proxy right -> Proxy value
+
+instance Grouped (function left) (function right) where
+  grouped :: forall (left :: Type). Proxy left -> Proxy (function right) -> Proxy left
+  grouped (value :: Proxy left) (_ :: Proxy (function right)) =
+    let
+      local :: forall (left :: Type). Proxy left -> Proxy (function right) -> Proxy left
+      local (localValue :: Proxy left) (_ :: Proxy (function right)) =
+        localValue :: Proxy left
+    in
+      local value Proxy :: Proxy left

--- a/tests-integration/fixtures/checking/1785435780_nested_source_type_variable_renaming/Main.snap
+++ b/tests-integration/fixtures/checking/1785435780_nested_source_type_variable_renaming/Main.snap
@@ -1,0 +1,40 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Proxy ::
+  forall (kind :: Prim.Type) (@value :: (kind :: Prim.Type)).
+    Main.Proxy @(kind :: Prim.Type) (value :: (kind :: Prim.Type))
+grouped ::
+  forall (@left :: Prim.Type) (@right :: Prim.Type).
+    Main.Grouped (left :: Prim.Type) (right :: Prim.Type) =>
+    (forall (value :: Prim.Type).
+      Main.Proxy @Prim.Type (value :: Prim.Type) ->
+      Main.Proxy @Prim.Type (right :: Prim.Type) ->
+      Main.Proxy @Prim.Type (value :: Prim.Type))
+
+Types
+Proxy :: forall (kind :: Prim.Type). (kind :: Prim.Type) -> Prim.Type
+Grouped :: Prim.Type -> Prim.Type -> Prim.Constraint
+
+Classes
+class forall (left :: Prim.Type) (right :: Prim.Type). Main.Grouped (left :: Prim.Type) (right :: Prim.Type)
+  grouped ::
+  forall (@left :: Prim.Type) (@right :: Prim.Type).
+    Main.Grouped (left :: Prim.Type) (right :: Prim.Type) =>
+    (forall (value :: Prim.Type).
+      Main.Proxy @Prim.Type (value :: Prim.Type) ->
+      Main.Proxy @Prim.Type (right :: Prim.Type) ->
+      Main.Proxy @Prim.Type (value :: Prim.Type))
+
+Instances
+instance forall (t0 :: Prim.Type) (function :: (t0 :: Prim.Type) -> Prim.Type) (left :: (t0 :: Prim.Type))
+  (right :: (t0 :: Prim.Type)).
+  Main.Grouped
+    ((function :: (t0 :: Prim.Type) -> Prim.Type) (left :: (t0 :: Prim.Type)))
+    ((function :: (t0 :: Prim.Type) -> Prim.Type) (right :: (t0 :: Prim.Type)))
+
+Roles
+Proxy = [Phantom]


### PR DESCRIPTION
## Motivation

Source type-variable checking currently stores explicit forall and implicit variables in separate append-only vectors. Scoped freshening duplicates source-key entries into both vectors, relies on reverse lookup to select the newest entry, and truncates them through an API named `with_implicit` even though it redirects both binding kinds.

This makes the source-to-semantic environment harder to reason about than the compiler's globally unique, name-based rigid-variable model requires.

## Changes

- Unify explicit and implicit source keys behind a checker-private `SourceTypeVariableKey` and one stable-key map.
- Replace duplicate scoped entries with ordered `with_source_type_renaming` frames keyed by semantic `Name`.
- Add a rigid-only `RigidRenaming` representation and share completed renamings through `Arc`.
- Preserve left-to-right substitution of dependent binder kinds and reconstruct source rigid references at the current checking depth.
- Record implicit source display names in `checked.names` when their rigid variables are created, instead of tying metadata lifetime to temporary binding entries.
- Add separate checking fixtures for grouped and shadowed variables, dependent-kind body annotations, and three nested renaming frames.

`Name` remains the semantic identity of `Type::Rigid`; `Depth` remains non-identity safety metadata. The change introduces no indices, shifting, offsets, environment-position identity, or scope-size arithmetic.

## Validation

- `just format`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (30 passed)
- `just integration` (569 passed)
- `git diff --check`