### PR TITLE
[checking] Generate Foldable derived members

### DIFF
--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -780,6 +780,14 @@ pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
     pub map: Option<(FileId, TermItemId)>,
     pub bimap: Option<(FileId, TermItemId)>,
+    pub foldr: Option<(FileId, TermItemId)>,
+    pub foldl: Option<(FileId, TermItemId)>,
+    pub fold_map: Option<(FileId, TermItemId)>,
+    pub bifoldr: Option<(FileId, TermItemId)>,
+    pub bifoldl: Option<(FileId, TermItemId)>,
+    pub bifold_map: Option<(FileId, TermItemId)>,
+    pub append: Option<(FileId, TermItemId)>,
+    pub mempty: Option<(FileId, TermItemId)>,
     pub pure: Option<(FileId, TermItemId)>,
     pub apply: Option<(FileId, TermItemId)>,
     pub traverse: Option<(FileId, TermItemId)>,
@@ -800,6 +808,14 @@ impl KnownTermsCore {
         let otherwise = fetch_known_term(queries, "Data.Boolean", "otherwise")?;
         let map = fetch_known_term(queries, "Data.Functor", "map")?;
         let bimap = fetch_known_term(queries, "Data.Bifunctor", "bimap")?;
+        let foldr = fetch_known_term(queries, "Data.Foldable", "foldr")?;
+        let foldl = fetch_known_term(queries, "Data.Foldable", "foldl")?;
+        let fold_map = fetch_known_term(queries, "Data.Foldable", "foldMap")?;
+        let bifoldr = fetch_known_term(queries, "Data.Bifoldable", "bifoldr")?;
+        let bifoldl = fetch_known_term(queries, "Data.Bifoldable", "bifoldl")?;
+        let bifold_map = fetch_known_term(queries, "Data.Bifoldable", "bifoldMap")?;
+        let append = fetch_known_term(queries, "Data.Semigroup", "append")?;
+        let mempty = fetch_known_term(queries, "Data.Monoid", "mempty")?;
         let pure = fetch_known_term(queries, "Control.Applicative", "pure")?;
         let apply = fetch_known_term(queries, "Control.Apply", "apply")?;
         let traverse = fetch_known_term(queries, "Data.Traversable", "traverse")?;
@@ -817,6 +833,14 @@ impl KnownTermsCore {
             otherwise,
             map,
             bimap,
+            foldr,
+            foldl,
+            fold_map,
+            bifoldr,
+            bifoldl,
+            bifold_map,
+            append,
+            mempty,
             pure,
             apply,
             traverse,

--- a/compiler-core/checking/src/source/derive/foldable.rs
+++ b/compiler-core/checking/src/source/derive/foldable.rs
@@ -41,9 +41,9 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: Some((class_file, class_id)),
-        function_policy: FunctionPolicy::Allow,
+        function_policy: FunctionPolicy::Reject,
     };
-    let config = VarianceConfig::Single { parameter, binary_class: None };
+    let config = VarianceConfig::Single { parameter, binary_class: context.known_types.bifoldable };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,
@@ -83,9 +83,13 @@ where
     let parameter = ParameterConfig {
         variance: Variance::Covariant,
         unary_class: context.known_types.foldable,
-        function_policy: FunctionPolicy::Allow,
+        function_policy: FunctionPolicy::Reject,
     };
-    let config = VarianceConfig::Pair { first: parameter, second: parameter, binary_class: None };
+    let config = VarianceConfig::Pair {
+        first: parameter,
+        second: parameter,
+        binary_class: Some((class_file, class_id)),
+    };
 
     Ok(Some(DeriveStrategy::VarianceConstraints {
         data_file,

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -17,6 +17,7 @@ use super::variance::VarianceRecipe;
 use super::{DeriveDispatch, DeriveHeadResult, DeriveStrategy, derive_dispatch};
 
 mod eq_ord;
+mod foldable;
 mod functor;
 mod traversable;
 
@@ -41,6 +42,8 @@ where
         | DeriveDispatch::Ord1
         | DeriveDispatch::Functor
         | DeriveDispatch::Bifunctor
+        | DeriveDispatch::Foldable
+        | DeriveDispatch::Bifoldable
         | DeriveDispatch::Traversable
         | DeriveDispatch::Bitraversable => {
             generate_known_instance(state, context, result, dispatch, variance_recipe)
@@ -192,6 +195,26 @@ where
                 )?
                 .into_iter()
                 .collect()
+            }
+            DeriveDispatch::Foldable | DeriveDispatch::Bifoldable => {
+                let Some(recipe) = variance_recipe else { return Ok(None) };
+                let traversal = match dispatch {
+                    DeriveDispatch::Foldable => foldable::TraversalKind::Foldable,
+                    DeriveDispatch::Bifoldable => foldable::TraversalKind::Bifoldable,
+                    _ => unreachable!(),
+                };
+                let Some(members) = foldable::generate_fold_members(
+                    state,
+                    context,
+                    result,
+                    &freshened.arguments,
+                    recipe,
+                    traversal,
+                )?
+                else {
+                    return Ok(None);
+                };
+                members
             }
             DeriveDispatch::Traversable | DeriveDispatch::Bitraversable => {
                 let Some(recipe) = variance_recipe else { return Ok(None) };

--- a/compiler-core/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-core/checking/src/source/derive/generate/foldable.rs
@@ -1,0 +1,911 @@
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use itertools::izip;
+use smol_str::format_smolstr;
+
+use crate::context::CheckContext;
+use crate::core::substitute::RigidRenaming;
+use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::evidence::Evidence;
+use crate::source::derive::builder::DerivedTreeBuilder;
+use crate::source::derive::field;
+use crate::source::derive::variance::{
+    ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, VarianceRecipe,
+};
+use crate::source::terms::ElaboratedExpression;
+use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+use super::{
+    DeriveHeadResult, DeriveStrategy, ResolvedMember, generated_member, resolve_known_member,
+};
+
+struct InstantiatedDataType {
+    type_id: TypeId,
+    constructor_arguments: Vec<KindOrType>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum TraversalKind {
+    Foldable,
+    Bifoldable,
+}
+
+#[derive(Clone, Copy)]
+enum FoldOperation {
+    Right,
+    Left,
+    Map,
+}
+
+#[derive(Clone, Copy)]
+enum Mappings<T> {
+    Foldable(T),
+    Bifoldable { first: T, second: T },
+}
+
+impl Mappings<ElaboratedExpression> {
+    fn mapping_for(self, parameter: TraversalParameter) -> Option<ElaboratedExpression> {
+        match (self, parameter) {
+            (Mappings::Foldable(function), TraversalParameter::First) => Some(function),
+            (Mappings::Bifoldable { first, .. }, TraversalParameter::First) => Some(first),
+            (Mappings::Bifoldable { second, .. }, TraversalParameter::Second) => Some(second),
+            (Mappings::Foldable(_), TraversalParameter::Second) => None,
+        }
+    }
+}
+
+struct DecodedFoldMember {
+    member: ResolvedMember,
+    renaming: Arc<RigidRenaming>,
+    constraints: Vec<TypeId>,
+    implementation_type: TypeId,
+    function_type: TypeId,
+    mappings: Mappings<TypeId>,
+    accumulator_type: TypeId,
+    data_file: files::FileId,
+    source: InstantiatedDataType,
+    result_type: TypeId,
+}
+
+impl DecodedFoldMember {
+    fn decode<Q>(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        member: ResolvedMember,
+        data_file: files::FileId,
+        traversal: TraversalKind,
+        operation: FoldOperation,
+    ) -> QueryResult<Option<DecodedFoldMember>>
+    where
+        Q: ExternalQueries,
+    {
+        // A directional fold supplies one transformation per traversed parameter, followed
+        // by the initial accumulator and structural source. A monoidal fold omits the
+        // explicit accumulator because its result type is the accumulator.
+        //
+        // List
+        //
+        //   foldr :: (a -> b -> b) -> b -> List a -> b
+        //
+        // Pair
+        //
+        //   bifoldr ::
+        //     (a -> c -> c) -> (b -> c -> c) -> c -> Pair a b -> c
+        //
+        //   bifoldMap :: Monoid m => (a -> m) -> (b -> m) -> Pair a b -> m
+        let argument_count = match (traversal, operation) {
+            (TraversalKind::Foldable, FoldOperation::Right | FoldOperation::Left) => 3,
+            (TraversalKind::Bifoldable, FoldOperation::Right | FoldOperation::Left) => 4,
+            (TraversalKind::Foldable, FoldOperation::Map) => 2,
+            (TraversalKind::Bifoldable, FoldOperation::Map) => 3,
+        };
+        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+            signature::expect_term_signature(
+                state,
+                context,
+                member.implementation_type,
+                argument_count,
+            )?;
+
+        let decoded = (traversal, operation, arguments.as_slice());
+        let (source_type, accumulator_type, mappings) = match decoded {
+            (
+                TraversalKind::Foldable,
+                FoldOperation::Right | FoldOperation::Left,
+                [mapping, accumulator, source],
+            ) => (*source, *accumulator, Mappings::Foldable(*mapping)),
+            (
+                TraversalKind::Bifoldable,
+                FoldOperation::Right | FoldOperation::Left,
+                [first, second, accumulator, source],
+            ) => (*source, *accumulator, Mappings::Bifoldable { first: *first, second: *second }),
+            (TraversalKind::Foldable, FoldOperation::Map, [mapping, source]) => {
+                (*source, result, Mappings::Foldable(*mapping))
+            }
+            (TraversalKind::Bifoldable, FoldOperation::Map, [first, second, source]) => {
+                (*source, result, Mappings::Bifoldable { first: *first, second: *second })
+            }
+            _ => return Ok(None),
+        };
+
+        let (_, source_arguments) = toolkit::extract_all_applications(state, context, source_type)?;
+        let function_arguments = arguments.iter().copied();
+        let function_type = context.intern_function_iter(function_arguments, result);
+
+        Ok(Some(DecodedFoldMember {
+            implementation_type: member.implementation_type,
+            member,
+            renaming,
+            constraints,
+            function_type,
+            mappings,
+            accumulator_type,
+            data_file,
+            source: InstantiatedDataType {
+                type_id: source_type,
+                constructor_arguments: source_arguments,
+            },
+            result_type: result,
+        }))
+    }
+}
+
+pub(super) fn generate_fold_members<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    recipe: &VarianceRecipe,
+    traversal: TraversalKind,
+) -> QueryResult<Option<Vec<tree::InstanceMember>>>
+where
+    Q: ExternalQueries,
+{
+    let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+        return Ok(None);
+    };
+    let operations = match traversal {
+        TraversalKind::Foldable => {
+            (context.known_terms.foldr, context.known_terms.foldl, context.known_terms.fold_map)
+        }
+        TraversalKind::Bifoldable => (
+            context.known_terms.bifoldr,
+            context.known_terms.bifoldl,
+            context.known_terms.bifold_map,
+        ),
+    };
+    let (Some(foldr), Some(foldl), Some(fold_map)) = operations else {
+        return Ok(None);
+    };
+
+    let Some(class) =
+        toolkit::lookup_file_class(state, context, result.class_file, result.class_id)?
+    else {
+        return Ok(None);
+    };
+
+    // Foldable and Bifoldable dictionaries require both directions and their monoidal fold.
+    // Match known identities rather than declaration order, and reject an incomplete
+    // dictionary.
+    let mut foldr_generated = false;
+    let mut foldl_generated = false;
+    let mut fold_map_generated = false;
+    let mut members = Vec::with_capacity(class.members.len());
+    for class_member in &class.members {
+        let resolution = (result.class_file, class_member.item_id);
+        let member = if resolution == foldr {
+            foldr_generated = true;
+            generate_fold_member(
+                state,
+                context,
+                result,
+                instance_arguments,
+                data_file,
+                recipe,
+                traversal,
+                FoldOperation::Right,
+                resolution,
+            )?
+        } else if resolution == foldl {
+            foldl_generated = true;
+            generate_fold_member(
+                state,
+                context,
+                result,
+                instance_arguments,
+                data_file,
+                recipe,
+                traversal,
+                FoldOperation::Left,
+                resolution,
+            )?
+        } else if resolution == fold_map {
+            fold_map_generated = true;
+            generate_fold_member(
+                state,
+                context,
+                result,
+                instance_arguments,
+                data_file,
+                recipe,
+                traversal,
+                FoldOperation::Map,
+                resolution,
+            )?
+        } else {
+            return Ok(None);
+        };
+        let Some(member) = member else {
+            return Ok(None);
+        };
+        members.push(member);
+    }
+
+    if !foldr_generated || !foldl_generated || !fold_map_generated {
+        return Ok(None);
+    }
+    Ok(Some(members))
+}
+
+fn generate_fold_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    data_file: files::FileId,
+    recipe: &VarianceRecipe,
+    traversal: TraversalKind,
+    operation: FoldOperation,
+    resolution: (files::FileId, indexing::TermItemId),
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    state.with_implication(|state| {
+        let Some(member) =
+            resolve_known_member(state, context, result, instance_arguments, resolution)?
+        else {
+            return Ok(None);
+        };
+        let Some(member) =
+            DecodedFoldMember::decode(state, context, member, data_file, traversal, operation)?
+        else {
+            return Ok(None);
+        };
+
+        let mut evidences = Vec::with_capacity(member.constraints.len());
+        for &constraint in &member.constraints {
+            evidences.push(Evidence::Given(state.push_given(constraint)));
+        }
+
+        let body = state.with_source_type_renaming(&member.renaming, |state| {
+            emit_variance_fold(state, context, result.derive_id, &member, recipe, operation)
+        })?;
+        let Some(body) = body else { return Ok(None) };
+
+        Ok(Some(generated_member(
+            result.derive_id,
+            (member.member.file_id, member.member.item_id),
+            member.implementation_type,
+            evidences,
+            body,
+        )))
+    })
+}
+
+fn emit_variance_fold<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    derive_id: indexing::DeriveId,
+    member: &DecodedFoldMember,
+    recipe: &VarianceRecipe,
+    operation: FoldOperation,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
+
+    let (mapping_binders, mapping_expressions) = match member.mappings {
+        Mappings::Foldable(mapping) => {
+            let function = builder.variable_binder("function", mapping);
+            let expression = builder.variable(function);
+            (vec![function], Mappings::Foldable(expression))
+        }
+        Mappings::Bifoldable { first, second } => {
+            let first = builder.variable_binder("firstFunction", first);
+            let second = builder.variable_binder("secondFunction", second);
+            let expressions = Mappings::Bifoldable {
+                first: builder.variable(first),
+                second: builder.variable(second),
+            };
+            (vec![first, second], expressions)
+        }
+    };
+    let (accumulator, initial) = match operation {
+        FoldOperation::Right | FoldOperation::Left => {
+            let accumulator = builder.variable_binder("accumulator", member.accumulator_type);
+            (Some(accumulator), Some(builder.variable(accumulator)))
+        }
+        FoldOperation::Map => (None, None),
+    };
+    let value = builder.variable_binder("value", member.source.type_id);
+    let value_expression = builder.variable(value);
+
+    let mut alternatives = Vec::with_capacity(recipe.constructors.len());
+    for constructor in &recipe.constructors {
+        let Some(alternative) = emit_fold_alternative(
+            &mut builder,
+            member,
+            constructor,
+            mapping_expressions,
+            operation,
+            initial,
+        )?
+        else {
+            return Ok(None);
+        };
+        alternatives.push(alternative);
+    }
+
+    let body = builder.case(member.result_type, vec![value_expression], alternatives);
+    let mut binders = mapping_binders;
+    binders.extend(accumulator);
+    binders.push(value);
+    Ok(Some(builder.lambda(member.function_type, binders, body)))
+}
+
+fn emit_fold_alternative<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    member: &DecodedFoldMember,
+    constructor: &ConstructorRecipe,
+    mapping_expressions: Mappings<ElaboratedExpression>,
+    operation: FoldOperation,
+    initial: Option<ElaboratedExpression>,
+) -> QueryResult<Option<tree::CaseAlternative>>
+where
+    Q: ExternalQueries,
+{
+    let constructor_type = toolkit::lookup_file_term(
+        builder.state,
+        builder.context,
+        member.data_file,
+        constructor.constructor_id,
+    )?;
+    let source_fields = field::instantiate_constructor_fields(
+        builder.state,
+        builder.context,
+        constructor_type,
+        &member.source.constructor_arguments,
+    )?;
+    if source_fields.len() != constructor.fields.len() {
+        return Ok(None);
+    }
+
+    let mut emitter = FoldEmitter {
+        builder,
+        mapping_expressions,
+        operation,
+        accumulator_type: member.accumulator_type,
+    };
+    let mut source_binders = Vec::with_capacity(source_fields.len());
+    let mut active_fields = Vec::new();
+    for (index, (source, operation)) in izip!(&source_fields, &constructor.fields).enumerate() {
+        let source_binder =
+            emitter.builder.variable_binder(&format_smolstr!("field{index}"), *source);
+        let source_value = emitter.builder.variable(source_binder);
+        source_binders.push(source_binder);
+        if let Some(operation) = operation {
+            active_fields.push((operation, source_value, *source));
+        }
+    }
+
+    let pattern = emitter.builder.constructor_pattern(
+        "constructor",
+        member.source.type_id,
+        (member.data_file, constructor.constructor_id),
+        source_binders,
+    );
+
+    // A right fold nests source fields from right to left so the first field remains
+    // the outermost application. A left fold threads the accumulator in source order.
+    // FoldMap preserves that field order in a right-associated append tree.
+    //
+    //   data Product a = Product a Int a a
+    //
+    //   foldr function initial (Product first _ second third) =
+    //     function first (function second (function third initial))
+    //
+    //   foldl function initial (Product first _ second third) =
+    //     function (function (function initial first) second) third
+    //
+    //   foldMap function (Product first _ second third) =
+    //     append (function first) (append (function second) (function third))
+    let accumulated = match operation {
+        FoldOperation::Right => {
+            let Some(mut accumulated) = initial else {
+                return Ok(None);
+            };
+            for &(operation, value, source_type) in active_fields.iter().rev() {
+                let Some(folded) =
+                    emitter.emit_operation(operation, value, Some(accumulated), source_type)?
+                else {
+                    return Ok(None);
+                };
+                accumulated = folded;
+            }
+            accumulated
+        }
+        FoldOperation::Left => {
+            let Some(mut accumulated) = initial else {
+                return Ok(None);
+            };
+            for &(operation, value, source_type) in &active_fields {
+                let Some(folded) =
+                    emitter.emit_operation(operation, value, Some(accumulated), source_type)?
+                else {
+                    return Ok(None);
+                };
+                accumulated = folded;
+            }
+            accumulated
+        }
+        FoldOperation::Map => {
+            let mut contributions = Vec::with_capacity(active_fields.len());
+            for &(operation, value, source_type) in &active_fields {
+                let Some(contribution) =
+                    emitter.emit_operation(operation, value, None, source_type)?
+                else {
+                    return Ok(None);
+                };
+                contributions.push(contribution);
+            }
+            let Some(combined) = emitter.combine_contributions(contributions)? else {
+                return Ok(None);
+            };
+            combined
+        }
+    };
+    let body = emitter.builder.subtype(accumulated, member.result_type)?;
+    Ok(Some(emitter.builder.alternative(vec![pattern], body)))
+}
+
+struct FoldEmitter<'builder, 'state, 'context, 'queries, Q: ExternalQueries> {
+    builder: &'builder mut DerivedTreeBuilder<'state, 'context, 'queries, Q>,
+    mapping_expressions: Mappings<ElaboratedExpression>,
+    operation: FoldOperation,
+    accumulator_type: TypeId,
+}
+
+impl<Q> FoldEmitter<'_, '_, '_, '_, Q>
+where
+    Q: ExternalQueries,
+{
+    fn emit_operation(
+        &mut self,
+        operation: &TraversalOperation,
+        value: ElaboratedExpression,
+        accumulator: Option<ElaboratedExpression>,
+        source_type: TypeId,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        match operation {
+            TraversalOperation::Parameter { parameter } => {
+                let Some(mapping_expression) = self.mapping_expressions.mapping_for(*parameter)
+                else {
+                    return Ok(None);
+                };
+                let applied = match self.operation {
+                    FoldOperation::Right => {
+                        let Some(accumulator) = accumulator else {
+                            return Ok(None);
+                        };
+                        let Some(applied) = self.builder.apply(mapping_expression, value)? else {
+                            return Ok(None);
+                        };
+                        let Some(applied) = self.builder.apply(applied, accumulator)? else {
+                            return Ok(None);
+                        };
+                        applied
+                    }
+                    FoldOperation::Left => {
+                        let Some(accumulator) = accumulator else {
+                            return Ok(None);
+                        };
+                        let Some(applied) = self.builder.apply(mapping_expression, accumulator)?
+                        else {
+                            return Ok(None);
+                        };
+                        let Some(applied) = self.builder.apply(applied, value)? else {
+                            return Ok(None);
+                        };
+                        applied
+                    }
+                    FoldOperation::Map => {
+                        let Some(applied) = self.builder.apply(mapping_expression, value)? else {
+                            return Ok(None);
+                        };
+                        applied
+                    }
+                };
+                Ok(Some(self.builder.subtype(applied, self.accumulator_type)?))
+            }
+            TraversalOperation::UnaryApplication { argument } => {
+                let Some((_, source_argument)) = toolkit::decompose_type_application(
+                    self.builder.state,
+                    self.builder.context,
+                    source_type,
+                )?
+                else {
+                    return Ok(None);
+                };
+
+                // Delegate the outer constructor to its Foldable instance. The generated
+                // transformer folds every contained value according to the argument recipe.
+                //
+                //   newtype Compose f g a = Compose (f (g a))
+                //
+                //   foldr function initial (Compose value) =
+                //     foldr
+                //       (\element accumulator -> foldr function accumulator element)
+                //       initial
+                //       value
+                let Some(transformer) = self.emit_transformer(argument, source_argument)? else {
+                    return Ok(None);
+                };
+                let operation = match self.operation {
+                    FoldOperation::Right => self.builder.context.known_terms.foldr,
+                    FoldOperation::Left => self.builder.context.known_terms.foldl,
+                    FoldOperation::Map => self.builder.context.known_terms.fold_map,
+                };
+                let Some(operation) = operation else {
+                    return Ok(None);
+                };
+                let operation = self.builder.term_reference(operation)?;
+                let Some(operation) = self.builder.apply(operation, transformer)? else {
+                    return Ok(None);
+                };
+                let operation = match self.operation {
+                    FoldOperation::Right | FoldOperation::Left => {
+                        let Some(accumulator) = accumulator else {
+                            return Ok(None);
+                        };
+                        let Some(operation) = self.builder.apply(operation, accumulator)? else {
+                            return Ok(None);
+                        };
+                        operation
+                    }
+                    FoldOperation::Map => operation,
+                };
+                let Some(folded) = self.builder.apply(operation, value)? else {
+                    return Ok(None);
+                };
+                Ok(Some(self.builder.subtype(folded, self.accumulator_type)?))
+            }
+            TraversalOperation::BinaryApplication { first, second } => {
+                self.emit_binary_fold(first, second.as_deref(), value, accumulator, source_type)
+            }
+            TraversalOperation::Record { fields } => {
+                self.emit_record_fold(fields, value, accumulator, source_type)
+            }
+            // Function operations are rejected during variance analysis.
+            TraversalOperation::Function { .. } => Ok(None),
+        }
+    }
+
+    fn emit_transformer(
+        &mut self,
+        operation: &TraversalOperation,
+        source_type: TypeId,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let element = self.builder.variable_binder("element", source_type);
+        let element_value = self.builder.variable(element);
+        let (arguments, function_arguments, body) = match self.operation {
+            FoldOperation::Right => {
+                let accumulator =
+                    self.builder.variable_binder("accumulator", self.accumulator_type);
+                let accumulator_value = self.builder.variable(accumulator);
+                let Some(body) = self.emit_operation(
+                    operation,
+                    element_value,
+                    Some(accumulator_value),
+                    source_type,
+                )?
+                else {
+                    return Ok(None);
+                };
+                (vec![element, accumulator], vec![source_type, self.accumulator_type], body)
+            }
+            FoldOperation::Left => {
+                let accumulator =
+                    self.builder.variable_binder("accumulator", self.accumulator_type);
+                let accumulator_value = self.builder.variable(accumulator);
+                let Some(body) = self.emit_operation(
+                    operation,
+                    element_value,
+                    Some(accumulator_value),
+                    source_type,
+                )?
+                else {
+                    return Ok(None);
+                };
+                (vec![accumulator, element], vec![self.accumulator_type, source_type], body)
+            }
+            FoldOperation::Map => {
+                let Some(body) =
+                    self.emit_operation(operation, element_value, None, source_type)?
+                else {
+                    return Ok(None);
+                };
+                (vec![element], vec![source_type], body)
+            }
+        };
+        let function_type =
+            self.builder.context.intern_function_iter(function_arguments, self.accumulator_type);
+        Ok(Some(self.builder.lambda(function_type, arguments, body)))
+    }
+
+    fn emit_binary_fold(
+        &mut self,
+        first: &TraversalOperation,
+        second: Option<&TraversalOperation>,
+        value: ElaboratedExpression,
+        accumulator: Option<ElaboratedExpression>,
+        source_type: TypeId,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some((source_function, source_second)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            source_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((_, source_first)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            source_function,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        let Some(first_transformer) = self.emit_transformer(first, source_first)? else {
+            return Ok(None);
+        };
+        let second_transformer = match second {
+            Some(second) => {
+                let Some(transformer) = self.emit_transformer(second, source_second)? else {
+                    return Ok(None);
+                };
+                transformer
+            }
+            None => {
+                let Some(transformer) = self.emit_ignoring_transformer(source_second)? else {
+                    return Ok(None);
+                };
+                transformer
+            }
+        };
+
+        // Bifoldable still requires a transformer for an inactive second argument. A
+        // directional fold returns the accumulator unchanged; foldMap returns mempty.
+        //
+        //   newtype LeftDuplicate p a = LeftDuplicate (p a Int)
+        //
+        //   foldr function initial (LeftDuplicate value) =
+        //     bifoldr function (\_ accumulator -> accumulator) initial value
+        //
+        //   foldMap function (LeftDuplicate value) =
+        //     bifoldMap function (\_ -> mempty) value
+        let operation = match self.operation {
+            FoldOperation::Right => self.builder.context.known_terms.bifoldr,
+            FoldOperation::Left => self.builder.context.known_terms.bifoldl,
+            FoldOperation::Map => self.builder.context.known_terms.bifold_map,
+        };
+        let Some(operation) = operation else {
+            return Ok(None);
+        };
+        let operation = self.builder.term_reference(operation)?;
+        let Some(operation) = self.builder.apply(operation, first_transformer)? else {
+            return Ok(None);
+        };
+        let Some(operation) = self.builder.apply(operation, second_transformer)? else {
+            return Ok(None);
+        };
+        let operation = match self.operation {
+            FoldOperation::Right | FoldOperation::Left => {
+                let Some(accumulator) = accumulator else {
+                    return Ok(None);
+                };
+                let Some(operation) = self.builder.apply(operation, accumulator)? else {
+                    return Ok(None);
+                };
+                operation
+            }
+            FoldOperation::Map => operation,
+        };
+        let Some(folded) = self.builder.apply(operation, value)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.builder.subtype(folded, self.accumulator_type)?))
+    }
+
+    fn emit_ignoring_transformer(
+        &mut self,
+        source_type: TypeId,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let element = self.builder.variable_binder("ignored", source_type);
+        let (arguments, function_arguments, body) = match self.operation {
+            FoldOperation::Right => {
+                let accumulator =
+                    self.builder.variable_binder("accumulator", self.accumulator_type);
+                (
+                    vec![element, accumulator],
+                    vec![source_type, self.accumulator_type],
+                    self.builder.variable(accumulator),
+                )
+            }
+            FoldOperation::Left => {
+                let accumulator =
+                    self.builder.variable_binder("accumulator", self.accumulator_type);
+                (
+                    vec![accumulator, element],
+                    vec![self.accumulator_type, source_type],
+                    self.builder.variable(accumulator),
+                )
+            }
+            FoldOperation::Map => {
+                let Some(mempty) = self.emit_mempty()? else {
+                    return Ok(None);
+                };
+                (vec![element], vec![source_type], mempty)
+            }
+        };
+        let function_type =
+            self.builder.context.intern_function_iter(function_arguments, self.accumulator_type);
+        Ok(Some(self.builder.lambda(function_type, arguments, body)))
+    }
+
+    fn emit_record_fold(
+        &mut self,
+        fields: &[RecordFieldRecipe],
+        value: ElaboratedExpression,
+        accumulator: Option<ElaboratedExpression>,
+        source_type: TypeId,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some(source_row) =
+            extract_record_row(self.builder.state, self.builder.context, source_type)?
+        else {
+            return Ok(None);
+        };
+
+        // Record recipes follow canonical row order. Fold right reverses that sequence
+        // while constructing its nested applications; fold left consumes it directly.
+        let mut active_fields = Vec::with_capacity(fields.len());
+        for field in fields {
+            let Some(source_field) = source_row.fields.iter().find(|row| row.label == field.label)
+            else {
+                return Ok(None);
+            };
+            active_fields.push((field, source_field.id));
+        }
+
+        let folded = match self.operation {
+            FoldOperation::Right => {
+                let Some(mut accumulated) = accumulator else {
+                    return Ok(None);
+                };
+                for &(field, source_field) in active_fields.iter().rev() {
+                    let accessed =
+                        self.builder.record_access(value, field.label.clone(), source_field);
+                    let Some(folded) = self.emit_operation(
+                        &field.operation,
+                        accessed,
+                        Some(accumulated),
+                        source_field,
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    accumulated = folded;
+                }
+                accumulated
+            }
+            FoldOperation::Left => {
+                let Some(mut accumulated) = accumulator else {
+                    return Ok(None);
+                };
+                for &(field, source_field) in &active_fields {
+                    let accessed =
+                        self.builder.record_access(value, field.label.clone(), source_field);
+                    let Some(folded) = self.emit_operation(
+                        &field.operation,
+                        accessed,
+                        Some(accumulated),
+                        source_field,
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    accumulated = folded;
+                }
+                accumulated
+            }
+            FoldOperation::Map => {
+                let mut contributions = Vec::with_capacity(active_fields.len());
+                for &(field, source_field) in &active_fields {
+                    let accessed =
+                        self.builder.record_access(value, field.label.clone(), source_field);
+                    let Some(contribution) =
+                        self.emit_operation(&field.operation, accessed, None, source_field)?
+                    else {
+                        return Ok(None);
+                    };
+                    contributions.push(contribution);
+                }
+                let Some(combined) = self.combine_contributions(contributions)? else {
+                    return Ok(None);
+                };
+                combined
+            }
+        };
+        Ok(Some(folded))
+    }
+
+    fn combine_contributions(
+        &mut self,
+        contributions: Vec<ElaboratedExpression>,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // FoldMap combines active contributions in logical field order. Construct the
+        // right-associated append tree from the final contribution, using mempty only
+        // when the constructor or record contains no active fields.
+        let contributions = contributions.into_iter().rev();
+        let mut contributions = contributions;
+        let Some(mut accumulated) = contributions.next() else {
+            return self.emit_mempty();
+        };
+
+        for contribution in contributions {
+            let Some(append) = self.builder.context.known_terms.append else {
+                return Ok(None);
+            };
+            let append = self.builder.term_reference(append)?;
+            let Some(append) = self.builder.apply(append, contribution)? else {
+                return Ok(None);
+            };
+            let Some(appended) = self.builder.apply(append, accumulated)? else {
+                return Ok(None);
+            };
+            accumulated = self.builder.subtype(appended, self.accumulator_type)?;
+        }
+        Ok(Some(accumulated))
+    }
+
+    fn emit_mempty(&mut self) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some(mempty) = self.builder.context.known_terms.mempty else {
+            return Ok(None);
+        };
+        let mempty = self.builder.term_reference(mempty)?;
+        Ok(Some(self.builder.subtype(mempty, self.accumulator_type)?))
+    }
+}
+
+fn extract_record_row<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    type_id: TypeId,
+) -> QueryResult<Option<RowType>>
+where
+    Q: ExternalQueries,
+{
+    let Some((_, row)) = toolkit::decompose_type_application(state, context, type_id)? else {
+        return Ok(None);
+    };
+    let row = normalise::expand(state, context, row)?;
+    let Type::Row(row) = context.lookup_type(row) else {
+        return Ok(None);
+    };
+    Ok(Some(context.lookup_row_type(row)))
+}

