### PR TITLE
[checking] Generate Contravariant and Profunctor derived members

### DIFF
--- a/compiler-core/checking/src/context.rs
+++ b/compiler-core/checking/src/context.rs
@@ -780,6 +780,8 @@ pub struct KnownTermsCore {
     pub otherwise: Option<(FileId, TermItemId)>,
     pub map: Option<(FileId, TermItemId)>,
     pub bimap: Option<(FileId, TermItemId)>,
+    pub cmap: Option<(FileId, TermItemId)>,
+    pub dimap: Option<(FileId, TermItemId)>,
     pub foldr: Option<(FileId, TermItemId)>,
     pub foldl: Option<(FileId, TermItemId)>,
     pub fold_map: Option<(FileId, TermItemId)>,
@@ -808,6 +810,8 @@ impl KnownTermsCore {
         let otherwise = fetch_known_term(queries, "Data.Boolean", "otherwise")?;
         let map = fetch_known_term(queries, "Data.Functor", "map")?;
         let bimap = fetch_known_term(queries, "Data.Bifunctor", "bimap")?;
+        let cmap = fetch_known_term(queries, "Data.Functor.Contravariant", "cmap")?;
+        let dimap = fetch_known_term(queries, "Data.Profunctor", "dimap")?;
         let foldr = fetch_known_term(queries, "Data.Foldable", "foldr")?;
         let foldl = fetch_known_term(queries, "Data.Foldable", "foldl")?;
         let fold_map = fetch_known_term(queries, "Data.Foldable", "foldMap")?;
@@ -833,6 +837,8 @@ impl KnownTermsCore {
             otherwise,
             map,
             bimap,
+            cmap,
+            dimap,
             foldr,
             foldl,
             fold_map,

--- a/compiler-core/checking/src/source/derive/contravariant.rs
+++ b/compiler-core/checking/src/source/derive/contravariant.rs
@@ -80,17 +80,15 @@ where
         return Ok(None);
     };
 
-    let contravariant = context.known_types.contravariant;
-    let functor = context.known_types.functor;
     let config = VarianceConfig::Pair {
         first: ParameterConfig {
             variance: Variance::Contravariant,
-            unary_class: contravariant,
+            unary_class: context.known_types.contravariant,
             function_policy: FunctionPolicy::Allow,
         },
         second: ParameterConfig {
             variance: Variance::Covariant,
-            unary_class: functor,
+            unary_class: context.known_types.functor,
             function_policy: FunctionPolicy::Allow,
         },
         binary_class: None,

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -16,16 +16,17 @@ use crate::{ExternalQueries, tree};
 use super::variance::VarianceRecipe;
 use super::{DeriveDispatch, DeriveHeadResult, DeriveStrategy, derive_dispatch};
 
+mod contravariant;
 mod eq_ord;
 mod foldable;
 mod functor;
 mod traversable;
 
-pub(crate) fn generate_instance<Q>(
+pub(super) fn generate_instance<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    variance_recipe: Option<&VarianceRecipe>,
+    recipe: Option<&VarianceRecipe>,
 ) -> QueryResult<Option<tree::TermDeclaration>>
 where
     Q: ExternalQueries,
@@ -42,11 +43,13 @@ where
         | DeriveDispatch::Ord1
         | DeriveDispatch::Functor
         | DeriveDispatch::Bifunctor
+        | DeriveDispatch::Contravariant
+        | DeriveDispatch::Profunctor
         | DeriveDispatch::Foldable
         | DeriveDispatch::Bifoldable
         | DeriveDispatch::Traversable
         | DeriveDispatch::Bitraversable => {
-            generate_known_instance(state, context, result, dispatch, variance_recipe)
+            generate_known_instance(state, context, result, dispatch, recipe)
         }
         _ => Ok(None),
     }
@@ -116,7 +119,7 @@ fn generate_known_instance<Q>(
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
     dispatch: DeriveDispatch,
-    variance_recipe: Option<&VarianceRecipe>,
+    recipe: Option<&VarianceRecipe>,
 ) -> QueryResult<Option<tree::TermDeclaration>>
 where
     Q: ExternalQueries,
@@ -179,7 +182,9 @@ where
             .into_iter()
             .collect(),
             DeriveDispatch::Functor | DeriveDispatch::Bifunctor => {
-                let Some(recipe) = variance_recipe else { return Ok(None) };
+                let Some(recipe) = recipe else {
+                    return Ok(None);
+                };
                 let traversal = match dispatch {
                     DeriveDispatch::Functor => functor::TraversalKind::Functor,
                     DeriveDispatch::Bifunctor => functor::TraversalKind::Bifunctor,
@@ -196,8 +201,30 @@ where
                 .into_iter()
                 .collect()
             }
+            DeriveDispatch::Contravariant | DeriveDispatch::Profunctor => {
+                let Some(recipe) = recipe else {
+                    return Ok(None);
+                };
+                let traversal = match dispatch {
+                    DeriveDispatch::Contravariant => contravariant::TraversalKind::Contravariant,
+                    DeriveDispatch::Profunctor => contravariant::TraversalKind::Profunctor,
+                    _ => unreachable!(),
+                };
+                contravariant::generate_traversal_member(
+                    state,
+                    context,
+                    result,
+                    &freshened.arguments,
+                    recipe,
+                    traversal,
+                )?
+                .into_iter()
+                .collect()
+            }
             DeriveDispatch::Foldable | DeriveDispatch::Bifoldable => {
-                let Some(recipe) = variance_recipe else { return Ok(None) };
+                let Some(recipe) = recipe else {
+                    return Ok(None);
+                };
                 let traversal = match dispatch {
                     DeriveDispatch::Foldable => foldable::TraversalKind::Foldable,
                     DeriveDispatch::Bifoldable => foldable::TraversalKind::Bifoldable,
@@ -217,7 +244,9 @@ where
                 members
             }
             DeriveDispatch::Traversable | DeriveDispatch::Bitraversable => {
-                let Some(recipe) = variance_recipe else { return Ok(None) };
+                let Some(recipe) = recipe else {
+                    return Ok(None);
+                };
                 let traversal = match dispatch {
                     DeriveDispatch::Traversable => traversable::TraversalKind::Traversable,
                     DeriveDispatch::Bitraversable => traversable::TraversalKind::Bitraversable,

--- a/compiler-core/checking/src/source/derive/generate/contravariant.rs
+++ b/compiler-core/checking/src/source/derive/generate/contravariant.rs
@@ -1,0 +1,644 @@
+use std::sync::Arc;
+
+use building_types::QueryResult;
+use itertools::izip;
+use smol_str::format_smolstr;
+
+use crate::context::CheckContext;
+use crate::core::substitute::RigidRenaming;
+use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::evidence::Evidence;
+use crate::source::derive::builder::DerivedTreeBuilder;
+use crate::source::derive::field;
+use crate::source::derive::variance::{
+    ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, Variance,
+    VarianceRecipe,
+};
+use crate::source::terms::ElaboratedExpression;
+use crate::state::CheckState;
+use crate::{ExternalQueries, tree};
+
+use super::{DeriveHeadResult, DeriveStrategy, ResolvedMember, generated_member, resolve_member};
+
+struct InstantiatedDataType {
+    type_id: TypeId,
+    constructor_arguments: Vec<KindOrType>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum TraversalKind {
+    Contravariant,
+    Profunctor,
+}
+
+#[derive(Clone, Copy)]
+enum Mappings<T> {
+    Contravariant(T),
+    Profunctor { first: T, second: T },
+}
+
+impl Mappings<ElaboratedExpression> {
+    fn mapping_for(self, parameter: TraversalParameter) -> Option<ElaboratedExpression> {
+        match (self, parameter) {
+            (Mappings::Contravariant(function), TraversalParameter::First) => Some(function),
+            (Mappings::Profunctor { first, .. }, TraversalParameter::First) => Some(first),
+            (Mappings::Profunctor { second, .. }, TraversalParameter::Second) => Some(second),
+            (Mappings::Contravariant(_), TraversalParameter::Second) => None,
+        }
+    }
+}
+
+struct DecodedTraversalMember {
+    member: ResolvedMember,
+    renaming: Arc<RigidRenaming>,
+    constraints: Vec<TypeId>,
+    implementation_type: TypeId,
+    function_type: TypeId,
+    mappings: Mappings<TypeId>,
+    data_file: files::FileId,
+    source: InstantiatedDataType,
+    target: InstantiatedDataType,
+}
+
+impl DecodedTraversalMember {
+    fn decode<Q>(
+        state: &mut CheckState,
+        context: &CheckContext<Q>,
+        member: ResolvedMember,
+        data_file: files::FileId,
+        traversal: TraversalKind,
+    ) -> QueryResult<Option<DecodedTraversalMember>>
+    where
+        Q: ExternalQueries,
+    {
+        let argument_count = match traversal {
+            TraversalKind::Contravariant => 2,
+            TraversalKind::Profunctor => 3,
+        };
+        let signature::SkolemisedSignature { renaming, constraints, arguments, result } =
+            signature::expect_term_signature(
+                state,
+                context,
+                member.implementation_type,
+                argument_count,
+            )?;
+
+        let (source_type, mappings) = match (traversal, arguments.as_slice()) {
+            (TraversalKind::Contravariant, [mapping, source]) => {
+                (*source, Mappings::Contravariant(*mapping))
+            }
+            (TraversalKind::Profunctor, [first, second, source]) => {
+                (*source, Mappings::Profunctor { first: *first, second: *second })
+            }
+            _ => return Ok(None),
+        };
+
+        let (_, source_arguments) = toolkit::extract_all_applications(state, context, source_type)?;
+        let (_, target_arguments) = toolkit::extract_all_applications(state, context, result)?;
+        let function_arguments = arguments.iter().copied();
+        let function_type = context.intern_function_iter(function_arguments, result);
+
+        Ok(Some(DecodedTraversalMember {
+            implementation_type: member.implementation_type,
+            member,
+            renaming,
+            constraints,
+            function_type,
+            mappings,
+            data_file,
+            source: InstantiatedDataType {
+                type_id: source_type,
+                constructor_arguments: source_arguments,
+            },
+            target: InstantiatedDataType {
+                type_id: result,
+                constructor_arguments: target_arguments,
+            },
+        }))
+    }
+}
+
+pub(super) fn generate_traversal_member<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    result: &DeriveHeadResult,
+    instance_arguments: &[KindOrType],
+    recipe: &VarianceRecipe,
+    traversal: TraversalKind,
+) -> QueryResult<Option<tree::InstanceMember>>
+where
+    Q: ExternalQueries,
+{
+    state.with_implication(|state| {
+        let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+            return Ok(None);
+        };
+
+        let Some(member) = resolve_member(state, context, result, instance_arguments)? else {
+            return Ok(None);
+        };
+        let Some(member) =
+            DecodedTraversalMember::decode(state, context, member, data_file, traversal)?
+        else {
+            return Ok(None);
+        };
+
+        let mut evidences = Vec::with_capacity(member.constraints.len());
+        for &constraint in &member.constraints {
+            evidences.push(Evidence::Given(state.push_given(constraint)));
+        }
+
+        let body = state.with_source_type_renaming(&member.renaming, |state| {
+            emit_variance_traversal(state, context, result.derive_id, &member, recipe)
+        })?;
+        let Some(body) = body else { return Ok(None) };
+
+        Ok(Some(generated_member(
+            result.derive_id,
+            (member.member.file_id, member.member.item_id),
+            member.implementation_type,
+            evidences,
+            body,
+        )))
+    })
+}
+
+fn emit_variance_traversal<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    derive_id: indexing::DeriveId,
+    member: &DecodedTraversalMember,
+    recipe: &VarianceRecipe,
+) -> QueryResult<Option<ElaboratedExpression>>
+where
+    Q: ExternalQueries,
+{
+    let mut builder = DerivedTreeBuilder::new(state, context, derive_id);
+    let (mapping_binders, mapping_expressions) = match member.mappings {
+        Mappings::Contravariant(mapping) => {
+            let function = builder.variable_binder("function", mapping);
+            let expression = builder.variable(function);
+            (vec![function], Mappings::Contravariant(expression))
+        }
+        Mappings::Profunctor { first, second } => {
+            let first = builder.variable_binder("firstFunction", first);
+            let second = builder.variable_binder("secondFunction", second);
+            let expressions = Mappings::Profunctor {
+                first: builder.variable(first),
+                second: builder.variable(second),
+            };
+            (vec![first, second], expressions)
+        }
+    };
+    let value = builder.variable_binder("value", member.source.type_id);
+    let value_expression = builder.variable(value);
+
+    let mut alternatives = Vec::with_capacity(recipe.constructors.len());
+    for constructor in &recipe.constructors {
+        let Some(alternative) =
+            emit_traversal_alternative(&mut builder, member, constructor, mapping_expressions)?
+        else {
+            return Ok(None);
+        };
+        alternatives.push(alternative);
+    }
+
+    let body = builder.case(member.target.type_id, vec![value_expression], alternatives);
+    let mut binders = mapping_binders;
+    binders.push(value);
+    Ok(Some(builder.lambda(member.function_type, binders, body)))
+}
+
+fn emit_traversal_alternative<Q>(
+    builder: &mut DerivedTreeBuilder<'_, '_, '_, Q>,
+    member: &DecodedTraversalMember,
+    constructor: &ConstructorRecipe,
+    mapping_expressions: Mappings<ElaboratedExpression>,
+) -> QueryResult<Option<tree::CaseAlternative>>
+where
+    Q: ExternalQueries,
+{
+    let constructor_type = toolkit::lookup_file_term(
+        builder.state,
+        builder.context,
+        member.data_file,
+        constructor.constructor_id,
+    )?;
+    let source_fields = field::instantiate_constructor_fields(
+        builder.state,
+        builder.context,
+        constructor_type,
+        &member.source.constructor_arguments,
+    )?;
+    let target_fields = field::instantiate_constructor_fields(
+        builder.state,
+        builder.context,
+        constructor_type,
+        &member.target.constructor_arguments,
+    )?;
+
+    if source_fields.len() != target_fields.len() || source_fields.len() != constructor.fields.len()
+    {
+        return Ok(None);
+    }
+
+    let mut emitter = ContravariantTraversalEmitter { builder, mapping_expressions };
+    let mut binders = Vec::with_capacity(source_fields.len());
+    let mut values = Vec::with_capacity(source_fields.len());
+    for (index, (source, target, operation)) in
+        izip!(&source_fields, &target_fields, &constructor.fields).enumerate()
+    {
+        let binder = emitter.builder.variable_binder(&format_smolstr!("field{index}"), *source);
+        let value = emitter.builder.variable(binder);
+        let value = if let Some(operation) = operation {
+            let traversal =
+                TraversalContext { source_type: *source, target_type: *target, function_depth: 0 };
+            let Some(value) = emitter.emit_traversal(operation, value, traversal)? else {
+                return Ok(None);
+            };
+            value
+        } else {
+            value
+        };
+        binders.push(binder);
+        values.push(value);
+    }
+
+    let pattern = emitter.builder.constructor_pattern(
+        "constructor",
+        member.source.type_id,
+        (member.data_file, constructor.constructor_id),
+        binders,
+    );
+    let mut reconstructed =
+        emitter.builder.term_reference((member.data_file, constructor.constructor_id))?;
+    for value in values {
+        let Some(applied) = emitter.builder.apply(reconstructed, value)? else {
+            return Ok(None);
+        };
+        reconstructed = applied;
+    }
+    let reconstructed = emitter.builder.subtype(reconstructed, member.target.type_id)?;
+    Ok(Some(emitter.builder.alternative(vec![pattern], reconstructed)))
+}
+
+#[derive(Clone, Copy)]
+struct TraversalContext {
+    source_type: TypeId,
+    target_type: TypeId,
+    function_depth: usize,
+}
+
+struct ContravariantTraversalEmitter<'builder, 'state, 'context, 'queries, Q: ExternalQueries> {
+    builder: &'builder mut DerivedTreeBuilder<'state, 'context, 'queries, Q>,
+    mapping_expressions: Mappings<ElaboratedExpression>,
+}
+
+impl<Q> ContravariantTraversalEmitter<'_, '_, '_, '_, Q>
+where
+    Q: ExternalQueries,
+{
+    fn emit_traversal(
+        &mut self,
+        operation: &TraversalOperation,
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        match operation {
+            TraversalOperation::Parameter { parameter } => {
+                let Some(mapping_expression) = self.mapping_expressions.mapping_for(*parameter)
+                else {
+                    return Ok(None);
+                };
+                let Some(mapped) = self.builder.apply(mapping_expression, value)? else {
+                    return Ok(None);
+                };
+                Ok(Some(self.builder.subtype(mapped, traversal.target_type)?))
+            }
+            TraversalOperation::Function { argument, result } => {
+                self.emit_function(argument.as_deref(), result.as_deref(), value, traversal)
+            }
+            TraversalOperation::UnaryApplication { argument_variance, argument } => {
+                self.emit_unary(*argument_variance, argument, value, traversal)
+            }
+            TraversalOperation::BinaryApplication { first_variance, arguments } => {
+                let (first, second) = arguments.operations();
+                self.emit_binary(*first_variance, first, second, value, traversal)
+            }
+            TraversalOperation::Record { fields } => {
+                self.emit_record_traversal(fields, value, traversal)
+            }
+        }
+    }
+
+    fn emit_unary(
+        &mut self,
+        argument_variance: Variance,
+        argument: &TraversalOperation,
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some((_, source_argument)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            traversal.source_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((_, target_argument)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            traversal.target_type,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        // A covariant edge transforms the source argument into the target argument. A
+        // contravariant edge reverses that obligation because `cmap` consumes the target-to-
+        // source transformation.
+        let argument_context = match argument_variance {
+            Variance::Covariant => TraversalContext {
+                source_type: source_argument,
+                target_type: target_argument,
+                function_depth: traversal.function_depth,
+            },
+            Variance::Contravariant => TraversalContext {
+                source_type: target_argument,
+                target_type: source_argument,
+                function_depth: traversal.function_depth,
+            },
+        };
+        let Some(transformer) = self.emit_transformer(argument, argument_context)? else {
+            return Ok(None);
+        };
+
+        let operation = match argument_variance {
+            Variance::Covariant => self.builder.context.known_terms.map,
+            Variance::Contravariant => self.builder.context.known_terms.cmap,
+        };
+        let Some(operation) = operation else {
+            return Ok(None);
+        };
+        let operation = self.builder.term_reference(operation)?;
+        let Some(operation) = self.builder.apply(operation, transformer)? else {
+            return Ok(None);
+        };
+        let Some(mapped) = self.builder.apply(operation, value)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.builder.subtype(mapped, traversal.target_type)?))
+    }
+
+    fn emit_function(
+        &mut self,
+        argument: Option<&TraversalOperation>,
+        result: Option<&TraversalOperation>,
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        // The target function's argument must be transformed into the source argument before
+        // applying `value`; its source result is then transformed into the target result.
+        let Some((source_argument, source_result)) = toolkit::decompose_function(
+            self.builder.state,
+            self.builder.context,
+            traversal.source_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((target_argument, target_result)) = toolkit::decompose_function(
+            self.builder.state,
+            self.builder.context,
+            traversal.target_type,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        let input_name = match traversal.function_depth {
+            0 => "argument".into(),
+            depth => format_smolstr!("argument{depth}"),
+        };
+        let input = self.builder.variable_binder(&input_name, target_argument);
+        let mut input_value = self.builder.variable(input);
+        if let Some(operation) = argument {
+            let argument_context = TraversalContext {
+                source_type: target_argument,
+                target_type: source_argument,
+                function_depth: traversal.function_depth + 1,
+            };
+            let Some(transformed) =
+                self.emit_traversal(operation, input_value, argument_context)?
+            else {
+                return Ok(None);
+            };
+            input_value = transformed;
+        }
+
+        let Some(output) = self.builder.apply(value, input_value)? else {
+            return Ok(None);
+        };
+        let output = if let Some(operation) = result {
+            let result_context = TraversalContext {
+                source_type: source_result,
+                target_type: target_result,
+                function_depth: traversal.function_depth + 1,
+            };
+            let Some(output) = self.emit_traversal(operation, output, result_context)? else {
+                return Ok(None);
+            };
+            output
+        } else {
+            output
+        };
+        let output = self.builder.subtype(output, target_result)?;
+        Ok(Some(self.builder.lambda(traversal.target_type, vec![input], output)))
+    }
+
+    fn emit_binary(
+        &mut self,
+        first_variance: Variance,
+        first: Option<&TraversalOperation>,
+        second: Option<&TraversalOperation>,
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some((source_function, source_second)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            traversal.source_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((_, source_first)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            source_function,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((target_function, target_second)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            traversal.target_type,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some((_, target_first)) = toolkit::decompose_type_application(
+            self.builder.state,
+            self.builder.context,
+            target_function,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        // Bifunctor transforms both arguments covariantly. Profunctor reverses only the
+        // first obligation, matching `dimap :: (a -> b) -> (c -> d) -> p b c -> p a d`.
+        let first_context = match first_variance {
+            Variance::Covariant => TraversalContext {
+                source_type: source_first,
+                target_type: target_first,
+                function_depth: traversal.function_depth,
+            },
+            Variance::Contravariant => TraversalContext {
+                source_type: target_first,
+                target_type: source_first,
+                function_depth: traversal.function_depth,
+            },
+        };
+        let first_transformer = if let Some(first) = first {
+            let Some(transformer) = self.emit_transformer(first, first_context)? else {
+                return Ok(None);
+            };
+            transformer
+        } else {
+            self.emit_identity(first_context)?
+        };
+
+        let second_context = TraversalContext {
+            source_type: source_second,
+            target_type: target_second,
+            function_depth: traversal.function_depth,
+        };
+        let second_transformer = if let Some(second) = second {
+            let Some(transformer) = self.emit_transformer(second, second_context)? else {
+                return Ok(None);
+            };
+            transformer
+        } else {
+            self.emit_identity(second_context)?
+        };
+
+        let operation = match first_variance {
+            Variance::Covariant => self.builder.context.known_terms.bimap,
+            Variance::Contravariant => self.builder.context.known_terms.dimap,
+        };
+        let Some(operation) = operation else {
+            return Ok(None);
+        };
+        let operation = self.builder.term_reference(operation)?;
+        let Some(operation) = self.builder.apply(operation, first_transformer)? else {
+            return Ok(None);
+        };
+        let Some(operation) = self.builder.apply(operation, second_transformer)? else {
+            return Ok(None);
+        };
+        let Some(mapped) = self.builder.apply(operation, value)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.builder.subtype(mapped, traversal.target_type)?))
+    }
+
+    fn emit_transformer(
+        &mut self,
+        operation: &TraversalOperation,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let input = self.builder.variable_binder("element", traversal.source_type);
+        let value = self.builder.variable(input);
+        let Some(body) = self.emit_traversal(operation, value, traversal)? else {
+            return Ok(None);
+        };
+        let function =
+            self.builder.context.intern_function(traversal.source_type, traversal.target_type);
+        Ok(Some(self.builder.lambda(function, vec![input], body)))
+    }
+
+    fn emit_identity(&mut self, traversal: TraversalContext) -> QueryResult<ElaboratedExpression> {
+        let input = self.builder.variable_binder("unchanged", traversal.source_type);
+        let value = self.builder.variable(input);
+        let body = self.builder.subtype(value, traversal.target_type)?;
+        let function =
+            self.builder.context.intern_function(traversal.source_type, traversal.target_type);
+        Ok(self.builder.lambda(function, vec![input], body))
+    }
+
+    fn emit_record_traversal(
+        &mut self,
+        fields: &[RecordFieldRecipe],
+        value: ElaboratedExpression,
+        traversal: TraversalContext,
+    ) -> QueryResult<Option<ElaboratedExpression>> {
+        let Some(source_row) =
+            extract_record_row(self.builder.state, self.builder.context, traversal.source_type)?
+        else {
+            return Ok(None);
+        };
+        let Some(target_row) =
+            extract_record_row(self.builder.state, self.builder.context, traversal.target_type)?
+        else {
+            return Ok(None);
+        };
+
+        let mut updates = Vec::with_capacity(fields.len());
+        for field in fields {
+            let Some(source_field) = source_row.fields.iter().find(|row| row.label == field.label)
+            else {
+                return Ok(None);
+            };
+            let Some(target_field) = target_row.fields.iter().find(|row| row.label == field.label)
+            else {
+                return Ok(None);
+            };
+            let accessed = self.builder.record_access(value, field.label.clone(), source_field.id);
+            let field_context = TraversalContext {
+                source_type: source_field.id,
+                target_type: target_field.id,
+                function_depth: traversal.function_depth,
+            };
+            let Some(updated) = self.emit_traversal(&field.operation, accessed, field_context)?
+            else {
+                return Ok(None);
+            };
+            updates.push(tree::RecordExpressionUpdate::Leaf {
+                label: field.label.clone(),
+                expression: updated.expression,
+            });
+        }
+        Ok(Some(self.builder.record_update(value, updates, traversal.target_type)))
+    }
+}
+
+fn extract_record_row<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    type_id: TypeId,
+) -> QueryResult<Option<RowType>>
+where
+    Q: ExternalQueries,
+{
+    let Some((_, row)) = toolkit::decompose_type_application(state, context, type_id)? else {
+        return Ok(None);
+    };
+    let row = normalise::expand(state, context, row)?;
+    let Type::Row(row) = context.lookup_type(row) else {
+        return Ok(None);
+    };
+    Ok(Some(context.lookup_row_type(row)))
+}

--- a/compiler-core/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-core/checking/src/source/derive/generate/foldable.rs
@@ -531,7 +531,7 @@ where
                 };
                 Ok(Some(self.builder.subtype(applied, self.accumulator_type)?))
             }
-            TraversalOperation::UnaryApplication { argument } => {
+            TraversalOperation::UnaryApplication { argument, .. } => {
                 let Some((_, source_argument)) = toolkit::decompose_type_application(
                     self.builder.state,
                     self.builder.context,
@@ -583,7 +583,7 @@ where
                 };
                 Ok(Some(self.builder.subtype(folded, self.accumulator_type)?))
             }
-            TraversalOperation::BinaryApplication { arguments } => {
+            TraversalOperation::BinaryApplication { arguments, .. } => {
                 let (first, second) = arguments.operations();
                 self.emit_binary_fold(first, second, value, accumulator, source_type)
             }

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -325,7 +325,7 @@ where
                 };
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::UnaryApplication { argument } => {
+            TraversalOperation::UnaryApplication { argument, .. } => {
                 // Map delegates traversal of a unary type constructor to its existing
                 // Functor instance. The generator only needs to produce the transformation
                 // that its map implementation applies to each contained value.
@@ -440,7 +440,7 @@ where
                 // Check the specialized result against the target established above.
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::BinaryApplication { arguments } => {
+            TraversalOperation::BinaryApplication { arguments, .. } => {
                 // Bimap lifts transformations through the first and second arguments of a
                 // binary type constructor. See `emit_bimap` for the staged construction.
                 let (first, second) = arguments.operations();

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -11,7 +11,8 @@ use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
 use crate::source::derive::variance::{
-    ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, VarianceRecipe,
+    ConstructorRecipe, RecordFieldRecipe, TraversalOperation, TraversalParameter, Variance,
+    VarianceRecipe,
 };
 use crate::source::terms::ElaboratedExpression;
 use crate::state::CheckState;
@@ -325,10 +326,10 @@ where
                 };
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::UnaryApplication { argument, .. } => {
-                // Map delegates traversal of a unary type constructor to its existing
-                // Functor instance. The generator only needs to produce the transformation
-                // that its map implementation applies to each contained value.
+            TraversalOperation::UnaryApplication { argument_variance, argument } => {
+                // A covariant edge delegates to `map`; a contravariant edge reverses the
+                // source-to-target obligation and delegates to `cmap`. The examples below
+                // trace the covariant case.
                 //
                 // NonEmpty
                 //
@@ -386,21 +387,28 @@ where
                 //   transformer :: { item :: a } -> { item :: b }
                 //   transformer = \element ->
                 //     element { item = function element.item }
-                let argument_context = TraversalContext {
-                    source_type: source_argument,
-                    target_type: target_argument,
-                    function_depth,
+                let argument_context = match argument_variance {
+                    Variance::Covariant => TraversalContext {
+                        source_type: source_argument,
+                        target_type: target_argument,
+                        function_depth,
+                    },
+                    Variance::Contravariant => TraversalContext {
+                        source_type: target_argument,
+                        target_type: source_argument,
+                        function_depth,
+                    },
                 };
                 let Some(transformer) = self.emit_transformer(argument, argument_context)? else {
                     return Ok(None);
                 };
 
-                // Resolve the polymorphic, constrained map declaration and specialize it
-                // through application. Applying `transformer` solves the element types;
-                // applying `source` solves the fresh constructor variable, specializing
-                // its wanted Functor evidence.
+                // Resolve the operation selected by the edge variance. Applying
+                // `transformer` solves the element types; applying `source` solves the
+                // fresh constructor variable and specializes the wanted evidence.
                 //
                 //   map :: forall f a b. Functor f => (a -> b) -> f a -> f b
+                //   cmap :: forall f a b. Contravariant f => (b -> a) -> f a -> f b
                 //
                 // NonEmpty
                 //
@@ -426,25 +434,29 @@ where
                 //   map function (Inventory items) =
                 //     Inventory
                 //       (map (\element -> element { item = function element.item }) items)
-                let Some(map) = self.builder.context.known_terms.map else {
+                let operation = match argument_variance {
+                    Variance::Covariant => self.builder.context.known_terms.map,
+                    Variance::Contravariant => self.builder.context.known_terms.cmap,
+                };
+                let Some(operation) = operation else {
                     return Ok(None);
                 };
-                let map = self.builder.term_reference(map)?;
-                let Some(map) = self.builder.apply(map, transformer)? else {
+                let operation = self.builder.term_reference(operation)?;
+                let Some(operation) = self.builder.apply(operation, transformer)? else {
                     return Ok(None);
                 };
-                let Some(mapped) = self.builder.apply(map, value)? else {
+                let Some(mapped) = self.builder.apply(operation, value)? else {
                     return Ok(None);
                 };
 
                 // Check the specialized result against the target established above.
                 Ok(Some(self.builder.subtype(mapped, target_type)?))
             }
-            TraversalOperation::BinaryApplication { arguments, .. } => {
-                // Bimap lifts transformations through the first and second arguments of a
-                // binary type constructor. See `emit_bimap` for the staged construction.
+            TraversalOperation::BinaryApplication { first_variance, arguments } => {
+                // Bimap and dimap lift transformations through a binary type constructor.
+                // See `emit_binary_application` for the staged construction.
                 let (first, second) = arguments.operations();
-                self.emit_bimap(first, second, value, traversal)
+                self.emit_binary_application(*first_variance, first, second, value, traversal)
             }
             // Function types require both covariant and contravariant transformations.
             // Given:
@@ -620,11 +632,10 @@ where
         operation: &TraversalOperation,
         traversal: TraversalContext,
     ) -> QueryResult<Option<ElaboratedExpression>> {
-        // Map and bimap require a function that transforms the inside of their source type
-        // into the inside of their target type. Bind one source value, emit its traversal,
-        // and return the resulting lambda to the map or bimap call site. A Parameter
-        // operation eta-expands its mapping expression; nested operations produce a more
-        // involved body.
+        // Each unary or binary traversal operation requires a transformer between its
+        // argument types. The caller has already oriented source and target according to
+        // the edge variance. A Parameter operation eta-expands its mapping expression;
+        // nested operations produce a more involved body.
         //
         //   source :: a
         //   target :: b
@@ -646,13 +657,18 @@ where
         Ok(Some(self.builder.lambda(function, vec![input], body)))
     }
 
-    fn emit_bimap(
+    fn emit_binary_application(
         &mut self,
+        first_variance: Variance,
         first: Option<&TraversalOperation>,
         second: Option<&TraversalOperation>,
         value: ElaboratedExpression,
         traversal: TraversalContext,
     ) -> QueryResult<Option<ElaboratedExpression>> {
+        // A covariant binary edge delegates to `bimap`. A Profunctor edge reverses the
+        // first argument obligation and delegates to `dimap`; its second argument remains
+        // covariant. The examples below trace the Bifunctor case.
+
         // Decompose both arguments of the binary type application.
         //
         //   firstFunction :: a -> c
@@ -728,10 +744,17 @@ where
         //
         //   firstTransformer :: Array a -> Array c
         //   firstTransformer = map firstFunction
-        let first_context = TraversalContext {
-            source_type: source_first,
-            target_type: target_first,
-            function_depth: traversal.function_depth,
+        let first_context = match first_variance {
+            Variance::Covariant => TraversalContext {
+                source_type: source_first,
+                target_type: target_first,
+                function_depth: traversal.function_depth,
+            },
+            Variance::Contravariant => TraversalContext {
+                source_type: target_first,
+                target_type: source_first,
+                function_depth: traversal.function_depth,
+            },
         };
         let first_transformer = if let Some(first) = first {
             let Some(transformer) = self.emit_transformer(first, first_context)? else {
@@ -778,9 +801,8 @@ where
             None => self.emit_identity(second_context)?,
         };
 
-        // Resolve the polymorphic, constrained bimap declaration and specialize it through
-        // application. Applying the source solves the fresh constructor variable and
-        // specializes its wanted Bifunctor evidence.
+        // Resolve the operation selected by the first argument's variance. Applying the
+        // source solves the fresh constructor variable and specializes its wanted evidence.
         //
         //   bimap :: forall f a b c d.
         //     Bifunctor f => (a -> b) -> (c -> d) -> f a c -> f b d
@@ -805,24 +827,28 @@ where
         //         (map firstFunction)
         //         (\record -> record { item = secondFunction record.item })
         //         pair)
-        let Some(bimap) = self.builder.context.known_terms.bimap else {
+        let operation = match first_variance {
+            Variance::Covariant => self.builder.context.known_terms.bimap,
+            Variance::Contravariant => self.builder.context.known_terms.dimap,
+        };
+        let Some(operation) = operation else {
             return Ok(None);
         };
-        let bimap = self.builder.term_reference(bimap)?;
-        let Some(bimap) = self.builder.apply(bimap, first_transformer)? else {
+        let operation = self.builder.term_reference(operation)?;
+        let Some(operation) = self.builder.apply(operation, first_transformer)? else {
             return Ok(None);
         };
-        let Some(bimap) = self.builder.apply(bimap, second_transformer)? else {
+        let Some(operation) = self.builder.apply(operation, second_transformer)? else {
             return Ok(None);
         };
-        let Some(mapped) = self.builder.apply(bimap, value)? else { return Ok(None) };
+        let Some(mapped) = self.builder.apply(operation, value)? else { return Ok(None) };
         Ok(Some(self.builder.subtype(mapped, traversal.target_type)?))
     }
 
     fn emit_identity(&mut self, traversal: TraversalContext) -> QueryResult<ElaboratedExpression> {
-        // Bimap still requires a transformer for an argument that omits the traversed
-        // parameter, so supply identity rather than treating the missing operation as a
-        // missing expression.
+        // Binary operations still require a transformer for an argument that omits the
+        // traversed parameter, so supply identity rather than treating the missing operation
+        // as a missing expression.
         //
         // LeftPair
         //

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -629,7 +629,7 @@ where
                 let effect_type = self.effect_type(traversal.target_type);
                 Ok(Some(self.builder.subtype(mapped, effect_type)?))
             }
-            TraversalOperation::UnaryApplication { argument } => {
+            TraversalOperation::UnaryApplication { argument, .. } => {
                 // Traverse delegates a unary type constructor to its Traversable instance.
                 // Supply the effectful transformation between its applied source and target.
                 //
@@ -698,7 +698,7 @@ where
                 let effect_type = self.effect_type(traversal.target_type);
                 Ok(Some(self.builder.subtype(traversed, effect_type)?))
             }
-            TraversalOperation::BinaryApplication { arguments } => {
+            TraversalOperation::BinaryApplication { arguments, .. } => {
                 // Bitraverse delegates both arguments of a binary type constructor. See
                 // `emit_binary_effect` for the staged construction of its transformers.
                 let (first, second) = arguments.operations();

--- a/compiler-core/checking/src/source/derive/member.rs
+++ b/compiler-core/checking/src/source/derive/member.rs
@@ -6,10 +6,7 @@ use crate::core::Type;
 use crate::error::ErrorCrumb;
 use crate::state::CheckState;
 
-use super::{
-    DeriveDispatch, DeriveHeadResult, DeriveStrategy, derive_dispatch, field, generate, tools,
-    variance,
-};
+use super::{DeriveHeadResult, DeriveStrategy, field, generate, tools, variance};
 
 pub fn check_derive_members<Q>(
     state: &mut CheckState,
@@ -97,18 +94,7 @@ where
                 config,
                 &result.constraints,
             )?;
-            if matches!(
-                derive_dispatch(context, result.class_file, result.class_id),
-                DeriveDispatch::Functor
-                    | DeriveDispatch::Bifunctor
-                    | DeriveDispatch::Foldable
-                    | DeriveDispatch::Bifoldable
-                    | DeriveDispatch::Traversable
-                    | DeriveDispatch::Bitraversable
-            ) && recipe.valid
-            {
-                variance_recipe = Some(recipe);
-            }
+            variance_recipe = recipe.valid.then_some(recipe);
         }
     }
 

--- a/compiler-core/checking/src/source/derive/variance.rs
+++ b/compiler-core/checking/src/source/derive/variance.rs
@@ -130,8 +130,11 @@ impl DerivedRigids {
         }
     }
 
-    fn has_contravariant_parameter(&self) -> bool {
-        self.iter().any(|parameter| parameter.expected == Variance::Contravariant)
+    fn supports_contravariant_traversal(&self) -> bool {
+        !matches!(self, DerivedRigids::Invalid)
+            && self
+                .iter()
+                .all(|parameter| matches!(parameter.function_policy, FunctionPolicy::Allow))
     }
 }
 
@@ -342,7 +345,7 @@ where
                 }
 
                 let application = TypeApplication { type_id, function, argument };
-                if self.rigids.has_contravariant_parameter() {
+                if self.rigids.supports_contravariant_traversal() {
                     return self.check_mixed_application(application, variance);
                 }
                 if let Some(binary_class) = self.rigids.binary_class() {

--- a/compiler-core/checking/src/source/derive/variance.rs
+++ b/compiler-core/checking/src/source/derive/variance.rs
@@ -67,8 +67,9 @@ pub enum TraversalParameter {
 pub enum TraversalOperation {
     Parameter { parameter: TraversalParameter },
     Function { argument: Option<Box<TraversalOperation>>, result: Option<Box<TraversalOperation>> },
-    UnaryApplication { argument: Box<TraversalOperation> },
-    BinaryApplication { arguments: BinaryApplicationArguments },
+    UnaryApplication { argument_variance: Variance, argument: Box<TraversalOperation> },
+    // Bifunctor and Profunctor are covariant in their second argument.
+    BinaryApplication { first_variance: Variance, arguments: BinaryApplicationArguments },
     Record { fields: Vec<RecordFieldRecipe> },
 }
 
@@ -127,6 +128,10 @@ impl DerivedRigids {
             | DerivedRigids::Pair { binary_class, .. } => *binary_class,
             DerivedRigids::Invalid => None,
         }
+    }
+
+    fn has_contravariant_parameter(&self) -> bool {
+        self.iter().any(|parameter| parameter.expected == Variance::Contravariant)
     }
 }
 
@@ -337,10 +342,17 @@ where
                 }
 
                 let application = TypeApplication { type_id, function, argument };
-                if let Some(binary_class) = self.rigids.binary_class() {
-                    return self.check_binary_application(application, variance, binary_class);
+                if self.rigids.has_contravariant_parameter() {
+                    return self.check_mixed_application(application, variance);
                 }
-                return self.check_unary_application(application, variance);
+                if let Some(binary_class) = self.rigids.binary_class() {
+                    return self.check_configured_binary_application(
+                        application,
+                        variance,
+                        binary_class,
+                    );
+                }
+                return self.check_configured_unary_application(application, variance);
             }
             Type::KindApplication(_, argument) => {
                 return self.check(argument, variance);
@@ -367,7 +379,7 @@ where
         Ok(None)
     }
 
-    fn check_unary_application(
+    fn check_configured_unary_application(
         &mut self,
         application: TypeApplication,
         variance: Variance,
@@ -392,11 +404,13 @@ where
         }
 
         let argument = self.check(application.argument, variance)?;
-        Ok(argument
-            .map(|argument| TraversalOperation::UnaryApplication { argument: Box::new(argument) }))
+        Ok(argument.map(|argument| TraversalOperation::UnaryApplication {
+            argument_variance: Variance::Covariant,
+            argument: Box::new(argument),
+        }))
     }
 
-    fn check_binary_application(
+    fn check_configured_binary_application(
         &mut self,
         application: TypeApplication,
         variance: Variance,
@@ -405,7 +419,7 @@ where
         let Some((binary_head, first_type)) =
             toolkit::decompose_type_application(self.state, self.context, application.function)?
         else {
-            return self.check_unary_application(application, variance);
+            return self.check_configured_unary_application(application, variance);
         };
 
         let mut head_is_fixed = true;
@@ -442,7 +456,10 @@ where
                 },
                 None => BinaryApplicationArguments::First(Box::new(first)),
             };
-            return Ok(Some(TraversalOperation::BinaryApplication { arguments }));
+            return Ok(Some(TraversalOperation::BinaryApplication {
+                first_variance: Variance::Covariant,
+                arguments,
+            }));
         }
 
         if let Some(second) = second {
@@ -460,13 +477,19 @@ where
                     tools::emit_constraint(self.context, self.state, binary_class, binary_head);
                 }
                 let arguments = BinaryApplicationArguments::Second(Box::new(second));
-                return Ok(Some(TraversalOperation::BinaryApplication { arguments }));
+                return Ok(Some(TraversalOperation::BinaryApplication {
+                    first_variance: Variance::Covariant,
+                    arguments,
+                }));
             }
 
             if *self.valid && head_is_fixed && second_is_valid {
                 self.emit_unary_constraints(application.argument, variance, application.function)?;
             }
-            return Ok(Some(TraversalOperation::UnaryApplication { argument: Box::new(second) }));
+            return Ok(Some(TraversalOperation::UnaryApplication {
+                argument_variance: Variance::Covariant,
+                argument: Box::new(second),
+            }));
         }
 
         Ok(None)
@@ -527,97 +550,7 @@ where
     }
 
     fn has_instance_head(&mut self, class: ClassReference, argument: TypeId) -> QueryResult<bool> {
-        // Derivation tests constructor-head availability rather than solving the exact
-        // candidate constraint. For example, `Foldable (p Int)` advertises unary traversal
-        // for the head `p`; the emitted wanted still checks the complete application.
-        let (argument_head, _) =
-            toolkit::extract_type_application(self.state, self.context, argument)?;
-
-        let type_heads_equal = |context: &CheckContext<Q>, left: TypeId, right: TypeId| {
-            if left == right {
-                return true;
-            }
-
-            match (context.lookup_type(left), context.lookup_type(right)) {
-                (
-                    Type::Constructor(left_file, left_id),
-                    Type::Constructor(right_file, right_id),
-                ) => left_file == right_file && left_id == right_id,
-                // Generalisation can reconstruct a rigid's kind while preserving the binder
-                // name. Constructor-head availability depends on that binder identity, not
-                // its kind ID.
-                (Type::Rigid(left_name, ..), Type::Rigid(right_name, ..)) => {
-                    left_name == right_name
-                }
-                (Type::Free(left_name), Type::Free(right_name)) => left_name == right_name,
-                _ => false,
-            }
-        };
-
-        let mut available_constraints = Vec::with_capacity(self.available_constraints.len());
-        for &available in self.available_constraints {
-            let Some(available) =
-                constraint::canonical::canonicalise(self.state, self.context, available)?
-            else {
-                continue;
-            };
-            available_constraints.push(available);
-        }
-        let available_constraints = constraint::elaborate::elaborate_superclasses(
-            self.state,
-            self.context,
-            &available_constraints,
-        )?;
-
-        for available in available_constraints {
-            let available = self.state.canonicals[available].clone();
-            if (available.file_id, available.type_id) != class {
-                continue;
-            }
-            let [KindOrType::Type(available_argument)] = available.arguments.as_ref() else {
-                continue;
-            };
-            let (available_head, _) =
-                toolkit::extract_type_application(self.state, self.context, *available_argument)?;
-            if type_heads_equal(self.context, available_head, argument_head) {
-                return Ok(true);
-            }
-        }
-
-        let class_type = self.context.queries.intern_type(Type::Constructor(class.0, class.1));
-        let constraint_type = self.context.intern_application(class_type, argument);
-        let Some(constraint) =
-            constraint::canonical::canonicalise(self.state, self.context, constraint_type)?
-        else {
-            return Ok(false);
-        };
-        let instances =
-            constraint::instances::collect_instance_chains(self.state, self.context, constraint)?;
-        for chain in instances.chains {
-            for candidate in chain {
-                let Some(candidate) = toolkit::instance_info(
-                    self.state,
-                    self.context,
-                    candidate.instance.signature,
-                    class,
-                )?
-                else {
-                    continue;
-                };
-                let [KindOrType::Type(candidate_argument)] = candidate.arguments.as_slice() else {
-                    continue;
-                };
-                let (candidate_head, _) = toolkit::extract_type_application(
-                    self.state,
-                    self.context,
-                    *candidate_argument,
-                )?;
-                if type_heads_equal(self.context, candidate_head, argument_head) {
-                    return Ok(true);
-                }
-            }
-        }
-        Ok(false)
+        has_instance_head(self.state, self.context, self.available_constraints, class, argument)
     }
 
     fn emit_unary_constraint(&mut self, parameter: &DerivedParameter, function: TypeId) {
@@ -628,6 +561,301 @@ where
             *self.valid = false;
         }
     }
+}
+
+impl<Q> VarianceFieldChecker<'_, '_, '_, '_, Q>
+where
+    Q: ExternalQueries,
+{
+    fn check_mixed_application(
+        &mut self,
+        application: TypeApplication,
+        variance: Variance,
+    ) -> QueryResult<Option<TraversalOperation>> {
+        let Some((binary_head, first_type)) =
+            toolkit::decompose_type_application(self.state, self.context, application.function)?
+        else {
+            return self.check_mixed_unary_application(application, variance);
+        };
+
+        if self.contains_parameter(binary_head)? {
+            self.reject(application.type_id);
+            return Ok(None);
+        }
+
+        // Match upstream's instance-driven priority. Once an edge class is available, a
+        // variance error beneath that edge is final rather than a reason to try the next class.
+        if let Some(bifunctor) = self.context.known_types.bifunctor
+            && has_instance_head(
+                self.state,
+                self.context,
+                self.available_constraints,
+                bifunctor,
+                binary_head,
+            )?
+        {
+            return self.check_mixed_binary_application(
+                application,
+                binary_head,
+                first_type,
+                variance,
+                Variance::Covariant,
+                bifunctor,
+            );
+        }
+
+        if let Some(profunctor) = self.context.known_types.profunctor
+            && has_instance_head(
+                self.state,
+                self.context,
+                self.available_constraints,
+                profunctor,
+                binary_head,
+            )?
+        {
+            return self.check_mixed_binary_application(
+                application,
+                binary_head,
+                first_type,
+                variance,
+                Variance::Contravariant,
+                profunctor,
+            );
+        }
+
+        if self.contains_parameter(first_type)? {
+            self.reject(application.type_id);
+            return Ok(None);
+        }
+
+        self.check_mixed_unary_application(application, variance)
+    }
+
+    fn check_mixed_unary_application(
+        &mut self,
+        application: TypeApplication,
+        variance: Variance,
+    ) -> QueryResult<Option<TraversalOperation>> {
+        let function_mentions_parameter = self.contains_parameter(application.function)?;
+        let argument_mentions_parameter = self.contains_parameter(application.argument)?;
+        if function_mentions_parameter {
+            self.reject(application.type_id);
+            return Ok(None);
+        }
+        if !argument_mentions_parameter {
+            return Ok(None);
+        }
+
+        if let Some(functor) = self.context.known_types.functor
+            && has_instance_head(
+                self.state,
+                self.context,
+                self.available_constraints,
+                functor,
+                application.function,
+            )?
+        {
+            let argument = self.check(application.argument, variance)?;
+            if let Some(argument) = argument {
+                if *self.valid {
+                    tools::emit_constraint(self.context, self.state, functor, application.function);
+                }
+                return Ok(Some(TraversalOperation::UnaryApplication {
+                    argument_variance: Variance::Covariant,
+                    argument: Box::new(argument),
+                }));
+            }
+            return Ok(None);
+        }
+
+        if let Some(contravariant) = self.context.known_types.contravariant
+            && has_instance_head(
+                self.state,
+                self.context,
+                self.available_constraints,
+                contravariant,
+                application.function,
+            )?
+        {
+            let argument = self.check(application.argument, variance.flip())?;
+            if let Some(argument) = argument {
+                if *self.valid {
+                    tools::emit_constraint(
+                        self.context,
+                        self.state,
+                        contravariant,
+                        application.function,
+                    );
+                }
+                return Ok(Some(TraversalOperation::UnaryApplication {
+                    argument_variance: Variance::Contravariant,
+                    argument: Box::new(argument),
+                }));
+            }
+            return Ok(None);
+        }
+
+        self.reject(application.type_id);
+        Ok(None)
+    }
+
+    fn check_mixed_binary_application(
+        &mut self,
+        application: TypeApplication,
+        binary_head: TypeId,
+        first_type: TypeId,
+        variance: Variance,
+        first_variance: Variance,
+        class: ClassReference,
+    ) -> QueryResult<Option<TraversalOperation>> {
+        let first_type_variance = match first_variance {
+            Variance::Covariant => variance,
+            Variance::Contravariant => variance.flip(),
+        };
+        let first = self.check(first_type, first_type_variance)?;
+        let second = self.check(application.argument, variance)?;
+
+        // A right-only binary occurrence uses the simpler partially applied Functor when
+        // available. The recipe must record that choice because generation must call `map`
+        // rather than the binary operation selected above.
+        if first.is_none()
+            && second.is_some()
+            && let Some(functor) = self.context.known_types.functor
+            && has_instance_head(
+                self.state,
+                self.context,
+                self.available_constraints,
+                functor,
+                application.function,
+            )?
+        {
+            if *self.valid {
+                tools::emit_constraint(self.context, self.state, functor, application.function);
+            }
+            let Some(second) = second else {
+                unreachable!("right-only traversal requires a second operation")
+            };
+            return Ok(Some(TraversalOperation::UnaryApplication {
+                argument_variance: Variance::Covariant,
+                argument: Box::new(second),
+            }));
+        }
+
+        let arguments = match (first, second) {
+            (Some(first), Some(second)) => BinaryApplicationArguments::Both {
+                first: Box::new(first),
+                second: Box::new(second),
+            },
+            (Some(first), None) => BinaryApplicationArguments::First(Box::new(first)),
+            (None, Some(second)) => BinaryApplicationArguments::Second(Box::new(second)),
+            (None, None) => return Ok(None),
+        };
+
+        if *self.valid {
+            tools::emit_constraint(self.context, self.state, class, binary_head);
+        }
+        Ok(Some(TraversalOperation::BinaryApplication { first_variance, arguments }))
+    }
+
+    fn contains_parameter(&mut self, type_id: TypeId) -> QueryResult<bool> {
+        for parameter in self.rigids.iter() {
+            if toolkit::contains_rigid(self.state, self.context, type_id, parameter.name)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn reject(&mut self, type_id: TypeId) {
+        self.state.insert_error(ErrorKind::CannotDeriveForType { type_id });
+        *self.valid = false;
+    }
+}
+
+fn has_instance_head<Q>(
+    state: &mut CheckState,
+    context: &CheckContext<Q>,
+    available_constraints: &[TypeId],
+    class: ClassReference,
+    argument: TypeId,
+) -> QueryResult<bool>
+where
+    Q: ExternalQueries,
+{
+    // Derivation tests constructor-head availability rather than solving the exact
+    // candidate constraint. For example, `Foldable (p Int)` advertises unary traversal
+    // for the head `p`; the emitted wanted still checks the complete application.
+    let (argument_head, _) = toolkit::extract_type_application(state, context, argument)?;
+
+    let type_heads_equal = |context: &CheckContext<Q>, left: TypeId, right: TypeId| {
+        if left == right {
+            return true;
+        }
+
+        match (context.lookup_type(left), context.lookup_type(right)) {
+            (Type::Constructor(left_file, left_id), Type::Constructor(right_file, right_id)) => {
+                left_file == right_file && left_id == right_id
+            }
+            // Generalisation can reconstruct a rigid's kind while preserving the binder
+            // name. Constructor-head availability depends on that binder identity, not
+            // its kind ID.
+            (Type::Rigid(left_name, ..), Type::Rigid(right_name, ..)) => left_name == right_name,
+            (Type::Free(left_name), Type::Free(right_name)) => left_name == right_name,
+            _ => false,
+        }
+    };
+
+    let mut canonical_constraints = Vec::with_capacity(available_constraints.len());
+    for &available in available_constraints {
+        let Some(available) = constraint::canonical::canonicalise(state, context, available)?
+        else {
+            continue;
+        };
+        canonical_constraints.push(available);
+    }
+    let canonical_constraints =
+        constraint::elaborate::elaborate_superclasses(state, context, &canonical_constraints)?;
+
+    for available in canonical_constraints {
+        let available = state.canonicals[available].clone();
+        if (available.file_id, available.type_id) != class {
+            continue;
+        }
+        let [KindOrType::Type(available_argument)] = available.arguments.as_ref() else {
+            continue;
+        };
+        let (available_head, _) =
+            toolkit::extract_type_application(state, context, *available_argument)?;
+        if type_heads_equal(context, available_head, argument_head) {
+            return Ok(true);
+        }
+    }
+
+    let class_type = context.queries.intern_type(Type::Constructor(class.0, class.1));
+    let constraint_type = context.intern_application(class_type, argument);
+    let Some(constraint) = constraint::canonical::canonicalise(state, context, constraint_type)?
+    else {
+        return Ok(false);
+    };
+    let instances = constraint::instances::collect_instance_chains(state, context, constraint)?;
+    for chain in instances.chains {
+        for candidate in chain {
+            let Some(candidate) =
+                toolkit::instance_info(state, context, candidate.instance.signature, class)?
+            else {
+                continue;
+            };
+            let [KindOrType::Type(candidate_argument)] = candidate.arguments.as_slice() else {
+                continue;
+            };
+            let (candidate_head, _) =
+                toolkit::extract_type_application(state, context, *candidate_argument)?;
+            if type_heads_equal(context, candidate_head, argument_head) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 fn emit_variance_error(

--- a/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
+++ b/tests-integration/fixtures/checking/1772565240_derive_bifunctor_missing_functor/Main.snap
@@ -35,12 +35,12 @@ Roles
 WrapBoth = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
+error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) (t0 :: Type)
   --> 6:1..6:41
   |
 6 | derive instance Bifunctor (WrapBoth f g)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Functor (g :: Type -> Type)
+error[CannotDeriveForType]: Cannot derive for type: (g :: Type -> Type) (t1 :: Type)
   --> 6:1..6:41
   |
 6 | derive instance Bifunctor (WrapBoth f g)

--- a/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567520_derive_functor_higher_kinded/Main.snap
@@ -32,7 +32,7 @@ Wrap = [Representational, Nominal]
 WrapNoFunctor = [Representational, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
+error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) (t0 :: Type)
   --> 9:1..9:42
   |
 9 | derive instance Functor (WrapNoFunctor f)

--- a/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
+++ b/tests-integration/fixtures/checking/1772567580_derive_bifunctor_higher_kinded/Main.snap
@@ -60,12 +60,12 @@ WrapBoth = [Representational, Representational, Nominal, Nominal]
 WrapBothNoConstraint = [Representational, Representational, Nominal, Nominal]
 
 Diagnostics
-error[NoInstanceFound]: No instance found for: Functor (f :: Type -> Type)
+error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) (t0 :: Type)
   --> 10:1..10:53
    |
 10 | derive instance Bifunctor (WrapBothNoConstraint f g)
    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[NoInstanceFound]: No instance found for: Functor (g :: Type -> Type)
+error[CannotDeriveForType]: Cannot derive for type: (g :: Type -> Type) (t1 :: Type)
   --> 10:1..10:53
    |
 10 | derive instance Bifunctor (WrapBothNoConstraint f g)

--- a/tests-integration/fixtures/checking/1785319620_derive_bifunctor_captured_application_argument/Main.snap
+++ b/tests-integration/fixtures/checking/1785319620_derive_bifunctor_captured_application_argument/Main.snap
@@ -44,7 +44,7 @@ error[CannotDeriveForType]: Cannot derive for type: Triple (t0 :: Type) Int (t1 
   |
 8 | derive instance Bifunctor Captured
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CannotDeriveForType]: Cannot derive for type: Triple (t2 :: Type) Int Boolean
+error[CannotDeriveForType]: Cannot derive for type: Outer (Triple (t2 :: Type) Int Boolean) (t3 :: Type)
   --> 13:1..13:41
    |
 13 | derive instance Bifunctor NestedCaptured

--- a/tests-integration/fixtures/checking/1785319980_preserve_unary_variance_application_checks/Main.snap
+++ b/tests-integration/fixtures/checking/1785319980_preserve_unary_variance_application_checks/Main.snap
@@ -34,17 +34,12 @@ Wrapped = [Representational, Representational]
 Wrong = [Representational, Nominal, Phantom]
 
 Diagnostics
-error[CovariantOccurrence]: Type variable occurs in covariant position: (f :: Type -> Type) ((t0 :: Type) -> Int)
+error[CannotDeriveForType]: Cannot derive for type: (f :: Type -> Type) ((t0 :: Type) -> Int)
   --> 7:1..7:42
   |
 7 | derive instance Contravariant (Wrapped f)
   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CovariantOccurrence]: Type variable occurs in covariant position: (f1 :: Type -> Type) (t1 :: Type)
-  --> 10:1..10:37
-   |
-10 | derive instance Profunctor (Wrong f)
-   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error[CovariantOccurrence]: Type variable occurs in covariant position: (t1 :: Type)
+error[CannotDeriveForType]: Cannot derive for type: (f1 :: Type -> Type) (t1 :: Type)
   --> 10:1..10:37
    |
 10 | derive instance Profunctor (Wrong f)

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_captured_application_head/Main.purs
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_captured_application_head/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Triple a b c = Triple
+
+data Captured a = Captured (Triple a Int String)
+derive instance Contravariant Captured

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_captured_application_head/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_captured_application_head/Main.snap
@@ -1,0 +1,40 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Triple ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type) (@a :: (t0 :: Prim.Type))
+    (@b :: (t1 :: Prim.Type)) (@c :: (t2 :: Prim.Type)).
+    Main.Triple @(t0 :: Prim.Type) @(t1 :: Prim.Type) @(t2 :: Prim.Type)
+      (a :: (t0 :: Prim.Type))
+      (b :: (t1 :: Prim.Type))
+      (c :: (t2 :: Prim.Type))
+Captured ::
+  forall (t0 :: Prim.Type) (@a :: (t0 :: Prim.Type)).
+    Main.Triple @(t0 :: Prim.Type) @Prim.Type @Prim.Type
+      (a :: (t0 :: Prim.Type))
+      Prim.Int
+      Prim.String ->
+    Main.Captured @(t0 :: Prim.Type) (a :: (t0 :: Prim.Type))
+
+Types
+Triple ::
+  forall (t0 :: Prim.Type) (t1 :: Prim.Type) (t2 :: Prim.Type).
+    (t0 :: Prim.Type) -> (t1 :: Prim.Type) -> (t2 :: Prim.Type) -> Prim.Type
+Captured :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> Prim.Type
+
+Derived
+derive Data.Functor.Contravariant.Contravariant (Main.Captured @Prim.Type)
+
+Roles
+Triple = [Phantom, Phantom, Phantom]
+Captured = [Representational]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Triple @Type @Type @Type (t0 :: Type) Int String
+  --> 8:1..8:39
+  |
+8 | derive instance Contravariant Captured
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_missing_traversal_instance/Main.purs
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_missing_traversal_instance/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Opaque a = Opaque a
+
+data Wrapped a = Wrapped (Opaque (a -> Int))
+derive instance Contravariant Wrapped

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_missing_traversal_instance/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_missing_traversal_instance/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Opaque :: forall (@a :: Prim.Type). (a :: Prim.Type) -> Main.Opaque (a :: Prim.Type)
+Wrapped ::
+  forall (@a :: Prim.Type).
+    Main.Opaque ((a :: Prim.Type) -> Prim.Int) -> Main.Wrapped (a :: Prim.Type)
+
+Types
+Opaque :: Prim.Type -> Prim.Type
+Wrapped :: Prim.Type -> Prim.Type
+
+Derived
+derive Data.Functor.Contravariant.Contravariant Main.Wrapped
+
+Roles
+Opaque = [Representational]
+Wrapped = [Representational]
+
+Diagnostics
+error[CannotDeriveForType]: Cannot derive for type: Opaque ((t0 :: Type) -> Int)
+  --> 8:1..8:38
+  |
+8 | derive instance Contravariant Wrapped
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_nested_parity_rejection/Main.purs
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_nested_parity_rejection/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Predicate a = Predicate (a -> Boolean)
+derive instance Contravariant Predicate
+
+data DoubleNegative a = DoubleNegative (Predicate (Predicate a))
+derive instance Contravariant DoubleNegative

--- a/tests-integration/fixtures/checking/1785598200_derive_contravariant_nested_parity_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_contravariant_nested_parity_rejection/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Predicate ::
+  forall (@a :: Prim.Type). ((a :: Prim.Type) -> Prim.Boolean) -> Main.Predicate (a :: Prim.Type)
+DoubleNegative ::
+  forall (@a :: Prim.Type).
+    Main.Predicate (Main.Predicate (a :: Prim.Type)) -> Main.DoubleNegative (a :: Prim.Type)
+
+Types
+Predicate :: Prim.Type -> Prim.Type
+DoubleNegative :: Prim.Type -> Prim.Type
+
+Derived
+derive Data.Functor.Contravariant.Contravariant Main.Predicate
+derive Data.Functor.Contravariant.Contravariant Main.DoubleNegative
+
+Roles
+Predicate = [Representational]
+DoubleNegative = [Representational]
+
+Diagnostics
+error[CovariantOccurrence]: Type variable occurs in covariant position: (t0 :: Type)
+  --> 9:1..9:45
+  |
+9 | derive instance Contravariant DoubleNegative
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1785598200_derive_profunctor_bifunctor_priority_rejection/Main.purs
+++ b/tests-integration/fixtures/checking/1785598200_derive_profunctor_bifunctor_priority_rejection/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Profunctor (class Profunctor)
+
+data Pair a b = Pair a b
+derive instance Bifunctor Pair
+
+data Nested a b = Nested (Pair a b)
+derive instance Profunctor Nested

--- a/tests-integration/fixtures/checking/1785598200_derive_profunctor_bifunctor_priority_rejection/Main.snap
+++ b/tests-integration/fixtures/checking/1785598200_derive_profunctor_bifunctor_priority_rejection/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Pair ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    (a :: Prim.Type) -> (b :: Prim.Type) -> Main.Pair (a :: Prim.Type) (b :: Prim.Type)
+Nested ::
+  forall (@a :: Prim.Type) (@b :: Prim.Type).
+    Main.Pair (a :: Prim.Type) (b :: Prim.Type) -> Main.Nested (a :: Prim.Type) (b :: Prim.Type)
+
+Types
+Pair :: Prim.Type -> Prim.Type -> Prim.Type
+Nested :: Prim.Type -> Prim.Type -> Prim.Type
+
+Derived
+derive Data.Bifunctor.Bifunctor Main.Pair
+derive Data.Profunctor.Profunctor Main.Nested
+
+Roles
+Pair = [Representational, Representational]
+Nested = [Representational, Representational]
+
+Diagnostics
+error[CovariantOccurrence]: Type variable occurs in covariant position: (t0 :: Type)
+  --> 10:1..10:34
+   |
+10 | derive instance Profunctor Nested
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Empty a
+derive instance Contravariant Empty

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_empty_data_body/Main.snap
@@ -1,0 +1,15 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Empty :: forall (k0 :: Prim.Type). k0 -> Prim.Type
+data Empty @a
+
+dictionary contravariantEmpty :: Data.Functor.Contravariant.Contravariant (Main.Empty @Prim.Type)
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a) -> Main.Empty @Prim.Type a -> Main.Empty @Prim.Type b
+  cmap = \function value ->
+    case value of
+      <error>

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_function_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_function_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Predicate a = Predicate (a -> Boolean)
+derive instance Contravariant Predicate

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_function_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_function_body/Main.snap
@@ -1,0 +1,14 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Predicate :: Prim.Type -> Prim.Type
+data Predicate @a
+  | Predicate :: (a -> Prim.Boolean) -> Main.Predicate a
+
+dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
+  cmap = \function value ->
+    case value of
+      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_functor_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_functor_application_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Functor.Contravariant (class Contravariant)
+
+data Box a = Box a
+derive instance Functor Box
+
+data BoxedPredicate a = BoxedPredicate (Box (a -> Boolean))
+derive instance Contravariant BoxedPredicate

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_functor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_functor_application_body/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Box :: Prim.Type -> Prim.Type
+data Box @a
+  | Box :: a -> Main.Box a
+
+data BoxedPredicate :: Prim.Type -> Prim.Type
+data BoxedPredicate @a
+  | BoxedPredicate :: Main.Box (a -> Prim.Boolean) -> Main.BoxedPredicate a
+
+dictionary functorBox :: Data.Functor.Functor Main.Box where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Box a -> Main.Box b
+  map = \function value ->
+    case value of
+      (Box field0) -> Box @b (function field0)
+
+dictionary contravariantBoxedPredicate ::
+  Data.Functor.Contravariant.Contravariant Main.BoxedPredicate
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.BoxedPredicate a -> Main.BoxedPredicate b
+  cmap = \function value ->
+    case value of
+      (BoxedPredicate field0) -> BoxedPredicate @b
+        (map @Main.Box {functorBox} @(a -> Prim.Boolean) @(b -> Prim.Boolean)
+          (\element -> \argument -> element (function argument))
+          field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_mixed_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_mixed_application_body/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Functor.Contravariant (class Contravariant)
+
+data Box a = Box a
+derive instance Functor Box
+
+data Predicate a = Predicate (a -> Boolean)
+derive instance Contravariant Predicate
+
+data BoxedInput a = BoxedInput (Predicate (Box a))
+derive instance Contravariant BoxedInput

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_mixed_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_mixed_application_body/Main.snap
@@ -1,0 +1,37 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Box :: Prim.Type -> Prim.Type
+data Box @a
+  | Box :: a -> Main.Box a
+
+data Predicate :: Prim.Type -> Prim.Type
+data Predicate @a
+  | Predicate :: (a -> Prim.Boolean) -> Main.Predicate a
+
+data BoxedInput :: Prim.Type -> Prim.Type
+data BoxedInput @a
+  | BoxedInput :: Main.Predicate (Main.Box a) -> Main.BoxedInput a
+
+dictionary functorBox :: Data.Functor.Functor Main.Box where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.Box a -> Main.Box b
+  map = \function value ->
+    case value of
+      (Box field0) -> Box @b (function field0)
+
+dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
+  cmap = \function value ->
+    case value of
+      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+
+dictionary contravariantBoxedInput :: Data.Functor.Contravariant.Contravariant Main.BoxedInput where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.BoxedInput a -> Main.BoxedInput b
+  cmap = \function value ->
+    case value of
+      (BoxedInput field0) -> BoxedInput @b
+        (cmap @Main.Predicate {contravariantPredicate} @(Main.Box a) @(Main.Box b)
+          (\element -> map @Main.Box {functorBox} @b @a (\element -> function element) element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_record_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data PredicateRecord a = PredicateRecord { label :: String, run :: a -> Boolean }
+derive instance Contravariant PredicateRecord

--- a/tests-integration/fixtures/semantic/1785598200_derive_contravariant_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_contravariant_record_body/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data PredicateRecord :: Prim.Type -> Prim.Type
+data PredicateRecord @a
+  | PredicateRecord :: { label :: Prim.String, run :: a -> Prim.Boolean } -> Main.PredicateRecord a
+
+dictionary contravariantPredicateRecord ::
+  Data.Functor.Contravariant.Contravariant Main.PredicateRecord
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a) -> Main.PredicateRecord a -> Main.PredicateRecord b
+  cmap = \function value ->
+    case value of
+      (PredicateRecord field0) -> PredicateRecord @b
+        field0 { run = \argument -> field0.run (function argument) }

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_function_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_function_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Profunctor (class Profunctor)
+
+data Function a b = Function (a -> b)
+derive instance Profunctor Function

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_function_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_function_body/Main.snap
@@ -1,0 +1,16 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_both_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_both_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Profunctor (class Profunctor)
+
+data Function a b = Function (a -> b)
+derive instance Profunctor Function
+
+data Nested a b = Nested (Function a b)
+derive instance Profunctor Nested

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_both_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_both_body/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+data Nested :: Prim.Type -> Prim.Type -> Prim.Type
+data Nested @a @b
+  | Nested :: Main.Function a b -> Main.Nested a b
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))
+
+dictionary profunctorNested :: Data.Profunctor.Profunctor Main.Nested where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Nested b c -> Main.Nested a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Nested field0) -> Nested @a @d
+        (dimap @Main.Function {profunctorFunction} @a @b @c @d (\element -> firstFunction element)
+          (\element -> secondFunction element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Profunctor (class Profunctor)
+
+data Function a b = Function (a -> b)
+derive instance Profunctor Function
+
+data NestedLeft a b = NestedLeft (Function a Int)
+derive instance Profunctor NestedLeft

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_nested_left_body/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+data NestedLeft :: forall (k0 :: Prim.Type). Prim.Type -> k0 -> Prim.Type
+data NestedLeft @a @b
+  | NestedLeft :: Main.Function a Prim.Int -> Main.NestedLeft a b
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))
+
+dictionary profunctorNestedLeft :: Data.Profunctor.Profunctor (Main.NestedLeft @Prim.Type) where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.NestedLeft @Prim.Type b c -> Main.NestedLeft @Prim.Type a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (NestedLeft field0) -> NestedLeft @Prim.Type @a @d
+        (dimap @Main.Function {profunctorFunction} @a @b @Prim.Int @Prim.Int
+          (\element -> firstFunction element)
+          (\unchanged -> unchanged)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Profunctor (class Profunctor)
+
+data Function a b = Function (a -> b)
+derive instance Profunctor Function
+derive instance Functor (Function a)
+
+data NestedRight a b = NestedRight (Function Int b)
+derive instance Profunctor NestedRight

--- a/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598200_derive_profunctor_unary_preference_body/Main.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+data NestedRight :: forall (k0 :: Prim.Type). k0 -> Prim.Type -> Prim.Type
+data NestedRight @a @b
+  | NestedRight :: Main.Function Prim.Int b -> Main.NestedRight a b
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))
+
+dictionary functorFunction :: forall a. Data.Functor.Functor (Main.Function a) where
+  map :: forall (a1 :: Prim.Type) (b :: Prim.Type). (a1 -> b) -> Main.Function a a1 -> Main.Function a b
+  map = \function value ->
+    case value of
+      (Function field0) -> Function @a @b \argument -> function (field0 argument)
+
+dictionary profunctorNestedRight :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type) where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.NestedRight @Prim.Type b c -> Main.NestedRight @Prim.Type a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (NestedRight field0) -> NestedRight @Prim.Type @a @d
+        (map @(Main.Function Prim.Int) {functorFunction} @c @d (\element -> secondFunction element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598260_derive_profunctor_bifunctor_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598260_derive_profunctor_bifunctor_application_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Profunctor (class Profunctor)
+
+data Pair a b = Pair a b
+derive instance Bifunctor Pair
+
+data Nested a b = Nested (Pair (a -> Int) b)
+derive instance Profunctor Nested

--- a/tests-integration/fixtures/semantic/1785598260_derive_profunctor_bifunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598260_derive_profunctor_bifunctor_application_body/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Pair :: Prim.Type -> Prim.Type -> Prim.Type
+data Pair @a @b
+  | Pair :: a -> b -> Main.Pair a b
+
+data Nested :: Prim.Type -> Prim.Type -> Prim.Type
+data Nested @a @b
+  | Nested :: Main.Pair (a -> Prim.Int) b -> Main.Nested a b
+
+dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
+
+dictionary profunctorNested :: Data.Profunctor.Profunctor Main.Nested where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Nested b c -> Main.Nested a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Nested field0) -> Nested @a @d
+        (bimap @Main.Pair {bifunctorPair} @(b -> Prim.Int) @(a -> Prim.Int) @c @d
+          (\element -> \argument -> element (firstFunction argument))
+          (\element -> secondFunction element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Nested f a = Nested (f a)
+derive instance Contravariant f => Contravariant (Nested f)

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_given_application_body/Main.snap
@@ -1,0 +1,20 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Nested :: forall (k0 :: Prim.Type). (k0 -> Prim.Type) -> k0 -> Prim.Type
+data Nested @f @a
+  | Nested :: f a -> Main.Nested f a
+
+dictionary contravariantNested ::
+  forall f.
+  { contravariantDict :: Data.Functor.Contravariant.Contravariant f } =>
+  Data.Functor.Contravariant.Contravariant (Main.Nested @Prim.Type f)
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a) -> Main.Nested @Prim.Type f a -> Main.Nested @Prim.Type f b
+  cmap = \function value ->
+    case value of
+      (Nested field0) -> Nested @Prim.Type @f @b
+        (cmap @f {contravariantDict} @a @b (\element -> function element) field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_triple_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_triple_application_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Predicate a = Predicate (a -> Boolean)
+derive instance Contravariant Predicate
+
+data TripleNegative a = TripleNegative (Predicate (Predicate (Predicate a)))
+derive instance Contravariant TripleNegative

--- a/tests-integration/fixtures/semantic/1785598320_derive_contravariant_triple_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_contravariant_triple_application_body/Main.snap
@@ -1,0 +1,34 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Predicate :: Prim.Type -> Prim.Type
+data Predicate @a
+  | Predicate :: (a -> Prim.Boolean) -> Main.Predicate a
+
+data TripleNegative :: Prim.Type -> Prim.Type
+data TripleNegative @a
+  | TripleNegative :: Main.Predicate (Main.Predicate (Main.Predicate a)) -> Main.TripleNegative a
+
+dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
+  cmap = \function value ->
+    case value of
+      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+
+dictionary contravariantTripleNegative ::
+  Data.Functor.Contravariant.Contravariant Main.TripleNegative
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.TripleNegative a -> Main.TripleNegative b
+  cmap = \function value ->
+    case value of
+      (TripleNegative field0) -> TripleNegative @b
+        (cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate (Main.Predicate a)) @(Main.Predicate (Main.Predicate b))
+          (\element ->
+            cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate b) @(Main.Predicate a)
+              (\element ->
+                cmap @Main.Predicate {contravariantPredicate} @a @b (\element -> function element)
+                  element)
+              element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Profunctor (class Profunctor)
+
+data Nested p a b = Nested (p a b)
+derive instance Profunctor p => Profunctor (Nested p)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_given_application_body/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Nested ::
+  forall (k0 :: Prim.Type) (k1 :: Prim.Type). (k0 -> k1 -> Prim.Type) -> k0 -> k1 -> Prim.Type
+data Nested @p @a @b
+  | Nested :: p a b -> Main.Nested p a b
+
+dictionary profunctorNested ::
+  forall p.
+  { profunctorDict :: Data.Profunctor.Profunctor p } =>
+  Data.Profunctor.Profunctor (Main.Nested @Prim.Type @Prim.Type p)
+  where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) ->
+  (c -> d) ->
+  Main.Nested @Prim.Type @Prim.Type p b c ->
+  Main.Nested @Prim.Type @Prim.Type p a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Nested field0) -> Nested @Prim.Type @Prim.Type @p @a @d
+        (dimap @p {profunctorDict} @a @b @c @d (\element -> firstFunction element)
+          (\element -> secondFunction element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Profunctor (class Profunctor)
+
+data Function a b = Function (a -> b)
+derive instance Profunctor Function
+
+data NestedRight a b = NestedRight (Function Int b)
+derive instance Profunctor NestedRight

--- a/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598320_derive_profunctor_nested_right_body/Main.snap
@@ -1,0 +1,31 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+data NestedRight :: forall (k0 :: Prim.Type). k0 -> Prim.Type -> Prim.Type
+data NestedRight @a @b
+  | NestedRight :: Main.Function Prim.Int b -> Main.NestedRight a b
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))
+
+dictionary profunctorNestedRight :: Data.Profunctor.Profunctor (Main.NestedRight @Prim.Type) where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.NestedRight @Prim.Type b c -> Main.NestedRight @Prim.Type a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (NestedRight field0) -> NestedRight @Prim.Type @a @d
+        (dimap @Main.Function {profunctorFunction} @Prim.Int @Prim.Int @c @d
+          (\unchanged -> unchanged)
+          (\element -> secondFunction element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_nullary_constructor_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_nullary_constructor_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data OptionalPredicate a = None | Some (a -> Boolean)
+derive instance Contravariant OptionalPredicate

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_nullary_constructor_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_nullary_constructor_body/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data OptionalPredicate :: Prim.Type -> Prim.Type
+data OptionalPredicate @a
+  | None :: Main.OptionalPredicate a
+  | Some :: (a -> Prim.Boolean) -> Main.OptionalPredicate a
+
+dictionary contravariantOptionalPredicate ::
+  Data.Functor.Contravariant.Contravariant Main.OptionalPredicate
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a) -> Main.OptionalPredicate a -> Main.OptionalPredicate b
+  cmap = \function value ->
+    case value of
+      None -> None @b
+      (Some field0) -> Some @b \argument -> field0 (function argument)

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_open_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_open_record_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data OpenPredicate r a = OpenPredicate { run :: a -> Boolean | r }
+derive instance Contravariant (OpenPredicate r)

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_open_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_open_record_body/Main.snap
@@ -1,0 +1,19 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data OpenPredicate :: Prim.Row Prim.Type -> Prim.Type -> Prim.Type
+data OpenPredicate @r @a
+  | OpenPredicate :: { run :: a -> Prim.Boolean | r } -> Main.OpenPredicate r a
+
+dictionary contravariantOpenPredicate ::
+  forall r.
+  Data.Functor.Contravariant.Contravariant (Main.OpenPredicate r)
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a) -> Main.OpenPredicate r a -> Main.OpenPredicate r b
+  cmap = \function value ->
+    case value of
+      (OpenPredicate field0) -> OpenPredicate @r @b
+        field0 { run = \argument -> field0.run (function argument) }

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Functor.Contravariant (class Contravariant)
+
+data Constant value a = Constant value
+derive instance Contravariant (Constant value)

--- a/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598440_derive_contravariant_phantom_body/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Constant :: forall (k0 :: Prim.Type). Prim.Type -> k0 -> Prim.Type
+data Constant @value @a
+  | Constant :: value -> Main.Constant value a
+
+dictionary contravariantConstant ::
+  forall value.
+  Data.Functor.Contravariant.Contravariant (Main.Constant @Prim.Type value)
+  where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type).
+  (b -> a) -> Main.Constant @Prim.Type value a -> Main.Constant @Prim.Type value b
+  cmap = \function value ->
+    case value of
+      (Constant field0) -> Constant @Prim.Type @value @b field0

--- a/tests-integration/fixtures/semantic/1785598920_derive_contravariant_bifunctor_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598920_derive_contravariant_bifunctor_application_body/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Functor.Contravariant (class Contravariant)
+
+data Pair a b = Pair a b
+derive instance Bifunctor Pair
+
+data Nested a = Nested (Pair (a -> Int) String)
+derive instance Contravariant Nested

--- a/tests-integration/fixtures/semantic/1785598920_derive_contravariant_bifunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598920_derive_contravariant_bifunctor_application_body/Main.snap
@@ -1,0 +1,29 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Pair :: Prim.Type -> Prim.Type -> Prim.Type
+data Pair @a @b
+  | Pair :: a -> b -> Main.Pair a b
+
+data Nested :: Prim.Type -> Prim.Type
+data Nested @a
+  | Nested :: Main.Pair (a -> Prim.Int) Prim.String -> Main.Nested a
+
+dictionary bifunctorPair :: Data.Bifunctor.Bifunctor Main.Pair where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Pair a c -> Main.Pair b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Pair field0 field1) -> Pair @b @d (firstFunction field0) (secondFunction field1)
+
+dictionary contravariantNested :: Data.Functor.Contravariant.Contravariant Main.Nested where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Nested a -> Main.Nested b
+  cmap = \function value ->
+    case value of
+      (Nested field0) -> Nested @b
+        (bimap @Main.Pair {bifunctorPair} @(a -> Prim.Int) @(b -> Prim.Int) @Prim.String @Prim.String
+          (\element -> \argument -> element (function argument))
+          (\unchanged -> unchanged)
+          field0)

--- a/tests-integration/fixtures/semantic/1785598920_derive_profunctor_record_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785598920_derive_profunctor_record_body/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Profunctor (class Profunctor)
+
+data RecordPro a b = RecordPro { consume :: a -> Int, fixed :: String, produce :: b }
+derive instance Profunctor RecordPro

--- a/tests-integration/fixtures/semantic/1785598920_derive_profunctor_record_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785598920_derive_profunctor_record_body/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data RecordPro :: Prim.Type -> Prim.Type -> Prim.Type
+data RecordPro @a @b
+  | RecordPro ::
+    { consume :: a -> Prim.Int, fixed :: Prim.String, produce :: b } -> Main.RecordPro a b
+
+dictionary profunctorRecordPro :: Data.Profunctor.Profunctor Main.RecordPro where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.RecordPro b c -> Main.RecordPro a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (RecordPro field0) -> RecordPro @a @d
+        field0 { consume = \argument ->
+          field0.consume (firstFunction argument), produce = secondFunction field0.produce }

--- a/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Data.Bifunctor (class Bifunctor)
+import Data.Functor.Contravariant (class Contravariant)
+import Data.Profunctor (class Profunctor)
+
+data Predicate a = Predicate (a -> Boolean)
+
+derive instance Contravariant Predicate
+
+data Function a b = Function (a -> b)
+
+derive instance Profunctor Function
+
+data Mixed a b = Mixed (Function (Predicate a) b)
+
+derive instance Bifunctor Mixed

--- a/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.snap
@@ -1,0 +1,30 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Predicate :: Prim.Type -> Prim.Type
+data Predicate @a
+  | Predicate :: (a -> Prim.Boolean) -> Main.Predicate a
+
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+data Mixed :: Prim.Type -> Prim.Type -> Prim.Type
+data Mixed @a @b
+  | Mixed :: Main.Function (Main.Predicate a) b -> Main.Mixed a b
+
+dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
+  cmap = \function value ->
+    case value of
+      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))

--- a/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_bifunctor_mixed_variance_application_body/Main.snap
@@ -28,3 +28,16 @@ dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
     case value of
       (Function field0) -> Function @a @d \argument ->
         secondFunction (field0 (firstFunction argument))
+
+dictionary bifunctorMixed :: Data.Bifunctor.Bifunctor Main.Mixed where
+  bimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Mixed a c -> Main.Mixed b d
+  bimap = \firstFunction secondFunction value ->
+    case value of
+      (Mixed field0) -> Mixed @b @d
+        (dimap @Main.Function {profunctorFunction} @(Main.Predicate b) @(Main.Predicate a) @c @d
+          (\element ->
+            cmap @Main.Predicate {contravariantPredicate} @b @a (\element -> firstFunction element)
+              element)
+          (\element -> secondFunction element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Functor.Contravariant (class Contravariant)
+
+data Predicate a = Predicate (a -> Boolean)
+
+derive instance Contravariant Predicate
+
+data DoubleNegative a = DoubleNegative (Predicate (Predicate a))
+
+derive instance Functor DoubleNegative

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.snap
@@ -16,3 +16,14 @@ dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Ma
   cmap = \function value ->
     case value of
       (Predicate field0) -> Predicate @b \argument -> field0 (function argument)
+
+dictionary functorDoubleNegative :: Data.Functor.Functor Main.DoubleNegative where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.DoubleNegative a -> Main.DoubleNegative b
+  map = \function value ->
+    case value of
+      (DoubleNegative field0) -> DoubleNegative @b
+        (cmap @Main.Predicate {contravariantPredicate} @(Main.Predicate a) @(Main.Predicate b)
+          (\element ->
+            cmap @Main.Predicate {contravariantPredicate} @b @a (\element -> function element)
+              element)
+          field0)

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_contravariant_application_body/Main.snap
@@ -1,0 +1,18 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Predicate :: Prim.Type -> Prim.Type
+data Predicate @a
+  | Predicate :: (a -> Prim.Boolean) -> Main.Predicate a
+
+data DoubleNegative :: Prim.Type -> Prim.Type
+data DoubleNegative @a
+  | DoubleNegative :: Main.Predicate (Main.Predicate a) -> Main.DoubleNegative a
+
+dictionary contravariantPredicate :: Data.Functor.Contravariant.Contravariant Main.Predicate where
+  cmap :: forall (a :: Prim.Type) (b :: Prim.Type). (b -> a) -> Main.Predicate a -> Main.Predicate b
+  cmap = \function value ->
+    case value of
+      (Predicate field0) -> Predicate @b \argument -> field0 (function argument)

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.purs
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Data.Functor (class Functor)
+import Data.Profunctor (class Profunctor)
+
+data Function a b = Function (a -> b)
+
+derive instance Profunctor Function
+
+data DoubleInput a = DoubleInput (Function (Function a Int) Int)
+
+derive instance Functor DoubleInput

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.snap
@@ -1,0 +1,26 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 68
+expression: report
+---
+data Function :: Prim.Type -> Prim.Type -> Prim.Type
+data Function @a @b
+  | Function :: (a -> b) -> Main.Function a b
+
+data DoubleInput :: Prim.Type -> Prim.Type
+data DoubleInput @a
+  | DoubleInput :: Main.Function (Main.Function a Prim.Int) Prim.Int -> Main.DoubleInput a
+
+dictionary profunctorFunction :: Data.Profunctor.Profunctor Main.Function where
+  dimap :: forall (a :: Prim.Type) (b :: Prim.Type) (c :: Prim.Type) (d :: Prim.Type).
+  (a -> b) -> (c -> d) -> Main.Function b c -> Main.Function a d
+  dimap = \firstFunction secondFunction value ->
+    case value of
+      (Function field0) -> Function @a @d \argument ->
+        secondFunction (field0 (firstFunction argument))
+
+dictionary functorDoubleInput :: Data.Functor.Functor Main.DoubleInput where
+  map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.DoubleInput a -> Main.DoubleInput b
+  map = \function value ->
+    case value of
+      (DoubleInput field0) -> DoubleInput @a field0

--- a/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.snap
+++ b/tests-integration/fixtures/semantic/1785603960_derive_functor_profunctor_application_body/Main.snap
@@ -23,4 +23,12 @@ dictionary functorDoubleInput :: Data.Functor.Functor Main.DoubleInput where
   map :: forall (a :: Prim.Type) (b :: Prim.Type). (a -> b) -> Main.DoubleInput a -> Main.DoubleInput b
   map = \function value ->
     case value of
-      (DoubleInput field0) -> DoubleInput @a field0
+      (DoubleInput field0) -> DoubleInput @b
+        (dimap @Main.Function {profunctorFunction} @(Main.Function b Prim.Int) @(Main.Function a Prim.Int) @Prim.Int @Prim.Int
+          (\element ->
+            dimap @Main.Function {profunctorFunction} @a @b @Prim.Int @Prim.Int
+              (\element -> function element)
+              (\unchanged -> unchanged)
+              element)
+          (\unchanged -> unchanged)
+          field0)


### PR DESCRIPTION
## Summary

Add generated instance members for the `Contravariant` and `Profunctor` class family.

The implementation keeps Contravariant/Profunctor emission in an independent generator while extending the shared variance recipe to represent covariant and contravariant application edges. It supports functions, records, unary applications, binary Bifunctor/Profunctor applications, phantom parameters, open records, and available instance constraints.

Functor and Bifunctor derivation can now traverse nested Contravariant and Profunctor edges, recovering covariance across negative boundaries. Foldable and Traversable retain their existing covariant-only traversal policy.

The commits preserve the mixed-variance regressions before applying the Functor/Bifunctor fix, making the generated semantic-tree changes directly reviewable.

## Testing

- `cargo check -p checking --tests`
- `cargo nextest run -p checking`
- `just t checking`
- `just t semantic`
- `cargo clippy -p checking --tests -- -D warnings -A clippy::too_many_arguments`
- `just format`