### PR TITLE
[checking] Generate Traversable derived members

### DIFF
--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -780,6 +780,12 @@ pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
     pub map: Option<(FileId, TermItemId)>,
     pub bimap: Option<(FileId, TermItemId)>,
+    pub pure: Option<(FileId, TermItemId)>,
+    pub apply: Option<(FileId, TermItemId)>,
+    pub traverse: Option<(FileId, TermItemId)>,
+    pub sequence: Option<(FileId, TermItemId)>,
+    pub bitraverse: Option<(FileId, TermItemId)>,
+    pub bisequence: Option<(FileId, TermItemId)>,
     pub eq: Option<(FileId, TermItemId)>,
     pub eq1: Option<(FileId, TermItemId)>,
     pub compare: Option<(FileId, TermItemId)>,
@@ -794,6 +800,12 @@ impl KnownTermsCore {
         let otherwise = fetch_known_term(queries, "Data.Boolean", "otherwise")?;
         let map = fetch_known_term(queries, "Data.Functor", "map")?;
         let bimap = fetch_known_term(queries, "Data.Bifunctor", "bimap")?;
+        let pure = fetch_known_term(queries, "Control.Applicative", "pure")?;
+        let apply = fetch_known_term(queries, "Control.Apply", "apply")?;
+        let traverse = fetch_known_term(queries, "Data.Traversable", "traverse")?;
+        let sequence = fetch_known_term(queries, "Data.Traversable", "sequence")?;
+        let bitraverse = fetch_known_term(queries, "Data.Bitraversable", "bitraverse")?;
+        let bisequence = fetch_known_term(queries, "Data.Bitraversable", "bisequence")?;
         let eq = fetch_known_term(queries, "Data.Eq", "eq")?;
         let eq1 = fetch_known_term(queries, "Data.Eq", "eq1")?;
         let compare = fetch_known_term(queries, "Data.Ord", "compare")?;
@@ -805,6 +817,12 @@ impl KnownTermsCore {
             otherwise,
             map,
             bimap,
+            pure,
+            apply,
+            traverse,
+            sequence,
+            bitraverse,
+            bisequence,
             eq,
             eq1,
             compare,

--- a/compiler-core/checking/src/source/derive/contravariant.rs
+++ b/compiler-core/checking/src/source/derive/contravariant.rs
@@ -9,7 +9,7 @@ use crate::error::ErrorKind;
 use crate::state::CheckState;
 
 use super::DeriveStrategy;
-use super::variance::{ParameterConfig, Variance, VarianceConfig};
+use super::variance::{FunctionPolicy, ParameterConfig, Variance, VarianceConfig};
 
 pub fn check_derive_contravariant<Q>(
     state: &mut CheckState,
@@ -41,8 +41,9 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Contravariant,
         unary_class: Some((class_file, class_id)),
+        function_policy: FunctionPolicy::Allow,
     };
-    let config = VarianceConfig::Single(parameter);
+    let config = VarianceConfig::Single { parameter, binary_class: None };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,
@@ -82,8 +83,16 @@ where
     let contravariant = context.known_types.contravariant;
     let functor = context.known_types.functor;
     let config = VarianceConfig::Pair {
-        first: ParameterConfig { variance: Variance::Contravariant, unary_class: contravariant },
-        second: ParameterConfig { variance: Variance::Covariant, unary_class: functor },
+        first: ParameterConfig {
+            variance: Variance::Contravariant,
+            unary_class: contravariant,
+            function_policy: FunctionPolicy::Allow,
+        },
+        second: ParameterConfig {
+            variance: Variance::Covariant,
+            unary_class: functor,
+            function_policy: FunctionPolicy::Allow,
+        },
         binary_class: None,
     };
 

--- a/compiler-core/checking/src/source/derive/foldable.rs
+++ b/compiler-core/checking/src/source/derive/foldable.rs
@@ -9,7 +9,7 @@ use crate::error::ErrorKind;
 use crate::state::CheckState;
 
 use super::DeriveStrategy;
-use super::variance::{ParameterConfig, Variance, VarianceConfig};
+use super::variance::{FunctionPolicy, ParameterConfig, Variance, VarianceConfig};
 
 pub fn check_derive_foldable<Q>(
     state: &mut CheckState,
@@ -41,8 +41,9 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: Some((class_file, class_id)),
+        function_policy: FunctionPolicy::Allow,
     };
-    let config = VarianceConfig::Single(parameter);
+    let config = VarianceConfig::Single { parameter, binary_class: None };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,
@@ -82,6 +83,7 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: context.known_types.foldable,
+        function_policy: FunctionPolicy::Allow,
     };
     let config = VarianceConfig::Pair { first: parameter, second: parameter, binary_class: None };
 

--- a/compiler-core/checking/src/source/derive/functor.rs
+++ b/compiler-core/checking/src/source/derive/functor.rs
@@ -9,7 +9,7 @@ use crate::error::ErrorKind;
 use crate::state::CheckState;
 
 use super::DeriveStrategy;
-use super::variance::{ParameterConfig, Variance, VarianceConfig};
+use super::variance::{FunctionPolicy, ParameterConfig, Variance, VarianceConfig};
 
 pub fn check_derive_functor<Q>(
     state: &mut CheckState,
@@ -41,8 +41,9 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: Some((class_file, class_id)),
+        function_policy: FunctionPolicy::Allow,
     };
-    let config = VarianceConfig::Single(parameter);
+    let config = VarianceConfig::Single { parameter, binary_class: None };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,
@@ -79,8 +80,11 @@ where
         return Ok(None);
     };
 