--- a/compiler-core/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-core/checking/src/source/derive/generate/foldable.rs
@@ -583,8 +583,9 @@ where
                 };
                 Ok(Some(self.builder.subtype(folded, self.accumulator_type)?))
             }
-            TraversalOperation::BinaryApplication { first, second } => {
-                self.emit_binary_fold(first, second.as_deref(), value, accumulator, source_type)
+            TraversalOperation::BinaryApplication { arguments } => {
+                let (first, second) = arguments.operations();
+                self.emit_binary_fold(first, second, value, accumulator, source_type)
             }
             TraversalOperation::Record { fields } => {
                 self.emit_record_fold(fields, value, accumulator, source_type)
@@ -648,7 +649,7 @@ where
 
     fn emit_binary_fold(
         &mut self,
-        first: &TraversalOperation,
+        first: Option<&TraversalOperation>,
         second: Option<&TraversalOperation>,
         value: ElaboratedExpression,
         accumulator: Option<ElaboratedExpression>,
@@ -671,8 +672,16 @@ where
             return Ok(None);
         };
 
-        let Some(first_transformer) = self.emit_transformer(first, source_first)? else {
-            return Ok(None);
+        let first_transformer = if let Some(first) = first {
+            let Some(transformer) = self.emit_transformer(first, source_first)? else {
+                return Ok(None);
+            };
+            transformer
+        } else {
+            let Some(transformer) = self.emit_ignoring_transformer(source_first)? else {
+                return Ok(None);
+            };
+            transformer
         };
         let second_transformer = match second {
             Some(second) => {
@@ -689,8 +698,8 @@ where
             }
         };
 
-        // Bifoldable still requires a transformer for an inactive second argument. A
-        // directional fold returns the accumulator unchanged; foldMap returns mempty.
+        // Bifoldable still requires a transformer for an inactive argument. A directional
+        // fold returns the accumulator unchanged; foldMap returns mempty.
         //
         //   newtype LeftDuplicate p a = LeftDuplicate (p a Int)
         //

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -440,10 +440,11 @@ where
                 // Check the specialized result against the target established above.
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::BinaryApplication { first, second } => {
+            TraversalOperation::BinaryApplication { arguments } => {
                 // Bimap lifts transformations through the first and second arguments of a
                 // binary type constructor. See `emit_bimap` for the staged construction.
-                self.emit_bimap(first, second.as_deref(), value, traversal)
+                let (first, second) = arguments.operations();
+                self.emit_bimap(first, second, value, traversal)
             }
             // Function types require both covariant and contravariant transformations.
             // Given:
@@ -647,7 +648,7 @@ where
 
     fn emit_bimap(
         &mut self,
-        first: &TraversalOperation,
+        first: Option<&TraversalOperation>,
         second: Option<&TraversalOperation>,
         value: ElaboratedExpression,
         traversal: TraversalContext,
@@ -712,6 +713,8 @@ where
         };
 
         // Generate the transformation that bimap calls for values in its first argument.
+        // When the traversed parameter does not occur there, bimap still requires an
+        // identity function.
         //
         //   bimap :: (a -> b) -> (c -> d) -> f a c -> f b d
         //   firstTransformer :: sourceFirst -> targetFirst
@@ -730,8 +733,13 @@ where
             target_type: target_first,
             function_depth: traversal.function_depth,
         };
-        let Some(first_transformer) = self.emit_transformer(first, first_context)? else {
-            return Ok(None);
+        let first_transformer = if let Some(first) = first {
+            let Some(transformer) = self.emit_transformer(first, first_context)? else {
+                return Ok(None);
+            };
+            transformer
+        } else {
+            self.emit_identity(first_context)?
         };
 
         // Generate the transformation that bimap calls for values in its second argument.
@@ -812,9 +820,9 @@ where
     }
 
     fn emit_identity(&mut self, traversal: TraversalContext) -> QueryResult<ElaboratedExpression> {
-        // A Bimap operation omits its second operation when the traversed parameter does
-        // not occur in that argument. Bimap still requires a second transformer, so supply
-        // identity rather than treating the missing operation as a missing expression.
+        // Bimap still requires a transformer for an argument that omits the traversed
+        // parameter, so supply identity rather than treating the missing operation as a
+        // missing expression.
         //
         // LeftPair
         //

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -698,10 +698,11 @@ where
                 let effect_type = self.effect_type(traversal.target_type);
                 Ok(Some(self.builder.subtype(traversed, effect_type)?))
             }
-            TraversalOperation::BinaryApplication { first, second } => {
+            TraversalOperation::BinaryApplication { arguments } => {
                 // Bitraverse delegates both arguments of a binary type constructor. See
                 // `emit_binary_effect` for the staged construction of its transformers.
-                self.emit_binary_effect(first, second.as_deref(), value, traversal)
+                let (first, second) = arguments.operations();
+                self.emit_binary_effect(first, second, value, traversal)
             }
             TraversalOperation::Record { fields } => {
                 // Record traversal combines the effects of its active field updates.
@@ -744,7 +745,7 @@ where
 
     fn emit_binary_effect(
         &mut self,
-        first: &TraversalOperation,
+        first: Option<&TraversalOperation>,
         second: Option<&TraversalOperation>,
         value: ElaboratedExpression,
         traversal: TraversalContext,
@@ -799,7 +800,8 @@ where
             return Ok(None);
         };
 
-        // Generate the effectful transformation for the first argument.
+        // Generate the effectful transformation for the first argument. If the
+        // derived parameter is absent there, lift the unchanged value with pure.
         //
         // Duplicate and LeftDuplicate
         //
@@ -807,8 +809,16 @@ where
         //   firstTransformer = function
         let first_context =
             TraversalContext { source_type: source_first, target_type: target_first };
-        let Some(first_transformer) = self.emit_transformer(first, first_context)? else {
-            return Ok(None);
+        let first_transformer = if let Some(first) = first {
+            let Some(transformer) = self.emit_transformer(first, first_context)? else {
+                return Ok(None);
+            };
+            transformer
+        } else {
+            let Some(transformer) = self.emit_pure_transformer(first_context)? else {
+                return Ok(None);
+            };
+            transformer
         };
 
         // Generate the effectful transformation for the second argument. If the
@@ -870,8 +880,8 @@ where
         &mut self,
         traversal: TraversalContext,
     ) -> QueryResult<Option<ElaboratedExpression>> {
-        // A binary argument has no operation when it omits the derived parameter.
-        // Bitraverse still needs an effectful transformer, so lift its value with pure.
+        // Bitraverse still needs an effectful transformer for a binary argument that omits
+        // the derived parameter, so lift its value with pure.
         //
         // LeftDuplicate
         //

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -100,6 +100,8 @@ where
                 derive_dispatch(context, result.class_file, result.class_id),
                 DeriveDispatch::Functor
                     | DeriveDispatch::Bifunctor
+                    | DeriveDispatch::Foldable
+                    | DeriveDispatch::Bifoldable
                     | DeriveDispatch::Traversable
                     | DeriveDispatch::Bitraversable
             ) && recipe.valid

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -95,6 +95,7 @@ where
                 data_id,
                 derived_type,
                 config,
+                &result.constraints,
             )?;
             if matches!(
                 derive_dispatch(context, result.class_file, result.class_id),

--- a/compiler-core/checking/src/source/derive/variance.rs
+++ b/compiler-core/checking/src/source/derive/variance.rs
@@ -6,7 +6,7 @@ use smol_str::SmolStr;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
-use crate::core::{KindOrType, Name, Type, TypeId, normalise, toolkit};
+use crate::core::{KindOrType, Name, Type, TypeId, constraint, normalise, toolkit};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 
@@ -68,8 +68,24 @@ pub enum TraversalOperation {
     Parameter { parameter: TraversalParameter },
     Function { argument: Option<Box<TraversalOperation>>, result: Option<Box<TraversalOperation>> },
     UnaryApplication { argument: Box<TraversalOperation> },
-    BinaryApplication { first: Box<TraversalOperation>, second: Option<Box<TraversalOperation>> },
+    BinaryApplication { arguments: BinaryApplicationArguments },
     Record { fields: Vec<RecordFieldRecipe> },
+}
+
+pub enum BinaryApplicationArguments {
+    First(Box<TraversalOperation>),
+    Second(Box<TraversalOperation>),
+    Both { first: Box<TraversalOperation>, second: Box<TraversalOperation> },
+}
+
+impl BinaryApplicationArguments {
+    pub fn operations(&self) -> (Option<&TraversalOperation>, Option<&TraversalOperation>) {
+        match self {
+            BinaryApplicationArguments::First(first) => (Some(first), None),
+            BinaryApplicationArguments::Second(second) => (None, Some(second)),
+            BinaryApplicationArguments::Both { first, second } => (Some(first), Some(second)),
+        }
+    }
 }
 
 pub struct RecordFieldRecipe {
@@ -121,6 +137,7 @@ pub fn generate_variance_constraints<Q>(
     data_id: TypeItemId,
     derived_type: TypeId,
     config: VarianceConfig,
+    available_constraints: &[TypeId],
 ) -> QueryResult<VarianceRecipe>
 where
     Q: ExternalQueries,
@@ -134,8 +151,13 @@ where
             extract_fields_with_rigids(state, context, constructor_t, derived_type, config)?;
         valid &= !matches!(rigids, DerivedRigids::Invalid);
 
-        let mut checker =
-            VarianceFieldChecker { state, context, rigids: &rigids, valid: &mut valid };
+        let mut checker = VarianceFieldChecker {
+            state,
+            context,
+            rigids: &rigids,
+            available_constraints,
+            valid: &mut valid,
+        };
         let mut field_recipes = Vec::with_capacity(fields.len());
         for field in fields {
             let operation = checker.check(field, Variance::Covariant)?;
@@ -230,6 +252,7 @@ struct VarianceFieldChecker<'state, 'context, 'queries, 'rigids, Q: ExternalQuer
     state: &'state mut CheckState,
     context: &'context CheckContext<'queries, Q>,
     rigids: &'rigids DerivedRigids,
+    available_constraints: &'rigids [TypeId],
     valid: &'state mut bool,
 }
 
@@ -412,13 +435,34 @@ where
             if *self.valid && head_is_fixed && first_is_valid && second_is_valid {
                 tools::emit_constraint(self.context, self.state, binary_class, binary_head);
             }
-            return Ok(Some(TraversalOperation::BinaryApplication {
-                first: Box::new(first),
-                second: second.map(Box::new),
-            }));
+            let arguments = match second {
+                Some(second) => BinaryApplicationArguments::Both {
+                    first: Box::new(first),
+                    second: Box::new(second),
+                },
+                None => BinaryApplicationArguments::First(Box::new(first)),
+            };
+            return Ok(Some(TraversalOperation::BinaryApplication { arguments }));
         }
 
         if let Some(second) = second {
+            // A right-only occurrence can use either the unary class for the partially
+            // applied constructor or the binary class for its head. Match purs by using
+            // the binary class only when the unary dictionary is unavailable.
+            let binary_available = self.has_instance_head(binary_class, binary_head)?;
+            let unary_available = self.unary_instances_available(
+                application.argument,
+                variance,
+                application.function,
+            )?;
+            if binary_available && !unary_available {
+                if *self.valid && head_is_fixed && second_is_valid {
+                    tools::emit_constraint(self.context, self.state, binary_class, binary_head);
+                }
+                let arguments = BinaryApplicationArguments::Second(Box::new(second));
+                return Ok(Some(TraversalOperation::BinaryApplication { arguments }));
+            }
+
             if *self.valid && head_is_fixed && second_is_valid {
                 self.emit_unary_constraints(application.argument, variance, application.function)?;
             }
@@ -457,6 +501,123 @@ where
             }
         }
         Ok(())
+    }
+
+    fn unary_instances_available(
+        &mut self,
+        argument: TypeId,
+        variance: Variance,
+        function: TypeId,
+    ) -> QueryResult<bool> {
+        for parameter in self.rigids.iter() {
+            if variance != parameter.expected
+                || !toolkit::contains_rigid(self.state, self.context, argument, parameter.name)?
+            {
+                continue;
+            }
+
+            let Some(class) = parameter.unary_class else {
+                return Ok(false);
+            };
+            if !self.has_instance_head(class, function)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn has_instance_head(&mut self, class: ClassReference, argument: TypeId) -> QueryResult<bool> {
+        // Derivation tests constructor-head availability rather than solving the exact
+        // candidate constraint. For example, `Foldable (p Int)` advertises unary traversal
+        // for the head `p`; the emitted wanted still checks the complete application.
+        let (argument_head, _) =
+            toolkit::extract_type_application(self.state, self.context, argument)?;
+
+        let type_heads_equal = |context: &CheckContext<Q>, left: TypeId, right: TypeId| {
+            if left == right {
+                return true;
+            }
+
+            match (context.lookup_type(left), context.lookup_type(right)) {
+                (
+                    Type::Constructor(left_file, left_id),
+                    Type::Constructor(right_file, right_id),
+                ) => left_file == right_file && left_id == right_id,
+                // Generalisation can reconstruct a rigid's kind while preserving the binder
+                // name. Constructor-head availability depends on that binder identity, not
+                // its kind ID.
+                (Type::Rigid(left_name, ..), Type::Rigid(right_name, ..)) => {
+                    left_name == right_name
+                }
+                (Type::Free(left_name), Type::Free(right_name)) => left_name == right_name,
+                _ => false,
+            }
+        };
+
+        let mut available_constraints = Vec::with_capacity(self.available_constraints.len());
+        for &available in self.available_constraints {
+            let Some(available) =
+                constraint::canonical::canonicalise(self.state, self.context, available)?
+            else {
+                continue;
+            };
+            available_constraints.push(available);
+        }
+        let available_constraints = constraint::elaborate::elaborate_superclasses(
+            self.state,
+            self.context,
+            &available_constraints,
+        )?;
+
+        for available in available_constraints {
+            let available = self.state.canonicals[available].clone();
+            if (available.file_id, available.type_id) != class {
+                continue;
+            }
+            let [KindOrType::Type(available_argument)] = available.arguments.as_ref() else {
+                continue;
+            };
+            let (available_head, _) =
+                toolkit::extract_type_application(self.state, self.context, *available_argument)?;
+            if type_heads_equal(self.context, available_head, argument_head) {
+                return Ok(true);
+            }
+        }
+
+        let class_type = self.context.queries.intern_type(Type::Constructor(class.0, class.1));
+        let constraint_type = self.context.intern_application(class_type, argument);
+        let Some(constraint) =
+            constraint::canonical::canonicalise(self.state, self.context, constraint_type)?
+        else {
+            return Ok(false);
+        };
+        let instances =
+            constraint::instances::collect_instance_chains(self.state, self.context, constraint)?;
+        for chain in instances.chains {
+            for candidate in chain {
+                let Some(candidate) = toolkit::instance_info(
+                    self.state,
+                    self.context,
+                    candidate.instance.signature,
+                    class,
+                )?
+                else {
+                    continue;
+                };
+                let [KindOrType::Type(candidate_argument)] = candidate.arguments.as_slice() else {
+                    continue;
+                };
+                let (candidate_head, _) = toolkit::extract_type_application(
+                    self.state,
+                    self.context,
+                    *candidate_argument,
+                )?;
+                if type_heads_equal(self.context, candidate_head, argument_head) {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
     }
 
     fn emit_unary_constraint(&mut self, parameter: &DerivedParameter, function: TypeId) {

--- a/compiler-core/checking/src/source/derive/variance.rs
+++ b/compiler-core/checking/src/source/derive/variance.rs
@@ -255,9 +255,12 @@ where
             toolkit::decompose_function(self.state, self.context, type_id)?
         {
             // Function results can be transformed pointwise when deriving `Functor`, but an
-            // applicative traversal cannot sequence those results. For example:
+            // arbitrary function cannot be folded or traversed structurally. For example:
             //
             //   data Reader a = Reader (Int -> a)
+            //
+            // A fold has no finite collection of `a` values to consume without an `Int`.
+            // An applicative traversal encounters a separate obstruction:
             //
             //   traverse :: (a -> m b) -> Reader a -> m (Reader b)
             //   function :: a -> m b
@@ -265,9 +268,9 @@ where
             //
             // Applying `function` pointwise produces `Int -> m b`, but reconstructing
             // `Reader b` inside the applicative requires `m (Int -> b)`. An arbitrary
-            // `Applicative m` cannot exchange the `Int ->` and `m` constructors. `Traversable`
-            // and `Bitraversable` therefore reject function types containing a derived
-            // parameter, while fixed function fields still require no traversal.
+            // `Applicative m` cannot exchange the `Int ->` and `m` constructors. Fold and
+            // traversal derivation therefore reject function types containing a derived
+            // parameter, while fixed function fields still require no operation.
             let mut allowed = true;
             for parameter in self.rigids.iter() {
                 if matches!(parameter.function_policy, FunctionPolicy::Reject)

--- a/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.purs
+++ b/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.purs
@@ -2,6 +2,7 @@ module Main where
 
 import Data.Functor (class Functor)
 import Data.Foldable (class Foldable)
+import Data.Monoid (mempty)
 import Data.Traversable (class Traversable)
 
 data Reader a = Reader (Int -> a)
@@ -10,5 +11,6 @@ derive instance Functor Reader
 instance Foldable Reader where
   foldr _ initial _ = initial
   foldl _ initial _ = initial
+  foldMap _ _ = mempty
 
 derive instance Traversable Reader

--- a/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785484200_derive_traversable_function_rejection/Main.snap
@@ -21,7 +21,7 @@ Reader = [Representational]
 
 Diagnostics
 error[CannotDeriveForType]: Cannot derive for type: Int -> (t0 :: Type)
-  --> 14:1..14:35
+  --> 16:1..16:35
    |
-14 | derive instance Traversable Reader
+16 | derive instance Traversable Reader
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1785518760_derive_bifoldable_function_rejection/Main.purs
+++ b/tests-integration/fixtures/checking/1785518760_derive_bifoldable_function_rejection/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+
+data ReaderPair a b = ReaderPair a (Int -> b)
+derive instance Bifoldable ReaderPair

--- a/tests-integration/fixtures/checking/1785518760_derive_bifoldable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785518760_derive_bifoldable_function_rejection/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+ReaderPair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) ->
+    (Prim.Int -> (b :: Prim.Type)) ->
+    Main.ReaderPair (a :: Prim.Type) (b :: Prim.Type)
+
+Types
+ReaderPair :: Prim.Type -> Prim.Type -> Prim.Type
+
+Derived
+derive Data.Bifoldable.Bifoldable Main.ReaderPair
+
+Roles
+ReaderPair = [Representational, Representational]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Int -> (t0 :: Type)
+  --> 6:1..6:38
+  |
+6 | derive instance Bifoldable ReaderPair
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1785518760_derive_foldable_function_rejection/Main.purs
+++ b/tests-integration/fixtures/checking/1785518760_derive_foldable_function_rejection/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Reader a = Reader (Int -> a)
+derive instance Foldable Reader

--- a/tests-integration/fixtures/checking/1785518760_derive_foldable_function_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785518760_derive_foldable_function_rejection/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Reader :: forall (@a :: Prim.Type). (Prim.Int -> (a :: Prim.Type)) -> Main.Reader (a :: Prim.Type)
+
+Types
+Reader :: Prim.Type -> Prim.Type
+
+Derived
+derive Data.Foldable.Foldable Main.Reader
+
+Roles
+Reader = [Representational]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Int -> (t0 :: Type)
+  --> 6:1..6:32
+  |
+6 | derive instance Foldable Reader
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/prelude/Data.Bifoldable.purs
+++ b/tests-integration/fixtures/checking/prelude/Data.Bifoldable.purs
@@ -1,5 +1,8 @@
 module Data.Bifoldable where
 
+import Data.Monoid (class Monoid)
+
 class Bifoldable p where
   bifoldr :: forall a b c. (a -> c -> c) -> (b -> c -> c) -> c -> p a b -> c
   bifoldl :: forall a b c. (c -> a -> c) -> (c -> b -> c) -> c -> p a b -> c
+  bifoldMap :: forall m a b. Monoid m => (a -> m) -> (b -> m) -> p a b -> m

--- a/tests-integration/fixtures/checking/prelude/Data.Foldable.purs
+++ b/tests-integration/fixtures/checking/prelude/Data.Foldable.purs
@@ -1,5 +1,8 @@
 module Data.Foldable where
 
+import Data.Monoid (class Monoid)
+
 class Foldable f where
   foldr :: forall a b. (a -> b -> b) -> b -> f a -> b
   foldl :: forall a b. (b -> a -> b) -> b -> f a -> b
+  foldMap :: forall a m. Monoid m => (a -> m) -> f a -> m

--- a/tests-integration/fixtures/checking/prelude/Data.Monoid.purs
+++ b/tests-integration/fixtures/checking/prelude/Data.Monoid.purs
@@ -1,0 +1,6 @@
+module Data.Monoid where
+
+import Data.Semigroup (class Semigroup)
+
+class Semigroup m <= Monoid m where
+  mempty :: m

--- a/tests-integration/fixtures/checking/prelude/Data.Semigroup.purs
+++ b/tests-integration/fixtures/checking/prelude/Data.Semigroup.purs
@@ -1,0 +1,6 @@
+module Data.Semigroup where
+
+class Semigroup a where
+  append :: a -> a -> a
+
+infixr 5 append as <>

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_either_body/Main.snap
@@ -16,9 +16,30 @@ dictionary bifunctorEither :: Data.Bifunctor.Bifunctor Main.Either where
       (Left field0) -> Left @b @d (firstFunction field0)
       (Right field0) -> Right @b @d (secondFunction field0)
 
+dictionary bifoldableEither :: Data.Bifoldable.Bifoldable Main.Either where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Either a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Left field0) -> firstFunction field0 accumulator
+      (Right field0) -> secondFunction field0 accumulator
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Either a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Left field0) -> firstFunction accumulator field0
+      (Right field0) -> secondFunction accumulator field0
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Either a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Left field0) -> firstFunction field0
+        (Right field0) -> secondFunction field0
+
 dictionary bitraversableEither :: Data.Bitraversable.Bitraversable Main.Either where
   superclass bifunctorDict = bifunctorEither
-  superclass bifoldableDict = <instance>
+  superclass bifoldableDict = bifoldableEither
   bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_binary_body/Main.snap
@@ -25,13 +25,46 @@ dictionary bifunctorNested ::
           (\element -> secondFunction element)
           field0)
 
+dictionary bifoldableNested ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Bifoldable.Bifoldable (Main.Nested @Prim.Type @Prim.Type p)
+  where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Nested field0) -> bifoldr @p {bifoldableDict} @a @b @c
+        (\element accumulator -> firstFunction element accumulator)
+        (\element accumulator -> secondFunction element accumulator)
+        accumulator
+        field0
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Nested field0) -> bifoldl @p {bifoldableDict} @a @b @c
+        (\accumulator element -> firstFunction accumulator element)
+        (\accumulator element -> secondFunction accumulator element)
+        accumulator
+        field0
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Nested @Prim.Type @Prim.Type p a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> bifoldMap @p {bifoldableDict} @m @a @b {monoidDict}
+          (\element -> firstFunction element)
+          (\element -> secondFunction element)
+          field0
+
 dictionary bitraversableNested ::
   forall p.
   { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Bitraversable.Bitraversable (Main.Nested @Prim.Type @Prim.Type p)
   where
   superclass bifunctorDict = bifunctorNested {bitraversableDict.bifunctorDict}
-  superclass bifoldableDict = <instance> {bitraversableDict.bifoldableDict}
+  superclass bifoldableDict = bifoldableNested {bitraversableDict.bifoldableDict}
   bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_nested_unary_body/Main.snap
@@ -26,6 +26,42 @@ dictionary bifunctorWrap ::
         (map @f {functorDict} @a @b (\element -> firstFunction element) field0)
         (map @g {functorDict1} @c @d (\element -> secondFunction element) field1)
 
+dictionary bifoldableWrap ::
+  forall f g.
+  { foldableDict :: Data.Foldable.Foldable f } =>
+  { foldableDict1 :: Data.Foldable.Foldable g } =>
+  Data.Bifoldable.Bifoldable (Main.Wrap @Prim.Type @Prim.Type f g)
+  where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Wrap field0 field1) -> foldr @f {foldableDict} @a @c
+        (\element accumulator -> firstFunction element accumulator)
+        (foldr @g {foldableDict1} @b @c (\element accumulator -> secondFunction element accumulator)
+          accumulator
+          field1)
+        field0
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Wrap field0 field1) -> foldl @g {foldableDict1} @b @c
+        (\accumulator element -> secondFunction accumulator element)
+        (foldl @f {foldableDict} @a @c (\accumulator element -> firstFunction accumulator element)
+          accumulator
+          field0)
+        field1
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Wrap @Prim.Type @Prim.Type f g a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Wrap field0 field1) -> append @m {monoidDict.semigroupDict}
+          (foldMap @f {foldableDict} @a @m {monoidDict} (\element -> firstFunction element) field0)
+          (foldMap @g {foldableDict1} @b @m {monoidDict} (\element -> secondFunction element)
+            field1)
+
 dictionary bitraversableWrap ::
   forall f g.
   { traversableDict :: Data.Traversable.Traversable f } =>
@@ -33,7 +69,7 @@ dictionary bitraversableWrap ::
   Data.Bitraversable.Bitraversable (Main.Wrap @Prim.Type @Prim.Type f g)
   where
   superclass bifunctorDict = bifunctorWrap {traversableDict.functorDict} {traversableDict1.functorDict}
-  superclass bifoldableDict = <instance> {traversableDict.foldableDict} {traversableDict1.foldableDict}
+  superclass bifoldableDict = bifoldableWrap {traversableDict.foldableDict} {traversableDict1.foldableDict}
   bitraverse :: forall (f1 :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
   (d :: Prim.Type).
   Control.Applicative.Applicative f1 =>

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_pair_body/Main.snap
@@ -15,9 +15,28 @@ dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
       (Pair field0 field1 field2) -> Pair @b @d (firstFunction field0) field1
         (secondFunction field2)
 
+dictionary bifoldablePair :: Data.Bifoldable.Bifoldable Main.Pair where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Pair a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Pair field0 field1 field2) -> firstFunction field0 (secondFunction field2 accumulator)
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Pair a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Pair field0 field1 field2) -> secondFunction (firstFunction accumulator field0) field2
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Pair a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1 field2) -> append @m {monoidDict.semigroupDict} (firstFunction field0)
+          (secondFunction field2)
+
 dictionary bitraversablePair :: Data.Bitraversable.Bitraversable Main.Pair where
   superclass bifunctorDict = bifunctorPair
-  superclass bifoldableDict = <instance>
+  superclass bifoldableDict = bifoldablePair
   bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>

--- a/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_bitraversable_record_body/Main.snap
@@ -15,9 +15,28 @@ dictionary bifunctorRecordPair :: Data.Bifunctor.Bifunctor Main.RecordPair where
       (RecordPair field0) -> RecordPair @b @d
         field0 { alpha = firstFunction field0.alpha, zeta = secondFunction field0.zeta }
 
+dictionary bifoldableRecordPair :: Data.Bifoldable.Bifoldable Main.RecordPair where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.RecordPair a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (RecordPair field0) -> firstFunction field0.alpha (secondFunction field0.zeta accumulator)
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.RecordPair a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (RecordPair field0) -> secondFunction (firstFunction accumulator field0.alpha) field0.zeta
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.RecordPair a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (RecordPair field0) -> append @m {monoidDict.semigroupDict} (firstFunction field0.alpha)
+          (secondFunction field0.zeta)
+
 dictionary bitraversableRecordPair :: Data.Bitraversable.Bitraversable Main.RecordPair where
   superclass bifunctorDict = bifunctorRecordPair
-  superclass bifoldableDict = <instance>
+  superclass bifoldableDict = bifoldableRecordPair
   bitraverse :: forall (f :: Prim.Type -> Prim.Type) (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type)
   (d :: Prim.Type).
   Control.Applicative.Applicative f =>

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.purs
@@ -3,7 +3,7 @@ module Main where
 import Data.Functor (class Functor)
 import Data.Bifunctor (class Bifunctor, bimap)
 import Data.Foldable (class Foldable)