-    let parameter =
-        ParameterConfig { variance: Variance::Covariant, unary_class: context.known_types.functor };
+    let parameter = ParameterConfig {
+        variance: Variance::Covariant,
+        unary_class: context.known_types.functor,
+        function_policy: FunctionPolicy::Allow,
+    };
     let config = VarianceConfig::Pair {
         first: parameter,
         second: parameter,

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -18,6 +18,7 @@ use super::{DeriveDispatch, DeriveHeadResult, DeriveStrategy, derive_dispatch};
 
 mod eq_ord;
 mod functor;
+mod traversable;
 
 pub(crate) fn generate_instance<Q>(
     state: &mut CheckState,
@@ -39,7 +40,9 @@ where
         | DeriveDispatch::Ord
         | DeriveDispatch::Ord1
         | DeriveDispatch::Functor
-        | DeriveDispatch::Bifunctor => {
+        | DeriveDispatch::Bifunctor
+        | DeriveDispatch::Traversable
+        | DeriveDispatch::Bitraversable => {
             generate_known_instance(state, context, result, dispatch, variance_recipe)
         }
         _ => Ok(None),
@@ -143,9 +146,11 @@ where
             &freshened.arguments,
         )?;
 
-        let member = match dispatch {
+        let members = match dispatch {
             DeriveDispatch::Eq => {
                 eq_ord::generate_eq_member(state, context, result, &freshened.arguments)?
+                    .into_iter()
+                    .collect()
             }
             DeriveDispatch::Eq1 => generate_delegated_member(
                 state,
@@ -153,9 +158,13 @@ where
                 result,
                 &freshened.arguments,
                 context.known_terms.eq,
-            )?,
+            )?
+            .into_iter()
+            .collect(),
             DeriveDispatch::Ord => {
                 eq_ord::generate_ord_member(state, context, result, &freshened.arguments)?
+                    .into_iter()
+                    .collect()
             }
             DeriveDispatch::Ord1 => generate_delegated_member(
                 state,
@@ -163,7 +172,9 @@ where
                 result,
                 &freshened.arguments,
                 context.known_terms.compare,
-            )?,
+            )?
+            .into_iter()
+            .collect(),
             DeriveDispatch::Functor | DeriveDispatch::Bifunctor => {
                 let Some(recipe) = variance_recipe else { return Ok(None) };
                 let traversal = match dispatch {
@@ -179,20 +190,42 @@ where
                     recipe,
                     traversal,
                 )?
+                .into_iter()
+                .collect()
             }
-            _ => None,
+            DeriveDispatch::Traversable | DeriveDispatch::Bitraversable => {
+                let Some(recipe) = variance_recipe else { return Ok(None) };
+                let traversal = match dispatch {
+                    DeriveDispatch::Traversable => traversable::TraversalKind::Traversable,
+                    DeriveDispatch::Bitraversable => traversable::TraversalKind::Bitraversable,
+                    _ => unreachable!(),
+                };
+                let Some(members) = traversable::generate_traversal_members(
+                    state,
+                    context,
+                    result,
+                    &freshened.arguments,
+                    recipe,
+                    traversal,
+                )?
+                else {
+                    return Ok(None);
+                };
+                members
+            }
+            _ => vec![],
         };
 
-        let Some(member) = member else {
+        if members.is_empty() {
             return Ok(None);
-        };
+        }
 
         let instance = tree::InstanceDeclaration {
             class: (result.class_file, result.class_id),
             rigid_parameters: Arc::from(freshened.rigids),
             evidences: Arc::from(evidences),
             superclasses: Arc::from(superclasses),
-            implementation: tree::InstanceImplementation::Members(Arc::from([member])),
+            implementation: tree::InstanceImplementation::Members(Arc::from(members)),
         };
         let declaration = tree::TermDeclaration {
             type_id: result.signature,
@@ -229,6 +262,30 @@ where
 
     let file_id = result.class_file;
     let item_id = member.item_id;
+    let Some(implementation_type) = instantiate_class_member_type(
+        state,
+        context,
+        (file_id, item_id),
+        (result.class_file, result.class_id),
+        instance_arguments,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedMember { file_id, item_id, implementation_type }))
+}
+
+pub(super) fn resolve_known_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    (file_id, item_id): (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<ResolvedMember>>
+where
+    Q: ExternalQueries,
+{
     let Some(implementation_type) = instantiate_class_member_type(
         state,
         context,

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -325,7 +325,7 @@ where
                 };
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::Map { argument } => {
+            TraversalOperation::UnaryApplication { argument } => {
                 // Map delegates traversal of a unary type constructor to its existing
                 // Functor instance. The generator only needs to produce the transformation
                 // that its map implementation applies to each contained value.
@@ -440,7 +440,7 @@ where
                 // Check the specialized result against the target established above.
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::Bimap { first, second } => {
+            TraversalOperation::BinaryApplication { first, second } => {
                 // Bimap lifts transformations through the first and second arguments of a
                 // binary type constructor. See `emit_bimap` for the staged construction.
                 self.emit_bimap(first, second.as_deref(), value, traversal)

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -1,0 +1,1097 @@
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use itertools::izip;
+use smol_str::format_smolstr;
+
+use crate::context::CheckContext;
+use crate::core::substitute::RigidRenaming;
+use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::evidence::Evidence;
+use crate::source::derive::builder::DerivedTreeBuilder;
+use crate::source::derive::field;
+use crate::source::derive::variance::{
+    ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, VarianceRecipe,
+};
+use crate::source::terms::ElaboratedExpression;
+use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+use super::{
+    DeriveHeadResult, DeriveStrategy, ResolvedMember, generated_member, resolve_known_member,
+};
+
+struct InstantiatedDataType {
+    type_id: TypeId,
+    constructor_arguments: Vec<KindOrType>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum TraversalKind {
+    Traversable,
+    Bitraversable,
+}
+
+#[derive(Clone, Copy)]
+enum Mappings<T> {
+    Traversable(T),
+    Bitraversable { first: T, second: T },
+}
+
+impl Mappings<ElaboratedExpression> {
+    fn mapping_for(self, parameter: TraversalParameter) -> Option<ElaboratedExpression> {
+        match (self, parameter) {
+            (Mappings::Traversable(function), TraversalParameter::First) => Some(function),
+            (Mappings::Bitraversable { first, .. }, TraversalParameter::First) => Some(first),
+            (Mappings::Bitraversable { second, .. }, TraversalParameter::Second) => Some(second),
+            (Mappings::Traversable(_), TraversalParameter::Second) => None,
+        }
+    }
+}
+
+struct DecodedTraversalMember {
+    member: ResolvedMember,
+    renaming: Arc<RigidRenaming>,
+    constraints: Vec<TypeId>,
+    implementation_type: TypeId,
+    function_type: TypeId,
+    mappings: Mappings<TypeId>,
+    effect: TypeId,
+    data_file: files::FileId,
+    source: InstantiatedDataType,
+    target: InstantiatedDataType,
+    result_type: TypeId,
+}
+
+impl DecodedTraversalMember {
+    fn decode<Q>(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        member: ResolvedMember,
+        data_file: files::FileId,
+        traversal: TraversalKind,
+    ) -> QueryResult<Option<DecodedTraversalMember>>
+    where
+        Q: ExternalQueries,
+    {
+        // Decode the operation member into its effectful transformations and
+        // structural source, together with its effect-wrapped structural target.
+        //
+        // List
+        //
+        //   data List a = Nil | Cons a (List a)
+        //
+        //   traverse :: (a -> m b) -> List a -> m (List b)
+        //
+        // Pair
+        //
+        //   data Pair a b = Pair a b
+        //
+        //   bitraverse ::
+        //     (a -> m c) -> (b -> m d) -> Pair a b -> m (Pair c d)
+        let argument_count = match traversal {
+            TraversalKind::Traversable => 2,
+            TraversalKind::Bitraversable => 3,
+        };
+        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+            signature::expect_term_signature(
+                state,
+                context,
+                member.implementation_type,
+                argument_count,
+            )?;
+
+        // Separate the transformations from the structural source.
+        //
+        // List
+        //
+        //   mappings = Traversable (a -> m b)
+        //   sourceType = List a
+        //
+        // Pair
+        //
+        //   mappings = Bitraversable (a -> m c) (b -> m d)
+        //   sourceType = Pair a b
+        let (source_type, mappings) = match (traversal, arguments.as_slice()) {
+            (TraversalKind::Traversable, [mapping, source]) => {
+                (*source, Mappings::Traversable(*mapping))
+            }
+            (TraversalKind::Bitraversable, [first, second, source]) => {
+                (*source, Mappings::Bitraversable { first: *first, second: *second })
+            }
+            _ => return Ok(None),
+        };
+
+        // Separate the applicative constructor from the structural target. Instantiate
+        // constructor fields against that target, not the effect-wrapped result.
+        //
+        // List
+        //
+        //   result = m (List b)
+        //   effect = m
+        //   targetType = List b
+        //
+        // Pair
+        //
+        //   result = m (Pair c d)
+        //   effect = m
+        //   targetType = Pair c d
+        let Some((effect, target_type)) =
+            toolkit::decompose_type_application(state, context, result)?
+        else {
+            return Ok(None);
+        };
+
+        // Retain the source and target arguments for constructor-field instantiation.
+        //
+        // List
+        //
+        //   sourceArguments = [a]
+        //   targetArguments = [b]
+        //
+        // Pair
+        //
+        //   sourceArguments = [a, b]
+        //   targetArguments = [c, d]
+        let (_, source_arguments) = toolkit::extract_all_applications(state, context, source_type)?;
+        let (_, target_arguments) = toolkit::extract_all_applications(state, context, target_type)?;
+        let function_arguments = arguments.iter().copied();
+        let function_type = context.intern_function_iter(function_arguments, result);
+
+        Ok(Some(DecodedTraversalMember {
+            implementation_type: member.implementation_type,
+            member,
+            renaming,
+            constraints,
+            function_type,
+            mappings,
+            effect,
+            data_file,
+            source: InstantiatedDataType {
+                type_id: source_type,
+                constructor_arguments: source_arguments,
+            },
+            target: InstantiatedDataType {
+                type_id: target_type,
+                constructor_arguments: target_arguments,
+            },
+            result_type: result,
+        }))
+    }
+}
+
+pub(super) fn generate_traversal_members<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    recipe: &VarianceRecipe,
+    traversal: TraversalKind,
+) -> QueryResult<Option<Vec<tree::InstanceMember>>>
+where
+    Q: ExternalQueries,
+{
+    let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+        return Ok(None);
+    };
+    let (operation, sequence) = match traversal {
+        TraversalKind::Traversable => (context.known_terms.traverse, context.known_terms.sequence),
+        TraversalKind::Bitraversable => {
+            (context.known_terms.bitraverse, context.known_terms.bisequence)
+        }
+    };
+    let (Some(operation), Some(sequence)) = (operation, sequence) else {
+        return Ok(None);
+    };
+
+    let Some(class) =
+        toolkit::lookup_file_class(state, context, result.class_file, result.class_id)?
+    else {
+        return Ok(None);
+    };
+
+    // Traversable and Bitraversable dictionaries require an operation and a sequence
+    // member. Resolve both by known identity because declaration order is not part
+    // of the class contract, and reject the dictionary if either one is absent.
+    let mut operation_generated = false;
+    let mut sequence_generated = false;
+    let mut members = Vec::with_capacity(class.members.len());
+    for class_member in &class.members {
+        let resolution = (result.class_file, class_member.item_id);
+        let member = if resolution == operation {
+            operation_generated = true;
+            generate_operation_member(
+                state,
+                context,
+                result,
+                instance_arguments,
+                data_file,
+                recipe,
+                traversal,
+                resolution,
+            )?
+        } else if resolution == sequence {
+            sequence_generated = true;
+            generate_sequence_member(
+                state,
+                context,
+                result,
+                instance_arguments,
+                traversal,
+                operation,
+                resolution,
+            )?
+        } else {
+            return Ok(None);
+        };
+        let Some(member) = member else {
+            return Ok(None);
+        };
+        members.push(member);
+    }
+
+    if !operation_generated || !sequence_generated {
+        return Ok(None);
+    }
+    Ok(Some(members))
+}
+
+fn generate_operation_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    data_file: files::FileId,
+    recipe: &VarianceRecipe,
+    traversal: TraversalKind,
+    resolution: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    state.with_implication(|state| {
+        let Some(member) =
+            resolve_known_member(state, context, result, instance_arguments, resolution)?
+        else {
+            return Ok(None);
+        };
+        let Some(member) =
+            DecodedTraversalMember::decode(state, context, member, data_file, traversal)?
+        else {
+            return Ok(None);
+        };
+
+        let mut evidences = Vec::with_capacity(member.constraints.len());
+        for &constraint in &member.constraints {
+            evidences.push(Evidence::Given(state.push_given(constraint)));
+        }
+
+        let body = state.with_source_type_renaming(&member.renaming, |state| {
+            emit_variance_traversal(state, context, result.derive_id, &member, recipe)
+        })?;
+        let Some(body) = body else { return Ok(None) };
+
+        Ok(Some(generated_member(
+            result.derive_id,
+            (member.member.file_id, member.member.item_id),
+            member.implementation_type,
+            evidences,
+            body,
+        )))
+    })
+}
+
+fn generate_sequence_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    traversal: TraversalKind,
+    operation: (files::FileId, indexing::TermItemId),
+    resolution: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    state.with_implication(|state| {
+        let Some(member) =
+            resolve_known_member(state, context, result, instance_arguments, resolution)?
+        else {
+            return Ok(None);
+        };
+        let signature::SkolemisedSignature { renaming, constraints, arguments, result: body_type } =
+            signature::expect_term_signature(state, context, member.implementation_type, 1)?;
+        let [source_type] = arguments.as_slice() else {
+            return Ok(None);
+        };
+
+        // Sequence delegates to the operation member with identity for each traversed
+        // parameter, avoiding a second structural traversal implementation.
+        //
+        // List
+        //
+        //   data List a = Nil | Cons a (List a)
+        //
+        //   sequence value = traverse identity value
+        //
+        // Pair
+        //
+        //   data Pair a b = Pair a b
+        //
+        //   bisequence value = bitraverse identity identity value
+        //
+        // Recover the instantiated parameter types from the source so each
+        // generated identity has the type expected by the operation member.
+        //
+        // List
+        //
+        //   sourceType    = List (m a)
+        //   identityTypes = [m a]
+        //
+        // Pair
+        //
+        //   sourceType    = Pair (m a) (m b)
+        //   identityTypes = [m a, m b]
+        let (_, source_arguments) =
+            toolkit::extract_all_applications(state, context, *source_type)?;
+        let identity_types = match (traversal, source_arguments.as_slice()) {
+            (TraversalKind::Traversable, [.., KindOrType::Type(effect)]) => vec![*effect],
+            (
+                TraversalKind::Bitraversable,
+                [.., KindOrType::Type(first), KindOrType::Type(second)],
+            ) => vec![*first, *second],
+            _ => return Ok(None),
+        };
+
+        let mut evidences = Vec::with_capacity(constraints.len());
+        for constraint in constraints {
+            evidences.push(Evidence::Given(state.push_given(constraint)));
+        }
+
+        let body = state.with_source_type_renaming(&renaming, |state| {
+            let mut builder = DerivedTreeBuilder::new(state, context, result.derive_id);
+            let value = builder.variable_binder("value", *source_type);
+            let value_expression = builder.variable(value);
+
+            // Apply the eta-expanded identities before the source value.
+            //
+            // List
+            //
+            //   traverse (\effect0 -> effect0) value
+            //
+            // Pair
+            //
+            //   bitraverse
+            //     (\effect0 -> effect0)
+            //     (\effect1 -> effect1)
+            //     value
+            let mut applied = builder.term_reference(operation)?;
+            for (index, identity_type) in identity_types.into_iter().enumerate() {
+                let name = format_smolstr!("effect{index}");
+                let input = builder.variable_binder(&name, identity_type);
+                let identity_value = builder.variable(input);
+                let identity_type = context.intern_function(identity_type, identity_type);
+                let identity = builder.lambda(identity_type, vec![input], identity_value);
+                let Some(application) = builder.apply(applied, identity)? else {
+                    return Ok(None);
+                };
+                applied = application;
+            }
+            let Some(applied) = builder.apply(applied, value_expression)? else {
+                return Ok(None);
+            };
+            let body = builder.subtype(applied, body_type)?;
+            let function_type = context.intern_function(*source_type, body_type);
+            Ok(Some(builder.lambda(function_type, vec![value], body)))
+        })?;
+        let Some(body) = body else { return Ok(None) };
+
+        Ok(Some(generated_member(
+            result.derive_id,
+            (member.file_id, member.item_id),
+            member.implementation_type,
+            evidences,
+            body,
+        )))
+    })
+}
+
+fn emit_variance_traversal<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    derive_id: indexing::DeriveId,
+    member: &DecodedTraversalMember,
+    recipe: &VarianceRecipe,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
+
+    let (mapping_binders, mapping_expressions) = match member.mappings {
+        Mappings::Traversable(mapping) => {
+            let function = builder.variable_binder("function", mapping);
+            let expression = builder.variable(function);
+            (vec![function], Mappings::Traversable(expression))
+        }
+        Mappings::Bitraversable { first, second } => {
+            let first = builder.variable_binder("firstFunction", first);
+            let second = builder.variable_binder("secondFunction", second);
+            let expressions = Mappings::Bitraversable {
+                first: builder.variable(first),
+                second: builder.variable(second),
+            };
+            (vec![first, second], expressions)
+        }
+    };
+    let value = builder.variable_binder("value", member.source.type_id);
+    let value_expression = builder.variable(value);
+
+    let mut alternatives = Vec::with_capacity(recipe.constructors.len());
+    for constructor in &recipe.constructors {
+        let Some(alternative) =
+            emit_traversal_alternative(&mut builder, member, constructor, mapping_expressions)?
+        else {
+            return Ok(None);
+        };
+        alternatives.push(alternative);
+    }
+
+    let body = builder.case(member.result_type, vec![value_expression], alternatives);
+    let mut binders = mapping_binders;
+    binders.push(value);
+    Ok(Some(builder.lambda(member.function_type, binders, body)))
+}
+
+fn emit_traversal_alternative<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    member: &DecodedTraversalMember,
+    constructor: &ConstructorRecipe,
+    mapping_expressions: Mappings<ElaboratedExpression>,
+) -> QueryResult<Option<tree::CaseAlternative>>
+where
+    Q: ExternalQueries,
+{
+    let constructor_type = toolkit::lookup_file_term(
+        builder.state,
+        builder.context,
+        member.data_file,
+        constructor.constructor_id,
+    )?;
+    let source_fields = field::instantiate_constructor_fields(
+        builder.state,
+        builder.context,
+        constructor_type,
+        &member.source.constructor_arguments,
+    )?;
+    let target_fields = field::instantiate_constructor_fields(
+        builder.state,
+        builder.context,
+        constructor_type,
+        &member.target.constructor_arguments,
+    )?;
+
+    if source_fields.len() != target_fields.len() || source_fields.len() != constructor.fields.len()
+    {
+        return Ok(None);
+    }
+
+    // Bind each source field and inspect its recipe. A field with a traversal
+    // operation is active and emits an effect; every other field remains fixed.
+    //
+    // List
+    //
+    //   data List a = Nil | Cons a (List a)
+    //
+    // Cons
+    //
+    //   head :: a
+    //   tail :: List a
+    //
+    //   headEffect = function head
+    //   tailEffect = traverse function tail
+    let mut emitter =
+        EffectTraversalEmitter { builder, mapping_expressions, effect: member.effect };
+    let mut source_binders = Vec::with_capacity(source_fields.len());
+    let mut reconstruction_values = Vec::with_capacity(source_fields.len());
+    let mut traversed_fields = Vec::with_capacity(source_fields.len());
+
+    for (index, (source, target, operation)) in
+        izip!(&source_fields, &target_fields, &constructor.fields).enumerate()
+    {
+        let source_binder =
+            emitter.builder.variable_binder(&format_smolstr!("field{index}"), *source);
+        let source_value = emitter.builder.variable(source_binder);
+        source_binders.push(source_binder);
+
+        if let Some(operation) = operation {
+            let traversal = TraversalContext { source_type: *source, target_type: *target };
+            let Some(effect) = emitter.emit_effect(operation, source_value, traversal)? else {
+                return Ok(None);
+            };
+            let result_binder =
+                emitter.builder.variable_binder(&format_smolstr!("field{index}Result"), *target);
+            reconstruction_values.push(emitter.builder.variable(result_binder));
+            traversed_fields.push((result_binder, effect));
+        } else {
+            reconstruction_values.push(source_value);
+        }
+    }
+
+    // Match the source constructor using the field binders allocated above.
+    //
+    // Nil
+    //
+    //   pattern = Nil
+    //
+    // Cons
+    //
+    //   pattern = Cons head tail
+    let pattern = emitter.builder.constructor_pattern(
+        "constructor",
+        member.source.type_id,
+        (member.data_file, constructor.constructor_id),
+        source_binders,
+    );
+
+    // Rebuild the target constructor. Applicative reconstruction supplies result
+    // binders for active fields; fixed fields reuse their source values directly.
+    //
+    // Nil
+    //
+    //   reconstructed = Nil
+    //
+    // Cons
+    //
+    //   reconstructed = Cons headResult tailResult
+    let mut reconstructed =
+        emitter.builder.term_reference((member.data_file, constructor.constructor_id))?;
+    for value in reconstruction_values {
+        let Some(applied) = emitter.builder.apply(reconstructed, value)? else {
+            return Ok(None);
+        };
+        reconstructed = applied;
+    }
+    let reconstructed = emitter.builder.subtype(reconstructed, member.target.type_id)?;
+
+    // Lift the reconstructed target over the field effects.
+    let Some(body) =
+        emitter.lift_reconstruction(member.target.type_id, traversed_fields, reconstructed)?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(emitter.builder.alternative(vec![pattern], body)))
+}
+
+#[derive(Clone, Copy)]
+struct TraversalContext {
+    source_type: TypeId,
+    target_type: TypeId,
+}
+
+struct EffectTraversalEmitter<'builder, 'state, 'context, 'queries, Q: ExternalQueries> {
+    builder: &'builder mut DerivedTreeBuilder<'state, 'context, 'queries, Q>,
+    mapping_expressions: Mappings<ElaboratedExpression>,
+    effect: TypeId,
+}
+
+impl<Q> EffectTraversalEmitter<'_, '_, '_, '_, Q>
+where
+    Q: ExternalQueries,
+{
+    fn emit_effect(
+        &mut self,
+        operation: &TraversalOperation,
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        match operation {
+            TraversalOperation::Parameter { parameter } => {
+                // A parameter is a traversal leaf whose function already introduces the
+                // applicative effect. Apply it directly to the constructor field.
+                //
+                // Identity
+                //
+                //   newtype Identity a = Identity a
+                //
+                //   field    :: a
+                //   target   :: b
+                //   function :: a -> m b
+                //
+                //   function field :: m b
+                let Some(mapping_expression) = self.mapping_expressions.mapping_for(*parameter)
+                else {
+                    return Ok(None);
+                };
+                let Some(mapped) = self.builder.apply(mapping_expression, value)? else {
+                    return Ok(None);
+                };
+                let effect_type = self.effect_type(traversal.target_type);
+                Ok(Some(self.builder.subtype(mapped, effect_type)?))
+            }
+            TraversalOperation::UnaryApplication { argument } => {
+                // Traverse delegates a unary type constructor to its Traversable instance.
+                // Supply the effectful transformation between its applied source and target.
+                //
+                // Compose
+                //
+                //   newtype Compose f g a = Compose (f (g a))
+                //
+                //   function :: a -> m b
+                //
+                //   field    :: f (g a)
+                //   target   :: f (g b)
+                let Some((_, source_argument)) = toolkit::decompose_type_application(
+                    self.builder.state,
+                    self.builder.context,
+                    traversal.source_type,
+                )?
+                else {
+                    return Ok(None);
+                };
+                let Some((_, target_argument)) = toolkit::decompose_type_application(
+                    self.builder.state,
+                    self.builder.context,
+                    traversal.target_type,
+                )?
+                else {
+                    return Ok(None);
+                };
+
+                // Generate the transformation for the delegated traverse call. Its argument
+                // operation recursively traverses the inner `g` application.
+                //
+                // Compose
+                //
+                //   sourceArgument :: g a
+                //   targetArgument :: g b
+                //
+                //   transformer :: g a -> m (g b)
+                //   transformer = \element -> traverse function element
+                let argument_context =
+                    TraversalContext { source_type: source_argument, target_type: target_argument };
+                let Some(transformer) = self.emit_transformer(argument, argument_context)? else {
+                    return Ok(None);
+                };
+
+                // Applying the transformer fixes the element types. Applying the field fixes
+                // the fresh constructor variable to `f`, specializing its wanted evidence.
+                //
+                //   traverse ::
+                //     forall t a b m.
+                //     Traversable t => Applicative m =>
+                //     (a -> m b) -> t a -> m (t b)
+                //
+                //   ?t := f
+                //
+                //   traverse transformer field :: m (f (g b))
+                let Some(traverse) = self.builder.context.known_terms.traverse else {
+                    return Ok(None);
+                };
+                let traverse = self.builder.term_reference(traverse)?;
+                let Some(traverse) = self.builder.apply(traverse, transformer)? else {
+                    return Ok(None);
+                };
+                let Some(traversed) = self.builder.apply(traverse, value)? else {
+                    return Ok(None);
+                };
+                let effect_type = self.effect_type(traversal.target_type);
+                Ok(Some(self.builder.subtype(traversed, effect_type)?))
+            }
+            TraversalOperation::BinaryApplication { first, second } => {
+                // Bitraverse delegates both arguments of a binary type constructor. See
+                // `emit_binary_effect` for the staged construction of its transformers.
+                self.emit_binary_effect(first, second.as_deref(), value, traversal)
+            }
+            TraversalOperation::Record { fields } => {
+                // Record traversal combines the effects of its active field updates.
+                // See `emit_record_effect` for applicative reconstruction.
+                self.emit_record_effect(fields, value, traversal)
+            }
+            // Function operations are rejected during variance analysis.
+            TraversalOperation::Function { .. } => Ok(None),
+        }
+    }
+
+    fn emit_transformer(
+        &mut self,
+        operation: &TraversalOperation,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // Traverse and bitraverse need effectful transformations for contained values.
+        // Bind one source value, emit its effect, and return the resulting lambda.
+        //
+        //   source  :: a
+        //   target  :: b
+        //   element :: a
+        //
+        //   body :: m b
+        //   body = emit_effect operation element
+        //
+        //   transformer :: a -> m b
+        //   transformer = \element -> body
+        let input = self.builder.variable_binder("element", traversal.source_type);
+        let value = self.builder.variable(input);
+        let Some(body) = self.emit_effect(operation, value, traversal)? else {
+            return Ok(None);
+        };
+
+        let effect_type = self.effect_type(traversal.target_type);
+        let function_type =
+            self.builder.context.intern_function(traversal.source_type, effect_type);
+        Ok(Some(self.builder.lambda(function_type, vec![input], body)))
+    }
+
+    fn emit_binary_effect(
+        &mut self,
+        first: &TraversalOperation,
+        second: Option<&TraversalOperation>,
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // Decompose both arguments of the binary type application.
+        //
+        //   function :: a -> m b
+        //
+        // Duplicate
+        //
+        //   newtype Duplicate p a = Duplicate (p a a)
+        //
+        //   source :: p a a
+        //   target :: p b b
+        //
+        // LeftDuplicate
+        //
+        //   newtype LeftDuplicate p a = LeftDuplicate (p a Int)
+        //
+        //   source :: p a Int
+        //   target :: p b Int
+        let Some((source_function, source_second)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            traversal.source_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((_, source_first)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            source_function,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((target_function, target_second)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            traversal.target_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((_, target_first)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            target_function,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        // Generate the effectful transformation for the first argument.
+        //
+        // Duplicate and LeftDuplicate
+        //
+        //   firstTransformer :: a -> m b
+        //   firstTransformer = function
+        let first_context =
+            TraversalContext { source_type: source_first, target_type: target_first };
+        let Some(first_transformer) = self.emit_transformer(first, first_context)? else {
+            return Ok(None);
+        };
+
+        // Generate the effectful transformation for the second argument. If the
+        // derived parameter is absent there, lift the unchanged value with pure.
+        //
+        // Duplicate
+        //
+        //   secondTransformer :: a -> m b
+        //   secondTransformer = function
+        //
+        // LeftDuplicate
+        //
+        //   secondTransformer :: Int -> m Int
+        //   secondTransformer = \unchanged -> pure unchanged
+        let second_context =
+            TraversalContext { source_type: source_second, target_type: target_second };
+        let second_transformer = match second {
+            Some(second) => {
+                let Some(transformer) = self.emit_transformer(second, second_context)? else {
+                    return Ok(None);
+                };
+                transformer
+            }
+            None => {
+                let Some(transformer) = self.emit_pure_transformer(second_context)? else {
+                    return Ok(None);
+                };
+                transformer
+            }
+        };
+
+        // Specialize bitraverse through its transformers and source field.
+        //
+        // Duplicate
+        //
+        //   bitraverse firstTransformer secondTransformer field :: m (p b b)
+        //
+        // LeftDuplicate
+        //
+        //   bitraverse firstTransformer secondTransformer field :: m (p b Int)
+        let Some(bitraverse) = self.builder.context.known_terms.bitraverse else {
+            return Ok(None);
+        };
+        let bitraverse = self.builder.term_reference(bitraverse)?;
+        let Some(bitraverse) = self.builder.apply(bitraverse, first_transformer)? else {
+            return Ok(None);
+        };
+        let Some(bitraverse) = self.builder.apply(bitraverse, second_transformer)? else {
+            return Ok(None);
+        };
+        let Some(traversed) = self.builder.apply(bitraverse, value)? else {
+            return Ok(None);
+        };
+        let effect_type = self.effect_type(traversal.target_type);
+        Ok(Some(self.builder.subtype(traversed, effect_type)?))
+    }
+
+    fn emit_pure_transformer(
+        &mut self,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // A binary argument has no operation when it omits the derived parameter.
+        // Bitraverse still needs an effectful transformer, so lift its value with pure.
+        //
+        // LeftDuplicate
+        //
+        //   sourceSecond :: Int
+        //   targetSecond :: Int
+        //
+        //   transformer :: Int -> m Int
+        //   transformer = \unchanged -> pure unchanged
+        let input = self.builder.variable_binder("unchanged", traversal.source_type);
+        let value = self.builder.variable(input);
+        let value = self.builder.subtype(value, traversal.target_type)?;
+        let Some(pure) = self.emit_pure(value, traversal.target_type)? else {
+            return Ok(None);
+        };
+        let effect_type = self.effect_type(traversal.target_type);
+        let function_type =
+            self.builder.context.intern_function(traversal.source_type, effect_type);
+        Ok(Some(self.builder.lambda(function_type, vec![input], pure)))
+    }
+
+    fn emit_record_effect(
+        &mut self,
+        fields: &[RecordFieldRecipe],
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // Recover the source and target rows used to type each access and update.
+        //
+        // Record
+        //
+        //   newtype Record a = Record { zeta :: a, fixed :: Int, alpha :: a }
+        //
+        //   function :: a -> m b
+        //
+        //   source :: { zeta :: a, fixed :: Int, alpha :: a }
+        //   target :: { zeta :: b, fixed :: Int, alpha :: b }
+        let Some(source_row) =
+            extract_record_row(self.builder.state, self.builder.context, traversal.source_type)?
+        else {
+            return Ok(None);
+        };
+        let Some(target_row) =
+            extract_record_row(self.builder.state, self.builder.context, traversal.target_type)?
+        else {
+            return Ok(None);
+        };
+
+        // The recipe lists active fields in canonical row order. Pair each field effect
+        // with a result binder; fields absent from the recipe remain unchanged.
+        //
+        // Record
+        //
+        //   alphaEffect = function source.alpha
+        //   zetaEffect = function source.zeta
+        let mut updates = Vec::with_capacity(fields.len());
+        let mut traversed_fields = Vec::with_capacity(fields.len());
+        for (index, field) in fields.iter().enumerate() {
+            let Some(source_field) = source_row.fields.iter().find(|row| row.label == field.label)
+            else {
+                return Ok(None);
+            };
+            let Some(target_field) = target_row.fields.iter().find(|row| row.label == field.label)
+            else {
+                return Ok(None);
+            };
+            let accessed = self.builder.record_access(value, field.label.clone(), source_field.id);
+            let field_context =
+                TraversalContext { source_type: source_field.id, target_type: target_field.id };
+            let Some(effect) = self.emit_effect(&field.operation, accessed, field_context)? else {
+                return Ok(None);
+            };
+            let binder = self
+                .builder
+                .variable_binder(&format_smolstr!("recordField{index}"), target_field.id);
+            let expression = self.builder.variable(binder);
+            updates.push(tree::RecordExpressionUpdate::Leaf {
+                label: field.label.clone(),
+                expression: expression.expression,
+            });
+            traversed_fields.push((binder, effect));
+        }
+
+        // Rebuild the target record from the active result binders. Applicative
+        // reconstruction supplies those binders in the same order as their effects.
+        //
+        // Record
+        //
+        //   reconstructed =
+        //     source { alpha = alphaResult, zeta = zetaResult }
+        let reconstructed = self.builder.record_update(value, updates, traversal.target_type);
+        self.lift_reconstruction(traversal.target_type, traversed_fields, reconstructed)
+    }
+
+    fn lift_reconstruction(
+        &mut self,
+        target_type: TypeId,
+        traversed_fields: Vec<(tree::BinderId, ElaboratedExpression)>,
+        reconstructed: ElaboratedExpression,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // Lift constructor or record reconstruction over its field effects. With no
+        // active fields, lift the reconstruction directly with pure.
+        //
+        // List
+        //
+        //   data List a = Nil | Cons a (List a)
+        //
+        // Nil
+        //
+        //   reconstructed = Nil
+        //   traversedFields = []
+        //
+        //   pure Nil :: m (List b)
+        let mut traversed_fields = traversed_fields.into_iter();
+        let Some((first_binder, first_effect)) = traversed_fields.next() else {
+            return self.emit_pure(reconstructed, target_type);
+        };
+
+        // Separate the result binders from the remaining effects. Preserve each
+        // binder's association with its effect and their shared order.
+        //
+        // Cons
+        //
+        //   headEffect :: m b
+        //   headEffect = function head
+        //
+        //   tailEffect :: m (List b)
+        //   tailEffect = traverse function tail
+        let mut binders = vec![first_binder];
+        let mut remaining_effects = Vec::new();
+        for (binder, effect) in traversed_fields {
+            binders.push(binder);
+            remaining_effects.push(effect);
+        }
+
+        // Abstract the reconstructed target over its active result binders.
+        //
+        // Cons
+        //
+        //   reconstruction :: b -> List b -> List b
+        //   reconstruction = \headResult tailResult -> Cons headResult tailResult
+        let binder_types =
+            binders.iter().map(|binder| self.builder.state.checked.tree[*binder].type_id);
+        let reconstruction_type =
+            self.builder.context.intern_function_iter(binder_types, target_type);
+        let reconstruction = self.builder.lambda(reconstruction_type, binders, reconstructed);
+
+        // Introduce the first effect by mapping the reconstruction function over it.
+        //
+        // Cons
+        //
+        //   reconstruction <$> headEffect :: m (List b -> List b)
+        let Some(map) = self.builder.context.known_terms.map else {
+            return Ok(None);
+        };
+        let map = self.builder.term_reference(map)?;
+        let Some(map) = self.builder.apply(map, reconstruction)? else {
+            return Ok(None);
+        };
+        let Some(mut accumulated) = self.builder.apply(map, first_effect)? else {
+            return Ok(None);
+        };
+
+        // Apply remaining effects from left to right in their established order.
+        //
+        // Cons
+        //
+        //   reconstruction <$> headEffect <*> tailEffect :: m (List b)
+        for effect in remaining_effects {
+            let Some(apply) = self.builder.context.known_terms.apply else {
+                return Ok(None);
+            };
+            let apply = self.builder.term_reference(apply)?;
+            let Some(apply) = self.builder.apply(apply, accumulated)? else {
+                return Ok(None);
+            };
+            let Some(applied) = self.builder.apply(apply, effect)? else {
+                return Ok(None);
+            };
+            accumulated = applied;
+        }
+
+        let effect_type = self.effect_type(target_type);
+        Ok(Some(self.builder.subtype(accumulated, effect_type)?))
+    }
+
+    fn emit_pure(
+        &mut self,
+        value: ElaboratedExpression,
+        target_type: TypeId,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some(pure) = self.builder.context.known_terms.pure else {
+            return Ok(None);
+        };
+        let pure = self.builder.term_reference(pure)?;
+        let Some(pure) = self.builder.apply(pure, value)? else {
+            return Ok(None);
+        };
+        let effect_type = self.effect_type(target_type);
+        Ok(Some(self.builder.subtype(pure, effect_type)?))
+    }
+
+    fn effect_type(&self, target_type: TypeId) -> TypeId {
+        self.builder.context.intern_application(self.effect, target_type)
+    }
+}
+
+fn extract_record_row<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    type_id: TypeId,
+) -> QueryResult<Option<RowType>>
+where
+    Q: ExternalQueries,
+{
+    let Some((_, row)) = toolkit::decompose_type_application(state, context, type_id)? else {
+        return Ok(None);
+    };
+    let row = normalise::expand(state, context, row)?;
+    let Type::Row(row) = context.lookup_type(row) else {
+        return Ok(None);
+    };
+    Ok(Some(context.lookup_row_type(row)))
+}

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -98,7 +98,10 @@ where
             )?;
             if matches!(
                 derive_dispatch(context, result.class_file, result.class_id),
-                DeriveDispatch::Functor | DeriveDispatch::Bifunctor
+                DeriveDispatch::Functor
+                    | DeriveDispatch::Bifunctor
+                    | DeriveDispatch::Traversable
+                    | DeriveDispatch::Bitraversable
             ) && recipe.valid
             {
                 variance_recipe = Some(recipe);

--- a/compiler-core/checking/src/source/derive/traversable.rs
+++ b/compiler-core/checking/src/source/derive/traversable.rs
@@ -9,7 +9,7 @@ use crate::error::ErrorKind;
 use crate::state::CheckState;
 
 use super::DeriveStrategy;
-use super::variance::{ParameterConfig, Variance, VarianceConfig};
+use super::variance::{FunctionPolicy, ParameterConfig, Variance, VarianceConfig};
 
 pub fn check_derive_traversable<Q>(
     state: &mut CheckState,
@@ -41,8 +41,10 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: Some((class_file, class_id)),
+        function_policy: FunctionPolicy::Reject,
     };
-    let config = VarianceConfig::Single(parameter);
+    let config =
+        VarianceConfig::Single { parameter, binary_class: context.known_types.bitraversable };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,
@@ -82,8 +84,13 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: context.known_types.traversable,
+        function_policy: FunctionPolicy::Reject,
     };
-    let config = VarianceConfig::Pair { first: parameter, second: parameter, binary_class: None };
+    let config = VarianceConfig::Pair {
+        first: parameter,
+        second: parameter,
+        binary_class: Some((class_file, class_id)),
+    };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,

--- a/compiler-core/checking/src/source/derive/variance.rs
+++ b/compiler-core/checking/src/source/derive/variance.rs
@@ -30,14 +30,21 @@ impl Variance {
 type ClassReference = (FileId, TypeItemId);
 
 #[derive(Clone, Copy)]
+pub(in crate::source) enum FunctionPolicy {
+    Allow,
+    Reject,
+}
+
+#[derive(Clone, Copy)]
 pub(in crate::source) struct ParameterConfig {
     pub variance: Variance,
     pub unary_class: Option<ClassReference>,
+    pub function_policy: FunctionPolicy,
 }
 
 #[derive(Clone, Copy)]
 pub(in crate::source) enum VarianceConfig {
-    Single(ParameterConfig),
+    Single { parameter: ParameterConfig, binary_class: Option<ClassReference> },
     Pair { first: ParameterConfig, second: ParameterConfig, binary_class: Option<ClassReference> },
 }
 
@@ -60,8 +67,8 @@ pub enum TraversalParameter {
 pub enum TraversalOperation {
     Parameter { parameter: TraversalParameter },
     Function { argument: Option<Box<TraversalOperation>>, result: Option<Box<TraversalOperation>> },
-    Map { argument: Box<TraversalOperation> },
-    Bimap { first: Box<TraversalOperation>, second: Option<Box<TraversalOperation>> },
+    UnaryApplication { argument: Box<TraversalOperation> },
+    BinaryApplication { first: Box<TraversalOperation>, second: Option<Box<TraversalOperation>> },
     Record { fields: Vec<RecordFieldRecipe> },
 }
 
@@ -75,11 +82,12 @@ struct DerivedParameter {
     traversal_parameter: TraversalParameter,
     expected: Variance,
     unary_class: Option<ClassReference>,
+    function_policy: FunctionPolicy,
 }
 
 enum DerivedRigids {
     Invalid,
-    Single(DerivedParameter),
+    Single { parameter: DerivedParameter, binary_class: Option<ClassReference> },
     Pair { first: DerivedParameter, second: DerivedParameter, binary_class: Option<ClassReference> },
 }
 
@@ -91,7 +99,7 @@ impl DerivedRigids {
     fn iter(&self) -> impl Iterator<Item = &DerivedParameter> {
         let (first, second) = match self {
             DerivedRigids::Invalid => (None, None),
-            DerivedRigids::Single(first) => (Some(first), None),
+            DerivedRigids::Single { parameter, .. } => (Some(parameter), None),
             DerivedRigids::Pair { first, second, .. } => (Some(first), Some(second)),
         };
         first.into_iter().chain(second)
@@ -99,8 +107,9 @@ impl DerivedRigids {
 
     fn binary_class(&self) -> Option<ClassReference> {
         match self {
-            DerivedRigids::Pair { binary_class, .. } => *binary_class,
-            DerivedRigids::Invalid | DerivedRigids::Single(_) => None,
+            DerivedRigids::Single { binary_class, .. }
+            | DerivedRigids::Pair { binary_class, .. } => *binary_class,
+            DerivedRigids::Invalid => None,
         }
     }
 }
@@ -178,26 +187,30 @@ where
     }
 
     let rigids = match (config, &names[..]) {
-        (VarianceConfig::Single(parameter), [.., name]) => {
-            DerivedRigids::Single(DerivedParameter {
+        (VarianceConfig::Single { parameter, binary_class }, [.., name]) => DerivedRigids::Single {
+            parameter: DerivedParameter {
                 name: *name,
                 traversal_parameter: TraversalParameter::First,
                 expected: parameter.variance,
                 unary_class: parameter.unary_class,
-            })
-        }
+                function_policy: parameter.function_policy,
+            },
+            binary_class,
+        },
         (VarianceConfig::Pair { first, second, binary_class }, [.., a, b]) => DerivedRigids::Pair {
             first: DerivedParameter {
                 name: *a,
                 traversal_parameter: TraversalParameter::First,
                 expected: first.variance,
                 unary_class: first.unary_class,
+                function_policy: first.function_policy,
             },
             second: DerivedParameter {
                 name: *b,
                 traversal_parameter: TraversalParameter::Second,
                 expected: second.variance,
                 unary_class: second.unary_class,
+                function_policy: second.function_policy,
             },
             binary_class,
         },
@@ -241,6 +254,35 @@ where
         if let Some((argument, result)) =
             toolkit::decompose_function(self.state, self.context, type_id)?
         {
+            // Function results can be transformed pointwise when deriving `Functor`, but an
+            // applicative traversal cannot sequence those results. For example:
+            //
+            //   data Reader a = Reader (Int -> a)
+            //
+            //   traverse :: (a -> m b) -> Reader a -> m (Reader b)
+            //   function :: a -> m b
+            //   program  :: Int -> a
+            //
+            // Applying `function` pointwise produces `Int -> m b`, but reconstructing
+            // `Reader b` inside the applicative requires `m (Int -> b)`. An arbitrary
+            // `Applicative m` cannot exchange the `Int ->` and `m` constructors. `Traversable`
+            // and `Bitraversable` therefore reject function types containing a derived
+            // parameter, while fixed function fields still require no traversal.
+            let mut allowed = true;
+            for parameter in self.rigids.iter() {
+                if matches!(parameter.function_policy, FunctionPolicy::Reject)
+                    && toolkit::contains_rigid(self.state, self.context, type_id, parameter.name)?
+                {
+                    allowed = false;
+                    break;
+                }
+            }
+            *self.valid &= allowed;
+            if !allowed {
+                self.state.insert_error(ErrorKind::CannotDeriveForType { type_id });
+                return Ok(None);
+            }
+
             let argument = self.check(argument, variance.flip())?;
             let result = self.check(result, variance)?;
             if argument.is_some() || result.is_some() {
@@ -324,7 +366,8 @@ where
         }
 
         let argument = self.check(application.argument, variance)?;
-        Ok(argument.map(|argument| TraversalOperation::Map { argument: Box::new(argument) }))
+        Ok(argument
+            .map(|argument| TraversalOperation::UnaryApplication { argument: Box::new(argument) }))
     }
 
     fn check_binary_application(
@@ -366,7 +409,7 @@ where
             if *self.valid && head_is_fixed && first_is_valid && second_is_valid {
                 tools::emit_constraint(self.context, self.state, binary_class, binary_head);
             }
-            return Ok(Some(TraversalOperation::Bimap {
+            return Ok(Some(TraversalOperation::BinaryApplication {
                 first: Box::new(first),
                 second: second.map(Box::new),
             }));
@@ -376,7 +419,7 @@ where
             if *self.valid && head_is_fixed && second_is_valid {
                 self.emit_unary_constraints(application.argument, variance, application.function)?;
             }
-            return Ok(Some(TraversalOperation::Map { argument: Box::new(second) }));
+            return Ok(Some(TraversalOperation::UnaryApplication { argument: Box::new(second) }));
         }
 
         Ok(None)

--- a/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.purs
+++ b/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Reader a = Reader (Int -> a)
+derive instance Functor Reader
+
+instance Foldable Reader where
+  foldr _ initial _ = initial
+  foldl _ initial _ = initial
+
+derive instance Traversable Reader

--- a/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Reader :: forall (@a :: Prim.Type). (Prim.Int -> (a :: Prim.Type)) -> Main.Reader (a :: Prim.Type)
+
+Types
+Reader :: Prim.Type -> Prim.Type
+
+Instances
+instance Data.Foldable.Foldable Main.Reader
+
+Derived
+derive Data.Functor.Functor Main.Reader
+derive Data.Traversable.Traversable Main.Reader
+
+Roles
+Reader = [Representational]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Int -> (t0 :: Type)
+  --> 14:1..14:35
+   |
+14 | derive instance Traversable Reader
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Bifoldable (class Bifoldable)
+import Data.Bitraversable (class Bitraversable)
+
+data Either a b = Left a | Right b
+derive instance Bifunctor Either
+derive instance Bifoldable Either
+derive instance Bitraversable Either

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.snap
@@ -1,0 +1,42 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Either :: Prim.Type -> Prim.Type -> Prim.Type
+data Either @a @b
+  | Left :: a -> Main.Either a b
+  | Right :: b -> Main.Either a b
+
+dictionary bifunctorEither :: Data.Bifunctor.Bifunctor Main.Either where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Either a c -> Main.Either b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Left field0) -> Left @b @d (firstFunction field0)
+      (Right field0) -> Right @b @d (secondFunction field0)
+
+dictionary bitraversableEither :: Data.Bitraversable.Bitraversable Main.Either where
+  superclass bifunctorDict = bifunctorEither
+  superclass bifoldableDict = <instance>
+  bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
+  (d :: Prim.Type).
+  Control.Applicative.Applicative f =>
+  (a -> f c) -> (b -> f d) -> Main.Either a b -> f (Main.Either c d)
+  bitraverse = \{applicativeDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Left field0) -> map @f {applicativeDict.applyDict.functorDict} @c @(Main.Either c d)
+          (\field0Result -> Left @c @d field0Result)
+          (firstFunction field0)
+        (Right field0) -> map @f {applicativeDict.applyDict.functorDict} @d @(Main.Either c d)
+          (\field0Result -> Right @c @d field0Result)
+          (secondFunction field0)
+  bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Control.Applicative.Applicative f => Main.Either (f a) (f b) -> f (Main.Either a b)
+  bisequence = \{applicativeDict} ->
+    \value ->
+      bitraverse @Main.Either {bitraversableEither} @f @(f a) @(f b) @a @b {applicativeDict}
+        (\effect0 -> effect0)
+        (\effect1 -> effect1)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Bifoldable (class Bifoldable)
+import Data.Bitraversable (class Bitraversable)
+
+data Nested p a b = Nested (p a b)
+derive instance Bifunctor p => Bifunctor (Nested p)
+derive instance Bifoldable p => Bifoldable (Nested p)
+derive instance Bitraversable p => Bitraversable (Nested p)

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
@@ -1,0 +1,59 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Nested ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type). (k0 -> k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
+data Nested @p @a @b
+  | Nested :: p a b -> Main.Nested p a b
+
+dictionary bifunctorNested ::
+  forall p.
+  { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
+  Data.Bifunctor.Bifunctor (Main.Nested @Prim.Type @Prim.Type p)
+  where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) ->
+  (c -> d) ->
+  Main.Nested @Prim.Type @Prim.Type p a c ->
+  Main.Nested @Prim.Type @Prim.Type p b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Nested field0) -> Nested @Prim.Type @Prim.Type @p @b @d
+        (bimap @p {bifunctorDict} @a @b @c @d (\element -> firstFunction element)
+          (\element -> secondFunction element)
+          field0)
+
+dictionary bitraversableNested ::
+  forall p.
+  { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
+  Data.Bitraversable.Bitraversable (Main.Nested @Prim.Type @Prim.Type p)
+  where
+  superclass bifunctorDict = bifunctorNested {bitraversableDict.bifunctorDict}
+  superclass bifoldableDict = <instance> {bitraversableDict.bifoldableDict}
+  bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
+  (d :: Prim.Type).
+  Control.Applicative.Applicative f =>
+  (a -> f c) ->
+  (b -> f d) ->
+  Main.Nested @Prim.Type @Prim.Type p a b ->
+  f (Main.Nested @Prim.Type @Prim.Type p c d)
+  bitraverse = \{applicativeDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> map @f {applicativeDict.applyDict.functorDict} @(p c d) @(Main.Nested @Prim.Type @Prim.Type p c d)
+          (\field0Result -> Nested @Prim.Type @Prim.Type @p @c @d field0Result)
+          (bitraverse @p {bitraversableDict} @f @a @b @c @d {applicativeDict}
+            (\element -> firstFunction element)
+            (\element -> secondFunction element)
+            field0)
+  bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Control.Applicative.Applicative f =>
+  Main.Nested @Prim.Type @Prim.Type p (f a) (f b) -> f (Main.Nested @Prim.Type @Prim.Type p a b)
+  bisequence = \{applicativeDict} ->
+    \value ->
+      bitraverse @(Main.Nested @Prim.Type @Prim.Type p) {bitraversableNested {bitraversableDict}} @f @(f a) @(f b) @a @b {applicativeDict}
+        (\effect0 -> effect0)
+        (\effect1 -> effect1)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Bifunctor (class Bifunctor)
+import Data.Foldable (class Foldable)
+import Data.Bifoldable (class Bifoldable)
+import Data.Traversable (class Traversable)
+import Data.Bitraversable (class Bitraversable)
+
+data Wrap f g a b = Wrap (f a) (g b)
+derive instance (Functor f, Functor g) => Bifunctor (Wrap f g)
+derive instance (Foldable f, Foldable g) => Bifoldable (Wrap f g)
+derive instance (Traversable f, Traversable g) => Bitraversable (Wrap f g)

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
@@ -1,0 +1,65 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Wrap ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type).
+    (k0 -> Prim.Type) -> (k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
+data Wrap @f @g @a @b
+  | Wrap :: f a -> g b -> Main.Wrap f g a b
+
+dictionary bifunctorWrap ::
+  forall f g.
+  { functorDict :: Data.Functor.Functor f } =>
+  { functorDict1 :: Data.Functor.Functor g } =>
+  Data.Bifunctor.Bifunctor (Main.Wrap @Prim.Type @Prim.Type f g)
+  where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) ->
+  (c -> d) ->
+  Main.Wrap @Prim.Type @Prim.Type f g a c ->
+  Main.Wrap @Prim.Type @Prim.Type f g b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Wrap field0 field1) -> Wrap @Prim.Type @Prim.Type @f @g @b @d
+        (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
+        (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
+
+dictionary bitraversableWrap ::
+  forall f g.
+  { traversableDict :: Data.Traversable.Traversable f } =>
+  { traversableDict1 :: Data.Traversable.Traversable g } =>
+  Data.Bitraversable.Bitraversable (Main.Wrap @Prim.Type @Prim.Type f g)
+  where
+  superclass bifunctorDict = bifunctorWrap {traversableDict.functorDict} {traversableDict1.functorDict}
+  superclass bifoldableDict = <instance> {traversableDict.foldableDict} {traversableDict1.foldableDict}
+  bitraverse :: forall (f1 :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
+  (d :: Prim.Type).
+  Control.Applicative.Applicative f1 =>
+  (a -> f1 c) ->
+  (b -> f1 d) ->
+  Main.Wrap @Prim.Type @Prim.Type f g a b ->
+  f1 (Main.Wrap @Prim.Type @Prim.Type f g c d)
+  bitraverse = \{applicativeDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Wrap field0 field1) -> apply @f1 {applicativeDict.applyDict} @(g d) @(Main.Wrap @Prim.Type @Prim.Type f g c d)
+          (map @f1 {applicativeDict.applyDict.functorDict} @(f c) @(g d -> Main.Wrap @Prim.Type @Prim.Type f g c d)
+            (\field0Result field1Result ->
+              Wrap @Prim.Type @Prim.Type @f @g @c @d field0Result field1Result)
+            (traverse @f {traversableDict} @a @c @f1 {applicativeDict}
+              (\element -> firstFunction element)
+              field0))
+          (traverse @g {traversableDict1} @b @d @f1 {applicativeDict}
+            (\element -> secondFunction element)
+            field1)
+  bisequence :: forall (f1 :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Control.Applicative.Applicative f1 =>
+  Main.Wrap @Prim.Type @Prim.Type f g (f1 a) (f1 b) -> f1 (Main.Wrap @Prim.Type @Prim.Type f g a b)
+  bisequence = \{applicativeDict} ->
+    \value ->
+      bitraverse @(Main.Wrap @Prim.Type @Prim.Type f g) {bitraversableWrap {traversableDict} {traversableDict1}} @f1 @(f1 a) @(f1 b) @a @b {applicativeDict}
+        (\effect0 -> effect0)
+        (\effect1 -> effect1)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Bifoldable (class Bifoldable)
+import Data.Bitraversable (class Bitraversable)
+
+data Pair a b = Pair a Int b
+derive instance Bifunctor Pair
+derive instance Bifoldable Pair
+derive instance Bitraversable Pair

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.snap
@@ -1,0 +1,40 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Pair :: Prim.Type -> Prim.Type -> Prim.Type
+data Pair @a @b
+  | Pair :: a -> Prim.Int -> b -> Main.Pair a b
+
+dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Pair field0 field1 field2) -> Pair @b @d (firstFunction field0) field1
+        (secondFunction field2)
+
+dictionary bitraversablePair :: Data.Bitraversable.Bitraversable Main.Pair where
+  superclass bifunctorDict = bifunctorPair
+  superclass bifoldableDict = <instance>
+  bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
+  (d :: Prim.Type).
+  Control.Applicative.Applicative f =>
+  (a -> f c) -> (b -> f d) -> Main.Pair a b -> f (Main.Pair c d)
+  bitraverse = \{applicativeDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1 field2) -> apply @f {applicativeDict.applyDict} @d @(Main.Pair c d)
+          (map @f {applicativeDict.applyDict.functorDict} @c @(d -> Main.Pair c d)
+            (\field0Result field2Result -> Pair @c @d field0Result field1 field2Result)
+            (firstFunction field0))
+          (secondFunction field2)
+  bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Control.Applicative.Applicative f => Main.Pair (f a) (f b) -> f (Main.Pair a b)
+  bisequence = \{applicativeDict} ->
+    \value ->
+      bitraverse @Main.Pair {bitraversablePair} @f @(f a) @(f b) @a @b {applicativeDict}
+        (\effect0 -> effect0)
+        (\effect1 -> effect1)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Bifoldable (class Bifoldable)
+import Data.Bitraversable (class Bitraversable)
+
+data RecordPair a b = RecordPair { zeta :: b, fixed :: Int, alpha :: a }
+derive instance Bifunctor RecordPair
+derive instance Bifoldable RecordPair
+derive instance Bitraversable RecordPair

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.snap
@@ -1,0 +1,42 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data RecordPair :: Prim.Type -> Prim.Type -> Prim.Type
+data RecordPair @a @b
+  | RecordPair :: { alpha :: a, fixed :: Prim.Int, zeta :: b } -> Main.RecordPair a b
+
+dictionary bifunctorRecordPair :: Data.Bifunctor.Bifunctor Main.RecordPair where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.RecordPair a c -> Main.RecordPair b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (RecordPair field0) -> RecordPair @b @d
+        field0 { alpha = firstFunction field0.alpha, zeta = secondFunction field0.zeta }
+
+dictionary bitraversableRecordPair :: Data.Bitraversable.Bitraversable Main.RecordPair where
+  superclass bifunctorDict = bifunctorRecordPair
+  superclass bifoldableDict = <instance>
+  bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
+  (d :: Prim.Type).
+  Control.Applicative.Applicative f =>
+  (a -> f c) -> (b -> f d) -> Main.RecordPair a b -> f (Main.RecordPair c d)
+  bitraverse = \{applicativeDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (RecordPair field0) -> map @f {applicativeDict.applyDict.functorDict} @{ alpha :: c, fixed :: Prim.Int, zeta :: d } @(Main.RecordPair c d)
+          (\field0Result -> RecordPair @c @d field0Result)
+          (apply @f {applicativeDict.applyDict} @d @{ alpha :: c, fixed :: Prim.Int, zeta :: d }
+            (map @f {applicativeDict.applyDict.functorDict} @c @(d -> { alpha :: c, fixed :: Prim.Int, zeta :: d })
+              (\recordField0 recordField1 -> field0 { alpha = recordField0, zeta = recordField1 })
+              (firstFunction field0.alpha))
+            (secondFunction field0.zeta))
+  bisequence :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Control.Applicative.Applicative f => Main.RecordPair (f a) (f b) -> f (Main.RecordPair a b)
+  bisequence = \{applicativeDict} ->
+    \value ->
+      bitraverse @Main.RecordPair {bitraversableRecordPair} @f @(f a) @(f b) @a @b {applicativeDict}
+        (\effect0 -> effect0)
+        (\effect1 -> effect1)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Bifunctor (class Bifunctor, bimap)
+import Data.Foldable (class Foldable)
+import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr)
+import Data.Traversable (class Traversable)
+import Data.Bitraversable (class Bitraversable)
+
+data Duplicate p a = Duplicate (p a a)
+
+instance Bifunctor p => Functor (Duplicate p) where
+  map function (Duplicate value) = Duplicate (bimap function function value)
+
+instance Bifoldable p => Foldable (Duplicate p) where
+  foldr function initial (Duplicate value) = bifoldr function function initial value
+  foldl function initial (Duplicate value) = bifoldl function function initial value
+
+derive instance Bitraversable p => Traversable (Duplicate p)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
@@ -1,0 +1,58 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Duplicate :: forall (k0 :: Prim.Type). (k0 -> k0 -> Prim.Type) -> k0 -> Prim.Type
+data Duplicate @p @a
+  | Duplicate :: p a a -> Main.Duplicate p a
+
+dictionary functorDuplicate ::
+  forall p.
+  { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
+  Data.Functor.Functor (Main.Duplicate @Prim.Type p)
+  where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.Duplicate @Prim.Type p a -> Main.Duplicate @Prim.Type p b
+  map = \function -> \(Duplicate value) ->
+    Duplicate @Prim.Type @p @b (bimap @p {bifunctorDict} @a @b @a @b function function value)
+
+dictionary foldableDuplicate ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Foldable.Foldable (Main.Duplicate @Prim.Type p)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
+  foldr = \function -> \initial -> \(Duplicate value) ->
+    bifoldr @p {bifoldableDict} @a @a @b function function initial value
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
+  foldl = \function -> \initial -> \(Duplicate value) ->
+    bifoldl @p {bifoldableDict} @a @a @b function function initial value
+
+dictionary traversableDuplicate ::
+  forall p.
+  { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
+  Data.Traversable.Traversable (Main.Duplicate @Prim.Type p)
+  where
+  superclass functorDict = functorDuplicate {bitraversableDict.bifunctorDict}
+  superclass foldableDict = foldableDuplicate {bitraversableDict.bifoldableDict}
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  (a -> m b) -> Main.Duplicate @Prim.Type p a -> m (Main.Duplicate @Prim.Type p b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Duplicate field0) -> map @m {applicativeDict.applyDict.functorDict} @(p b b) @(Main.Duplicate @Prim.Type p b)
+          (\field0Result -> Duplicate @Prim.Type @p @b field0Result)
+          (bitraverse @p {bitraversableDict} @m @a @a @b @b {applicativeDict}
+            (\element -> function element)
+            (\element -> function element)
+            field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  Main.Duplicate @Prim.Type p (m a) -> m (Main.Duplicate @Prim.Type p a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @(Main.Duplicate @Prim.Type p) {traversableDuplicate {bitraversableDict}} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.purs
@@ -1,0 +1,22 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Bifunctor (class Bifunctor, bimap)
+import Data.Foldable (class Foldable)
+import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr)
+import Data.Traversable (class Traversable)
+import Data.Bitraversable (class Bitraversable)
+
+data LeftDuplicate p a = LeftDuplicate (p a Int)
+
+instance Bifunctor p => Functor (LeftDuplicate p) where
+  map function (LeftDuplicate value) =
+    LeftDuplicate (bimap function (\fixed -> fixed) value)
+
+instance Bifoldable p => Foldable (LeftDuplicate p) where
+  foldr function initial (LeftDuplicate value) =
+    bifoldr function (\_ accumulated -> accumulated) initial value
+  foldl function initial (LeftDuplicate value) =
+    bifoldl function (\accumulated _ -> accumulated) initial value
+
+derive instance Bitraversable p => Traversable (LeftDuplicate p)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
@@ -1,0 +1,63 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data LeftDuplicate :: forall (k0 :: Prim.Type). (k0 -> Prim.Type -> Prim.Type) -> k0 -> Prim.Type
+data LeftDuplicate @p @a
+  | LeftDuplicate :: p a Prim.Int -> Main.LeftDuplicate p a
+
+dictionary functorLeftDuplicate ::
+  forall p.
+  { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
+  Data.Functor.Functor (Main.LeftDuplicate @Prim.Type p)
+  where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.LeftDuplicate @Prim.Type p a -> Main.LeftDuplicate @Prim.Type p b
+  map = \function -> \(LeftDuplicate value) ->
+    LeftDuplicate @Prim.Type @p @b
+      (bimap @p {bifunctorDict} @a @b @Prim.Int @Prim.Int function (\fixed -> fixed) value)
+
+dictionary foldableLeftDuplicate ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Foldable.Foldable (Main.LeftDuplicate @Prim.Type p)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
+  foldr = \function -> \initial -> \(LeftDuplicate value) ->
+    bifoldr @p {bifoldableDict} @a @Prim.Int @b function (\_ accumulated -> accumulated) initial
+      value
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
+  foldl = \function -> \initial -> \(LeftDuplicate value) ->
+    bifoldl @p {bifoldableDict} @a @Prim.Int @b function (\accumulated _ -> accumulated) initial
+      value
+
+dictionary traversableLeftDuplicate ::
+  forall p.
+  { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
+  Data.Traversable.Traversable (Main.LeftDuplicate @Prim.Type p)
+  where
+  superclass functorDict = functorLeftDuplicate {bitraversableDict.bifunctorDict}
+  superclass foldableDict = foldableLeftDuplicate {bitraversableDict.bifoldableDict}
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  (a -> m b) -> Main.LeftDuplicate @Prim.Type p a -> m (Main.LeftDuplicate @Prim.Type p b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (LeftDuplicate field0) -> map @m {applicativeDict.applyDict.functorDict} @(p b Prim.Int) @(Main.LeftDuplicate @Prim.Type p b)
+          (\field0Result -> LeftDuplicate @Prim.Type @p @b field0Result)
+          (bitraverse @p {bitraversableDict} @m @a @Prim.Int @b @Prim.Int {applicativeDict}
+            (\element -> function element)
+            (\unchanged -> pure @m {applicativeDict} @Prim.Int unchanged)
+            field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  Main.LeftDuplicate @Prim.Type p (m a) -> m (Main.LeftDuplicate @Prim.Type p a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @(Main.LeftDuplicate @Prim.Type p) {traversableLeftDuplicate {bitraversableDict}} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Const e a = Const e
+derive instance Functor (Const e)
+derive instance Foldable (Const e)
+derive instance Traversable (Const e)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
@@ -1,0 +1,36 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Const :: forall (k0 :: Prim.Type). Prim.Type -> k0 -> Prim.Type
+data Const @e @a
+  | Const :: e -> Main.Const e a
+
+dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type e) where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.Const @Prim.Type e a -> Main.Const @Prim.Type e b
+  map = \function value ->
+    case value of
+      (Const field0) -> Const @Prim.Type @e @b field0
+
+dictionary traversableConst :: forall e. Data.Traversable.Traversable (Main.Const @Prim.Type e)
+  where
+  superclass functorDict = functorConst
+  superclass foldableDict = <instance>
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  (a -> m b) -> Main.Const @Prim.Type e a -> m (Main.Const @Prim.Type e b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Const field0) -> pure @m {applicativeDict} @(Main.Const @Prim.Type e b)
+          (Const @Prim.Type @e @b field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  Main.Const @Prim.Type e (m a) -> m (Main.Const @Prim.Type e a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @(Main.Const @Prim.Type e) {traversableConst} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Identity a = Identity a
+derive instance Functor Identity
+derive instance Foldable Identity
+derive instance Traversable Identity

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Identity :: Prim.Type -> Prim.Type
+data Identity @a
+  | Identity :: a -> Main.Identity a
+
+dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Identity a -> Main.Identity b
+  map = \function value ->
+    case value of
+      (Identity field0) -> Identity @b (function field0)
+
+dictionary traversableIdentity :: Data.Traversable.Traversable Main.Identity where
+  superclass functorDict = functorIdentity
+  superclass foldableDict = <instance>
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => (a -> m b) -> Main.Identity a -> m (Main.Identity b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Identity field0) -> map @m {applicativeDict.applyDict.functorDict} @b @(Main.Identity b)
+          (\field0Result -> Identity @b field0Result)
+          (function field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => Main.Identity (m a) -> m (Main.Identity a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @Main.Identity {traversableIdentity} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Maybe a = Nothing | Just a
+derive instance Functor Maybe
+derive instance Foldable Maybe
+derive instance Traversable Maybe

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Prim.Type -> Prim.Type
+data Maybe @a
+  | Nothing :: Main.Maybe a
+  | Just :: a -> Main.Maybe a
+
+dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Maybe a -> Main.Maybe b
+  map = \function value ->
+    case value of
+      Nothing -> Nothing @b
+      (Just field0) -> Just @b (function field0)
+
+dictionary traversableMaybe :: Data.Traversable.Traversable Main.Maybe where
+  superclass functorDict = functorMaybe
+  superclass foldableDict = <instance>
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => (a -> m b) -> Main.Maybe a -> m (Main.Maybe b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        Nothing -> pure @m {applicativeDict} @(Main.Maybe b) (Nothing @b)
+        (Just field0) -> map @m {applicativeDict.applyDict.functorDict} @b @(Main.Maybe b)
+          (\field0Result -> Just @b field0Result)
+          (function field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => Main.Maybe (m a) -> m (Main.Maybe a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @Main.Maybe {traversableMaybe} @(m a) @a @m {applicativeDict} (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Compose f g a = Compose (f (g a))
+derive instance (Functor f, Functor g) => Functor (Compose f g)
+derive instance (Foldable f, Foldable g) => Foldable (Compose f g)
+derive instance (Traversable f, Traversable g) => Traversable (Compose f g)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
@@ -1,0 +1,57 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Compose ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type). (k0 -> Prim.Type) -> (k1 -> k0) -> k1 -> Prim.Type
+data Compose @f @g @a
+  | Compose :: f (g a) -> Main.Compose f g a
+
+dictionary functorCompose ::
+  forall f g.
+  { functorDict :: Data.Functor.Functor f } =>
+  { functorDict1 :: Data.Functor.Functor g } =>
+  Data.Functor.Functor (Main.Compose @Prim.Type @Prim.Type f g)
+  where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.Compose @Prim.Type @Prim.Type f g a -> Main.Compose @Prim.Type @Prim.Type f g b
+  map = \function value ->
+    case value of
+      (Compose field0) -> Compose @Prim.Type @Prim.Type @f @g @b
+        (map @f {functorDict} @(g a) @(g b)
+          (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
+          field0)
+
+dictionary traversableCompose ::
+  forall f g.
+  { traversableDict :: Data.Traversable.Traversable f } =>
+  { traversableDict1 :: Data.Traversable.Traversable g } =>
+  Data.Traversable.Traversable (Main.Compose @Prim.Type @Prim.Type f g)
+  where
+  superclass functorDict = functorCompose {traversableDict.functorDict} {traversableDict1.functorDict}
+  superclass foldableDict = <instance> {traversableDict.foldableDict} {traversableDict1.foldableDict}
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  (a -> m b) ->
+  Main.Compose @Prim.Type @Prim.Type f g a ->
+  m (Main.Compose @Prim.Type @Prim.Type f g b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Compose field0) -> map @m {applicativeDict.applyDict.functorDict} @(f (g b)) @(Main.Compose @Prim.Type @Prim.Type f g b)
+          (\field0Result -> Compose @Prim.Type @Prim.Type @f @g @b field0Result)
+          (traverse @f {traversableDict} @(g a) @(g b) @m {applicativeDict}
+            (\element ->
+              traverse @g {traversableDict1} @a @b @m {applicativeDict}
+                (\element -> function element)
+                element)
+            field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  Main.Compose @Prim.Type @Prim.Type f g (m a) -> m (Main.Compose @Prim.Type @Prim.Type f g a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @(Main.Compose @Prim.Type @Prim.Type f g) {traversableCompose {traversableDict} {traversableDict1}} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Product a = Product a Int a
+derive instance Functor Product
+derive instance Foldable Product
+derive instance Traversable Product

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Product :: Prim.Type -> Prim.Type
+data Product @a
+  | Product :: a -> Prim.Int -> a -> Main.Product a
+
+dictionary functorProduct :: Data.Functor.Functor Main.Product where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Product a -> Main.Product b
+  map = \function value ->
+    case value of
+      (Product field0 field1 field2) -> Product @b (function field0) field1 (function field2)
+
+dictionary traversableProduct :: Data.Traversable.Traversable Main.Product where
+  superclass functorDict = functorProduct
+  superclass foldableDict = <instance>
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => (a -> m b) -> Main.Product a -> m (Main.Product b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Product field0 field1 field2) -> apply @m {applicativeDict.applyDict} @b @(Main.Product b)
+          (map @m {applicativeDict.applyDict.functorDict} @b @(b -> Main.Product b)
+            (\field0Result field2Result -> Product @b field0Result field1 field2Result)
+            (function field0))
+          (function field2)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => Main.Product (m a) -> m (Main.Product a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @Main.Product {traversableProduct} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Record a = Record { zeta :: a, fixed :: Int, alpha :: a }
+derive instance Functor Record
+derive instance Foldable Record
+derive instance Traversable Record

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Record :: Prim.Type -> Prim.Type
+data Record @a
+  | Record :: { alpha :: a, fixed :: Prim.Int, zeta :: a } -> Main.Record a
+
+dictionary functorRecord :: Data.Functor.Functor Main.Record where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Record a -> Main.Record b
+  map = \function value ->
+    case value of
+      (Record field0) -> Record @b
+        field0 { alpha = function field0.alpha, zeta = function field0.zeta }
+
+dictionary traversableRecord :: Data.Traversable.Traversable Main.Record where
+  superclass functorDict = functorRecord
+  superclass foldableDict = <instance>
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => (a -> m b) -> Main.Record a -> m (Main.Record b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Record field0) -> map @m {applicativeDict.applyDict.functorDict} @{ alpha :: b, fixed :: Prim.Int, zeta :: b } @(Main.Record b)
+          (\field0Result -> Record @b field0Result)
+          (apply @m {applicativeDict.applyDict} @b @{ alpha :: b, fixed :: Prim.Int, zeta :: b }
+            (map @m {applicativeDict.applyDict.functorDict} @b @(b -> { alpha :: b, fixed :: Prim.Int, zeta :: b })
+              (\recordField0 recordField1 -> field0 { alpha = recordField0, zeta = recordField1 })
+              (function field0.alpha))
+            (function field0.zeta))
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => Main.Record (m a) -> m (Main.Record a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @Main.Record {traversableRecord} @(m a) @a @m {applicativeDict} (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Foldable (class Foldable)
+import Data.Traversable (class Traversable)
+
+data Tree a = Leaf a | Branch (Tree a) (Tree a)
+derive instance Functor Tree
+derive instance Foldable Tree
+derive instance Traversable Tree

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.snap
@@ -1,0 +1,45 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Tree :: Prim.Type -> Prim.Type
+data Tree @a
+  | Leaf :: a -> Main.Tree a
+  | Branch :: Main.Tree a -> Main.Tree a -> Main.Tree a
+
+dictionary functorTree :: Data.Functor.Functor Main.Tree where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Tree a -> Main.Tree b
+  map = \function value ->
+    case value of
+      (Leaf field0) -> Leaf @b (function field0)
+      (Branch field0 field1) -> Branch @b
+        (map @Main.Tree {functorTree} @a @b (\element -> function element) field0)
+        (map @Main.Tree {functorTree} @a @b (\element -> function element) field1)
+
+dictionary traversableTree :: Data.Traversable.Traversable Main.Tree where
+  superclass functorDict = functorTree
+  superclass foldableDict = <instance>
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => (a -> m b) -> Main.Tree a -> m (Main.Tree b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (Leaf field0) -> map @m {applicativeDict.applyDict.functorDict} @b @(Main.Tree b)
+          (\field0Result -> Leaf @b field0Result)
+          (function field0)
+        (Branch field0 field1) -> apply @m {applicativeDict.applyDict} @(Main.Tree b) @(Main.Tree b)
+          (map @m {applicativeDict.applyDict.functorDict} @(Main.Tree b) @(Main.Tree b -> Main.Tree b)
+            (\field0Result field1Result -> Branch @b field0Result field1Result)
+            (traverse @Main.Tree {traversableTree} @a @b @m {applicativeDict}
+              (\element -> function element)
+              field0))
+          (traverse @Main.Tree {traversableTree} @a @b @m {applicativeDict}
+            (\element -> function element)
+            field1)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m => Main.Tree (m a) -> m (Main.Tree a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @Main.Tree {traversableTree} @(m a) @a @m {applicativeDict} (\effect0 -> effect0)
+        value


### PR DESCRIPTION
## Summary

Alexandrite already validates and registers derived `Traversable` and `Bitraversable` instance heads, but it does not generate their dictionary members. This change completes those instances by generating:

- `traverse` and `sequence` for `Traversable`
- `bitraverse` and `bisequence` for `Bitraversable`

Constructor fields are traversed in source order and reconstructed applicatively with `pure`, `map`, and `apply`. Records follow canonical row order, and recursive derived instances are resolved through the instance head registered before member generation.

## Implementation

- Add a dedicated effectful traversal generator while reusing the structural recipes produced by variance analysis.
- Generalize known-instance generation to emit every class member in declaration order, atomically, rather than assuming a one-member dictionary.
- Generate `sequence` as `traverse` with an identity lambda and `bisequence` as `bitraverse` with two identity lambdas.
- Register the required `Applicative`, `Apply`, `Traversable`, and `Bitraversable` known terms.
- Model nested unary and binary applications explicitly, including the binary class needed by `Bitraversable`.
- Reject function-shaped occurrences such as `Int -> a`, which can be mapped but cannot be traversed, during variance checking.

This follows the canonical PureScript class signatures and keeps member generation all-or-nothing when a required known term or decoded member signature is unavailable.

## Tests

Semantic fixtures cover:

- identity, constant, optional, product, nested, recursive, and record-shaped `Traversable` types
- left and both-argument binary applications
- `Bitraversable` sums, products, unary and binary nesting, and records
- rejection of function-shaped traversals

Validation completed:

- `just format`
- `git diff --check`
- `just t checking`
- `just t semantic`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (30 tests passed)

## Stack

This is the base PR for the deriving stack. The Foldable implementation follows in a separate PR based on `traversable-deriving`.