-import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr)
+import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr, bifoldMap)
 import Data.Traversable (class Traversable)
 import Data.Bitraversable (class Bitraversable)
 
@@ -15,5 +15,6 @@ instance Bifunctor p => Functor (Duplicate p) where
 instance Bifoldable p => Foldable (Duplicate p) where
   foldr function initial (Duplicate value) = bifoldr function function initial value
   foldl function initial (Duplicate value) = bifoldl function function initial value
+  foldMap function (Duplicate value) = bifoldMap function function value
 
 derive instance Bitraversable p => Traversable (Duplicate p)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_both_body/Main.snap
@@ -28,6 +28,10 @@ dictionary foldableDuplicate ::
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
   foldl = \function -> \initial -> \(Duplicate value) ->
     bifoldl @p {bifoldableDict} @a @a @b function function initial value
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.Duplicate @Prim.Type p a -> m
+  foldMap = \{monoidDict} -> \function -> \(Duplicate value) ->
+    bifoldMap @p {bifoldableDict} @m @a @a {monoidDict} function function value
 
 dictionary traversableDuplicate ::
   forall p.

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.purs
@@ -3,7 +3,8 @@ module Main where
 import Data.Functor (class Functor)
 import Data.Bifunctor (class Bifunctor, bimap)
 import Data.Foldable (class Foldable)
-import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr)
+import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr, bifoldMap)
+import Data.Monoid (mempty)
 import Data.Traversable (class Traversable)
 import Data.Bitraversable (class Bitraversable)
 
@@ -18,5 +19,6 @@ instance Bifoldable p => Foldable (LeftDuplicate p) where
     bifoldr function (\_ accumulated -> accumulated) initial value
   foldl function initial (LeftDuplicate value) =
     bifoldl function (\accumulated _ -> accumulated) initial value
+  foldMap function (LeftDuplicate value) = bifoldMap function (\_ -> mempty) value
 
 derive instance Bitraversable p => Traversable (LeftDuplicate p)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_binary_left_body/Main.snap
@@ -33,6 +33,12 @@ dictionary foldableLeftDuplicate ::
   foldl = \function -> \initial -> \(LeftDuplicate value) ->
     bifoldl @p {bifoldableDict} @a @Prim.Int @b function (\accumulated _ -> accumulated) initial
       value
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.LeftDuplicate @Prim.Type p a -> m
+  foldMap = \{monoidDict} -> \function -> \(LeftDuplicate value) ->
+    bifoldMap @p {bifoldableDict} @m @a @Prim.Int {monoidDict} function
+      (\_ -> mempty @m {monoidDict})
+      value
 
 dictionary traversableLeftDuplicate ::
   forall p.

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_const_body/Main.snap
@@ -14,10 +14,26 @@ dictionary functorConst :: forall e. Data.Functor.Functor (Main.Const @Prim.Type
     case value of
       (Const field0) -> Const @Prim.Type @e @b field0
 
+dictionary foldableConst :: forall e. Data.Foldable.Foldable (Main.Const @Prim.Type e) where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Const @Prim.Type e a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Const field0) -> accumulator
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Const @Prim.Type e a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Const field0) -> accumulator
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.Const @Prim.Type e a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Const field0) -> mempty @m {monoidDict}
+
 dictionary traversableConst :: forall e. Data.Traversable.Traversable (Main.Const @Prim.Type e)
   where
   superclass functorDict = functorConst
-  superclass foldableDict = <instance>
+  superclass foldableDict = foldableConst
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) -> Main.Const @Prim.Type e a -> m (Main.Const @Prim.Type e b)

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_identity_body/Main.snap
@@ -13,9 +13,24 @@ dictionary functorIdentity :: Data.Functor.Functor Main.Identity where
     case value of
       (Identity field0) -> Identity @b (function field0)
 
+dictionary foldableIdentity :: Data.Foldable.Foldable Main.Identity where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Identity a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Identity field0) -> function field0 accumulator
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Identity a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Identity field0) -> function accumulator field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Identity a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Identity field0) -> function field0
+
 dictionary traversableIdentity :: Data.Traversable.Traversable Main.Identity where
   superclass functorDict = functorIdentity
-  superclass foldableDict = <instance>
+  superclass foldableDict = foldableIdentity
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Identity a -> m (Main.Identity b)
   traverse = \{applicativeDict} ->

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_maybe_body/Main.snap
@@ -15,9 +15,27 @@ dictionary functorMaybe :: Data.Functor.Functor Main.Maybe where
       Nothing -> Nothing @b
       (Just field0) -> Just @b (function field0)
 
+dictionary foldableMaybe :: Data.Foldable.Foldable Main.Maybe where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Maybe a -> b
+  foldr = \function accumulator value ->
+    case value of
+      Nothing -> accumulator
+      (Just field0) -> function field0 accumulator
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Maybe a -> b
+  foldl = \function accumulator value ->
+    case value of
+      Nothing -> accumulator
+      (Just field0) -> function accumulator field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Maybe a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        Nothing -> mempty @m {monoidDict}
+        (Just field0) -> function field0
+
 dictionary traversableMaybe :: Data.Traversable.Traversable Main.Maybe where
   superclass functorDict = functorMaybe
-  superclass foldableDict = <instance>
+  superclass foldableDict = foldableMaybe
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Maybe a -> m (Main.Maybe b)
   traverse = \{applicativeDict} ->

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_nested_body/Main.snap
@@ -23,6 +23,44 @@ dictionary functorCompose ::
           (\element -> map @g {functorDict1} @a @b (\element -> function element) element)
           field0)
 
+dictionary foldableCompose ::
+  forall f g.
+  { foldableDict :: Data.Foldable.Foldable f } =>
+  { foldableDict1 :: Data.Foldable.Foldable g } =>
+  Data.Foldable.Foldable (Main.Compose @Prim.Type @Prim.Type f g)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Compose field0) -> foldr @f {foldableDict} @(g a) @b
+        (\element accumulator ->
+          foldr @g {foldableDict1} @a @b (\element accumulator -> function element accumulator)
+            accumulator
+            element)
+        accumulator
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Compose field0) -> foldl @f {foldableDict} @(g a) @b
+        (\accumulator element ->
+          foldl @g {foldableDict1} @a @b (\accumulator element -> function accumulator element)
+            accumulator
+            element)
+        accumulator
+        field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.Compose @Prim.Type @Prim.Type f g a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Compose field0) -> foldMap @f {foldableDict} @(g a) @m {monoidDict}
+          (\element ->
+            foldMap @g {foldableDict1} @a @m {monoidDict} (\element -> function element) element)
+          field0
+
 dictionary traversableCompose ::
   forall f g.
   { traversableDict :: Data.Traversable.Traversable f } =>
@@ -30,7 +68,7 @@ dictionary traversableCompose ::
   Data.Traversable.Traversable (Main.Compose @Prim.Type @Prim.Type f g)
   where
   superclass functorDict = functorCompose {traversableDict.functorDict} {traversableDict1.functorDict}
-  superclass foldableDict = <instance> {traversableDict.foldableDict} {traversableDict1.foldableDict}
+  superclass foldableDict = foldableCompose {traversableDict.foldableDict} {traversableDict1.foldableDict}
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m =>
   (a -> m b) ->

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_product_body/Main.snap
@@ -13,9 +13,25 @@ dictionary functorProduct :: Data.Functor.Functor Main.Product where
     case value of
       (Product field0 field1 field2) -> Product @b (function field0) field1 (function field2)
 
+dictionary foldableProduct :: Data.Foldable.Foldable Main.Product where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Product a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Product field0 field1 field2) -> function field0 (function field2 accumulator)
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Product a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Product field0 field1 field2) -> function (function accumulator field0) field2
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Product a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Product field0 field1 field2) -> append @m {monoidDict.semigroupDict} (function field0)
+          (function field2)
+
 dictionary traversableProduct :: Data.Traversable.Traversable Main.Product where
   superclass functorDict = functorProduct
-  superclass foldableDict = <instance>
+  superclass foldableDict = foldableProduct
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Product a -> m (Main.Product b)
   traverse = \{applicativeDict} ->

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_record_body/Main.snap
@@ -14,9 +14,25 @@ dictionary functorRecord :: Data.Functor.Functor Main.Record where
       (Record field0) -> Record @b
         field0 { alpha = function field0.alpha, zeta = function field0.zeta }
 
+dictionary foldableRecord :: Data.Foldable.Foldable Main.Record where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Record a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Record field0) -> function field0.alpha (function field0.zeta accumulator)
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Record a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Record field0) -> function (function accumulator field0.alpha) field0.zeta
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Record a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Record field0) -> append @m {monoidDict.semigroupDict} (function field0.alpha)
+          (function field0.zeta)
+
 dictionary traversableRecord :: Data.Traversable.Traversable Main.Record where
   superclass functorDict = functorRecord
-  superclass foldableDict = <instance>
+  superclass foldableDict = foldableRecord
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Record a -> m (Main.Record b)
   traverse = \{applicativeDict} ->

--- a/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785484440_derive_traversable_recursive_body/Main.snap
@@ -17,9 +17,43 @@ dictionary functorTree :: Data.Functor.Functor Main.Tree where
         (map @Main.Tree {functorTree} @a @b (\element -> function element) field0)
         (map @Main.Tree {functorTree} @a @b (\element -> function element) field1)
 
+dictionary foldableTree :: Data.Foldable.Foldable Main.Tree where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Tree a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Leaf field0) -> function field0 accumulator
+      (Branch field0 field1) -> foldr @Main.Tree {foldableTree} @a @b
+        (\element accumulator -> function element accumulator)
+        (foldr @Main.Tree {foldableTree} @a @b
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field1)
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Tree a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Leaf field0) -> function accumulator field0
+      (Branch field0 field1) -> foldl @Main.Tree {foldableTree} @a @b
+        (\accumulator element -> function accumulator element)
+        (foldl @Main.Tree {foldableTree} @a @b
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0)
+        field1
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Tree a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Leaf field0) -> function field0
+        (Branch field0 field1) -> append @m {monoidDict.semigroupDict}
+          (foldMap @Main.Tree {foldableTree} @a @m {monoidDict} (\element -> function element)
+            field0)
+          (foldMap @Main.Tree {foldableTree} @a @m {monoidDict} (\element -> function element)
+            field1)
+
 dictionary traversableTree :: Data.Traversable.Traversable Main.Tree where
   superclass functorDict = functorTree
-  superclass foldableDict = <instance>
+  superclass foldableDict = foldableTree
   traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
   Control.Applicative.Applicative m => (a -> m b) -> Main.Tree a -> m (Main.Tree b)
   traverse = \{applicativeDict} ->

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_either_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_either_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+
+data Either a b = Left a | Right b
+derive instance Bifoldable Either

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_either_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_either_body/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Either :: Prim.Type -> Prim.Type -> Prim.Type
+data Either @a @b
+  | Left :: a -> Main.Either a b
+  | Right :: b -> Main.Either a b
+
+dictionary bifoldableEither :: Data.Bifoldable.Bifoldable Main.Either where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Either a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Left field0) -> firstFunction field0 accumulator
+      (Right field0) -> secondFunction field0 accumulator
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Either a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Left field0) -> firstFunction accumulator field0
+      (Right field0) -> secondFunction accumulator field0
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Either a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Left field0) -> firstFunction field0
+        (Right field0) -> secondFunction field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+
+data Nested p a b = Nested (p a b)
+derive instance Bifoldable p => Bifoldable (Nested p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_binary_body/Main.snap
@@ -1,0 +1,42 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Nested ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type). (k0 -> k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
+data Nested @p @a @b
+  | Nested :: p a b -> Main.Nested p a b
+
+dictionary bifoldableNested ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Bifoldable.Bifoldable (Main.Nested @Prim.Type @Prim.Type p)
+  where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Nested field0) -> bifoldr @p {bifoldableDict} @a @b @c
+        (\element accumulator -> firstFunction element accumulator)
+        (\element accumulator -> secondFunction element accumulator)
+        accumulator
+        field0
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Nested @Prim.Type @Prim.Type p a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Nested field0) -> bifoldl @p {bifoldableDict} @a @b @c
+        (\accumulator element -> firstFunction accumulator element)
+        (\accumulator element -> secondFunction accumulator element)
+        accumulator
+        field0
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Nested @Prim.Type @Prim.Type p a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Nested field0) -> bifoldMap @p {bifoldableDict} @m @a @b {monoidDict}
+          (\element -> firstFunction element)
+          (\element -> secondFunction element)
+          field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+import Data.Bifoldable (class Bifoldable)
+
+data Wrap f g a b = Wrap (f a) (g b)
+derive instance (Foldable f, Foldable g) => Bifoldable (Wrap f g)

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_nested_unary_body/Main.snap
@@ -1,0 +1,46 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Wrap ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type).
+    (k0 -> Prim.Type) -> (k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
+data Wrap @f @g @a @b
+  | Wrap :: f a -> g b -> Main.Wrap f g a b
+
+dictionary bifoldableWrap ::
+  forall f g.
+  { foldableDict :: Data.Foldable.Foldable f } =>
+  { foldableDict1 :: Data.Foldable.Foldable g } =>
+  Data.Bifoldable.Bifoldable (Main.Wrap @Prim.Type @Prim.Type f g)
+  where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Wrap field0 field1) -> foldr @f {foldableDict} @a @c
+        (\element accumulator -> firstFunction element accumulator)
+        (foldr @g {foldableDict1} @b @c (\element accumulator -> secondFunction element accumulator)
+          accumulator
+          field1)
+        field0
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Wrap @Prim.Type @Prim.Type f g a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Wrap field0 field1) -> foldl @g {foldableDict1} @b @c
+        (\accumulator element -> secondFunction accumulator element)
+        (foldl @f {foldableDict} @a @c (\accumulator element -> firstFunction accumulator element)
+          accumulator
+          field0)
+        field1
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Wrap @Prim.Type @Prim.Type f g a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Wrap field0 field1) -> append @m {monoidDict.semigroupDict}
+          (foldMap @f {foldableDict} @a @m {monoidDict} (\element -> firstFunction element) field0)
+          (foldMap @g {foldableDict1} @b @m {monoidDict} (\element -> secondFunction element)
+            field1)

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_pair_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_pair_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+
+data Pair a b = Pair a Int b
+derive instance Bifoldable Pair

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_pair_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_pair_body/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Pair :: Prim.Type -> Prim.Type -> Prim.Type
+data Pair @a @b
+  | Pair :: a -> Prim.Int -> b -> Main.Pair a b
+
+dictionary bifoldablePair :: Data.Bifoldable.Bifoldable Main.Pair where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Pair a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Pair field0 field1 field2) -> firstFunction field0 (secondFunction field2 accumulator)
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Pair a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Pair field0 field1 field2) -> secondFunction (firstFunction accumulator field0) field2
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Pair a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Pair field0 field1 field2) -> append @m {monoidDict.semigroupDict} (firstFunction field0)
+          (secondFunction field2)

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_record_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+
+data RecordPair a b = RecordPair { zeta :: b, fixed :: Int, alpha :: a }
+derive instance Bifoldable RecordPair

--- a/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_bifoldable_record_body/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data RecordPair :: Prim.Type -> Prim.Type -> Prim.Type
+data RecordPair @a @b
+  | RecordPair :: { alpha :: a, fixed :: Prim.Int, zeta :: b } -> Main.RecordPair a b
+
+dictionary bifoldableRecordPair :: Data.Bifoldable.Bifoldable Main.RecordPair where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.RecordPair a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (RecordPair field0) -> firstFunction field0.alpha (secondFunction field0.zeta accumulator)
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.RecordPair a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (RecordPair field0) -> secondFunction (firstFunction accumulator field0.alpha) field0.zeta
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.RecordPair a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (RecordPair field0) -> append @m {monoidDict.semigroupDict} (firstFunction field0.alpha)
+          (secondFunction field0.zeta)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+import Data.Bifoldable (class Bifoldable)
+
+data Duplicate p a = Duplicate (p a a)
+derive instance Bifoldable p => Foldable (Duplicate p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_both_body/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Duplicate :: forall (k0 :: Prim.Type). (k0 -> k0 -> Prim.Type) -> k0 -> Prim.Type
+data Duplicate @p @a
+  | Duplicate :: p a a -> Main.Duplicate p a
+
+dictionary foldableDuplicate ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Foldable.Foldable (Main.Duplicate @Prim.Type p)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Duplicate field0) -> bifoldr @p {bifoldableDict} @a @a @b
+        (\element accumulator -> function element accumulator)
+        (\element accumulator -> function element accumulator)
+        accumulator
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Duplicate @Prim.Type p a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Duplicate field0) -> bifoldl @p {bifoldableDict} @a @a @b
+        (\accumulator element -> function accumulator element)
+        (\accumulator element -> function accumulator element)
+        accumulator
+        field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.Duplicate @Prim.Type p a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Duplicate field0) -> bifoldMap @p {bifoldableDict} @m @a @a {monoidDict}
+          (\element -> function element)
+          (\element -> function element)
+          field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+import Data.Bifoldable (class Bifoldable)
+
+data LeftDuplicate p a = LeftDuplicate (p a Int)
+derive instance Bifoldable p => Foldable (LeftDuplicate p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_left_body/Main.snap
@@ -1,0 +1,41 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data LeftDuplicate :: forall (k0 :: Prim.Type). (k0 -> Prim.Type -> Prim.Type) -> k0 -> Prim.Type
+data LeftDuplicate @p @a
+  | LeftDuplicate :: p a Prim.Int -> Main.LeftDuplicate p a
+
+dictionary foldableLeftDuplicate ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Foldable.Foldable (Main.LeftDuplicate @Prim.Type p)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (LeftDuplicate field0) -> bifoldr @p {bifoldableDict} @a @Prim.Int @b
+        (\element accumulator -> function element accumulator)
+        (\ignored accumulator -> accumulator)
+        accumulator
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a -> b) -> b -> Main.LeftDuplicate @Prim.Type p a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (LeftDuplicate field0) -> bifoldl @p {bifoldableDict} @a @Prim.Int @b
+        (\accumulator element -> function accumulator element)
+        (\accumulator ignored -> accumulator)
+        accumulator
+        field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.LeftDuplicate @Prim.Type p a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (LeftDuplicate field0) -> bifoldMap @p {bifoldableDict} @m @a @Prim.Int {monoidDict}
+          (\element -> function element)
+          (\ignored -> mempty @m {monoidDict})
+          field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data RightNested p a = RightNested (p Int a)
+derive instance Foldable (p Int) => Foldable (RightNested p)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_binary_right_body/Main.snap
@@ -1,0 +1,36 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data RightNested :: forall (k0 :: Prim.Type). (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
+data RightNested @p @a
+  | RightNested :: p Prim.Int a -> Main.RightNested p a
+
+dictionary foldableRightNested ::
+  forall p.
+  { foldableDict :: Data.Foldable.Foldable (p Prim.Int) } =>
+  Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (RightNested field0) -> foldr @(p Prim.Int) {foldableDict} @a @b
+        (\element accumulator -> function element accumulator)
+        accumulator
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (RightNested field0) -> foldl @(p Prim.Int) {foldableDict} @a @b
+        (\accumulator element -> function accumulator element)
+        accumulator
+        field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (RightNested field0) -> foldMap @(p Prim.Int) {foldableDict} @a @m {monoidDict}
+          (\element -> function element)
+          field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_identity_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_identity_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Identity a = Identity a
+derive instance Foldable Identity

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_identity_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_identity_body/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Identity :: Prim.Type -> Prim.Type
+data Identity @a
+  | Identity :: a -> Main.Identity a
+
+dictionary foldableIdentity :: Data.Foldable.Foldable Main.Identity where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Identity a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Identity field0) -> function field0 accumulator
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Identity a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Identity field0) -> function accumulator field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Identity a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Identity field0) -> function field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_maybe_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_maybe_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Maybe a = Nothing | Just a
+derive instance Foldable Maybe

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_maybe_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_maybe_body/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Maybe :: Prim.Type -> Prim.Type
+data Maybe @a
+  | Nothing :: Main.Maybe a
+  | Just :: a -> Main.Maybe a
+
+dictionary foldableMaybe :: Data.Foldable.Foldable Main.Maybe where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Maybe a -> b
+  foldr = \function accumulator value ->
+    case value of
+      Nothing -> accumulator
+      (Just field0) -> function field0 accumulator
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Maybe a -> b
+  foldl = \function accumulator value ->
+    case value of
+      Nothing -> accumulator
+      (Just field0) -> function accumulator field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Maybe a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        Nothing -> mempty @m {monoidDict}
+        (Just field0) -> function field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Compose f g a = Compose (f (g a))
+derive instance (Foldable f, Foldable g) => Foldable (Compose f g)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_nested_body/Main.snap
@@ -1,0 +1,47 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Compose ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type). (k0 -> Prim.Type) -> (k1 -> k0) -> k1 -> Prim.Type
+data Compose @f @g @a
+  | Compose :: f (g a) -> Main.Compose f g a
+
+dictionary foldableCompose ::
+  forall f g.
+  { foldableDict :: Data.Foldable.Foldable f } =>
+  { foldableDict1 :: Data.Foldable.Foldable g } =>
+  Data.Foldable.Foldable (Main.Compose @Prim.Type @Prim.Type f g)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Compose field0) -> foldr @f {foldableDict} @(g a) @b
+        (\element accumulator ->
+          foldr @g {foldableDict1} @a @b (\element accumulator -> function element accumulator)
+            accumulator
+            element)
+        accumulator
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a -> b) -> b -> Main.Compose @Prim.Type @Prim.Type f g a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Compose field0) -> foldl @f {foldableDict} @(g a) @b
+        (\accumulator element ->
+          foldl @g {foldableDict1} @a @b (\accumulator element -> function accumulator element)
+            accumulator
+            element)
+        accumulator
+        field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.Compose @Prim.Type @Prim.Type f g a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Compose field0) -> foldMap @f {foldableDict} @(g a) @m {monoidDict}
+          (\element ->
+            foldMap @g {foldableDict1} @a @m {monoidDict} (\element -> function element) element)
+          field0

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_product_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_product_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Product a = Product a Int a a
+derive instance Foldable Product

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_product_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_product_body/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Product :: Prim.Type -> Prim.Type
+data Product @a
+  | Product :: a -> Prim.Int -> a -> a -> Main.Product a
+
+dictionary foldableProduct :: Data.Foldable.Foldable Main.Product where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Product a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Product field0 field1 field2 field3) -> function field0
+        (function field2 (function field3 accumulator))
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Product a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Product field0 field1 field2 field3) -> function
+        (function (function accumulator field0) field2)
+        field3
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Product a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Product field0 field1 field2 field3) -> append @m {monoidDict.semigroupDict}
+          (function field0)
+          (append @m {monoidDict.semigroupDict} (function field2) (function field3))

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_record_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Record a = Record { zeta :: a, fixed :: Int, alpha :: a }
+derive instance Foldable Record

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_record_body/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Record :: Prim.Type -> Prim.Type
+data Record @a
+  | Record :: { alpha :: a, fixed :: Prim.Int, zeta :: a } -> Main.Record a
+
+dictionary foldableRecord :: Data.Foldable.Foldable Main.Record where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Record a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Record field0) -> function field0.alpha (function field0.zeta accumulator)
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Record a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Record field0) -> function (function accumulator field0.alpha) field0.zeta
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Record a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Record field0) -> append @m {monoidDict.semigroupDict} (function field0.alpha)
+          (function field0.zeta)

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_recursive_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_recursive_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Foldable (class Foldable)
+
+data Tree a = Leaf a | Branch (Tree a) (Tree a)
+derive instance Foldable Tree

--- a/tests-integration/fixtures/semantic/1785518760_derive_foldable_recursive_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785518760_derive_foldable_recursive_body/Main.snap
@@ -1,0 +1,43 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Tree :: Prim.Type -> Prim.Type
+data Tree @a
+  | Leaf :: a -> Main.Tree a
+  | Branch :: Main.Tree a -> Main.Tree a -> Main.Tree a
+
+dictionary foldableTree :: Data.Foldable.Foldable Main.Tree where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Tree a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Leaf field0) -> function field0 accumulator
+      (Branch field0 field1) -> foldr @Main.Tree {foldableTree} @a @b
+        (\element accumulator -> function element accumulator)
+        (foldr @Main.Tree {foldableTree} @a @b
+          (\element accumulator -> function element accumulator)
+          accumulator
+          field1)
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Tree a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Leaf field0) -> function accumulator field0
+      (Branch field0 field1) -> foldl @Main.Tree {foldableTree} @a @b
+        (\accumulator element -> function accumulator element)
+        (foldl @Main.Tree {foldableTree} @a @b
+          (\accumulator element -> function accumulator element)
+          accumulator
+          field0)
+        field1
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type). Data.Monoid.Monoid m => (a -> m) -> Main.Tree a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Leaf field0) -> function field0
+        (Branch field0 field1) -> append @m {monoidDict.semigroupDict}
+          (foldMap @Main.Tree {foldableTree} @a @m {monoidDict} (\element -> function element)
+            field0)
+          (foldMap @Main.Tree {foldableTree} @a @m {monoidDict} (\element -> function element)
+            field1)

--- a/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.purs
+++ b/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+import Data.Foldable (class Foldable)
+
+data RightNested p a = RightNested (p Int a)
+
+derive instance Bifoldable p => Foldable (RightNested p)

--- a/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_foldable_right_bifoldable_context/Main.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data RightNested :: forall (k0 :: Prim.Type). (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
+data RightNested @p @a
+  | RightNested :: p Prim.Int a -> Main.RightNested p a

--- a/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.purs
+++ b/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.purs
@@ -1,0 +1,24 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable, bifoldl, bifoldMap, bifoldr)
+import Data.Bifunctor (class Bifunctor, bimap)
+import Data.Bitraversable (class Bitraversable)
+import Data.Foldable (class Foldable)
+import Data.Functor (class Functor)
+import Data.Monoid (mempty)
+import Data.Traversable (class Traversable)
+
+data RightNested p a = RightNested (p Int a)
+
+instance Bifunctor p => Functor (RightNested p) where
+  map function (RightNested value) =
+    RightNested (bimap (\fixed -> fixed) function value)
+
+instance Bifoldable p => Foldable (RightNested p) where
+  foldr function initial (RightNested value) =
+    bifoldr (\_ accumulated -> accumulated) function initial value
+  foldl function initial (RightNested value) =
+    bifoldl (\accumulated _ -> accumulated) function initial value
+  foldMap function (RightNested value) = bifoldMap (\_ -> mempty) function value
+
+derive instance Bitraversable p => Traversable (RightNested p)

--- a/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
@@ -1,0 +1,39 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data RightNested :: forall (k0 :: Prim.Type). (Prim.Type -> k0 -> Prim.Type) -> k0 -> Prim.Type
+data RightNested @p @a
+  | RightNested :: p Prim.Int a -> Main.RightNested p a
+
+dictionary functorRightNested ::
+  forall p.
+  { bifunctorDict :: Data.Bifunctor.Bifunctor p } =>
+  Data.Functor.Functor (Main.RightNested @Prim.Type p)
+  where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (a -> b) -> Main.RightNested @Prim.Type p a -> Main.RightNested @Prim.Type p b
+  map = \function -> \(RightNested value) ->
+    RightNested @Prim.Type @p @b
+      (bimap @p {bifunctorDict} @Prim.Int @Prim.Int @a @b (\fixed -> fixed) function value)
+
+dictionary foldableRightNested ::
+  forall p.
+  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
+  where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
+  foldr = \function -> \initial -> \(RightNested value) ->
+    bifoldr @p {bifoldableDict} @Prim.Int @a @b (\_ accumulated -> accumulated) function initial
+      value
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
+  foldl = \function -> \initial -> \(RightNested value) ->
+    bifoldl @p {bifoldableDict} @Prim.Int @a @b (\accumulated _ -> accumulated) function initial
+      value
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.RightNested @Prim.Type p a -> m
+  foldMap = \{monoidDict} -> \function -> \(RightNested value) ->
+    bifoldMap @p {bifoldableDict} @m @Prim.Int @a {monoidDict} (\_ -> mempty @m {monoidDict})
+      function
+      value

--- a/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785522600_derive_traversable_right_bitraversable_context/Main.snap
@@ -37,3 +37,31 @@ dictionary foldableRightNested ::
     bifoldMap @p {bifoldableDict} @m @Prim.Int @a {monoidDict} (\_ -> mempty @m {monoidDict})
       function
       value
+
+dictionary traversableRightNested ::
+  forall p.
+  { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
+  Data.Traversable.Traversable (Main.RightNested @Prim.Type p)
+  where
+  superclass functorDict = functorRightNested {bitraversableDict.bifunctorDict}
+  superclass foldableDict = foldableRightNested {bitraversableDict.bifoldableDict}
+  traverse :: forall (a :: Prim.Type) (b :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  (a -> m b) -> Main.RightNested @Prim.Type p a -> m (Main.RightNested @Prim.Type p b)
+  traverse = \{applicativeDict} ->
+    \function value ->
+      case value of
+        (RightNested field0) -> map @m {applicativeDict.applyDict.functorDict} @(p Prim.Int b) @(Main.RightNested @Prim.Type p b)
+          (\field0Result -> RightNested @Prim.Type @p @b field0Result)
+          (bitraverse @p {bitraversableDict} @m @Prim.Int @a @Prim.Int @b {applicativeDict}
+            (\unchanged -> pure @m {applicativeDict} @Prim.Int unchanged)
+            (\element -> function element)
+            field0)
+  sequence :: forall (a :: Prim.Type) (m :: Prim.Type -> Prim.Type).
+  Control.Applicative.Applicative m =>
+  Main.RightNested @Prim.Type p (m a) -> m (Main.RightNested @Prim.Type p a)
+  sequence = \{applicativeDict} ->
+    \value ->
+      traverse @(Main.RightNested @Prim.Type p) {traversableRightNested {bitraversableDict}} @(m a) @a @m {applicativeDict}
+        (\effect0 -> effect0)
+        value

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.purs
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Data.Bitraversable (class Bitraversable)
+import Data.Foldable (class Foldable)
+
+data RightNested p a = RightNested (p Int a)
+
+derive instance Bitraversable p => Foldable (RightNested p)

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_binary_superclass_context/Main.snap
@@ -9,13 +9,13 @@ data RightNested @p @a
 
 dictionary foldableRightNested ::
   forall p.
-  { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  { bitraversableDict :: Data.Bitraversable.Bitraversable p } =>
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
   foldr = \function accumulator value ->
     case value of
-      (RightNested field0) -> bifoldr @p {bifoldableDict} @Prim.Int @a @b
+      (RightNested field0) -> bifoldr @p {bitraversableDict.bifoldableDict} @Prim.Int @a @b
         (\ignored accumulator -> accumulator)
         (\element accumulator -> function element accumulator)
         accumulator
@@ -23,7 +23,7 @@ dictionary foldableRightNested ::
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
   foldl = \function accumulator value ->
     case value of
-      (RightNested field0) -> bifoldl @p {bifoldableDict} @Prim.Int @a @b
+      (RightNested field0) -> bifoldl @p {bitraversableDict.bifoldableDict} @Prim.Int @a @b
         (\accumulator ignored -> accumulator)
         (\accumulator element -> function accumulator element)
         accumulator
@@ -33,7 +33,7 @@ dictionary foldableRightNested ::
   foldMap = \{monoidDict} ->
     \function value ->
       case value of
-        (RightNested field0) -> bifoldMap @p {bifoldableDict} @m @Prim.Int @a {monoidDict}
+        (RightNested field0) -> bifoldMap @p {bitraversableDict.bifoldableDict} @m @Prim.Int @a {monoidDict}
           (\ignored -> mempty @m {monoidDict})
           (\element -> function element)
           field0

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.purs
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+import Data.Foldable (class Foldable)
+
+data Product a b = Product a b
+
+derive instance Bifoldable Product
+derive instance Foldable (Product Int)
+
+data RightNested a = RightNested (Product Int a)
+
+derive instance Foldable RightNested

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_concrete_instance_heads/Main.snap
@@ -1,0 +1,71 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Product :: Prim.Type -> Prim.Type -> Prim.Type
+data Product @a @b
+  | Product :: a -> b -> Main.Product a b
+
+data RightNested :: Prim.Type -> Prim.Type
+data RightNested @a
+  | RightNested :: Main.Product Prim.Int a -> Main.RightNested a
+
+dictionary bifoldableProduct :: Data.Bifoldable.Bifoldable Main.Product where
+  bifoldr :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (a -> c -> c) -> (b -> c -> c) -> c -> Main.Product a b -> c
+  bifoldr = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Product field0 field1) -> firstFunction field0 (secondFunction field1 accumulator)
+  bifoldl :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type).
+  (c -> a -> c) -> (c -> b -> c) -> c -> Main.Product a b -> c
+  bifoldl = \firstFunction secondFunction accumulator value ->
+    case value of
+      (Product field0 field1) -> secondFunction (firstFunction accumulator field0) field1
+  bifoldMap :: forall (m :: Prim.Type) (a :: Prim.Type) (b :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> (b -> m) -> Main.Product a b -> m
+  bifoldMap = \{monoidDict} ->
+    \firstFunction secondFunction value ->
+      case value of
+        (Product field0 field1) -> append @m {monoidDict.semigroupDict} (firstFunction field0)
+          (secondFunction field1)
+
+dictionary foldableProduct :: Data.Foldable.Foldable (Main.Product Prim.Int) where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.Product Prim.Int a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (Product field0 field1) -> function field1 accumulator
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.Product Prim.Int a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (Product field0 field1) -> function accumulator field1
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.Product Prim.Int a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (Product field0 field1) -> function field1
+
+dictionary foldableRightNested :: Data.Foldable.Foldable Main.RightNested where
+  foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested a -> b
+  foldr = \function accumulator value ->
+    case value of
+      (RightNested field0) -> foldr @(Main.Product Prim.Int) {foldableProduct} @a @b
+        (\element accumulator -> function element accumulator)
+        accumulator
+        field0
+  foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested a -> b
+  foldl = \function accumulator value ->
+    case value of
+      (RightNested field0) -> foldl @(Main.Product Prim.Int) {foldableProduct} @a @b
+        (\accumulator element -> function accumulator element)
+        accumulator
+        field0
+  foldMap :: forall (a :: Prim.Type) (m :: Prim.Type).
+  Data.Monoid.Monoid m => (a -> m) -> Main.RightNested a -> m
+  foldMap = \{monoidDict} ->
+    \function value ->
+      case value of
+        (RightNested field0) -> foldMap @(Main.Product Prim.Int) {foldableProduct} @a @m {monoidDict}
+          (\element -> function element)
+          field0

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.purs
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Data.Bifoldable (class Bifoldable)
+import Data.Foldable (class Foldable)
+
+data RightNested p a = RightNested (p Int a)
+
+derive instance (Bifoldable p, Foldable (p Int)) => Foldable (RightNested p)

--- a/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.snap
+++ b/tests-integration/fixtures/semantic/1785523440_derive_foldable_right_prefers_unary_context/Main.snap
@@ -10,21 +10,20 @@ data RightNested @p @a
 dictionary foldableRightNested ::
   forall p.
   { bifoldableDict :: Data.Bifoldable.Bifoldable p } =>
+  { foldableDict :: Data.Foldable.Foldable (p Prim.Int) } =>
   Data.Foldable.Foldable (Main.RightNested @Prim.Type p)
   where
   foldr :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b -> b) -> b -> Main.RightNested @Prim.Type p a -> b
   foldr = \function accumulator value ->
     case value of
-      (RightNested field0) -> bifoldr @p {bifoldableDict} @Prim.Int @a @b
-        (\ignored accumulator -> accumulator)
+      (RightNested field0) -> foldr @(p Prim.Int) {foldableDict} @a @b
         (\element accumulator -> function element accumulator)
         accumulator
         field0
   foldl :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a -> b) -> b -> Main.RightNested @Prim.Type p a -> b
   foldl = \function accumulator value ->
     case value of
-      (RightNested field0) -> bifoldl @p {bifoldableDict} @Prim.Int @a @b
-        (\accumulator ignored -> accumulator)
+      (RightNested field0) -> foldl @(p Prim.Int) {foldableDict} @a @b
         (\accumulator element -> function accumulator element)
         accumulator
         field0
@@ -33,7 +32,6 @@ dictionary foldableRightNested ::
   foldMap = \{monoidDict} ->
     \function value ->
       case value of
-        (RightNested field0) -> bifoldMap @p {bifoldableDict} @m @Prim.Int @a {monoidDict}
-          (\ignored -> mempty @m {monoidDict})
+        (RightNested field0) -> foldMap @(p Prim.Int) {foldableDict} @a @m {monoidDict}
           (\element -> function element)
           field0


### PR DESCRIPTION
## Summary

Complete derived `Foldable` and `Bifoldable` dictionaries using the canonical PureScript definitions:

- `Foldable`: `foldr`, `foldl`, and `foldMap`
- `Bifoldable`: `bifoldr`, `bifoldl`, and `bifoldMap`

The checking prelude now includes the canonical `Semigroup` and `Monoid` definitions required by `foldMap` and `bifoldMap`. Generated members support products, sums, records, recursive types, nested unary applications, and nested binary applications while preserving the expected fold direction and field order.

## PureScript compatibility

For a right-only occurrence such as `p Int a`, upstream `purs` can derive through either a unary instance for the partial application (`Foldable (p Int)` / `Traversable (p Int)`) or a binary instance for the constructor (`Bifoldable p` / `Bitraversable p`). Alexandrite previously required the unary route even when only the canonical binary evidence was available.

This change matches `purs` by:

- preferring the unary partially-applied instance when both strategies are available
- falling back to the binary class when the unary instance is unavailable
- considering explicit constraints, expanded superclass constraints, and visible declared, derived, and imported instance heads when selecting a strategy
- representing binary recipes explicitly as first-only, second-only, or both-argument traversals

The compatibility failure is preserved in an earlier commit in this PR, followed by the implementation that turns those snapshots into successful derived instances.

## Implementation decisions

- Reuse variance-analysis recipes across Functor, Foldable, and Traversable generation rather than duplicating structural type analysis.
- Keep Foldable generation in a dedicated emitter because directional accumulator threading and monoidal folds differ from mapping and applicative reconstruction.
- Resolve all canonical class members by known-term identity and emit the dictionary only when every required member can be generated.
- Use the binary class only as a compatibility fallback for right-only applications; this preserves the behavior of an explicitly available unary instance.
- Keep instance-head discovery local to variance analysis because it is used only to choose the structurally valid recipe.
- Reject function-shaped occurrences for Foldable and Bifoldable rather than silently producing incomplete members.

## Tests

Semantic fixtures cover:

- identity, optional, product, nested, recursive, and record-shaped `Foldable` types
- left-only, right-only, and both-argument binary applications
- `Bifoldable` sums, products, unary and binary nesting, and records
- right-only evidence from binary constraints, superclass-expanded constraints, and concrete visible instance heads
- unary-instance preference when unary and binary strategies are both available
- rejection of function-shaped folds

Validation completed:

- `just format`
- `git diff --check`
- `just t checking`
- `just t semantic`
- `cargo check -p checking --tests`
- `cargo nextest run -p checking` (30 tests passed)

The final implementation was reviewed by Oracle and approved with no blockers.

## Stack

This PR is based on and should be reviewed after #230. Its base branch is `traversable-deriving`; once #230 lands, this PR can be retargeted to `main`.