### PR TITLE
[checking] Clarify compiler tree representation names

### DIFF
--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -87,8 +87,10 @@ pub struct RowField {
     pub id: TypeId,
 }
 
+/// An application spine argument, classified by whether it came from
+/// [`Type::KindApplication`] or [`Type::Application`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum KindOrType {
+pub enum ApplicationArgument {
     Kind(TypeId),
     Type(TypeId),
 }

--- a/compiler-core/checking/src/core.rs
+++ b/compiler-core/checking/src/core.rs
@@ -102,7 +102,7 @@ pub struct CheckedDataDeclaration {
 pub struct CheckedSynonym {
     pub kind: TypeId,
     pub parameters: Vec<ForallBinder>,
-    pub synonym: TypeId,
+    pub expansion: TypeId,
 }
 
 /// Represents a checked class declaration.

--- a/compiler-core/checking/src/core/constraint.rs
+++ b/compiler-core/checking/src/core/constraint.rs
@@ -27,7 +27,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
 use crate::core::fd::{compute_closure, get_functional_dependencies};
-use crate::core::{KindOrType, TypeId, unification};
+use crate::core::{ApplicationArgument, TypeId, unification};
 use crate::error::{CheckingError, ErrorKind};
 use crate::evidence::{Evidence, EvidenceId, EvidenceVarId};
 use crate::implication::{GivenConstraint, ImplicationId, Patterns, WantedConstraint};
@@ -143,7 +143,7 @@ where
     }
 
     let arguments = arguments.iter().filter_map(|argument| {
-        if let KindOrType::Type(argument) = argument { Some(*argument) } else { None }
+        if let ApplicationArgument::Type(argument) = argument { Some(*argument) } else { None }
     });
 
     let arguments = arguments.collect_vec();

--- a/compiler-core/checking/src/core/constraint/canonical.rs
+++ b/compiler-core/checking/src/core/constraint/canonical.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashMap;
 
 use crate::context::CheckContext;
 use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{KindOrType, Type, TypeId, normalise, toolkit, zonk};
+use crate::core::{ApplicationArgument, Type, TypeId, normalise, toolkit, zonk};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
 
@@ -21,7 +21,7 @@ use crate::{ExternalQueries, safe_loop};
 pub struct CanonicalConstraint {
     pub file_id: FileId,
     pub type_id: TypeItemId,
-    pub arguments: Arc<[KindOrType]>,
+    pub arguments: Arc<[ApplicationArgument]>,
 }
 
 impl CanonicalConstraint {
@@ -29,8 +29,8 @@ impl CanonicalConstraint {
         self.arguments
             .iter()
             .filter_map(|argument| match argument {
-                KindOrType::Type(argument) => Some(*argument),
-                KindOrType::Kind(_) => None,
+                ApplicationArgument::Type(argument) => Some(*argument),
+                ApplicationArgument::Kind(_) => None,
             })
             .collect_array()
     }
@@ -60,8 +60,12 @@ impl Canonicals {
 
         for &argument in arguments.iter() {
             constraint = match argument {
-                KindOrType::Kind(argument) => context.intern_kind_application(constraint, argument),
-                KindOrType::Type(argument) => context.intern_application(constraint, argument),
+                ApplicationArgument::Kind(argument) => {
+                    context.intern_kind_application(constraint, argument)
+                }
+                ApplicationArgument::Type(argument) => {
+                    context.intern_application(constraint, argument)
+                }
             };
         }
 
@@ -125,8 +129,12 @@ where
 {
     let canonical = state.canonicals[id].clone();
     let arguments = canonical.arguments.iter().map(|&argument| match argument {
-        KindOrType::Kind(argument) => zonk::zonk(state, context, argument).map(KindOrType::Kind),
-        KindOrType::Type(argument) => zonk::zonk(state, context, argument).map(KindOrType::Type),
+        ApplicationArgument::Kind(argument) => {
+            zonk::zonk(state, context, argument).map(ApplicationArgument::Kind)
+        }
+        ApplicationArgument::Type(argument) => {
+            zonk::zonk(state, context, argument).map(ApplicationArgument::Type)
+        }
     });
 
     let arguments = arguments.collect::<QueryResult<Arc<[_]>>>()?;
@@ -148,11 +156,11 @@ where
 
     let canonical = state.canonicals[id].clone();
     let arguments = canonical.arguments.iter().copied().map(|argument| match argument {
-        KindOrType::Kind(argument) => {
-            substitute_type(state, context, substitution, argument).map(KindOrType::Kind)
+        ApplicationArgument::Kind(argument) => {
+            substitute_type(state, context, substitution, argument).map(ApplicationArgument::Kind)
         }
-        KindOrType::Type(argument) => {
-            substitute_type(state, context, substitution, argument).map(KindOrType::Type)
+        ApplicationArgument::Type(argument) => {
+            substitute_type(state, context, substitution, argument).map(ApplicationArgument::Type)
         }
     });
 

--- a/compiler-core/checking/src/core/constraint/elaborate.rs
+++ b/compiler-core/checking/src/core/constraint/elaborate.rs
@@ -12,7 +12,7 @@ use crate::context::CheckContext;
 use crate::core::constraint::canonical::CanonicalConstraint;
 use crate::core::constraint::{CanonicalConstraintId, canonical, compiler};
 use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{CheckedClass, KindOrType, Name, Type, TypeId, normalise, toolkit};
+use crate::core::{ApplicationArgument, CheckedClass, Name, Type, TypeId, normalise, toolkit};
 use crate::evidence::{Evidence, EvidenceId, Evidences, SuperclassId};
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -157,7 +157,7 @@ where
 pub(crate) fn superclass_substitutions<Q>(
     context: &CheckContext<Q>,
     class: &CheckedClass,
-    arguments: &[KindOrType],
+    arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<NameToType>>
 where
     Q: ExternalQueries,
@@ -166,7 +166,7 @@ where
     let mut arguments = arguments.iter().copied();
 
     for &binder_id in class.kind_binders.iter() {
-        let Some(KindOrType::Kind(argument)) = arguments.next() else {
+        let Some(ApplicationArgument::Kind(argument)) = arguments.next() else {
             return Ok(None);
         };
         let binder = context.lookup_forall_binder(binder_id);
@@ -174,7 +174,7 @@ where
     }
 
     for &binder_id in class.type_parameters.iter() {
-        let Some(KindOrType::Type(argument)) = arguments.next() else {
+        let Some(ApplicationArgument::Type(argument)) = arguments.next() else {
             return Ok(None);
         };
         let binder = context.lookup_forall_binder(binder_id);
@@ -207,8 +207,11 @@ where
             return None;
         }
 
-        let (kind @ KindOrType::Kind(_), left @ KindOrType::Type(_), right @ KindOrType::Type(_)) =
-            arguments.iter().copied().collect_tuple()?
+        let (
+            kind @ ApplicationArgument::Kind(_),
+            left @ ApplicationArgument::Type(_),
+            right @ ApplicationArgument::Type(_),
+        ) = arguments.iter().copied().collect_tuple()?
         else {
             return None;
         };

--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -106,7 +106,7 @@ where
             Some((origin, instance))
         }
         IndexedTermItemKind::Derive { id } => {
-            let instance = state.checked.lookup_derived(id)?;
+            let instance = state.checked.lookup_derived_instance(id)?;
             let origin = InstanceCandidateOrigin::Derive(context.id, id);
             Some((origin, instance))
         }
@@ -329,7 +329,7 @@ fn collect_instances_from_checked(
         });
 
     let derived = checked
-        .derived
+        .derived_instances
         .iter()
         .filter(|(_, instance)| instance.resolution == (class_file, class_id))
         .map(|(&id, &instance)| {

--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -14,7 +14,9 @@ use crate::context::CheckContext;
 use crate::core::constraint::{CanonicalConstraint, CanonicalConstraintId};
 use crate::core::fd::{get_all_determined, get_functional_dependencies};
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
-use crate::core::{CheckedInstance, KindOrType, Type, TypeId, constraint, normalise, toolkit};
+use crate::core::{
+    ApplicationArgument, CheckedInstance, Type, TypeId, constraint, normalise, toolkit,
+};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 use crate::{CheckedModule, ExternalQueries};
@@ -193,7 +195,7 @@ where
     let mut blocking = vec![];
     for &argument in constraint.arguments.iter() {
         let argument = match argument {
-            KindOrType::Kind(id) | KindOrType::Type(id) => id,
+            ApplicationArgument::Kind(id) | ApplicationArgument::Type(id) => id,
         };
         CollectFileReferences::collect(state, context, argument, &mut files, &mut blocking)?;
     }

--- a/compiler-core/checking/src/core/constraint/instances.rs
+++ b/compiler-core/checking/src/core/constraint/instances.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{
-    DeriveId, IndexedModule, InstanceChainId, InstanceId, TermItemId, TermItemKind, TypeItemId,
+    DeriveId, IndexedModule, IndexedTermItemKind, InstanceChainId, InstanceId, TermItemId,
+    TypeItemId,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -99,12 +100,12 @@ where
     Q: ExternalQueries,
 {
     match context.indexed.items[item_id].kind {
-        TermItemKind::Instance { id } => {
+        IndexedTermItemKind::Instance { id } => {
             let instance = state.checked.lookup_instance(id)?;
             let origin = InstanceCandidateOrigin::Instance(context.id, id);
             Some((origin, instance))
         }
-        TermItemKind::Derive { id } => {
+        IndexedTermItemKind::Derive { id } => {
             let instance = state.checked.lookup_derived(id)?;
             let origin = InstanceCandidateOrigin::Derive(context.id, id);
             Some((origin, instance))
@@ -276,12 +277,14 @@ where
     Q: ExternalQueries,
 {
     context.indexed.items.iter_terms().position(|(_, item)| match (origin, &item.kind) {
-        (InstanceCandidateOrigin::Instance(file_id, origin_id), TermItemKind::Instance { id }) => {
-            file_id == context.id && origin_id == *id
-        }
-        (InstanceCandidateOrigin::Derive(file_id, origin_id), TermItemKind::Derive { id }) => {
-            file_id == context.id && origin_id == *id
-        }
+        (
+            InstanceCandidateOrigin::Instance(file_id, origin_id),
+            IndexedTermItemKind::Instance { id },
+        ) => file_id == context.id && origin_id == *id,
+        (
+            InstanceCandidateOrigin::Derive(file_id, origin_id),
+            IndexedTermItemKind::Derive { id },
+        ) => file_id == context.id && origin_id == *id,
         _ => false,
     })
 }

--- a/compiler-core/checking/src/core/constraint/matching.rs
+++ b/compiler-core/checking/src/core/constraint/matching.rs
@@ -14,7 +14,8 @@ use crate::core::fd::{
 use crate::core::substitute::SubstituteName;
 use crate::core::walk::{TypeWalker, WalkAction, walk_type};
 use crate::core::{
-    CheckedInstance, KindOrType, Name, RowField, RowTypeId, Type, TypeId, normalise, toolkit,
+    ApplicationArgument, CheckedInstance, Name, RowField, RowTypeId, Type, TypeId, normalise,
+    toolkit,
 };
 use crate::source::types;
 use crate::state::CheckState;
@@ -567,13 +568,21 @@ where
     let wanted_arguments = wanted
         .arguments
         .iter()
-        .filter_map(|argument| if let KindOrType::Type(id) = argument { Some(*id) } else { None })
+        .filter_map(
+            |argument| {
+                if let ApplicationArgument::Type(id) = argument { Some(*id) } else { None }
+            },
+        )
         .collect_vec();
 
     let provided_arguments = provided
         .arguments
         .iter()
-        .filter_map(|argument| if let KindOrType::Type(id) = argument { Some(*id) } else { None })
+        .filter_map(
+            |argument| {
+                if let ApplicationArgument::Type(id) = argument { Some(*id) } else { None }
+            },
+        )
         .collect_vec();
 
     match match_instance(
@@ -716,10 +725,14 @@ where
     instances_overlap(state, context, &functional_dependencies, &left_arguments, &right_arguments)
 }
 
-fn type_arguments(arguments: &[KindOrType]) -> Vec<TypeId> {
+fn type_arguments(arguments: &[ApplicationArgument]) -> Vec<TypeId> {
     arguments
         .iter()
-        .filter_map(|argument| if let KindOrType::Type(id) = argument { Some(*id) } else { None })
+        .filter_map(
+            |argument| {
+                if let ApplicationArgument::Type(id) = argument { Some(*id) } else { None }
+            },
+        )
         .collect_vec()
 }
 

--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -1061,8 +1061,8 @@ where
     Q: ExternalQueries,
 {
     let on_lowered = |lowered: &lowering::LoweredModule| {
-        if let Some(lowering::TermItemIr::Constructor { arguments }) =
-            lowered.tree.get_term_item(term_id)
+        if let Some(lowering::TermItemKind::Constructor { arguments }) =
+            lowered.tree.get_term_item_kind(term_id)
         {
             arguments.len()
         } else {

--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -1062,7 +1062,7 @@ where
 {
     let on_lowered = |lowered: &lowering::LoweredModule| {
         if let Some(lowering::TermItemIr::Constructor { arguments }) =
-            lowered.info.get_term_item(term_id)
+            lowered.tree.get_term_item(term_id)
         {
             arguments.len()
         } else {
@@ -1177,7 +1177,7 @@ where
     let Some(expression_id) = guard.expression else {
         return false;
     };
-    let Some(kind) = context.lowered.info.get_expression_kind(expression_id) else {
+    let Some(kind) = context.lowered.tree.get_expression_kind(expression_id) else {
         return false;
     };
     match kind {
@@ -1193,7 +1193,7 @@ fn is_irrefutable_binder<Q>(context: &CheckContext<Q>, binder_id: lowering::Bind
 where
     Q: ExternalQueries,
 {
-    let Some(kind) = context.lowered.info.get_binder_kind(binder_id) else {
+    let Some(kind) = context.lowered.tree.get_binder_kind(binder_id) else {
         return false;
     };
     match kind {

--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -965,10 +965,10 @@ where
     Q: ExternalQueries,
 {
     let constructor_type = if file_id == context.id {
-        state.checked.lookup_term(term_id)
+        state.checked.lookup_term_item_type(term_id)
     } else {
         let checked = context.checked_dependency(file_id)?;
-        checked.lookup_term(term_id)
+        checked.lookup_term_item_type(term_id)
     };
 
     if let Some(constructor_type) = constructor_type {

--- a/compiler-core/checking/src/core/exhaustive/convert.rs
+++ b/compiler-core/checking/src/core/exhaustive/convert.rs
@@ -25,7 +25,7 @@ where
 {
     let t = state
         .checked
-        .nodes
+        .node_types
         .lookup_binder(id)
         .unwrap_or_else(|| context.unknown("unresolved binder"));
 
@@ -297,7 +297,7 @@ where
     };
 
     let Some(OperatorBranchTypes { left, right, result }) =
-        state.checked.nodes.lookup_term_operator(operator_id)
+        state.checked.node_types.lookup_term_operator(operator_id)
     else {
         return Ok(state.allocate_wildcard(t));
     };

--- a/compiler-core/checking/src/core/exhaustive/convert.rs
+++ b/compiler-core/checking/src/core/exhaustive/convert.rs
@@ -325,8 +325,8 @@ where
     Q: ExternalQueries,
 {
     let on_lowered = |lowered: &lowering::LoweredModule| {
-        if let Some(lowering::TermItemIr::Operator { resolution, .. }) =
-            lowered.tree.get_term_item(item_id)
+        if let Some(lowering::TermItemKind::Operator { resolution, .. }) =
+            lowered.tree.get_term_item_kind(item_id)
         {
             *resolution
         } else {

--- a/compiler-core/checking/src/core/exhaustive/convert.rs
+++ b/compiler-core/checking/src/core/exhaustive/convert.rs
@@ -29,7 +29,7 @@ where
         .lookup_binder(id)
         .unwrap_or_else(|| context.unknown("unresolved binder"));
 
-    let Some(kind) = context.lowered.info.get_binder_kind(id) else {
+    let Some(kind) = context.lowered.tree.get_binder_kind(id) else {
         return Ok(state.allocate_wildcard(t));
     };
 
@@ -284,7 +284,7 @@ fn convert_operator_branch<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some((file_id, item_id)) = context.lowered.info.get_term_operator(operator_id) else {
+    let Some((file_id, item_id)) = context.lowered.tree.get_term_operator(operator_id) else {
         return Ok(state.allocate_wildcard(t));
     };
 
@@ -326,7 +326,7 @@ where
 {
     let on_lowered = |lowered: &lowering::LoweredModule| {
         if let Some(lowering::TermItemIr::Operator { resolution, .. }) =
-            lowered.info.get_term_item(item_id)
+            lowered.tree.get_term_item(item_id)
         {
             *resolution
         } else {

--- a/compiler-core/checking/src/core/normalise.rs
+++ b/compiler-core/checking/src/core/normalise.rs
@@ -309,9 +309,9 @@ where
 
     // Apply the substitutions if there are any.
     let mut substituted = if bindings.is_empty() {
-        checked_synonym.synonym
+        checked_synonym.expansion
     } else {
-        SubstituteName::many(state, context, &bindings, checked_synonym.synonym)?
+        SubstituteName::many(state, context, &bindings, checked_synonym.expansion)?
     };
 
     // Reconstruct applications from remaining oversaturated arguments.

--- a/compiler-core/checking/src/core/normalise.rs
+++ b/compiler-core/checking/src/core/normalise.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 
 use crate::context::CheckContext;
 use crate::core::substitute::{NameToType, SubstituteName};
-use crate::core::{KindOrType, Type, TypeId, toolkit};
+use crate::core::{ApplicationArgument, Type, TypeId, toolkit};
 use crate::state::{CheckState, UnificationState};
 use crate::{ExternalQueries, safe_loop};
 
@@ -239,11 +239,11 @@ where
         current = normalise(state, context, current)?;
         match context.lookup_type(current) {
             Type::Application(function, argument) => {
-                arguments.push(KindOrType::Type(argument));
+                arguments.push(ApplicationArgument::Type(argument));
                 current = function;
             }
             Type::KindApplication(function, argument) => {
-                arguments.push(KindOrType::Kind(argument));
+                arguments.push(ApplicationArgument::Kind(argument));
                 current = function;
             }
             _ => break,
@@ -289,7 +289,7 @@ where
             break;
         };
 
-        let Some(KindOrType::Kind(argument)) = arguments.next() else {
+        let Some(ApplicationArgument::Kind(argument)) = arguments.next() else {
             return Ok(id);
         };
 
@@ -301,7 +301,7 @@ where
 
     // Create substitutions for type arguments.
     for parameter in &checked_synonym.parameters {
-        let Some(KindOrType::Type(argument)) = arguments.next() else {
+        let Some(ApplicationArgument::Type(argument)) = arguments.next() else {
             return Ok(id);
         };
         bindings.insert(parameter.name, argument);
@@ -317,8 +317,12 @@ where
     // Reconstruct applications from remaining oversaturated arguments.
     for argument in arguments {
         substituted = match argument {
-            KindOrType::Type(argument) => context.intern_application(substituted, argument),
-            KindOrType::Kind(argument) => context.intern_kind_application(substituted, argument),
+            ApplicationArgument::Type(argument) => {
+                context.intern_application(substituted, argument)
+            }
+            ApplicationArgument::Kind(argument) => {
+                context.intern_kind_application(substituted, argument)
+            }
         };
     }
 

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -13,8 +13,8 @@ use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
 use crate::core::walk::{self, TypeWalker};
 use crate::core::{
-    CheckedClass, CheckedSynonym, ForallBinder, KindOrType, Name, Role, SmolStrId, Type, TypeId,
-    constraint, normalise, unification,
+    ApplicationArgument, CheckedClass, CheckedSynonym, ForallBinder, Name, Role, SmolStrId, Type,
+    TypeId, constraint, normalise, unification,
 };
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -38,7 +38,7 @@ pub enum InspectMode {
 pub struct InstanceInfo {
     pub binders: Vec<ForallBinder>,
     pub constraints: Vec<TypeId>,
-    pub arguments: Vec<KindOrType>,
+    pub arguments: Vec<ApplicationArgument>,
 }
 
 pub struct NewtypeInner {
@@ -78,7 +78,7 @@ pub fn extract_all_applications<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     mut id: TypeId,
-) -> QueryResult<(TypeId, Vec<KindOrType>)>
+) -> QueryResult<(TypeId, Vec<ApplicationArgument>)>
 where
     Q: ExternalQueries,
 {
@@ -88,11 +88,11 @@ where
         id = normalise::expand(state, context, id)?;
         match context.lookup_type(id) {
             Type::Application(function, argument) => {
-                arguments.push(crate::core::KindOrType::Type(argument));
+                arguments.push(crate::core::ApplicationArgument::Type(argument));
                 id = function;
             }
             Type::KindApplication(function, argument) => {
-                arguments.push(crate::core::KindOrType::Kind(argument));
+                arguments.push(crate::core::ApplicationArgument::Kind(argument));
                 id = function;
             }
             _ => break,
@@ -848,7 +848,9 @@ where
         let replacement = arguments
             .next()
             .map(|argument| match argument {
-                KindOrType::Kind(argument) | KindOrType::Type(argument) => argument,
+                ApplicationArgument::Kind(argument) | ApplicationArgument::Type(argument) => {
+                    argument
+                }
             })
             .unwrap_or_else(|| {
                 let text = state.checked.lookup_name(binder.name);

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -252,7 +252,7 @@ where
     Q: ExternalQueries,
 {
     let resolve = |lowered: &lowering::LoweredModule| {
-        lowered.info.get_type_item(type_id).and_then(|item| match item {
+        lowered.tree.get_type_item(type_id).and_then(|item| match item {
             TypeItemIr::Operator { resolution, .. } => *resolution,
             _ => None,
         })
@@ -275,7 +275,7 @@ where
     Q: ExternalQueries,
 {
     let resolve = |lowered: &lowering::LoweredModule| {
-        lowered.info.get_term_item(term_id).and_then(|item| match item {
+        lowered.tree.get_term_item(term_id).and_then(|item| match item {
             TermItemIr::Operator { resolution, .. } => *resolution,
             _ => None,
         })
@@ -752,11 +752,11 @@ where
     Q: ExternalQueries,
 {
     let type_item = if file_id == context.id {
-        context.lowered.info.get_type_item(item_id)
+        context.lowered.tree.get_type_item(item_id)
     } else {
         let lowered = context.queries.lowered(file_id)?;
         return Ok(matches!(
-            lowered.info.get_type_item(item_id),
+            lowered.tree.get_type_item(item_id),
             Some(lowering::TypeItemIr::NewtypeGroup { .. })
         ));
     };

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -113,10 +113,10 @@ where
     Q: ExternalQueries,
 {
     let kind = if file_id == context.id {
-        state.checked.lookup_type(type_id)
+        state.checked.lookup_type_item_kind(type_id)
     } else {
         let checked = context.checked_dependency(file_id)?;
-        checked.lookup_type(type_id)
+        checked.lookup_type_item_kind(type_id)
     };
 
     if let Some(kind) = kind { Ok(kind) } else { Ok(context.unknown("invalid type item")) }
@@ -132,10 +132,10 @@ where
     Q: ExternalQueries,
 {
     let term = if file_id == context.id {
-        state.checked.lookup_term(term_id)
+        state.checked.lookup_term_item_type(term_id)
     } else {
         let checked = context.checked_dependency(file_id)?;
-        checked.lookup_term(term_id)
+        checked.lookup_term_item_type(term_id)
     };
 
     if let Some(term) = term { Ok(term) } else { Ok(context.unknown("invalid term item")) }
@@ -230,10 +230,10 @@ where
     Q: ExternalQueries,
 {
     let operator_kind = if file_id == context.id {
-        state.checked.lookup_type(type_id)
+        state.checked.lookup_type_item_kind(type_id)
     } else {
         let checked = context.checked_dependency(file_id)?;
-        checked.lookup_type(type_id)
+        checked.lookup_type_item_kind(type_id)
     };
 
     if let Some(operator_kind) = operator_kind {
@@ -299,10 +299,10 @@ where
     Q: ExternalQueries,
 {
     let operator_type = if file_id == context.id {
-        state.checked.lookup_term(term_id)
+        state.checked.lookup_term_item_type(term_id)
     } else {
         let checked = context.checked_dependency(file_id)?;
-        checked.lookup_term(term_id)
+        checked.lookup_term_item_type(term_id)
     };
 
     if let Some(operator_type) = operator_type {

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{TermItemId, TypeItemId};
-use lowering::{TermItemIr, TypeItemIr};
+use lowering::{TermItemKind, TypeItemKind};
 
 use rustc_hash::FxHashMap;
 
@@ -252,8 +252,8 @@ where
     Q: ExternalQueries,
 {
     let resolve = |lowered: &lowering::LoweredModule| {
-        lowered.tree.get_type_item(type_id).and_then(|item| match item {
-            TypeItemIr::Operator { resolution, .. } => *resolution,
+        lowered.tree.get_type_item_kind(type_id).and_then(|item| match item {
+            TypeItemKind::Operator { resolution, .. } => *resolution,
             _ => None,
         })
     };
@@ -275,8 +275,8 @@ where
     Q: ExternalQueries,
 {
     let resolve = |lowered: &lowering::LoweredModule| {
-        lowered.tree.get_term_item(term_id).and_then(|item| match item {
-            TermItemIr::Operator { resolution, .. } => *resolution,
+        lowered.tree.get_term_item_kind(term_id).and_then(|item| match item {
+            TermItemKind::Operator { resolution, .. } => *resolution,
             _ => None,
         })
     };
@@ -752,15 +752,15 @@ where
     Q: ExternalQueries,
 {
     let type_item = if file_id == context.id {
-        context.lowered.tree.get_type_item(item_id)
+        context.lowered.tree.get_type_item_kind(item_id)
     } else {
         let lowered = context.queries.lowered(file_id)?;
         return Ok(matches!(
-            lowered.tree.get_type_item(item_id),
-            Some(lowering::TypeItemIr::NewtypeGroup { .. })
+            lowered.tree.get_type_item_kind(item_id),
+            Some(lowering::TypeItemKind::Newtype { .. })
         ));
     };
-    Ok(matches!(type_item, Some(lowering::TypeItemIr::NewtypeGroup { .. })))
+    Ok(matches!(type_item, Some(lowering::TypeItemKind::Newtype { .. })))
 }
 
 pub fn extract_type_constructor<Q>(

--- a/compiler-core/checking/src/core/toolkit.rs
+++ b/compiler-core/checking/src/core/toolkit.rs
@@ -152,17 +152,17 @@ where
     match resolution {
         lowering::TermVariableResolution::Binder(binder_id) => Ok(state
             .checked
-            .nodes
+            .node_types
             .lookup_binder(binder_id)
             .unwrap_or_else(|| context.unknown("unresolved binder"))),
         lowering::TermVariableResolution::Let(let_binding_id) => Ok(state
             .checked
-            .nodes
+            .node_types
             .lookup_let(let_binding_id)
             .unwrap_or_else(|| context.unknown("unresolved let"))),
         lowering::TermVariableResolution::RecordPun(pun_id) => Ok(state
             .checked
-            .nodes
+            .node_types
             .lookup_pun(pun_id)
             .unwrap_or_else(|| context.unknown("unresolved pun"))),
         lowering::TermVariableResolution::Reference(file_id, term_id) => {

--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -45,23 +45,23 @@ where
 {
     macro_rules! zonk_type_map {
         ($field:ident) => {
-            for (node_id, type_id) in mem::take(&mut state.checked.nodes.$field) {
+            for (node_id, type_id) in mem::take(&mut state.checked.node_types.$field) {
                 let type_id = zonk(state, context, type_id)?;
-                state.checked.nodes.$field.insert(node_id, type_id);
+                state.checked.node_types.$field.insert(node_id, type_id);
             }
         };
     }
 
     macro_rules! zonk_operator_map {
         ($field:ident) => {
-            for (node_id, branch_types) in mem::take(&mut state.checked.nodes.$field) {
+            for (node_id, branch_types) in mem::take(&mut state.checked.node_types.$field) {
                 let branch_types = zonk_operator_branch(state, context, branch_types)?;
-                state.checked.nodes.$field.insert(node_id, branch_types);
+                state.checked.node_types.$field.insert(node_id, branch_types);
             }
         };
     }
 
-    zonk_type_map!(types);
+    zonk_type_map!(type_kinds);
     zonk_type_map!(expressions);
     zonk_type_map!(binders);
     zonk_type_map!(lets);
@@ -69,8 +69,8 @@ where
     zonk_type_map!(sections);
     zonk_type_map!(forall_bindings);
     zonk_type_map!(implicit_bindings);
-    zonk_operator_map!(term_operator);
-    zonk_operator_map!(type_operator);
+    zonk_operator_map!(term_operators);
+    zonk_operator_map!(type_operators);
 
     Ok(())
 }

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -65,7 +65,7 @@ pub struct CheckedModule {
     pub derived: FxHashMap<DeriveId, CheckedInstance>,
     pub roles: FxHashMap<TypeItemId, Arc<[Role]>>,
     pub nodes: CheckedNodes,
-    pub tree: tree::Module,
+    pub tree: tree::CheckedTree,
     pub holes: CheckedHoles,
     pub errors: Vec<CheckingError>,
     pub names: FxHashMap<Name, SmolStrId>,

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -56,8 +56,8 @@ pub trait ExternalQueries:
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct CheckedModule {
     pub evidence: evidence::Evidences,
-    pub types: FxHashMap<TypeItemId, TypeId>,
-    pub terms: FxHashMap<TermItemId, TypeId>,
+    pub type_item_kinds: FxHashMap<TypeItemId, TypeId>,
+    pub term_item_types: FxHashMap<TermItemId, TypeId>,
     pub data_declarations: FxHashMap<TypeItemId, CheckedDataDeclaration>,
     pub synonyms: FxHashMap<TypeItemId, CheckedSynonym>,
     pub classes: FxHashMap<TypeItemId, CheckedClass>,
@@ -99,12 +99,12 @@ pub struct OperatorBranchTypes {
 }
 
 impl CheckedModule {
-    pub fn lookup_type(&self, id: TypeItemId) -> Option<TypeId> {
-        self.types.get(&id).copied()
+    pub fn lookup_type_item_kind(&self, id: TypeItemId) -> Option<TypeId> {
+        self.type_item_kinds.get(&id).copied()
     }
 
-    pub fn lookup_term(&self, id: TermItemId) -> Option<TypeId> {
-        self.terms.get(&id).copied()
+    pub fn lookup_term_item_type(&self, id: TermItemId) -> Option<TypeId> {
+        self.term_item_types.get(&id).copied()
     }
 
     pub fn lookup_data_declaration(&self, id: TypeItemId) -> Option<CheckedDataDeclaration> {
@@ -254,7 +254,7 @@ fn check_prim(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<Ch
 
     let mut insert_type = |name: &str, id: TypeId| {
         let (_, item_id) = lookup_type(name);
-        checked.types.insert(item_id, id);
+        checked.type_item_kinds.insert(item_id, id);
     };
 
     insert_type("Type", type_core);
@@ -271,7 +271,7 @@ fn check_prim(queries: &impl ExternalQueries, file_id: FileId) -> QueryResult<Ch
     insert_type("Row", type_to_type);
 
     let (_, partial_id) = lookup_class("Partial");
-    checked.types.insert(partial_id, constraint_core);
+    checked.type_item_kinds.insert(partial_id, constraint_core);
 
     let mut insert_roles = |name: &str, roles: &[Role]| {
         let (_, item_id) = lookup_type(name);

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -62,7 +62,7 @@ pub struct CheckedModule {
     pub synonyms: FxHashMap<TypeItemId, CheckedSynonym>,
     pub classes: FxHashMap<TypeItemId, CheckedClass>,
     pub instances: FxHashMap<InstanceId, CheckedInstance>,
-    pub derived: FxHashMap<DeriveId, CheckedInstance>,
+    pub derived_instances: FxHashMap<DeriveId, CheckedInstance>,
     pub roles: FxHashMap<TypeItemId, Arc<[Role]>>,
     pub node_types: CheckedNodeTypes,
     pub tree: tree::CheckedTree,
@@ -124,8 +124,8 @@ impl CheckedModule {
         self.instances.get(&id).cloned()
     }
 
-    pub fn lookup_derived(&self, id: DeriveId) -> Option<CheckedInstance> {
-        self.derived.get(&id).cloned()
+    pub fn lookup_derived_instance(&self, id: DeriveId) -> Option<CheckedInstance> {
+        self.derived_instances.get(&id).cloned()
     }
 
     pub fn lookup_roles(&self, id: TypeItemId) -> Option<Arc<[Role]>> {

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -64,7 +64,7 @@ pub struct CheckedModule {
     pub instances: FxHashMap<InstanceId, CheckedInstance>,
     pub derived: FxHashMap<DeriveId, CheckedInstance>,
     pub roles: FxHashMap<TypeItemId, Arc<[Role]>>,
-    pub nodes: CheckedNodes,
+    pub node_types: CheckedNodeTypes,
     pub tree: tree::CheckedTree,
     pub holes: CheckedHoles,
     pub errors: Vec<CheckingError>,
@@ -77,9 +77,10 @@ pub struct CheckedHoles {
     pub types: FxHashMap<lowering::TypeId, TypeHole>,
 }
 
+/// Checked types and kinds keyed by stable node IDs from lowering.
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct CheckedNodes {
-    pub types: FxHashMap<lowering::TypeId, TypeId>,
+pub struct CheckedNodeTypes {
+    pub type_kinds: FxHashMap<lowering::TypeId, TypeId>,
     pub expressions: FxHashMap<lowering::ExpressionId, TypeId>,
     pub binders: FxHashMap<lowering::BinderId, TypeId>,
     pub lets: FxHashMap<lowering::LetBindingNameGroupId, TypeId>,
@@ -87,8 +88,8 @@ pub struct CheckedNodes {
     pub sections: FxHashMap<lowering::ExpressionId, TypeId>,
     pub forall_bindings: FxHashMap<lowering::TypeVariableBindingId, TypeId>,
     pub implicit_bindings: FxHashMap<(lowering::GraphNodeId, lowering::ImplicitBindingId), TypeId>,
-    pub term_operator: FxHashMap<lowering::TermOperatorId, OperatorBranchTypes>,
-    pub type_operator: FxHashMap<lowering::TypeOperatorId, OperatorBranchTypes>,
+    pub term_operators: FxHashMap<lowering::TermOperatorId, OperatorBranchTypes>,
+    pub type_operators: FxHashMap<lowering::TypeOperatorId, OperatorBranchTypes>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -144,13 +145,13 @@ impl CheckedModule {
     }
 }
 
-impl CheckedNodes {
+impl CheckedNodeTypes {
     pub fn lookup_expression(&self, id: lowering::ExpressionId) -> Option<TypeId> {
         self.expressions.get(&id).copied()
     }
 
-    pub fn lookup_type(&self, id: lowering::TypeId) -> Option<TypeId> {
-        self.types.get(&id).copied()
+    pub fn lookup_type_kind(&self, id: lowering::TypeId) -> Option<TypeId> {
+        self.type_kinds.get(&id).copied()
     }
 
     pub fn lookup_binder(&self, id: lowering::BinderId) -> Option<TypeId> {
@@ -185,14 +186,14 @@ impl CheckedNodes {
         &self,
         id: lowering::TypeOperatorId,
     ) -> Option<OperatorBranchTypes> {
-        self.type_operator.get(&id).copied()
+        self.type_operators.get(&id).copied()
     }
 
     pub fn lookup_term_operator(
         &self,
         id: lowering::TermOperatorId,
     ) -> Option<OperatorBranchTypes> {
-        self.term_operator.get(&id).copied()
+        self.term_operators.get(&id).copied()
     }
 }
 

--- a/compiler-core/checking/src/source/binder.rs
+++ b/compiler-core/checking/src/source/binder.rs
@@ -81,7 +81,7 @@ pub fn requires_instantiation<Q>(context: &CheckContext<Q>, binder_id: lowering:
 where
     Q: ExternalQueries,
 {
-    let Some(kind) = context.lowered.info.get_binder_kind(binder_id) else {
+    let Some(kind) = context.lowered.tree.get_binder_kind(binder_id) else {
         return false;
     };
     match kind {
@@ -107,7 +107,7 @@ fn type_annotation_requires_instantiation<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(kind) = context.lowered.info.get_type_kind(type_id) else {
+    let Some(kind) = context.lowered.tree.get_type_kind(type_id) else {
         return false;
     };
     match kind {
@@ -176,7 +176,7 @@ where
 {
     let unknown = context.unknown("missing binder");
 
-    let Some(kind) = context.lowered.info.get_binder_kind(binder_id) else {
+    let Some(kind) = context.lowered.tree.get_binder_kind(binder_id) else {
         return Ok(allocate_checked_binder(state, binder_id, unknown, tree::BinderKind::Error));
     };
 

--- a/compiler-core/checking/src/source/binder.rs
+++ b/compiler-core/checking/src/source/binder.rs
@@ -232,7 +232,7 @@ where
                     tree::BinderKind::Error,
                 ));
             };
-            state.checked.nodes.binders.insert(binder_id, inferred_type);
+            state.checked.node_types.binders.insert(binder_id, inferred_type);
             return Ok(elaborated);
         }
 
@@ -450,7 +450,7 @@ where
                 ));
             };
             let elaborated = binder_core(state, context, *parenthesized, mode)?;
-            state.checked.nodes.binders.insert(binder_id, elaborated.type_id);
+            state.checked.node_types.binders.insert(binder_id, elaborated.type_id);
             return Ok(elaborated);
         }
     };
@@ -464,7 +464,7 @@ fn allocate_checked_binder(
     type_id: TypeId,
     kind: tree::BinderKind,
 ) -> ElaboratedBinder {
-    state.checked.nodes.binders.insert(source, type_id);
+    state.checked.node_types.binders.insert(source, type_id);
     let binder = match kind {
         tree::BinderKind::Error => state.allocate_error_binder(source, type_id),
         kind => state.allocate_binder(source, type_id, kind),
@@ -574,7 +574,7 @@ where
             })
         }
         PatternItem::Pun(pun_id) => {
-            state.checked.nodes.puns.insert(pun_id, expected_type);
+            state.checked.node_types.puns.insert(pun_id, expected_type);
             Ok(tree::RecordBinderField::Pun { label: SmolStr::clone(label) })
         }
     }
@@ -607,7 +607,7 @@ where
             lowering::BinderRecordItem::RecordPun { id, name } => {
                 let Some(label) = name else { continue };
                 let field_type = state.fresh_unification(context.queries, context.prim.t);
-                state.checked.nodes.puns.insert(*id, field_type);
+                state.checked.node_types.puns.insert(*id, field_type);
                 fields.push(RowField { label: SmolStr::clone(label), id: field_type });
                 checked_fields.push(tree::RecordBinderField::Pun { label: SmolStr::clone(label) });
             }
@@ -618,7 +618,7 @@ where
     let row_type = context.intern_row(fields, Some(row_tail));
     let record_type = context.intern_application(context.prim.record, row_type);
 
-    state.checked.nodes.binders.insert(binder_id, record_type);
+    state.checked.node_types.binders.insert(binder_id, record_type);
     Ok((record_type, checked_fields.into()))
 }
 
@@ -716,6 +716,6 @@ where
         }
     }
 
-    state.checked.nodes.binders.insert(binder_id, expected_type);
+    state.checked.node_types.binders.insert(binder_id, expected_type);
     Ok((expected_type, checked_fields.into()))
 }

--- a/compiler-core/checking/src/source/derive/field.rs
+++ b/compiler-core/checking/src/source/derive/field.rs
@@ -5,7 +5,7 @@ use indexing::TypeItemId;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
-use crate::core::{KindOrType, Type, TypeId, normalise, toolkit};
+use crate::core::{ApplicationArgument, Type, TypeId, normalise, toolkit};
 use crate::state::CheckState;
 
 use super::tools;
@@ -53,7 +53,7 @@ pub fn instantiate_constructor_fields<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     constructor_t: TypeId,
-    arguments: &[KindOrType],
+    arguments: &[ApplicationArgument],
 ) -> QueryResult<Vec<TypeId>>
 where
     Q: ExternalQueries,
@@ -71,7 +71,9 @@ where
         let replacement = arguments
             .next()
             .map(|argument| match argument {
-                KindOrType::Kind(argument) | KindOrType::Type(argument) => argument,
+                ApplicationArgument::Kind(argument) | ApplicationArgument::Type(argument) => {
+                    argument
+                }
             })
             .unwrap_or_else(|| state.fresh_rigid(context.queries, binder.kind));
         current = SubstituteName::one(state, context, binder.name, replacement, inner)?;

--- a/compiler-core/checking/src/source/derive/generate.rs
+++ b/compiler-core/checking/src/source/derive/generate.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 
 use crate::context::CheckContext;
-use crate::core::{KindOrType, TypeId, signature, toolkit};
+use crate::core::{ApplicationArgument, TypeId, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::term_items::{
@@ -297,7 +297,7 @@ pub(super) fn resolve_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<ResolvedMember>>
 where
     Q: ExternalQueries,
@@ -332,7 +332,7 @@ pub(super) fn resolve_known_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     (file_id, item_id): (files::FileId, indexing::TermItemId),
 ) -> QueryResult<Option<ResolvedMember>>
 where
@@ -356,7 +356,7 @@ fn generate_delegated_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     operation: Option<(files::FileId, indexing::TermItemId)>,
 ) -> QueryResult<Option<tree::InstanceMember>>
 where

--- a/compiler-core/checking/src/source/derive/generate/contravariant.rs
+++ b/compiler-core/checking/src/source/derive/generate/contravariant.rs
@@ -6,7 +6,7 @@ use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
-use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
@@ -22,7 +22,7 @@ use super::{DeriveHeadResult, DeriveStrategy, ResolvedMember, generated_member, 
 
 struct InstantiatedDataType {
     type_id: TypeId,
-    constructor_arguments: Vec<KindOrType>,
+    constructor_arguments: Vec<ApplicationArgument>,
 }
 
 #[derive(Clone, Copy)]
@@ -122,7 +122,7 @@ pub(super) fn generate_traversal_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
 ) -> QueryResult<Option<tree::InstanceMember>>

--- a/compiler-core/checking/src/source/derive/generate/eq_ord.rs
+++ b/compiler-core/checking/src/source/derive/generate/eq_ord.rs
@@ -2,7 +2,7 @@ use building_types::QueryResult;
 use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
-use crate::core::{KindOrType, TypeId, toolkit};
+use crate::core::{ApplicationArgument, TypeId, toolkit};
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::{field, tools};
 use crate::source::terms::ElaboratedExpression;
@@ -31,7 +31,7 @@ fn resolve_comparison_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<ComparisonMember>>
 where
     Q: ExternalQueries,
@@ -39,7 +39,7 @@ where
     let DeriveStrategy::FieldConstraints { data_file, data_id, .. } = result.strategy else {
         return Ok(None);
     };
-    let Some(KindOrType::Type(derived_type)) = instance_arguments.last() else {
+    let Some(ApplicationArgument::Type(derived_type)) = instance_arguments.last() else {
         return Ok(None);
     };
 
@@ -83,7 +83,7 @@ pub(super) fn generate_eq_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,
@@ -115,7 +115,7 @@ pub(super) fn generate_ord_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,

--- a/compiler-core/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-core/checking/src/source/derive/generate/foldable.rs
@@ -163,7 +163,7 @@ pub(super) fn generate_fold_members<Q>(
 where
     Q: ExternalQueries,
 {
-    let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+    let DeriveStrategy::VarianceConstraints { .. } = result.strategy else {
         return Ok(None);
     };
     let operations = match traversal {
@@ -202,11 +202,9 @@ where
                 context,
                 result,
                 instance_arguments,
-                data_file,
                 recipe,
                 traversal,
                 FoldOperation::Right,
-                resolution,
             )?
         } else if resolution == foldl {
             foldl_generated = true;
@@ -215,11 +213,9 @@ where
                 context,
                 result,
                 instance_arguments,
-                data_file,
                 recipe,
                 traversal,
                 FoldOperation::Left,
-                resolution,
             )?
         } else if resolution == fold_map {
             fold_map_generated = true;
@@ -228,11 +224,9 @@ where
                 context,
                 result,
                 instance_arguments,
-                data_file,
                 recipe,
                 traversal,
                 FoldOperation::Map,
-                resolution,
             )?
         } else {
             return Ok(None);
@@ -254,15 +248,26 @@ fn generate_fold_member<Q>(
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
     instance_arguments: &[ApplicationArgument],
-    data_file: files::FileId,
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
     operation: FoldOperation,
-    resolution: (files::FileId, indexing::TermItemId),
 ) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,
 {
+    let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+        return Ok(None);
+    };
+    let resolution = match (traversal, operation) {
+        (TraversalKind::Foldable, FoldOperation::Right) => context.known_terms.foldr,
+        (TraversalKind::Foldable, FoldOperation::Left) => context.known_terms.foldl,
+        (TraversalKind::Foldable, FoldOperation::Map) => context.known_terms.fold_map,
+        (TraversalKind::Bifoldable, FoldOperation::Right) => context.known_terms.bifoldr,
+        (TraversalKind::Bifoldable, FoldOperation::Left) => context.known_terms.bifoldl,
+        (TraversalKind::Bifoldable, FoldOperation::Map) => context.known_terms.bifold_map,
+    };
+    let Some(resolution) = resolution else { return Ok(None) };
+
     state.with_implication(|state| {
         let Some(member) =
             resolve_known_member(state, context, result, instance_arguments, resolution)?

--- a/compiler-core/checking/src/source/derive/generate/foldable.rs
+++ b/compiler-core/checking/src/source/derive/generate/foldable.rs
@@ -6,7 +6,7 @@ use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
-use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
@@ -23,7 +23,7 @@ use super::{
 
 struct InstantiatedDataType {
     type_id: TypeId,
-    constructor_arguments: Vec<KindOrType>,
+    constructor_arguments: Vec<ApplicationArgument>,
 }
 
 #[derive(Clone, Copy)]
@@ -156,7 +156,7 @@ pub(super) fn generate_fold_members<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
 ) -> QueryResult<Option<Vec<tree::InstanceMember>>>
@@ -253,7 +253,7 @@ fn generate_fold_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     data_file: files::FileId,
     recipe: &VarianceRecipe,
     traversal: TraversalKind,

--- a/compiler-core/checking/src/source/derive/generate/functor.rs
+++ b/compiler-core/checking/src/source/derive/generate/functor.rs
@@ -6,7 +6,7 @@ use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
-use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
@@ -22,7 +22,7 @@ use super::{DeriveHeadResult, DeriveStrategy, ResolvedMember, generated_member, 
 
 struct InstantiatedDataType {
     type_id: TypeId,
-    constructor_arguments: Vec<KindOrType>,
+    constructor_arguments: Vec<ApplicationArgument>,
 }
 
 #[derive(Clone, Copy)]
@@ -120,7 +120,7 @@ pub(super) fn generate_traversal_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
 ) -> QueryResult<Option<tree::InstanceMember>>

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -6,7 +6,7 @@ use smol_str::format_smolstr;
 
 use crate::context::CheckContext;
 use crate::core::substitute::RigidRenaming;
-use crate::core::{KindOrType, RowType, Type, TypeId, normalise, signature, toolkit};
+use crate::core::{ApplicationArgument, RowType, Type, TypeId, normalise, signature, toolkit};
 use crate::evidence::Evidence;
 use crate::source::derive::builder::DerivedTreeBuilder;
 use crate::source::derive::field;
@@ -23,7 +23,7 @@ use super::{
 
 struct InstantiatedDataType {
     type_id: TypeId,
-    constructor_arguments: Vec<KindOrType>,
+    constructor_arguments: Vec<ApplicationArgument>,
 }
 
 #[derive(Clone, Copy)]
@@ -184,7 +184,7 @@ pub(super) fn generate_traversal_members<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
 ) -> QueryResult<Option<Vec<tree::InstanceMember>>>
@@ -260,7 +260,7 @@ fn generate_operation_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     data_file: files::FileId,
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
@@ -305,7 +305,7 @@ fn generate_sequence_member<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
     traversal: TraversalKind,
     operation: (files::FileId, indexing::TermItemId),
     resolution: (files::FileId, indexing::TermItemId),
@@ -355,10 +355,10 @@ where
         let (_, source_arguments) =
             toolkit::extract_all_applications(state, context, *source_type)?;
         let identity_types = match (traversal, source_arguments.as_slice()) {
-            (TraversalKind::Traversable, [.., KindOrType::Type(effect)]) => vec![*effect],
+            (TraversalKind::Traversable, [.., ApplicationArgument::Type(effect)]) => vec![*effect],
             (
                 TraversalKind::Bitraversable,
-                [.., KindOrType::Type(first), KindOrType::Type(second)],
+                [.., ApplicationArgument::Type(first), ApplicationArgument::Type(second)],
             ) => vec![*first, *second],
             _ => return Ok(None),
         };

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -227,19 +227,10 @@ where
                 instance_arguments,
                 recipe,
                 traversal,
-                resolution,
             )?
         } else if resolution == sequence {
             sequence_generated = true;
-            generate_sequence_member(
-                state,
-                context,
-                result,
-                instance_arguments,
-                traversal,
-                operation,
-                resolution,
-            )?
+            generate_sequence_member(state, context, result, instance_arguments, traversal)?
         } else {
             return Ok(None);
         };
@@ -262,7 +253,6 @@ fn generate_operation_member<Q>(
     instance_arguments: &[ApplicationArgument],
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
-    resolution: (files::FileId, indexing::TermItemId),
 ) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,
@@ -270,6 +260,11 @@ where
     let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
         return Ok(None);
     };
+    let resolution = match traversal {
+        TraversalKind::Traversable => context.known_terms.traverse,
+        TraversalKind::Bitraversable => context.known_terms.bitraverse,
+    };
+    let Some(resolution) = resolution else { return Ok(None) };
 
     state.with_implication(|state| {
         let Some(member) =
@@ -309,12 +304,20 @@ fn generate_sequence_member<Q>(
     result: &DeriveHeadResult,
     instance_arguments: &[ApplicationArgument],
     traversal: TraversalKind,
-    operation: (files::FileId, indexing::TermItemId),
-    resolution: (files::FileId, indexing::TermItemId),
 ) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,
 {
+    let (operation, resolution) = match traversal {
+        TraversalKind::Traversable => (context.known_terms.traverse, context.known_terms.sequence),
+        TraversalKind::Bitraversable => {
+            (context.known_terms.bitraverse, context.known_terms.bisequence)
+        }
+    };
+    let (Some(operation), Some(resolution)) = (operation, resolution) else {
+        return Ok(None);
+    };
+
     state.with_implication(|state| {
         let Some(member) =
             resolve_known_member(state, context, result, instance_arguments, resolution)?

--- a/compiler-core/checking/src/source/derive/generate/traversable.rs
+++ b/compiler-core/checking/src/source/derive/generate/traversable.rs
@@ -191,7 +191,7 @@ pub(super) fn generate_traversal_members<Q>(
 where
     Q: ExternalQueries,
 {
-    let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+    let DeriveStrategy::VarianceConstraints { .. } = result.strategy else {
         return Ok(None);
     };
     let (operation, sequence) = match traversal {
@@ -225,7 +225,6 @@ where
                 context,
                 result,
                 instance_arguments,
-                data_file,
                 recipe,
                 traversal,
                 resolution,
@@ -261,7 +260,6 @@ fn generate_operation_member<Q>(
     context: &CheckContext<Q>,
     result: &DeriveHeadResult,
     instance_arguments: &[ApplicationArgument],
-    data_file: files::FileId,
     recipe: &VarianceRecipe,
     traversal: TraversalKind,
     resolution: (files::FileId, indexing::TermItemId),
@@ -269,6 +267,10 @@ fn generate_operation_member<Q>(
 where
     Q: ExternalQueries,
 {
+    let DeriveStrategy::VarianceConstraints { data_file, .. } = result.strategy else {
+        return Ok(None);
+    };
+
     state.with_implication(|state| {
         let Some(member) =
             resolve_known_member(state, context, result, instance_arguments, resolution)?

--- a/compiler-core/checking/src/source/derive/head.rs
+++ b/compiler-core/checking/src/source/derive/head.rs
@@ -1,6 +1,6 @@
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TermItemKind, TypeItemId};
+use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
 use lowering::TermItemIr;
 
 use crate::ExternalQueries;
@@ -86,7 +86,7 @@ where
         return Ok(None);
     };
 
-    let TermItemKind::Derive { id: derive_id } = context.indexed.items[item_id].kind else {
+    let IndexedTermItemKind::Derive { id: derive_id } = context.indexed.items[item_id].kind else {
         return Ok(None);
     };
 

--- a/compiler-core/checking/src/source/derive/head.rs
+++ b/compiler-core/checking/src/source/derive/head.rs
@@ -30,7 +30,7 @@ where
         let items = scc.as_slice();
 
         let items = items.iter().filter_map(|&item_id| {
-            let item = context.lowered.info.get_term_item(item_id)?;
+            let item = context.lowered.tree.get_term_item(item_id)?;
             let TermItemIr::Derive { newtype, constraints, resolution, arguments } = item else {
                 return None;
             };

--- a/compiler-core/checking/src/source/derive/head.rs
+++ b/compiler-core/checking/src/source/derive/head.rs
@@ -283,7 +283,7 @@ where
     let matchable = toolkit::freshen_instance_signature(state, context, signature)?;
 
     let checked = CheckedInstance { resolution, signature, matchable };
-    state.checked.derived.insert(derive_id, checked);
+    state.checked.derived_instances.insert(derive_id, checked);
 
     Ok(strategy.map(|strategy| DeriveHeadResult {
         derive_id,

--- a/compiler-core/checking/src/source/derive/head.rs
+++ b/compiler-core/checking/src/source/derive/head.rs
@@ -1,7 +1,7 @@
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
-use lowering::TermItemIr;
+use lowering::TermItemKind;
 
 use crate::ExternalQueries;
 use crate::context::CheckContext;
@@ -30,8 +30,8 @@ where
         let items = scc.as_slice();
 
         let items = items.iter().filter_map(|&item_id| {
-            let item = context.lowered.tree.get_term_item(item_id)?;
-            let TermItemIr::Derive { newtype, constraints, resolution, arguments } = item else {
+            let item = context.lowered.tree.get_term_item_kind(item_id)?;
+            let TermItemKind::Derive { newtype, constraints, resolution, arguments } = item else {
                 return None;
             };
             let resolution = *resolution;

--- a/compiler-core/checking/src/source/derive/tools.rs
+++ b/compiler-core/checking/src/source/derive/tools.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TypeItemId, TypeItemKind};
+use indexing::{IndexedTypeItemKind, TermItemId, TypeItemId};
 use rustc_hash::FxHashMap;
 
 use crate::ExternalQueries;
@@ -93,7 +93,9 @@ where
 
     let kind = &context.indexed.items[data_id].kind;
     match kind {
-        TypeItemKind::Data { .. } | TypeItemKind::Newtype { .. } => Ok(Some((data_file, data_id))),
+        IndexedTypeItemKind::Data { .. } | IndexedTypeItemKind::Newtype { .. } => {
+            Ok(Some((data_file, data_id)))
+        }
         _ => Ok(None),
     }
 }

--- a/compiler-core/checking/src/source/derive/variance.rs
+++ b/compiler-core/checking/src/source/derive/variance.rs
@@ -6,7 +6,7 @@ use smol_str::SmolStr;
 use crate::ExternalQueries;
 use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
-use crate::core::{KindOrType, Name, Type, TypeId, constraint, normalise, toolkit};
+use crate::core::{ApplicationArgument, Name, Type, TypeId, constraint, normalise, toolkit};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 
@@ -202,7 +202,9 @@ where
         let replacement = arguments
             .next()
             .map(|argument| match argument {
-                KindOrType::Kind(argument) | KindOrType::Type(argument) => argument,
+                ApplicationArgument::Kind(argument) | ApplicationArgument::Type(argument) => {
+                    argument
+                }
             })
             .unwrap_or_else(|| {
                 let rigid = state.fresh_rigid(context.queries, binder.kind);
@@ -824,7 +826,7 @@ where
         if (available.file_id, available.type_id) != class {
             continue;
         }
-        let [KindOrType::Type(available_argument)] = available.arguments.as_ref() else {
+        let [ApplicationArgument::Type(available_argument)] = available.arguments.as_ref() else {
             continue;
         };
         let (available_head, _) =
@@ -848,7 +850,8 @@ where
             else {
                 continue;
             };
-            let [KindOrType::Type(candidate_argument)] = candidate.arguments.as_slice() else {
+            let [ApplicationArgument::Type(candidate_argument)] = candidate.arguments.as_slice()
+            else {
                 continue;
             };
             let (candidate_head, _) =

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -391,8 +391,8 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
     ) {
         state
             .checked
-            .nodes
-            .term_operator
+            .node_types
+            .term_operators
             .insert(operator_id, OperatorBranchTypes { left, right, result });
     }
 }
@@ -521,8 +521,8 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
     ) {
         state
             .checked
-            .nodes
-            .type_operator
+            .node_types
+            .type_operators
             .insert(operator_id, OperatorBranchTypes { left, right, result });
     }
 }
@@ -614,8 +614,8 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
     ) {
         state
             .checked
-            .nodes
-            .term_operator
+            .node_types
+            .term_operators
             .insert(operator_id, OperatorBranchTypes { left, right, result });
     }
 }

--- a/compiler-core/checking/src/source/operator.rs
+++ b/compiler-core/checking/src/source/operator.rs
@@ -305,7 +305,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::ExpressionId {
         context: &CheckContext<Q>,
         id: Self::OperatorId,
     ) -> Option<(FileId, Self::ItemId)> {
-        context.lowered.info.get_term_operator(id)
+        context.lowered.tree.get_term_operator(id)
     }
 
     fn lookup_item(
@@ -416,7 +416,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::TypeId {
         context: &CheckContext<Q>,
         id: Self::OperatorId,
     ) -> Option<(FileId, Self::ItemId)> {
-        context.lowered.info.get_type_operator(id)
+        context.lowered.tree.get_type_operator(id)
     }
 
     fn lookup_item(
@@ -546,7 +546,7 @@ impl<Q: ExternalQueries> IsOperator<Q> for lowering::BinderId {
         context: &CheckContext<Q>,
         id: Self::OperatorId,
     ) -> Option<(FileId, Self::ItemId)> {
-        context.lowered.info.get_term_operator(id)
+        context.lowered.tree.get_term_operator(id)
     }
 
     fn lookup_item(

--- a/compiler-core/checking/src/source/synonym.rs
+++ b/compiler-core/checking/src/source/synonym.rs
@@ -30,7 +30,7 @@ where
     Q: ExternalQueries,
 {
     let Some(lowering::TypeKind::Constructor { resolution }) =
-        context.lowered.info.get_type_kind(function)
+        context.lowered.tree.get_type_kind(function)
     else {
         return Ok(None);
     };

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TermItemKind, TypeItemId};
+use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
 use lowering::TermItemIr;
 use rustc_hash::FxHashMap;
 
@@ -116,7 +116,8 @@ where
         return Ok(());
     };
 
-    let TermItemKind::Instance { id: instance_id } = context.indexed.items[item_id].kind else {
+    let IndexedTermItemKind::Instance { id: instance_id } = context.indexed.items[item_id].kind
+    else {
         return Ok(());
     };
 
@@ -226,7 +227,8 @@ where
                 continue;
             };
 
-            let TermItemKind::Instance { id: instance_id } = context.indexed.items[item_id].kind
+            let IndexedTermItemKind::Instance { id: instance_id } =
+                context.indexed.items[item_id].kind
             else {
                 continue;
             };
@@ -926,7 +928,8 @@ fn record_value_declaration<Q>(
 ) where
     Q: ExternalQueries,
 {
-    let TermItemKind::Value { equations: sources, .. } = &context.indexed.items[item_id].kind
+    let IndexedTermItemKind::Value { equations: sources, .. } =
+        &context.indexed.items[item_id].kind
     else {
         return;
     };

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -10,8 +10,8 @@ use crate::context::CheckContext;
 use crate::core::constraint::ConstraintInScope;
 use crate::core::substitute::{NameToType, RigidRenaming, SubstituteName};
 use crate::core::{
-    CheckedInstance, KindOrType, Type, TypeId, constraint, exhaustive, generalise, normalise,
-    signature, toolkit, unification, zonk,
+    ApplicationArgument, CheckedInstance, Type, TypeId, constraint, exhaustive, generalise,
+    normalise, signature, toolkit, unification, zonk,
 };
 use crate::error::{ErrorCrumb, ErrorKind};
 use crate::evidence::{Evidence, SuperclassId};
@@ -366,7 +366,7 @@ fn check_instance_member_group<Q>(
     context: &CheckContext<Q>,
     member: &lowering::InstanceMemberGroup,
     (class_file, class_id): (FileId, TypeItemId),
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<tree::InstanceMember>>
 where
     Q: ExternalQueries,
@@ -468,7 +468,7 @@ fn record_instance_member(
 
 pub(crate) struct FreshenedInstanceRigids {
     pub(crate) constraints: Vec<TypeId>,
-    pub(crate) arguments: Vec<KindOrType>,
+    pub(crate) arguments: Vec<ApplicationArgument>,
     pub(crate) renaming: Arc<RigidRenaming>,
     pub(crate) rigids: Vec<TypeId>,
 }
@@ -513,7 +513,7 @@ pub(crate) fn emit_instance_superclass_constraints<Q>(
     context: &CheckContext<Q>,
     class_file: FileId,
     class_id: TypeItemId,
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Vec<tree::InstanceSuperclass>>
 where
     Q: ExternalQueries,
@@ -548,7 +548,7 @@ pub(crate) fn instantiate_class_member_type<Q>(
     context: &CheckContext<Q>,
     (member_file, member_id): (FileId, TermItemId),
     (class_file, class_id): (FileId, TypeItemId),
-    instance_arguments: &[KindOrType],
+    instance_arguments: &[ApplicationArgument],
 ) -> QueryResult<Option<TypeId>>
 where
     Q: ExternalQueries,
@@ -568,7 +568,7 @@ where
     let mut instance_arguments = instance_arguments.iter().copied();
 
     for &binder_id in class_info.kind_binders.iter() {
-        let Some(KindOrType::Kind(argument)) = instance_arguments.next() else {
+        let Some(ApplicationArgument::Kind(argument)) = instance_arguments.next() else {
             return Ok(None);
         };
         let binder = context.lookup_forall_binder(binder_id);
@@ -576,7 +576,7 @@ where
     }
 
     for &binder_id in class_info.type_parameters.iter() {
-        let Some(KindOrType::Type(argument)) = instance_arguments.next() else {
+        let Some(ApplicationArgument::Type(argument)) = instance_arguments.next() else {
             return Ok(None);
         };
         let binder = context.lookup_forall_binder(binder_id);
@@ -596,17 +596,17 @@ fn substitute_kind_or_type<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     renaming: &RigidRenaming,
-    argument: KindOrType,
-) -> QueryResult<KindOrType>
+    argument: ApplicationArgument,
+) -> QueryResult<ApplicationArgument>
 where
     Q: ExternalQueries,
 {
     Ok(match argument {
-        KindOrType::Kind(argument) => {
-            KindOrType::Kind(renaming.substitute(state, context, argument)?)
+        ApplicationArgument::Kind(argument) => {
+            ApplicationArgument::Kind(renaming.substitute(state, context, argument)?)
         }
-        KindOrType::Type(argument) => {
-            KindOrType::Type(renaming.substitute(state, context, argument)?)
+        ApplicationArgument::Type(argument) => {
+            ApplicationArgument::Type(renaming.substitute(state, context, argument)?)
         }
     })
 }

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -61,7 +61,7 @@ where
         let items = scc.as_slice();
 
         let items = items.iter().filter_map(|&item_id| {
-            let item = context.lowered.info.get_term_item(item_id)?;
+            let item = context.lowered.tree.get_term_item(item_id)?;
             let TermItemIr::Instance { constraints, resolution, arguments, .. } = item else {
                 return None;
             };
@@ -218,7 +218,7 @@ where
     for scc in &context.grouped.term_scc {
         for &item_id in scc.as_slice() {
             let Some(TermItemIr::Instance { members, resolution, .. }) =
-                context.lowered.info.get_term_item(item_id)
+                context.lowered.tree.get_term_item(item_id)
             else {
                 continue;
             };
@@ -620,7 +620,7 @@ where
             continue;
         }
 
-        let item = context.lowered.info.get_term_item(item_id);
+        let item = context.lowered.tree.get_term_item(item_id);
 
         let resolution = item.and_then(|item| match item {
             TermItemIr::Operator { resolution, .. } => *resolution,
@@ -649,7 +649,7 @@ fn check_term_signature<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.info.get_term_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_term_item(item_id) else {
         return Ok(());
     };
 
@@ -694,7 +694,7 @@ fn check_term_equation<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.info.get_term_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_term_item(item_id) else {
         return Ok(());
     };
 

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -616,7 +616,7 @@ where
     Q: ExternalQueries,
 {
     for &item_id in items {
-        if state.checked.terms.contains_key(&item_id) {
+        if state.checked.term_item_types.contains_key(&item_id) {
             continue;
         }
 
@@ -628,7 +628,7 @@ where
         });
 
         let item_type = resolution.and_then(|(file_id, item_id)| {
-            if file_id == context.id { state.checked.lookup_term(item_id) } else { None }
+            if file_id == context.id { state.checked.lookup_term_item_type(item_id) } else { None }
         });
 
         let item_type = if let Some(item_type) = item_type {
@@ -637,7 +637,7 @@ where
             state.fresh_unification(context.queries, context.prim.t)
         };
 
-        state.checked.terms.insert(item_id, item_type);
+        state.checked.term_item_types.insert(item_id, item_type);
     }
 }
 
@@ -681,7 +681,7 @@ where
     Q: ExternalQueries,
 {
     let (checked_kind, _) = types::check_kind(state, context, signature, context.prim.t)?;
-    state.checked.terms.insert(item_id, checked_kind);
+    state.checked.term_item_types.insert(item_id, checked_kind);
     Ok(checked_kind)
 }
 
@@ -742,7 +742,7 @@ where
     Q: ExternalQueries,
 {
     if let Some(signature_id) = signature
-        && let Some(signature_type) = state.checked.lookup_term(item_id)
+        && let Some(signature_type) = state.checked.lookup_term_item_type(item_id)
     {
         let (residuals, evidences, equations) =
             check_value_group_core_check(state, context, signature_id, signature_type, equations)?;
@@ -792,7 +792,7 @@ where
     Q: ExternalQueries,
 {
     let group_type = state.fresh_unification(context.queries, context.prim.t);
-    state.checked.terms.insert(item_id, group_type);
+    state.checked.term_item_types.insert(item_id, group_type);
     let checked_equations =
         equations::infer_value_equations(state, context, group_type, equations)?;
     let exhaustiveness = exhaustive::check_equation_patterns(
@@ -833,7 +833,7 @@ where
     let mut pending = vec![];
 
     for &item_id in items {
-        let Some(marker) = state.checked.terms.get(&item_id).copied() else {
+        let Some(marker) = state.checked.term_item_types.get(&item_id).copied() else {
             continue;
         };
 
@@ -875,7 +875,7 @@ where
     ) in pending
     {
         let marker = generalise::generalise_unsolved(state, context, marker, &unsolved)?;
-        state.checked.terms.insert(item_id, marker);
+        state.checked.term_item_types.insert(item_id, marker);
 
         if recursive && inferred_constraints {
             // Keep constraint evidence consistent with the candidate type used for error recovery.
@@ -967,10 +967,10 @@ where
     let Some((file_id, term_id)) = resolution else { return Ok(()) };
     let operator_type = toolkit::lookup_file_term_operator(state, context, file_id, term_id)?;
 
-    if let Some(item_type) = state.checked.lookup_term(item_id) {
+    if let Some(item_type) = state.checked.lookup_term_item_type(item_id) {
         unification::subtype(state, context, operator_type, item_type)?;
     } else {
-        state.checked.terms.insert(item_id, operator_type);
+        state.checked.term_item_types.insert(item_id, operator_type);
     }
 
     Ok(())

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
-use lowering::TermItemIr;
+use lowering::TermItemKind;
 use rustc_hash::FxHashMap;
 
 use crate::context::CheckContext;
@@ -61,8 +61,8 @@ where
         let items = scc.as_slice();
 
         let items = items.iter().filter_map(|&item_id| {
-            let item = context.lowered.tree.get_term_item(item_id)?;
-            let TermItemIr::Instance { constraints, resolution, arguments, .. } = item else {
+            let item = context.lowered.tree.get_term_item_kind(item_id)?;
+            let TermItemKind::Instance { constraints, resolution, arguments, .. } = item else {
                 return None;
             };
             let resolution = *resolution;
@@ -217,8 +217,8 @@ where
 {
     for scc in &context.grouped.term_scc {
         for &item_id in scc.as_slice() {
-            let Some(TermItemIr::Instance { members, resolution, .. }) =
-                context.lowered.tree.get_term_item(item_id)
+            let Some(TermItemKind::Instance { members, resolution, .. }) =
+                context.lowered.tree.get_term_item_kind(item_id)
             else {
                 continue;
             };
@@ -620,10 +620,10 @@ where
             continue;
         }
 
-        let item = context.lowered.tree.get_term_item(item_id);
+        let item = context.lowered.tree.get_term_item_kind(item_id);
 
         let resolution = item.and_then(|item| match item {
-            TermItemIr::Operator { resolution, .. } => *resolution,
+            TermItemKind::Operator { resolution, .. } => *resolution,
             _ => None,
         });
 
@@ -649,19 +649,19 @@ fn check_term_signature<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.tree.get_term_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_term_item_kind(item_id) else {
         return Ok(());
     };
 
     match item {
-        TermItemIr::Foreign { signature } => {
+        TermItemKind::Foreign { signature } => {
             let Some(signature) = signature else { return Ok(()) };
             let type_id = check_signature_type(state, context, item_id, *signature)?;
             let declaration =
                 tree::TermDeclaration { type_id, kind: tree::TermDeclarationKind::Foreign };
             state.checked.tree.insert_term(item_id, declaration);
         }
-        TermItemIr::ValueGroup { signature, .. } => {
+        TermItemKind::Value { signature, .. } => {
             let Some(signature) = signature else { return Ok(()) };
             check_signature_type(state, context, item_id, *signature)?;
         }
@@ -694,15 +694,15 @@ fn check_term_equation<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.tree.get_term_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_term_item_kind(item_id) else {
         return Ok(());
     };
 
     match item {
-        TermItemIr::Operator { resolution, .. } => {
+        TermItemKind::Operator { resolution, .. } => {
             check_term_operator(state, context, item_id, *resolution)?;
         }
-        TermItemIr::ValueGroup { signature, equations } => {
+        TermItemKind::Value { signature, equations } => {
             let pending = state.with_implication(|state| {
                 check_value_group(state, context, item_id, *signature, equations)
             })?;

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -56,12 +56,12 @@ where
     Q: ExternalQueries,
 {
     let is_constructor = if file_id == context.id {
-        let item = context.lowered.tree.get_term_item(term_id);
-        matches!(item, Some(lowering::TermItemIr::Constructor { .. }))
+        let item = context.lowered.tree.get_term_item_kind(term_id);
+        matches!(item, Some(lowering::TermItemKind::Constructor { .. }))
     } else {
         let lowered = context.queries.lowered(file_id)?;
-        let item = lowered.tree.get_term_item(term_id);
-        matches!(item, Some(lowering::TermItemIr::Constructor { .. }))
+        let item = lowered.tree.get_term_item_kind(term_id);
+        matches!(item, Some(lowering::TermItemKind::Constructor { .. }))
     };
 
     let kind = if is_constructor {

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -56,11 +56,11 @@ where
     Q: ExternalQueries,
 {
     let is_constructor = if file_id == context.id {
-        let item = context.lowered.info.get_term_item(term_id);
+        let item = context.lowered.tree.get_term_item(term_id);
         matches!(item, Some(lowering::TermItemIr::Constructor { .. }))
     } else {
         let lowered = context.queries.lowered(file_id)?;
-        let item = lowered.info.get_term_item(term_id);
+        let item = lowered.tree.get_term_item(term_id);
         matches!(item, Some(lowering::TermItemIr::Constructor { .. }))
     };
 
@@ -208,7 +208,7 @@ where
 {
     let unknown = context.unknown("missing expression");
 
-    let Some(kind) = context.lowered.info.get_expression_kind(expression) else {
+    let Some(kind) = context.lowered.tree.get_expression_kind(expression) else {
         return Ok(allocate_error_expression(state, unknown));
     };
 
@@ -316,7 +316,7 @@ where
 {
     let unknown = context.unknown("missing expression");
 
-    let Some(kind) = context.lowered.info.get_expression_kind(expression) else {
+    let Some(kind) = context.lowered.tree.get_expression_kind(expression) else {
         return Ok(allocate_error_expression(state, unknown));
     };
 

--- a/compiler-core/checking/src/source/terms.rs
+++ b/compiler-core/checking/src/source/terms.rs
@@ -86,7 +86,7 @@ where
 {
     state.with_error_crumb(ErrorCrumb::CheckingExpression(expression), |state| {
         let checked = check_expression_quiet(state, context, expression, expected)?;
-        state.checked.nodes.expressions.insert(expression, checked.type_id);
+        state.checked.node_types.expressions.insert(expression, checked.type_id);
         Ok(checked)
     })
 }
@@ -260,7 +260,7 @@ where
 {
     state.with_error_crumb(ErrorCrumb::InferringExpression(expression), |state| {
         let inferred = infer_expression_quiet(state, context, expression)?;
-        state.checked.nodes.expressions.insert(expression, inferred.type_id);
+        state.checked.node_types.expressions.insert(expression, inferred.type_id);
         Ok(inferred)
     })
 }
@@ -433,7 +433,7 @@ where
         }
 
         lowering::ExpressionKind::Section => {
-            let type_id = state.checked.nodes.lookup_section(expression);
+            let type_id = state.checked.node_types.lookup_section(expression);
             let binder = state.checked.tree.lookup_section_binder(expression);
             match (type_id, binder) {
                 (Some(type_id), Some(binder)) => {
@@ -565,7 +565,7 @@ fn collect_graph_term_hole_bindings<Q>(
 
                 for (name, binder_id) in binders {
                     if seen.insert(SmolStr::clone(name))
-                        && let Some(type_id) = state.checked.nodes.lookup_binder(*binder_id)
+                        && let Some(type_id) = state.checked.node_types.lookup_binder(*binder_id)
                     {
                         let name = SmolStr::clone(name);
                         result.push(HoleBinding { name, type_id });
@@ -577,7 +577,7 @@ fn collect_graph_term_hole_bindings<Q>(
 
                 for (name, pun_id) in puns {
                     if seen.insert(SmolStr::clone(name))
-                        && let Some(type_id) = state.checked.nodes.lookup_pun(*pun_id)
+                        && let Some(type_id) = state.checked.node_types.lookup_pun(*pun_id)
                     {
                         let name = SmolStr::clone(name);
                         result.push(HoleBinding { name, type_id });
@@ -590,7 +590,7 @@ fn collect_graph_term_hole_bindings<Q>(
 
                 for (name, let_id) in bindings {
                     if seen.insert(SmolStr::clone(name))
-                        && let Some(type_id) = state.checked.nodes.lookup_let(*let_id)
+                        && let Some(type_id) = state.checked.node_types.lookup_let(*let_id)
                     {
                         let name = SmolStr::clone(name);
                         result.push(HoleBinding { name, type_id });

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -299,7 +299,7 @@ where
         (field_type, inferred.expression)
     };
 
-    state.checked.nodes.puns.insert(pun, id);
+    state.checked.node_types.puns.insert(pun, id);
 
     let checked =
         tree::RecordExpressionField::Pun { source: pun, label: SmolStr::clone(&label), expression };

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -47,7 +47,7 @@ fn should_instantiate_record_field<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(kind) = context.lowered.info.get_expression_kind(expression) else {
+    let Some(kind) = context.lowered.tree.get_expression_kind(expression) else {
         return false;
     };
 

--- a/compiler-core/checking/src/source/terms/form_ado.rs
+++ b/compiler-core/checking/src/source/terms/form_ado.rs
@@ -98,7 +98,7 @@ where
     let mut steps = vec![];
     let mut has_missing_action = false;
     for &statement_id in statement_ids.iter() {
-        let Some(statement) = context.lowered.info.get_do_statement(statement_id) else {
+        let Some(statement) = context.lowered.tree.get_do_statement(statement_id) else {
             continue;
         };
         match statement {

--- a/compiler-core/checking/src/source/terms/form_do.rs
+++ b/compiler-core/checking/src/source/terms/form_do.rs
@@ -200,7 +200,7 @@ where
     // are checked inline during the statement checking loop.
     let mut steps = vec![];
     for &statement_id in statement_id.iter() {
-        let Some(statement) = context.lowered.info.get_do_statement(statement_id) else {
+        let Some(statement) = context.lowered.tree.get_do_statement(statement_id) else {
             continue;
         };
         match statement {

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -158,10 +158,10 @@ where
         };
         if let Some(signature_id) = name.signature {
             let (name_type, _) = types::check_kind(state, context, signature_id, context.prim.t)?;
-            state.checked.nodes.lets.insert(id, name_type);
+            state.checked.node_types.lets.insert(id, name_type);
         } else {
             let name_type = state.fresh_unification(context.queries, context.prim.t);
-            state.checked.nodes.lets.insert(id, name_type);
+            state.checked.node_types.lets.insert(id, name_type);
         }
     }
 
@@ -226,7 +226,7 @@ where
         .expect("invariant violated: let binding group has no lowered binding");
     let name_type = state
         .checked
-        .nodes
+        .node_types
         .lookup_let(id)
         .expect("invariant violated: let binding has no preallocated type");
 

--- a/compiler-core/checking/src/source/terms/form_let.rs
+++ b/compiler-core/checking/src/source/terms/form_let.rs
@@ -153,7 +153,7 @@ where
     Q: ExternalQueries,
 {
     for &id in bindings {
-        let Some(name) = context.lowered.info.get_let_binding(id) else {
+        let Some(name) = context.lowered.tree.get_let_binding(id) else {
             continue;
         };
         if let Some(signature_id) = name.signature {
@@ -218,10 +218,10 @@ pub fn check_let_name_binding_core<Q>(
 where
     Q: ExternalQueries,
 {
-    let group = context.lowered.info.get_let_binding_group(id);
+    let group = context.lowered.tree.get_let_binding_group(id);
     let name = context
         .lowered
-        .info
+        .tree
         .get_let_binding(id)
         .expect("invariant violated: let binding group has no lowered binding");
     let name_type = state

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItemId, TypeItemId, TypeItemKind};
+use indexing::{IndexedTypeItemKind, TermItemId, TypeItemId};
 use lowering::{
     ClassIr, DataIr, LoweringError, NewtypeIr, RecursiveGroup, Scc, SynonymIr, TermItemIr,
     TypeItemIr, TypeVariableBinding,
@@ -605,8 +605,8 @@ where
         };
 
         let declaration = match &context.indexed.items[item_id].kind {
-            TypeItemKind::Data { .. } => tree::TypeDeclarationKind::Data(data),
-            TypeItemKind::Newtype { .. } => tree::TypeDeclarationKind::Newtype(data),
+            IndexedTypeItemKind::Data { .. } => tree::TypeDeclarationKind::Data(data),
+            IndexedTypeItemKind::Newtype { .. } => tree::TypeDeclarationKind::Newtype(data),
             _ => unreachable!("invariant violated: pending data type is not data or newtype"),
         };
 

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -387,7 +387,7 @@ where
         let kind = resolve_type_variable_binding(state, context, signature_kind, equation_binding)?;
 
         let name = state.names.fresh();
-        state.checked.nodes.forall_bindings.insert(equation_binding.id, kind);
+        state.checked.node_types.forall_bindings.insert(equation_binding.id, kind);
         state.bindings.bind_forall(equation_binding.id, name, kind);
 
         let text = if let Some(name) = &equation_binding.name {

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -5,8 +5,8 @@ use building_types::QueryResult;
 use files::FileId;
 use indexing::{IndexedTypeItemKind, TermItemId, TypeItemId};
 use lowering::{
-    ClassIr, DataIr, LoweringError, NewtypeIr, RecursiveGroup, Scc, SynonymIr, TermItemIr,
-    TypeItemIr, TypeVariableBinding,
+    ClassDeclaration, DataDeclaration, LoweringError, NewtypeDeclaration, RecursiveGroup, Scc,
+    TermItemKind, TypeItemKind, TypeSynonymDeclaration, TypeVariableBinding,
 };
 use smol_str::SmolStr;
 
@@ -241,32 +241,32 @@ fn check_type_signature<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.tree.get_type_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_type_item_kind(item_id) else {
         return Ok(());
     };
 
     match item {
-        TypeItemIr::DataGroup { signature, .. } => {
+        TypeItemKind::Data { signature, .. } => {
             let Some(signature) = signature else { return Ok(()) };
             check_signature_kind(state, context, item_id, *signature)?;
         }
-        TypeItemIr::NewtypeGroup { signature, .. } => {
+        TypeItemKind::Newtype { signature, .. } => {
             let Some(signature) = signature else { return Ok(()) };
             check_signature_kind(state, context, item_id, *signature)?;
         }
-        TypeItemIr::SynonymGroup { signature, .. } => {
+        TypeItemKind::Synonym { signature, .. } => {
             let Some(signature) = signature else { return Ok(()) };
             check_signature_kind(state, context, item_id, *signature)?;
         }
-        TypeItemIr::ClassGroup { signature, .. } => {
+        TypeItemKind::Class { signature, .. } => {
             let Some(signature) = signature else { return Ok(()) };
             check_signature_kind(state, context, item_id, *signature)?;
         }
-        TypeItemIr::Foreign { signature, .. } => {
+        TypeItemKind::Foreign { signature, .. } => {
             let Some(signature) = signature else { return Ok(()) };
             check_signature_kind(state, context, item_id, *signature)?;
         }
-        TypeItemIr::Operator { .. } => {}
+        TypeItemKind::Operator { .. } => {}
     }
 
     Ok(())
@@ -295,31 +295,33 @@ fn check_type_equation<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.tree.get_type_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_type_item_kind(item_id) else {
         return Ok(());
     };
 
     match item {
-        TypeItemIr::DataGroup { signature, data, roles } => {
-            let Some(DataIr { variables }) = data else { return Ok(()) };
+        TypeItemKind::Data { signature, declaration, roles } => {
+            let Some(DataDeclaration { variables }) = declaration else { return Ok(()) };
             check_data_equation(state, context, scc, item_id, *signature, variables, roles)?;
         }
-        TypeItemIr::NewtypeGroup { signature, newtype, roles } => {
-            let Some(NewtypeIr { variables }) = newtype else { return Ok(()) };
+        TypeItemKind::Newtype { signature, declaration, roles } => {
+            let Some(NewtypeDeclaration { variables }) = declaration else { return Ok(()) };
             check_data_equation(state, context, scc, item_id, *signature, variables, roles)?;
         }
-        TypeItemIr::SynonymGroup { signature, synonym, .. } => {
-            let Some(SynonymIr { variables, synonym }) = synonym else { return Ok(()) };
-            check_synonym_equation(state, context, scc, item_id, *signature, variables, *synonym)?;
+        TypeItemKind::Synonym { signature, declaration, .. } => {
+            let Some(TypeSynonymDeclaration { variables, type_ }) = declaration else {
+                return Ok(());
+            };
+            check_synonym_equation(state, context, scc, item_id, *signature, variables, *type_)?;
         }
-        TypeItemIr::ClassGroup { signature, class } => {
-            let Some(class) = class else { return Ok(()) };
-            check_class_equation(state, context, scc, item_id, *signature, class)?;
+        TypeItemKind::Class { signature, declaration } => {
+            let Some(declaration) = declaration else { return Ok(()) };
+            check_class_equation(state, context, scc, item_id, *signature, declaration)?;
         }
-        TypeItemIr::Foreign { roles, .. } => {
+        TypeItemKind::Foreign { roles, .. } => {
             scc.foreign.push((item_id, Arc::clone(roles)));
         }
-        TypeItemIr::Operator { resolution, .. } => {
+        TypeItemKind::Operator { resolution, .. } => {
             check_type_operator(state, context, item_id, *resolution)?;
         }
     }
@@ -468,8 +470,8 @@ where
     let mut constructors = vec![];
 
     for constructor_id in context.indexed.data_constructors(item_id) {
-        let Some(TermItemIr::Constructor { arguments }) =
-            context.lowered.tree.get_term_item(constructor_id)
+        let Some(TermItemKind::Constructor { arguments }) =
+            context.lowered.tree.get_term_item_kind(constructor_id)
         else {
             continue;
         };
@@ -756,12 +758,12 @@ fn check_class_equation<Q>(
     scc: &mut TypeSccState,
     item_id: TypeItemId,
     signature: Option<lowering::TypeId>,
-    class: &ClassIr,
+    declaration: &ClassDeclaration,
 ) -> QueryResult<()>
 where
     Q: ExternalQueries,
 {
-    let ClassIr { constraints, variables, functional_dependencies } = class;
+    let ClassDeclaration { constraints, variables, functional_dependencies } = declaration;
 
     let parameters = if let Some(signature_id) = signature
         && let Some(signature_kind) = state.checked.lookup_type(item_id)
@@ -837,8 +839,8 @@ where
     let mut members = vec![];
 
     for member_id in context.indexed.class_members(item_id) {
-        let Some(TermItemIr::ClassMember { signature }) =
-            context.lowered.tree.get_term_item(member_id)
+        let Some(TermItemKind::ClassMember { signature }) =
+            context.lowered.tree.get_term_item_kind(member_id)
         else {
             continue;
         };

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -151,11 +151,11 @@ where
     Q: ExternalQueries,
 {
     for &item_id in items {
-        if state.checked.types.contains_key(&item_id) {
+        if state.checked.type_item_kinds.contains_key(&item_id) {
             continue;
         }
         let kind = state.fresh_unification(context.queries, context.prim.t);
-        state.checked.types.insert(item_id, kind);
+        state.checked.type_item_kinds.insert(item_id, kind);
     }
 }
 
@@ -170,7 +170,7 @@ where
     let mut pending = Vec::with_capacity(items.len());
 
     for &item_id in items {
-        let Some(kind) = state.checked.types.get(&item_id).copied() else {
+        let Some(kind) = state.checked.type_item_kinds.get(&item_id).copied() else {
             continue;
         };
 
@@ -182,7 +182,7 @@ where
 
     for (item_id, kind, unsolved) in pending {
         let kind = generalise::generalise_unsolved(state, context, kind, &unsolved)?;
-        state.checked.types.insert(item_id, kind);
+        state.checked.type_item_kinds.insert(item_id, kind);
     }
 
     Ok(())
@@ -230,7 +230,7 @@ fn populate_skipped_items<Q>(
 {
     let unknown = context.unknown("invalid recursive type");
     let skipped = items.iter().map(|item| (*item, unknown));
-    state.checked.types.extend(skipped);
+    state.checked.type_item_kinds.extend(skipped);
 }
 
 fn check_type_signature<Q>(
@@ -282,7 +282,7 @@ where
     Q: ExternalQueries,
 {
     let (checked_kind, _) = types::check_kind(state, context, signature, context.prim.t)?;
-    state.checked.types.insert(item_id, checked_kind);
+    state.checked.type_item_kinds.insert(item_id, checked_kind);
     Ok(())
 }
 
@@ -342,7 +342,7 @@ where
     Q: ExternalQueries,
 {
     let parameters = if let Some(signature_id) = signature
-        && let Some(signature_kind) = state.checked.lookup_type(item_id)
+        && let Some(signature_kind) = state.checked.lookup_type_item_kind(item_id)
     {
         check_data_equation_check(state, context, (signature_id, signature_kind), variables)?
     } else {
@@ -450,10 +450,10 @@ where
     let kinds = bindings.iter().map(|binder| binder.kind);
     let inferred = context.intern_function_iter(kinds, context.prim.t);
 
-    if let Some(expected) = state.checked.lookup_type(item_id) {
+    if let Some(expected) = state.checked.lookup_type_item_kind(item_id) {
         unification::subtype(state, context, inferred, expected)?;
     } else {
-        state.checked.types.insert(item_id, inferred);
+        state.checked.type_item_kinds.insert(item_id, inferred);
     }
 
     Ok(bindings)
@@ -503,7 +503,7 @@ where
         // constructor_kind should have already been generalised by the
         // finalise_binding_group function. The kind signature is used
         // as the source of truth for constructing kind applications.
-        let Some(constructor_kind) = state.checked.types.get(&item_id).copied() else {
+        let Some(constructor_kind) = state.checked.type_item_kinds.get(&item_id).copied() else {
             continue;
         };
 
@@ -585,7 +585,7 @@ where
                 result = context.intern_forall(binder_id, result);
             }
 
-            state.checked.terms.insert(constructor_id, result);
+            state.checked.term_item_types.insert(constructor_id, result);
 
             let constructor = tree::DataConstructor { arguments: Arc::from(arguments) };
             let declaration = tree::TermDeclaration {
@@ -643,7 +643,7 @@ where
     }
 
     for (item_id, declared_roles) in mem::take(&mut scc.foreign) {
-        let Some(kind) = state.checked.lookup_type(item_id) else {
+        let Some(kind) = state.checked.lookup_type_item_kind(item_id) else {
             continue;
         };
 
@@ -676,7 +676,7 @@ where
     Q: ExternalQueries,
 {
     let (parameters, result) = if let Some(signature_id) = signature
-        && let Some(signature_kind) = state.checked.lookup_type(item_id)
+        && let Some(signature_kind) = state.checked.lookup_type_item_kind(item_id)
     {
         check_synonym_equation_check(state, context, bindings, (signature_id, signature_kind))?
     } else {
@@ -724,10 +724,10 @@ where
     let result = state.fresh_unification(context.queries, context.prim.t);
     let inferred = context.intern_function_iter(kinds, result);
 
-    if let Some(expected) = state.checked.lookup_type(item_id) {
+    if let Some(expected) = state.checked.lookup_type_item_kind(item_id) {
         unification::subtype(state, context, inferred, expected)?;
     } else {
-        state.checked.types.insert(item_id, inferred);
+        state.checked.type_item_kinds.insert(item_id, inferred);
     }
 
     Ok((bindings, result))
@@ -742,7 +742,7 @@ where
     Q: ExternalQueries,
 {
     for (item_id, PendingSynonymType { parameters, synonym }) in mem::take(&mut scc.synonym) {
-        let Some(kind) = state.checked.lookup_type(item_id) else {
+        let Some(kind) = state.checked.lookup_type_item_kind(item_id) else {
             continue;
         };
         let synonym = zonk::zonk(state, context, synonym)?;
@@ -766,7 +766,7 @@ where
     let ClassDeclaration { constraints, variables, functional_dependencies } = declaration;
 
     let parameters = if let Some(signature_id) = signature
-        && let Some(signature_kind) = state.checked.lookup_type(item_id)
+        && let Some(signature_kind) = state.checked.lookup_type_item_kind(item_id)
     {
         check_class_equation_check(state, context, variables, (signature_id, signature_kind))?
     } else {
@@ -819,10 +819,10 @@ where
     let kinds = bindings.iter().map(|binder| binder.kind);
     let inferred = context.intern_function_iter(kinds, context.prim.constraint);
 
-    if let Some(expected) = state.checked.lookup_type(item_id) {
+    if let Some(expected) = state.checked.lookup_type_item_kind(item_id) {
         unification::subtype(state, context, inferred, expected)?;
     } else {
-        state.checked.types.insert(item_id, inferred);
+        state.checked.type_item_kinds.insert(item_id, inferred);
     }
 
     Ok(bindings)
@@ -866,7 +866,7 @@ where
         let PendingClassType { parameters, superclasses, functional_dependencies, members } =
             pending;
 
-        let Some(class_kind) = state.checked.types.get(&item_id).copied() else {
+        let Some(class_kind) = state.checked.type_item_kinds.get(&item_id).copied() else {
             continue;
         };
 
@@ -959,7 +959,7 @@ where
                 selector_type = context.intern_forall(*kind_binder, selector_type);
             }
 
-            state.checked.terms.insert(member_id, selector_type);
+            state.checked.term_item_types.insert(member_id, selector_type);
             checked_members.push(CheckedClassMember { item_id: member_id, field_type });
             semantic_members.push(tree::ClassMember { source: member_id, field_type });
         }
@@ -1005,10 +1005,10 @@ where
     let Some((file_id, type_id)) = resolution else { return Ok(()) };
     let operator_kind = toolkit::lookup_file_type_operator(state, context, file_id, type_id)?;
 
-    if let Some(item_kind) = state.checked.lookup_type(item_id) {
+    if let Some(item_kind) = state.checked.lookup_type_item_kind(item_id) {
         unification::subtype(state, context, operator_kind, item_kind)?;
     } else {
-        state.checked.types.insert(item_id, operator_kind);
+        state.checked.type_item_kinds.insert(item_id, operator_kind);
     }
 
     Ok(())

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -746,7 +746,7 @@ where
             continue;
         };
         let synonym = zonk::zonk(state, context, synonym)?;
-        let synonym = CheckedSynonym { kind, parameters, synonym };
+        let synonym = CheckedSynonym { kind, parameters, expansion: synonym };
         state.checked.synonyms.insert(item_id, synonym);
     }
     Ok(())

--- a/compiler-core/checking/src/source/type_items.rs
+++ b/compiler-core/checking/src/source/type_items.rs
@@ -241,7 +241,7 @@ fn check_type_signature<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.info.get_type_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_type_item(item_id) else {
         return Ok(());
     };
 
@@ -295,7 +295,7 @@ fn check_type_equation<Q>(
 where
     Q: ExternalQueries,
 {
-    let Some(item) = context.lowered.info.get_type_item(item_id) else {
+    let Some(item) = context.lowered.tree.get_type_item(item_id) else {
         return Ok(());
     };
 
@@ -469,7 +469,7 @@ where
 
     for constructor_id in context.indexed.data_constructors(item_id) {
         let Some(TermItemIr::Constructor { arguments }) =
-            context.lowered.info.get_term_item(constructor_id)
+            context.lowered.tree.get_term_item(constructor_id)
         else {
             continue;
         };
@@ -838,7 +838,7 @@ where
 
     for member_id in context.indexed.class_members(item_id) {
         let Some(TermItemIr::ClassMember { signature }) =
-            context.lowered.info.get_term_item(member_id)
+            context.lowered.tree.get_term_item(member_id)
         else {
             continue;
         };

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -86,7 +86,7 @@ where
         (u, u)
     };
 
-    let Some(kind) = context.lowered.info.get_type_kind(id) else {
+    let Some(kind) = context.lowered.tree.get_type_kind(id) else {
         return Ok(unknown("missing syntax"));
     };
 

--- a/compiler-core/checking/src/source/types.rs
+++ b/compiler-core/checking/src/source/types.rs
@@ -36,7 +36,7 @@ where
     state.with_error_crumb(ErrorCrumb::CheckingKind(source_type), |state| {
         let (inferred_type, inferred_kind) =
             check_kind_core(state, context, source_type, expected_kind)?;
-        state.checked.nodes.types.insert(source_type, inferred_kind);
+        state.checked.node_types.type_kinds.insert(source_type, inferred_kind);
         Ok((inferred_type, inferred_kind))
     })
 }
@@ -68,7 +68,7 @@ where
 {
     state.with_error_crumb(ErrorCrumb::InferringKind(source_type), |state| {
         let (inferred_type, inferred_kind) = infer_kind_core(state, context, source_type)?;
-        state.checked.nodes.types.insert(source_type, inferred_kind);
+        state.checked.node_types.type_kinds.insert(source_type, inferred_kind);
         Ok((inferred_type, inferred_kind))
     })
 }
@@ -279,7 +279,11 @@ where
                     }
 
                     state.bindings.bind_implicit(implicit.node, implicit.id, n, k);
-                    state.checked.nodes.implicit_bindings.insert((implicit.node, implicit.id), k);
+                    state
+                        .checked
+                        .node_types
+                        .implicit_bindings
+                        .insert((implicit.node, implicit.id), k);
 
                     let t = context.intern_rigid(n, state.depth, k);
 
@@ -394,7 +398,7 @@ fn collect_forall_binding<'a>(
     seen: &mut FxHashSet<&'a SmolStr>,
     result: &mut Vec<HoleBinding>,
 ) {
-    let Some(type_id) = state.checked.nodes.lookup_forall_binding(binding_id).or_else(|| {
+    let Some(type_id) = state.checked.node_types.lookup_forall_binding(binding_id).or_else(|| {
         let key = SourceTypeVariableKey::Forall(binding_id);
         state.bindings.lookup(key).map(|variable| variable.kind)
     }) else {
@@ -415,7 +419,7 @@ fn collect_implicit_binding<'a>(
     result: &mut Vec<HoleBinding>,
 ) {
     let Some(type_id) =
-        state.checked.nodes.lookup_implicit_binding(node_id, binding_id).or_else(|| {
+        state.checked.node_types.lookup_implicit_binding(node_id, binding_id).or_else(|| {
             let key = SourceTypeVariableKey::Implicit { node: node_id, id: binding_id };
             state.bindings.lookup(key).map(|variable| variable.kind)
         })
@@ -488,7 +492,7 @@ where
     let text = context.queries.intern_smol_str(text);
 
     state.checked.names.insert(name, text);
-    state.checked.nodes.forall_bindings.insert(binding.id, kind);
+    state.checked.node_types.forall_bindings.insert(binding.id, kind);
     state.bindings.bind_forall(binding.id, name, kind);
     Ok(ForallBinder { visible, name, kind })
 }

--- a/compiler-core/checking/src/source/types/application.rs
+++ b/compiler-core/checking/src/source/types/application.rs
@@ -2,7 +2,7 @@ use building_types::QueryResult;
 
 use crate::context::CheckContext;
 use crate::core::substitute::SubstituteName;
-use crate::core::{KindOrType, Type, TypeId, normalise, unification};
+use crate::core::{ApplicationArgument, Type, TypeId, normalise, unification};
 use crate::error::ErrorKind;
 use crate::state::CheckState;
 use crate::{ExternalQueries, safe_loop};
@@ -25,7 +25,7 @@ pub struct Options {
 
 pub enum Records {
     Ignore,
-    Collect(Vec<KindOrType>),
+    Collect(Vec<ApplicationArgument>),
 }
 
 impl Records {
@@ -33,7 +33,7 @@ impl Records {
         Records::Collect(vec![])
     }
 
-    fn push(&mut self, argument: KindOrType) {
+    fn push(&mut self, argument: ApplicationArgument) {
         if let Records::Collect(recorded_arguments) = self {
             recorded_arguments.push(argument);
         }
@@ -88,7 +88,7 @@ where
                 let result_type = context.intern_application(function_type, argument_type);
                 let result_kind = options.normalise(state, context, result_kind)?;
 
-                records.push(KindOrType::Type(argument_type));
+                records.push(ApplicationArgument::Type(argument_type));
                 break Ok(((result_type, result_kind), records));
             }
 
@@ -109,7 +109,7 @@ where
                 let result_type = context.intern_application(function_type, argument_type);
                 let result_kind = options.normalise(state, context, result_kind)?;
 
-                records.push(KindOrType::Type(argument_type));
+                records.push(ApplicationArgument::Type(argument_type));
                 break Ok(((result_type, result_kind), records));
             }
 
@@ -123,7 +123,7 @@ where
                 function_kind =
                     SubstituteName::one(state, context, binder.name, kind_argument, inner_kind)?;
 
-                records.push(KindOrType::Kind(kind_argument));
+                records.push(ApplicationArgument::Kind(kind_argument));
             }
 
             _ => {
@@ -141,7 +141,7 @@ where
                     argument_type,
                 });
 
-                records.push(KindOrType::Type(argument_type));
+                records.push(ApplicationArgument::Type(argument_type));
                 break Ok(((invalid_type, unknown_kind), records));
             }
         }

--- a/compiler-core/checking/src/state.rs
+++ b/compiler-core/checking/src/state.rs
@@ -298,7 +298,7 @@ impl CheckState {
         type_id: TypeId,
     ) -> tree::BinderId {
         let binder = self.checked.tree.allocate_section_binder(source, type_id);
-        let previous = self.checked.nodes.sections.insert(source, type_id);
+        let previous = self.checked.node_types.sections.insert(source, type_id);
         assert!(previous.is_none(), "invariant violated: section type inserted twice");
         binder
     }

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -26,8 +26,8 @@ pub type TypeDeclarationId = Idx<TypeDeclaration>;
 pub type LocalDeclarationId = Idx<LocalDeclaration>;
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct Module {
-    pub(crate) arena: ModuleArena,
+pub struct CheckedTree {
+    pub(crate) arena: CheckedTreeArena,
     terms: ArenaMap<TermItemId, TermDeclarationId>,
     types: ArenaMap<TypeItemId, TypeDeclarationId>,
     lets: ArenaMap<LetBindingNameGroupId, LocalDeclarationId>,
@@ -35,7 +35,7 @@ pub struct Module {
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub(crate) struct ModuleArena {
+pub(crate) struct CheckedTreeArena {
     pub(crate) expressions: Arena<Expression>,
     pub(crate) binders: Arena<Binder>,
     pub(crate) terms: Arena<TermDeclaration>,
@@ -371,7 +371,7 @@ pub enum RecordExpressionUpdate {
     Branch { label: SmolStr, updates: Arc<[RecordExpressionUpdate]> },
 }
 
-impl Module {
+impl CheckedTree {
     pub fn allocate_expression(&mut self, expression: Expression) -> ExpressionId {
         self.arena.expressions.alloc(expression)
     }
@@ -434,7 +434,7 @@ impl Module {
     }
 }
 
-impl Index<ExpressionId> for Module {
+impl Index<ExpressionId> for CheckedTree {
     type Output = Expression;
 
     fn index(&self, index: ExpressionId) -> &Expression {
@@ -442,7 +442,7 @@ impl Index<ExpressionId> for Module {
     }
 }
 
-impl Index<BinderId> for Module {
+impl Index<BinderId> for CheckedTree {
     type Output = Binder;
 
     fn index(&self, index: BinderId) -> &Binder {
@@ -450,7 +450,7 @@ impl Index<BinderId> for Module {
     }
 }
 
-impl Index<TermDeclarationId> for Module {
+impl Index<TermDeclarationId> for CheckedTree {
     type Output = TermDeclaration;
 
     fn index(&self, index: TermDeclarationId) -> &TermDeclaration {
@@ -458,7 +458,7 @@ impl Index<TermDeclarationId> for Module {
     }
 }
 
-impl Index<TypeDeclarationId> for Module {
+impl Index<TypeDeclarationId> for CheckedTree {
     type Output = TypeDeclaration;
 
     fn index(&self, index: TypeDeclarationId) -> &TypeDeclaration {
@@ -466,7 +466,7 @@ impl Index<TypeDeclarationId> for Module {
     }
 }
 
-impl Index<LocalDeclarationId> for Module {
+impl Index<LocalDeclarationId> for CheckedTree {
     type Output = LocalDeclaration;
 
     fn index(&self, index: LocalDeclarationId) -> &LocalDeclaration {

--- a/compiler-core/checking/src/tree.rs
+++ b/compiler-core/checking/src/tree.rs
@@ -1,3 +1,8 @@
+//! The checked semantic tree produced by type checking and elaboration.
+//!
+//! Nodes in this tree have complete checked structure and arena-local identities.
+//! Their source provenance refers back to stable identities in `lowering::tree`.
+
 pub mod pretty;
 
 use std::ops::Index;

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -1158,7 +1158,7 @@ where
                 BinderSource::Binder(source) => {
                     let kind = self
                         .lowered
-                        .info
+                        .tree
                         .get_binder_kind(source)
                         .expect("invariant violated: semantic variable binder has no source");
                     let lowering::BinderKind::Variable { variable: Some(variable) } = kind else {
@@ -1412,7 +1412,7 @@ where
                     }
                     VariableResolution::Source(resolution) => match resolution {
                         TermVariableResolution::Binder(binder) => {
-                            let kind = self.lowered.info.get_binder_kind(binder).expect(
+                            let kind = self.lowered.tree.get_binder_kind(binder).expect(
                                 "invariant violated: variable expression binder is missing",
                             );
                             match kind {
@@ -1784,7 +1784,7 @@ where
     }
 
     fn record_pun_name(&self, record_pun: lowering::RecordPunId) -> Option<String> {
-        self.lowered.info.iter_binder().find_map(|(_, kind)| {
+        self.lowered.tree.iter_binder().find_map(|(_, kind)| {
             let lowering::BinderKind::Record { record } = kind else {
                 return None;
             };
@@ -1798,7 +1798,7 @@ where
     }
 
     fn local_declaration_name(&self, source: lowering::LetBindingNameGroupId) -> String {
-        let group = self.lowered.info.get_let_binding_group(source);
+        let group = self.lowered.tree.get_let_binding_group(source);
         group.name.as_ref().map(ToString::to_string).unwrap_or_else(|| {
             let index = source.into_raw().into_u32();
             format!("<let#{index}>")

--- a/compiler-core/checking/src/tree/pretty.rs
+++ b/compiler-core/checking/src/tree/pretty.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use building_types::QueryResult;
 use files::FileId;
-use indexing::{TermItem, TermItemKind, TypeItem};
+use indexing::{IndexedTermItem, IndexedTermItemKind, IndexedTypeItem};
 use lowering::TermVariableResolution;
 use pretty::{Arena, DocAllocator, DocBuilder};
 use rustc_hash::FxHashMap;
@@ -220,7 +220,7 @@ where
     fn module(&mut self) -> QueryResult<Doc<'arena>> {
         let mut declarations = vec![];
 
-        for (type_id, TypeItem { name, .. }) in self.indexed.items.iter_types() {
+        for (type_id, IndexedTypeItem { name, .. }) in self.indexed.items.iter_types() {
             let Some(name) = name else { continue };
             let Some(declaration_id) = self.checked.tree.lookup_type_declaration(type_id) else {
                 continue;
@@ -248,13 +248,13 @@ where
         }
 
         let mut term_names = PrettyNames::new();
-        for (_, TermItem { name, .. }) in self.indexed.items.iter_terms() {
+        for (_, IndexedTermItem { name, .. }) in self.indexed.items.iter_terms() {
             if let Some(name) = name {
                 term_names.allocate_display_name(SmolStr::clone(name));
             }
         }
 
-        for (term_id, TermItem { name, .. }) in self.indexed.items.iter_terms() {
+        for (term_id, IndexedTermItem { name, .. }) in self.indexed.items.iter_terms() {
             let Some(declaration_id) = self.checked.tree.lookup_term(term_id) else {
                 continue;
             };
@@ -337,7 +337,8 @@ where
         let mut declaration = head;
         let constructors = self.indexed.data_constructors(type_id);
         for (&declaration_id, constructor_id) in data.constructors.iter().zip(constructors) {
-            let TermItem { name: constructor_name, .. } = &self.indexed.items[constructor_id];
+            let IndexedTermItem { name: constructor_name, .. } =
+                &self.indexed.items[constructor_id];
             let Some(constructor_name) = constructor_name else { continue };
             let constructor = &self.checked.tree[declaration_id];
             let TermDeclarationKind::Constructor(constructor) = &constructor.kind else {
@@ -413,7 +414,7 @@ where
 
         let mut field_names = PrettyNames::new();
         for member_id in self.indexed.class_members(type_id) {
-            let TermItem { name: Some(name), .. } = &self.indexed.items[member_id] else {
+            let IndexedTermItem { name: Some(name), .. } = &self.indexed.items[member_id] else {
                 continue;
             };
             field_names.allocate_display_name(SmolStr::clone(name));
@@ -428,7 +429,8 @@ where
         }
 
         for member in class.members.iter() {
-            let TermItem { name: Some(name), .. } = &self.indexed.items[member.source] else {
+            let IndexedTermItem { name: Some(name), .. } = &self.indexed.items[member.source]
+            else {
                 continue;
             };
             let field_type = self.type_pretty.render(member.field_type);
@@ -1645,12 +1647,13 @@ where
         let term_id = term_items.find_map(|(term_id, item)| {
             let matches = match (&item.kind, origin) {
                 (
-                    TermItemKind::Instance { id },
+                    IndexedTermItemKind::Instance { id },
                     InstanceCandidateOrigin::Instance(_, origin_id),
                 ) => *id == origin_id,
-                (TermItemKind::Derive { id }, InstanceCandidateOrigin::Derive(_, origin_id)) => {
-                    *id == origin_id
-                }
+                (
+                    IndexedTermItemKind::Derive { id },
+                    InstanceCandidateOrigin::Derive(_, origin_id),
+                ) => *id == origin_id,
                 (_, _) => false,
             };
             matches.then_some(term_id)

--- a/compiler-core/diagnostics/src/context.rs
+++ b/compiler-core/diagnostics/src/context.rs
@@ -193,7 +193,7 @@ where
             | ErrorCrumb::InferringAdoApply(id)
             | ErrorCrumb::CheckingAdoLet(id) => self.stabilized.syntax_ptr(*id)?,
             ErrorCrumb::CheckingLetName(id) => {
-                let group = self.lowered.info.get_let_binding_group(*id);
+                let group = self.lowered.tree.get_let_binding_group(*id);
 
                 let signature = group
                     .signature

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -1,6 +1,6 @@
 use checking::error::{CheckingError, ErrorKind};
 use checking::holes::HoleBinding;
-use indexing::{IndexingError, TypeItemKind};
+use indexing::{IndexedTypeItemKind, IndexingError};
 use itertools::Itertools;
 use lowering::LoweringError;
 use resolving::ResolvingError;
@@ -107,9 +107,15 @@ where
 {
     let spans = group.iter().filter_map(|id| {
         let ptr = match context.indexed.items[*id].kind {
-            TypeItemKind::Synonym { equation, .. } => context.stabilized.syntax_ptr(equation?)?,
-            TypeItemKind::Data { equation, .. } => context.stabilized.syntax_ptr(equation?)?,
-            TypeItemKind::Newtype { equation, .. } => context.stabilized.syntax_ptr(equation?)?,
+            IndexedTypeItemKind::Synonym { equation, .. } => {
+                context.stabilized.syntax_ptr(equation?)?
+            }
+            IndexedTypeItemKind::Data { equation, .. } => {
+                context.stabilized.syntax_ptr(equation?)?
+            }
+            IndexedTypeItemKind::Newtype { equation, .. } => {
+                context.stabilized.syntax_ptr(equation?)?
+            }
             _ => return None,
         };
         context.span_from_syntax_ptr(&ptr)

--- a/compiler-core/documenting/src/annotation.rs
+++ b/compiler-core/documenting/src/annotation.rs
@@ -3,7 +3,9 @@ use stabilizing::StabilizedModule;
 use syntax::ast::AstNode;
 use syntax::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxNodePtr, WalkEvent};
 
-use indexing::{DataConstructorId, TermItem, TermItemKind, TypeItem, TypeItemKind};
+use indexing::{
+    DataConstructorId, IndexedTermItem, IndexedTermItemKind, IndexedTypeItem, IndexedTypeItemKind,
+};
 use parsing::ParsedModule;
 use stabilizing::AstId;
 
@@ -56,28 +58,28 @@ pub fn module_documentation(source: &str, parsed: &ParsedModule) -> String {
 pub fn term_documentation(
     stabilized: &StabilizedModule,
     annotations: &AnnotationIndex,
-    item: &TermItem,
+    item: &IndexedTermItem,
 ) -> String {
     match &item.kind {
-        TermItemKind::ClassMember { id } => {
+        IndexedTermItemKind::ClassMember { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        TermItemKind::Constructor { id } => {
+        IndexedTermItemKind::Constructor { id } => {
             data_constructor_item_documentation(stabilized, annotations, *id)
         }
-        TermItemKind::Derive { id } => {
+        IndexedTermItemKind::Derive { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        TermItemKind::Foreign { id } => {
+        IndexedTermItemKind::Foreign { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        TermItemKind::Instance { id } => {
+        IndexedTermItemKind::Instance { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        TermItemKind::Operator { id } => {
+        IndexedTermItemKind::Operator { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        TermItemKind::Value { signature, equations } => {
+        IndexedTermItemKind::Value { signature, equations } => {
             let equation = equations.first().copied();
             signature_equation_documentation(stabilized, annotations, signature, &equation)
         }
@@ -87,25 +89,25 @@ pub fn term_documentation(
 pub fn type_documentation(
     stabilized: &StabilizedModule,
     annotations: &AnnotationIndex,
-    item: &TypeItem,
+    item: &IndexedTypeItem,
 ) -> String {
     match &item.kind {
-        TypeItemKind::Data { signature, equation, .. } => {
+        IndexedTypeItemKind::Data { signature, equation, .. } => {
             signature_equation_documentation(stabilized, annotations, signature, equation)
         }
-        TypeItemKind::Newtype { signature, equation, .. } => {
+        IndexedTypeItemKind::Newtype { signature, equation, .. } => {
             signature_equation_documentation(stabilized, annotations, signature, equation)
         }
-        TypeItemKind::Synonym { signature, equation, .. } => {
+        IndexedTypeItemKind::Synonym { signature, equation, .. } => {
             signature_equation_documentation(stabilized, annotations, signature, equation)
         }
-        TypeItemKind::Class { signature, declaration, .. } => {
+        IndexedTypeItemKind::Class { signature, declaration, .. } => {
             signature_equation_documentation(stabilized, annotations, signature, declaration)
         }
-        TypeItemKind::Foreign { id, .. } => {
+        IndexedTypeItemKind::Foreign { id, .. } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
-        TypeItemKind::Operator { id } => {
+        IndexedTypeItemKind::Operator { id } => {
             signature_equation_documentation(stabilized, annotations, &Some(*id), &Some(*id))
         }
     }
@@ -218,7 +220,7 @@ fn extract_annotation(text: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use indexing::TermItemKind;
+    use indexing::IndexedTermItemKind;
 
     use super::*;
 
@@ -245,7 +247,7 @@ value = 1
 
         let id = indexed.names.terms.lookup("value").unwrap();
         let item = &indexed.items[id];
-        assert!(matches!(item.kind, TermItemKind::Value { .. }));
+        assert!(matches!(item.kind, IndexedTermItemKind::Value { .. }));
 
         let documentation = term_documentation(&stabilized, &annotations, item);
         assert_eq!(documentation, "Equation documentation.");
@@ -275,7 +277,7 @@ data Maybe a
         let annotations = AnnotationIndex::new(source, &root);
 
         let documentation = indexed.items.iter_terms().filter_map(|(_, item)| {
-            if !matches!(item.kind, TermItemKind::Constructor { .. }) {
+            if !matches!(item.kind, IndexedTermItemKind::Constructor { .. }) {
                 return None;
             }
 

--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -40,7 +40,10 @@ impl<'a> State<'a> {
         State { source, name, ..Default::default() }
     }
 
-    fn open_term_group(&mut self, name: &Option<SmolStr>) -> Option<(TermItemId, &mut TermItem)> {
+    fn open_term_group(
+        &mut self,
+        name: &Option<SmolStr>,
+    ) -> Option<(TermItemId, &mut IndexedTermItem)> {
         let OpenItemGroup::Term(id) = self.open? else {
             return None;
         };
@@ -51,7 +54,10 @@ impl<'a> State<'a> {
         Some((id, &mut self.items.terms[id]))
     }
 
-    fn open_type_group(&mut self, name: &Option<SmolStr>) -> Option<(TypeItemId, &mut TypeItem)> {
+    fn open_type_group(
+        &mut self,
+        name: &Option<SmolStr>,
+    ) -> Option<(TypeItemId, &mut IndexedTypeItem)> {
         let OpenItemGroup::Type(id) = self.open? else {
             return None;
         };
@@ -62,13 +68,13 @@ impl<'a> State<'a> {
         Some((id, &mut self.items.types[id]))
     }
 
-    fn alloc_term(&mut self, item: TermItem) -> TermItemId {
+    fn alloc_term(&mut self, item: IndexedTermItem) -> TermItemId {
         let id = self.items.terms.alloc(item);
         self.open = Some(OpenItemGroup::Term(id));
         id
     }
 
-    fn alloc_type(&mut self, item: TypeItem) -> TypeItemId {
+    fn alloc_type(&mut self, item: IndexedTypeItem) -> TypeItemId {
         let id = self.items.types.alloc(item);
         self.open = Some(OpenItemGroup::Type(id));
         id
@@ -158,14 +164,14 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Synonym { signature: Some(id), equation: None },
+                    kind: IndexedTypeItemKind::Synonym { signature: Some(id), equation: None },
                     exported: false,
                 },
                 ItemKind::SynonymSignature,
                 |item| {
-                    if let TypeItemKind::Synonym { signature, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Synonym { signature, .. } = &mut item.kind {
                         Some(signature)
                     } else {
                         None
@@ -181,14 +187,14 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Synonym { signature: None, equation: Some(id) },
+                    kind: IndexedTypeItemKind::Synonym { signature: None, equation: Some(id) },
                     exported: false,
                 },
                 ItemKind::SynonymEquation,
                 |item| {
-                    if let TypeItemKind::Synonym { equation, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Synonym { equation, .. } = &mut item.kind {
                         Some(equation)
                     } else {
                         None
@@ -204,9 +210,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Class {
+                    kind: IndexedTypeItemKind::Class {
                         signature: Some(id),
                         declaration: None,
                         members: vec![],
@@ -215,7 +221,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 },
                 ItemKind::ClassSignature,
                 |item| {
-                    if let TypeItemKind::Class { signature, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Class { signature, .. } = &mut item.kind {
                         Some(signature)
                     } else {
                         None
@@ -231,9 +237,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Class {
+                    kind: IndexedTypeItemKind::Class {
                         signature: None,
                         declaration: Some(id),
                         members: vec![],
@@ -242,7 +248,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 },
                 ItemKind::ClassDeclaration,
                 |item| {
-                    if let TypeItemKind::Class { declaration, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Class { declaration, .. } = &mut item.kind {
                         Some(declaration)
                     } else {
                         None
@@ -253,7 +259,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 for cst in cst.children() {
                     let member_id = stabilized.lookup_cst(&cst).expect_id();
                     let term_id = index_class_member(state, member_id, &cst);
-                    if let TypeItemKind::Class { members, .. } =
+                    if let IndexedTypeItemKind::Class { members, .. } =
                         &mut state.items.types[type_id].kind
                     {
                         members.push(term_id);
@@ -280,9 +286,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Newtype {
+                    kind: IndexedTypeItemKind::Newtype {
                         signature: Some(id),
                         equation: None,
                         role: None,
@@ -292,7 +298,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 },
                 ItemKind::NewtypeSignature,
                 |item| {
-                    if let TypeItemKind::Newtype { signature, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Newtype { signature, .. } = &mut item.kind {
                         Some(signature)
                     } else {
                         None
@@ -308,9 +314,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Newtype {
+                    kind: IndexedTypeItemKind::Newtype {
                         signature: None,
                         equation: Some(id),
                         role: None,
@@ -320,7 +326,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 },
                 ItemKind::NewtypeEquation,
                 |item| {
-                    if let TypeItemKind::Newtype { equation, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Newtype { equation, .. } = &mut item.kind {
                         Some(equation)
                     } else {
                         None
@@ -330,7 +336,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             for cst in cst.data_constructors() {
                 let constructor_id = stabilized.lookup_cst(&cst).expect_id();
                 let term_id = index_data_constructor(state, constructor_id, &cst);
-                if let TypeItemKind::Newtype { constructors, .. } =
+                if let IndexedTypeItemKind::Newtype { constructors, .. } =
                     &mut state.items.types[type_id].kind
                 {
                     constructors.push(term_id);
@@ -346,9 +352,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Data {
+                    kind: IndexedTypeItemKind::Data {
                         signature: Some(id),
                         equation: None,
                         role: None,
@@ -358,7 +364,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 },
                 ItemKind::DataSignature,
                 |item| {
-                    if let TypeItemKind::Data { signature, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Data { signature, .. } = &mut item.kind {
                         Some(signature)
                     } else {
                         None
@@ -374,9 +380,9 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 state,
                 id,
                 token,
-                |name, id| TypeItem {
+                |name, id| IndexedTypeItem {
                     name,
-                    kind: TypeItemKind::Data {
+                    kind: IndexedTypeItemKind::Data {
                         signature: None,
                         equation: Some(id),
                         role: None,
@@ -386,7 +392,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 },
                 ItemKind::DataEquation,
                 |item| {
-                    if let TypeItemKind::Data { equation, .. } = &mut item.kind {
+                    if let IndexedTypeItemKind::Data { equation, .. } = &mut item.kind {
                         Some(equation)
                     } else {
                         None
@@ -396,7 +402,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
             for cst in cst.data_constructors() {
                 let constructor_id = stabilized.lookup_cst(&cst).expect_id();
                 let term_id = index_data_constructor(state, constructor_id, &cst);
-                if let TypeItemKind::Data { constructors, .. } =
+                if let IndexedTypeItemKind::Data { constructors, .. } =
                     &mut state.items.types[type_id].kind
                 {
                     constructors.push(term_id);
@@ -421,11 +427,11 @@ fn index_value_signature(
     let name = name_from_token(state.source, cst.name_token());
 
     let Some((active_id, active)) = state.open_term_group(&name) else {
-        let kind = TermItemKind::Value { signature: Some(id), equations: vec![] };
-        return state.alloc_term(TermItem { name, kind, exported: false });
+        let kind = IndexedTermItemKind::Value { signature: Some(id), equations: vec![] };
+        return state.alloc_term(IndexedTermItem { name, kind, exported: false });
     };
 
-    if let TermItemKind::Value { signature, .. } = &mut active.kind {
+    if let IndexedTermItemKind::Value { signature, .. } = &mut active.kind {
         if signature.is_some() {
             let kind = ItemKind::ValueSignature(id);
             let existing = ExistingKind::Term(active_id);
@@ -450,11 +456,11 @@ fn index_value_equation(
     let name = name_from_token(state.source, cst.name_token());
 
     let Some((active_id, active)) = state.open_term_group(&name) else {
-        let kind = TermItemKind::Value { signature: None, equations: vec![id] };
-        return state.alloc_term(TermItem { name, kind, exported: false });
+        let kind = IndexedTermItemKind::Value { signature: None, equations: vec![id] };
+        return state.alloc_term(IndexedTermItem { name, kind, exported: false });
     };
 
-    if let TermItemKind::Value { equations, .. } = &mut active.kind {
+    if let IndexedTermItemKind::Value { equations, .. } = &mut active.kind {
         equations.push(id);
     } else {
         let kind = ItemKind::ValueEquation(id);
@@ -477,14 +483,14 @@ fn index_infix(
     let name = name_from_token(state.source, operator_token);
 
     if type_token.is_some() {
-        let kind = TypeItemKind::Operator { id: infix_id };
-        let item = TypeItem { name, kind, exported: false };
+        let kind = IndexedTypeItemKind::Operator { id: infix_id };
+        let item = IndexedTypeItem { name, kind, exported: false };
 
         let type_id = state.alloc_type(item);
         state.pairs.declaration_to_type.push((declaration_id, type_id))
     } else {
-        let kind = TermItemKind::Operator { id: infix_id };
-        let item = TermItem { name, kind, exported: false };
+        let kind = IndexedTermItemKind::Operator { id: infix_id };
+        let item = IndexedTermItem { name, kind, exported: false };
 
         let term_id = state.alloc_term(item);
         state.pairs.declaration_to_term.push((declaration_id, term_id))
@@ -498,9 +504,9 @@ fn index_type_role(state: &mut State, id: TypeRoleId, cst: &cst::TypeRoleDeclara
         return state.errors.push(IndexingError::InvalidRole { id, existing: None });
     };
 
-    if let TypeItemKind::Data { role, .. }
-    | TypeItemKind::Newtype { role, .. }
-    | TypeItemKind::Foreign { role, .. } = &mut active.kind
+    if let IndexedTypeItemKind::Data { role, .. }
+    | IndexedTypeItemKind::Newtype { role, .. }
+    | IndexedTypeItemKind::Foreign { role, .. } = &mut active.kind
     {
         if role.is_some() {
             state.errors.push(IndexingError::InvalidRole { id, existing: Some(active_id) });
@@ -512,8 +518,8 @@ fn index_type_role(state: &mut State, id: TypeRoleId, cst: &cst::TypeRoleDeclara
     }
 }
 
-type Item<T> = fn(Option<SmolStr>, AstId<T>) -> TypeItem;
-type Extract<T> = fn(&mut TypeItem) -> Option<&mut Option<AstId<T>>>;
+type Item<T> = fn(Option<SmolStr>, AstId<T>) -> IndexedTypeItem;
+type Extract<T> = fn(&mut IndexedTypeItem) -> Option<&mut Option<AstId<T>>>;
 type MakeItemKind<T> = fn(AstId<T>) -> ItemKind;
 
 fn index_type_signature<T: AstNode>(
@@ -586,8 +592,8 @@ fn index_data_constructor(
     cst: &cst::DataConstructor,
 ) -> TermItemId {
     let name = name_from_token(state.source, cst.name_token());
-    let kind = TermItemKind::Constructor { id };
-    state.items.terms.alloc(TermItem { name, kind, exported: false })
+    let kind = IndexedTermItemKind::Constructor { id };
+    state.items.terms.alloc(IndexedTermItem { name, kind, exported: false })
 }
 
 fn index_class_member(
@@ -596,8 +602,8 @@ fn index_class_member(
     cst: &cst::ClassMemberStatement,
 ) -> TermItemId {
     let name = name_from_token(state.source, cst.name_token());
-    let kind = TermItemKind::ClassMember { id };
-    state.items.terms.alloc(TermItem { name, kind, exported: false })
+    let kind = IndexedTermItemKind::ClassMember { id };
+    state.items.terms.alloc(IndexedTermItem { name, kind, exported: false })
 }
 
 fn index_foreign_data(
@@ -606,8 +612,8 @@ fn index_foreign_data(
     cst: &cst::ForeignImportDataDeclaration,
 ) -> TypeItemId {
     let name = name_from_token(state.source, cst.name_token());
-    let kind = TypeItemKind::Foreign { id, role: None };
-    state.alloc_type(TypeItem { name, kind, exported: false })
+    let kind = IndexedTypeItemKind::Foreign { id, role: None };
+    state.alloc_type(IndexedTypeItem { name, kind, exported: false })
 }
 
 fn index_foreign_value(
@@ -616,7 +622,11 @@ fn index_foreign_value(
     cst: &cst::ForeignImportValueDeclaration,
 ) -> TermItemId {
     let name = name_from_token(state.source, cst.name_token());
-    state.alloc_term(TermItem { name, kind: TermItemKind::Foreign { id }, exported: false })
+    state.alloc_term(IndexedTermItem {
+        name,
+        kind: IndexedTermItemKind::Foreign { id },
+        exported: false,
+    })
 }
 
 fn index_instance(state: &mut State, id: InstanceId, cst: &cst::InstanceDeclaration) -> TermItemId {
@@ -625,7 +635,11 @@ fn index_instance(state: &mut State, id: InstanceId, cst: &cst::InstanceDeclarat
         let text = token.text(state.source);
         Some(SmolStr::from(text))
     });
-    state.alloc_term(TermItem { name, kind: TermItemKind::Instance { id }, exported: true })
+    state.alloc_term(IndexedTermItem {
+        name,
+        kind: IndexedTermItemKind::Instance { id },
+        exported: true,
+    })
 }
 
 fn index_derive(state: &mut State, id: DeriveId, cst: &cst::DeriveDeclaration) -> TermItemId {
@@ -634,7 +648,11 @@ fn index_derive(state: &mut State, id: DeriveId, cst: &cst::DeriveDeclaration) -
         let text = token.text(state.source);
         Some(SmolStr::from(text))
     });
-    state.alloc_term(TermItem { name, kind: TermItemKind::Derive { id }, exported: true })
+    state.alloc_term(IndexedTermItem {
+        name,
+        kind: IndexedTermItemKind::Derive { id },
+        exported: true,
+    })
 }
 
 fn validate_items(state: &mut State) {
@@ -843,8 +861,8 @@ fn index_exports(state: &mut State, stabilized: &StabilizedModule, cst: &cst::Ex
             item.exported = true;
             if let Some(implicit) = implicit {
                 let constructors: Vec<_> = match &item.kind {
-                    TypeItemKind::Data { constructors, .. }
-                    | TypeItemKind::Newtype { constructors, .. } => constructors.clone(),
+                    IndexedTypeItemKind::Data { constructors, .. }
+                    | IndexedTypeItemKind::Newtype { constructors, .. } => constructors.clone(),
                     _ => vec![],
                 };
 
@@ -872,7 +890,7 @@ fn index_exports(state: &mut State, stabilized: &StabilizedModule, cst: &cst::Ex
                 }
             }
             let members: Vec<_> = match &item.kind {
-                TypeItemKind::Class { members, .. } => members.clone(),
+                IndexedTypeItemKind::Class { members, .. } => members.clone(),
                 _ => vec![],
             };
             for term_id in members {

--- a/compiler-core/indexing/src/items.rs
+++ b/compiler-core/indexing/src/items.rs
@@ -4,14 +4,14 @@ use smol_str::SmolStr;
 use crate::source::*;
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct TermItem {
+pub struct IndexedTermItem {
     pub name: Option<SmolStr>,
-    pub kind: TermItemKind,
+    pub kind: IndexedTermItemKind,
     pub exported: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum TermItemKind {
+pub enum IndexedTermItemKind {
     ClassMember { id: ClassMemberId },
     Constructor { id: DataConstructorId },
     Derive { id: DeriveId },
@@ -21,17 +21,17 @@ pub enum TermItemKind {
     Value { signature: Option<ValueSignatureId>, equations: Vec<ValueEquationId> },
 }
 
-pub type TermItemId = Idx<TermItem>;
+pub type TermItemId = Idx<IndexedTermItem>;
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct TypeItem {
+pub struct IndexedTypeItem {
     pub name: Option<SmolStr>,
-    pub kind: TypeItemKind,
+    pub kind: IndexedTypeItemKind,
     pub exported: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum TypeItemKind {
+pub enum IndexedTypeItemKind {
     Data {
         signature: Option<DataSignatureId>,
         equation: Option<DataEquationId>,
@@ -62,4 +62,4 @@ pub enum TypeItemKind {
     },
 }
 
-pub type TypeItemId = Idx<TypeItem>;
+pub type TypeItemId = Idx<IndexedTypeItem>;

--- a/compiler-core/indexing/src/items.rs
+++ b/compiler-core/indexing/src/items.rs
@@ -3,6 +3,7 @@ use smol_str::SmolStr;
 
 use crate::source::*;
 
+/// A term item assembled from the source declarations that share its module-level identity.
 #[derive(Debug, PartialEq, Eq)]
 pub struct IndexedTermItem {
     pub name: Option<SmolStr>,
@@ -10,6 +11,7 @@ pub struct IndexedTermItem {
     pub exported: bool,
 }
 
+/// The source declarations grouped into an [`IndexedTermItem`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum IndexedTermItemKind {
     ClassMember { id: ClassMemberId },
@@ -21,8 +23,10 @@ pub enum IndexedTermItemKind {
     Value { signature: Option<ValueSignatureId>, equations: Vec<ValueEquationId> },
 }
 
+/// A module-local term identity preserved by later compiler representations.
 pub type TermItemId = Idx<IndexedTermItem>;
 
+/// A type item assembled from the source declarations that share its module-level identity.
 #[derive(Debug, PartialEq, Eq)]
 pub struct IndexedTypeItem {
     pub name: Option<SmolStr>,
@@ -30,6 +34,7 @@ pub struct IndexedTypeItem {
     pub exported: bool,
 }
 
+/// The source declarations grouped into an [`IndexedTypeItem`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum IndexedTypeItemKind {
     Data {
@@ -62,4 +67,5 @@ pub enum IndexedTypeItemKind {
     },
 }
 
+/// A module-local type identity preserved by later compiler representations.
 pub type TypeItemId = Idx<IndexedTypeItem>;

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -63,8 +63,8 @@ impl IndexedModule {
 
     pub fn data_constructors(&self, id: TypeItemId) -> impl Iterator<Item = TermItemId> + '_ {
         let constructors = match &self.items[id].kind {
-            TypeItemKind::Data { constructors, .. }
-            | TypeItemKind::Newtype { constructors, .. } => constructors.as_slice(),
+            IndexedTypeItemKind::Data { constructors, .. }
+            | IndexedTypeItemKind::Newtype { constructors, .. } => constructors.as_slice(),
             _ => &[],
         };
 
@@ -83,7 +83,7 @@ impl IndexedModule {
 
     pub fn class_members(&self, id: TypeItemId) -> impl Iterator<Item = TermItemId> + '_ {
         let members = match &self.items[id].kind {
-            TypeItemKind::Class { members, .. } => members.as_slice(),
+            IndexedTypeItemKind::Class { members, .. } => members.as_slice(),
             _ => &[],
         };
 
@@ -174,32 +174,32 @@ pub enum TypeSelection {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct IndexedItems {
-    terms: Arena<TermItem>,
-    types: Arena<TypeItem>,
+    terms: Arena<IndexedTermItem>,
+    types: Arena<IndexedTypeItem>,
 }
 
 impl IndexedItems {
-    pub fn iter_terms(&self) -> impl Iterator<Item = (TermItemId, &TermItem)> {
+    pub fn iter_terms(&self) -> impl Iterator<Item = (TermItemId, &IndexedTermItem)> {
         self.terms.iter()
     }
 
-    pub fn iter_types(&self) -> impl Iterator<Item = (TypeItemId, &TypeItem)> {
+    pub fn iter_types(&self) -> impl Iterator<Item = (TypeItemId, &IndexedTypeItem)> {
         self.types.iter()
     }
 }
 
 impl ops::Index<TermItemId> for IndexedItems {
-    type Output = TermItem;
+    type Output = IndexedTermItem;
 
-    fn index(&self, index: TermItemId) -> &TermItem {
+    fn index(&self, index: TermItemId) -> &IndexedTermItem {
         &self.terms[index]
     }
 }
 
 impl ops::Index<TypeItemId> for IndexedItems {
-    type Output = TypeItem;
+    type Output = IndexedTypeItem;
 
-    fn index(&self, index: TypeItemId) -> &TypeItem {
+    fn index(&self, index: TypeItemId) -> &IndexedTypeItem {
         &self.types[index]
     }
 }

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use files::FileId;
 use indexing::{
-    EquationSourceId, IndexedModule, TermItem, TermItemId, TermItemKind, TypeItem, TypeItemId,
-    TypeItemKind, TypeRoleId,
+    EquationSourceId, IndexedModule, IndexedTermItem, IndexedTermItemKind, IndexedTypeItem,
+    IndexedTypeItemKind, TermItemId, TypeItemId, TypeRoleId,
 };
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -267,7 +267,7 @@ impl State {
             self.type_edges.insert((current_id, type_id));
 
             if let Some(synonym_id) = self.current_synonym
-                && let TypeItemKind::Synonym { .. } = context.indexed.items[type_id].kind
+                && let IndexedTypeItemKind::Synonym { .. } = context.indexed.items[type_id].kind
             {
                 self.synonym_edges.insert((synonym_id, type_id));
             }
@@ -294,7 +294,7 @@ impl State {
             self.type_edges.insert((current_id, type_id));
 
             if let Some(synonym_id) = self.current_synonym
-                && let TypeItemKind::Synonym { .. } = context.indexed.items[type_id].kind
+                && let IndexedTypeItemKind::Synonym { .. } = context.indexed.items[type_id].kind
             {
                 self.synonym_edges.insert((synonym_id, type_id));
             }
@@ -408,13 +408,18 @@ pub(super) fn lower_module(
     state
 }
 
-fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, item: &TermItem) {
+fn lower_term_item(
+    state: &mut State,
+    context: &Context,
+    item_id: TermItemId,
+    item: &IndexedTermItem,
+) {
     match &item.kind {
-        TermItemKind::ClassMember { .. } => (), // See lower_type_item
+        IndexedTermItemKind::ClassMember { .. } => (), // See lower_type_item
 
-        TermItemKind::Constructor { .. } => (), // See lower_type_item
+        IndexedTermItemKind::Constructor { .. } => (), // See lower_type_item
 
-        TermItemKind::Derive { id } => {
+        IndexedTermItemKind::Derive { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
             let newtype = cst.as_ref().map(|cst| cst.newtype_token().is_some()).unwrap_or(false);
@@ -455,7 +460,7 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
             state.info.term_item.insert(item_id, kind);
         }
 
-        TermItemKind::Foreign { id } => {
+        IndexedTermItemKind::Foreign { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
             let signature = cst.and_then(|cst| {
@@ -467,7 +472,7 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
             state.info.term_item.insert(item_id, kind);
         }
 
-        TermItemKind::Instance { id } => {
+        IndexedTermItemKind::Instance { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
             let resolution = cst.as_ref().and_then(|cst| {
@@ -511,7 +516,7 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
             state.info.term_item.insert(item_id, kind);
         }
 
-        TermItemKind::Operator { id } => {
+        IndexedTermItemKind::Operator { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
             let associativity = cst.as_ref().and_then(|cst| {
@@ -550,7 +555,7 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
             state.info.term_item.insert(item_id, kind);
         }
 
-        TermItemKind::Value { signature, equations } => {
+        IndexedTermItemKind::Value { signature, equations } => {
             let signature = signature.and_then(|id| {
                 let cst =
                     context.stabilized.ast_ptr(id).and_then(|cst| cst.try_to_node(context.root))?;
@@ -582,9 +587,14 @@ fn lower_term_item(state: &mut State, context: &Context, item_id: TermItemId, it
     }
 }
 
-fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, item: &TypeItem) {
+fn lower_type_item(
+    state: &mut State,
+    context: &Context,
+    item_id: TypeItemId,
+    item: &IndexedTypeItem,
+) {
     match &item.kind {
-        TypeItemKind::Data { signature, equation, role, .. } => {
+        IndexedTypeItemKind::Data { signature, equation, role, .. } => {
             state.begin_kind(item_id);
 
             let signature = signature.and_then(|id| {
@@ -617,7 +627,7 @@ fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, it
             lower_constructors(state, context, item_id);
         }
 
-        TypeItemKind::Newtype { signature, equation, role, .. } => {
+        IndexedTypeItemKind::Newtype { signature, equation, role, .. } => {
             state.begin_kind(item_id);
 
             let signature = signature.and_then(|id| {
@@ -650,7 +660,7 @@ fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, it
             lower_constructors(state, context, item_id);
         }
 
-        TypeItemKind::Synonym { signature, equation } => {
+        IndexedTypeItemKind::Synonym { signature, equation } => {
             state.begin_kind(item_id);
 
             let signature = signature.and_then(|id| {
@@ -685,7 +695,7 @@ fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, it
             state.info.type_item.insert(item_id, kind);
         }
 
-        TypeItemKind::Class { signature, declaration, .. } => {
+        IndexedTypeItemKind::Class { signature, declaration, .. } => {
             state.begin_kind(item_id);
 
             let signature = signature.and_then(|id| {
@@ -740,7 +750,7 @@ fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, it
             lower_class_members(state, context, item_id);
         }
 
-        TypeItemKind::Foreign { id, role } => {
+        IndexedTypeItemKind::Foreign { id, role } => {
             state.begin_kind(item_id);
 
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
@@ -758,7 +768,7 @@ fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, it
             state.info.type_item.insert(item_id, kind);
         }
 
-        TypeItemKind::Operator { id } => {
+        IndexedTypeItemKind::Operator { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
             let associativity = cst.as_ref().and_then(|cst| {
@@ -795,8 +805,8 @@ fn lower_type_item(state: &mut State, context: &Context, item_id: TypeItemId, it
 
 fn lower_constructors(state: &mut State, context: &Context, id: TypeItemId) {
     for item_id in context.indexed.data_constructors(id) {
-        let TermItemKind::Constructor { id } = context.indexed.items[item_id].kind else {
-            unreachable!("invariant violated: expected TermItemKind::Constructor");
+        let IndexedTermItemKind::Constructor { id } = context.indexed.items[item_id].kind else {
+            unreachable!("invariant violated: expected IndexedTermItemKind::Constructor");
         };
 
         let Some(cst) =
@@ -814,8 +824,8 @@ fn lower_constructors(state: &mut State, context: &Context, id: TypeItemId) {
 
 fn lower_class_members(state: &mut State, context: &Context, id: TypeItemId) {
     for item_id in context.indexed.class_members(id) {
-        let TermItemKind::ClassMember { id } = context.indexed.items[item_id].kind else {
-            unreachable!("invariant violated: expected TermItemKind::ClassMember");
+        let IndexedTermItemKind::ClassMember { id } = context.indexed.items[item_id].kind else {
+            unreachable!("invariant violated: expected IndexedTermItemKind::ClassMember");
         };
 
         let Some(cst) =

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -19,9 +19,9 @@ use syntax::ast::AstNode;
 use syntax::cst;
 
 use crate::error::*;
-use crate::intermediate::*;
 use crate::scope::*;
 use crate::source::*;
+use crate::tree::*;
 
 #[derive(Default)]
 pub(crate) struct State {

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -25,7 +25,7 @@ use crate::tree::*;
 
 #[derive(Default)]
 pub(crate) struct State {
-    pub(crate) info: LoweringInfo,
+    pub(crate) tree: LoweredTree,
     pub(crate) graph: LoweringGraph,
     pub(crate) nodes: LoweringGraphNodes,
     pub(crate) graph_scope: Option<GraphNodeId>,
@@ -97,23 +97,23 @@ impl State {
     }
 
     fn alloc_let_binding(&mut self, group: LetBindingNameGroup) -> LetBindingNameGroupId {
-        self.info.let_binding.alloc(group)
+        self.tree.let_binding_groups.alloc(group)
     }
 
-    fn associate_binder_info(&mut self, id: BinderId, kind: BinderKind) {
-        self.info.binder_kind.insert(id, kind);
+    fn associate_binder_kind(&mut self, id: BinderId, kind: BinderKind) {
+        self.tree.binders.insert(id, kind);
         let Some(node) = self.graph_scope else { return };
         self.nodes.binder_node.insert(id, node);
     }
 
-    fn associate_expression_info(&mut self, id: ExpressionId, kind: ExpressionKind) {
-        self.info.expression_kind.insert(id, kind);
+    fn associate_expression_kind(&mut self, id: ExpressionId, kind: ExpressionKind) {
+        self.tree.expressions.insert(id, kind);
         let Some(node) = self.graph_scope else { return };
         self.nodes.expression_node.insert(id, node);
     }
 
-    fn associate_type_info(&mut self, id: TypeId, kind: TypeKind) {
-        self.info.type_kind.insert(id, kind);
+    fn associate_type_kind(&mut self, id: TypeId, kind: TypeKind) {
+        self.tree.types.insert(id, kind);
         let Some(node) = self.graph_scope else { return };
         self.nodes.type_node.insert(id, node);
     }
@@ -124,16 +124,16 @@ impl State {
         resolution: Option<TermVariableResolution>,
     ) {
         if let Some(resolution) = resolution {
-            self.info.expression_pun.insert(id, resolution);
+            self.tree.expression_puns.insert(id, resolution);
         }
     }
 
     fn associate_do_statement(&mut self, id: DoStatementId, statement: DoStatement) {
-        self.info.do_statement.insert(id, statement);
+        self.tree.do_statements.insert(id, statement);
     }
 
     fn associate_let_binding_name(&mut self, id: LetBindingNameGroupId, info: LetBindingName) {
-        self.info.let_binding_name.insert(id, info);
+        self.tree.let_binding_names.insert(id, info);
         let Some(node) = self.graph_scope else { return };
         self.nodes.let_node.insert(id, node);
     }
@@ -457,7 +457,7 @@ fn lower_term_item(
             state.finish_implicit_scope();
 
             let kind = TermItemIr::Derive { newtype, constraints, resolution, arguments };
-            state.info.term_item.insert(item_id, kind);
+            state.tree.term_items.insert(item_id, kind);
         }
 
         IndexedTermItemKind::Foreign { id } => {
@@ -469,7 +469,7 @@ fn lower_term_item(
             });
 
             let kind = TermItemIr::Foreign { signature };
-            state.info.term_item.insert(item_id, kind);
+            state.tree.term_items.insert(item_id, kind);
         }
 
         IndexedTermItemKind::Instance { id } => {
@@ -513,7 +513,7 @@ fn lower_term_item(
             };
 
             let kind = TermItemIr::Instance { constraints, resolution, arguments, members };
-            state.info.term_item.insert(item_id, kind);
+            state.tree.term_items.insert(item_id, kind);
         }
 
         IndexedTermItemKind::Operator { id } => {
@@ -552,7 +552,7 @@ fn lower_term_item(
             });
 
             let kind = TermItemIr::Operator { associativity, precedence, resolution };
-            state.info.term_item.insert(item_id, kind);
+            state.tree.term_items.insert(item_id, kind);
         }
 
         IndexedTermItemKind::Value { signature, equations } => {
@@ -582,7 +582,7 @@ fn lower_term_item(
                 .collect();
 
             let kind = TermItemIr::ValueGroup { signature, equations };
-            state.info.term_item.insert(item_id, kind);
+            state.tree.term_items.insert(item_id, kind);
         }
     }
 }
@@ -622,7 +622,7 @@ fn lower_type_item(
             let roles = role.map(|id| lower_roles(context, id)).unwrap_or_default();
 
             let kind = TypeItemIr::DataGroup { signature, data, roles };
-            state.info.type_item.insert(item_id, kind);
+            state.tree.type_items.insert(item_id, kind);
 
             lower_constructors(state, context, item_id);
         }
@@ -655,7 +655,7 @@ fn lower_type_item(
             let roles = role.map(|id| lower_roles(context, id)).unwrap_or_default();
 
             let kind = TypeItemIr::NewtypeGroup { signature, newtype, roles };
-            state.info.type_item.insert(item_id, kind);
+            state.tree.type_items.insert(item_id, kind);
 
             lower_constructors(state, context, item_id);
         }
@@ -692,7 +692,7 @@ fn lower_type_item(
             state.end_synonym();
 
             let kind = TypeItemIr::SynonymGroup { signature, synonym };
-            state.info.type_item.insert(item_id, kind);
+            state.tree.type_items.insert(item_id, kind);
         }
 
         IndexedTypeItemKind::Class { signature, declaration, .. } => {
@@ -745,7 +745,7 @@ fn lower_type_item(
             });
 
             let kind = TypeItemIr::ClassGroup { signature, class };
-            state.info.type_item.insert(item_id, kind);
+            state.tree.type_items.insert(item_id, kind);
 
             lower_class_members(state, context, item_id);
         }
@@ -765,7 +765,7 @@ fn lower_type_item(
             let roles = role.map(|id| lower_roles(context, id)).unwrap_or_default();
 
             let kind = TypeItemIr::Foreign { signature, roles };
-            state.info.type_item.insert(item_id, kind);
+            state.tree.type_items.insert(item_id, kind);
         }
 
         IndexedTypeItemKind::Operator { id } => {
@@ -798,7 +798,7 @@ fn lower_type_item(
             state.end_kind();
 
             let kind = TypeItemIr::Operator { associativity, precedence, resolution };
-            state.info.type_item.insert(item_id, kind);
+            state.tree.type_items.insert(item_id, kind);
         }
     }
 }
@@ -818,7 +818,7 @@ fn lower_constructors(state: &mut State, context: &Context, id: TypeItemId) {
         let arguments = cst.children().map(|t| recursive::lower_type(state, context, &t)).collect();
 
         let kind = TermItemIr::Constructor { arguments };
-        state.info.term_item.insert(item_id, kind);
+        state.tree.term_items.insert(item_id, kind);
     }
 }
 
@@ -837,7 +837,7 @@ fn lower_class_members(state: &mut State, context: &Context, id: TypeItemId) {
         let signature = cst.type_().map(|t| recursive::lower_type(state, context, &t));
 
         let kind = TermItemIr::ClassMember { signature };
-        state.info.term_item.insert(item_id, kind);
+        state.tree.term_items.insert(item_id, kind);
     }
 }
 

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -456,7 +456,7 @@ fn lower_term_item(
             state.in_constraint = false;
             state.finish_implicit_scope();
 
-            let kind = TermItemIr::Derive { newtype, constraints, resolution, arguments };
+            let kind = TermItemKind::Derive { newtype, constraints, resolution, arguments };
             state.tree.term_items.insert(item_id, kind);
         }
 
@@ -468,7 +468,7 @@ fn lower_term_item(
                 Some(recursive::lower_type(state, context, &cst))
             });
 
-            let kind = TermItemIr::Foreign { signature };
+            let kind = TermItemKind::Foreign { signature };
             state.tree.term_items.insert(item_id, kind);
         }
 
@@ -512,7 +512,7 @@ fn lower_term_item(
                 lower_instance_statements(state, context, &statements, resolution)
             };
 
-            let kind = TermItemIr::Instance { constraints, resolution, arguments, members };
+            let kind = TermItemKind::Instance { constraints, resolution, arguments, members };
             state.tree.term_items.insert(item_id, kind);
         }
 
@@ -551,7 +551,7 @@ fn lower_term_item(
                 state.resolve_term_reference(context, qualifier.as_deref(), &name)
             });
 
-            let kind = TermItemIr::Operator { associativity, precedence, resolution };
+            let kind = TermItemKind::Operator { associativity, precedence, resolution };
             state.tree.term_items.insert(item_id, kind);
         }
 
@@ -581,7 +581,7 @@ fn lower_term_item(
                 })
                 .collect();
 
-            let kind = TermItemIr::ValueGroup { signature, equations };
+            let kind = TermItemKind::Value { signature, equations };
             state.tree.term_items.insert(item_id, kind);
         }
     }
@@ -606,7 +606,7 @@ fn lower_type_item(
 
             state.end_kind();
 
-            let data = equation.and_then(|id| {
+            let declaration = equation.and_then(|id| {
                 let cst =
                     context.stabilized.ast_ptr(id).and_then(|cst| cst.try_to_node(context.root))?;
 
@@ -616,12 +616,12 @@ fn lower_type_item(
                     .map(|t| recursive::lower_type_variable_binding(state, context, &t, true))
                     .collect();
 
-                Some(DataIr { variables })
+                Some(DataDeclaration { variables })
             });
 
             let roles = role.map(|id| lower_roles(context, id)).unwrap_or_default();
 
-            let kind = TypeItemIr::DataGroup { signature, data, roles };
+            let kind = TypeItemKind::Data { signature, declaration, roles };
             state.tree.type_items.insert(item_id, kind);
 
             lower_constructors(state, context, item_id);
@@ -639,7 +639,7 @@ fn lower_type_item(
 
             state.end_kind();
 
-            let newtype = equation.and_then(|id| {
+            let declaration = equation.and_then(|id| {
                 let cst =
                     context.stabilized.ast_ptr(id).and_then(|cst| cst.try_to_node(context.root))?;
 
@@ -649,12 +649,12 @@ fn lower_type_item(
                     .map(|t| recursive::lower_type_variable_binding(state, context, &t, true))
                     .collect();
 
-                Some(NewtypeIr { variables })
+                Some(NewtypeDeclaration { variables })
             });
 
             let roles = role.map(|id| lower_roles(context, id)).unwrap_or_default();
 
-            let kind = TypeItemIr::NewtypeGroup { signature, newtype, roles };
+            let kind = TypeItemKind::Newtype { signature, declaration, roles };
             state.tree.type_items.insert(item_id, kind);
 
             lower_constructors(state, context, item_id);
@@ -674,7 +674,7 @@ fn lower_type_item(
 
             state.begin_synonym(item_id);
 
-            let synonym = equation.and_then(|id| {
+            let declaration = equation.and_then(|id| {
                 let cst =
                     context.stabilized.ast_ptr(id).and_then(|cst| cst.try_to_node(context.root))?;
 
@@ -684,14 +684,14 @@ fn lower_type_item(
                     .map(|cst| recursive::lower_type_variable_binding(state, context, &cst, false))
                     .collect();
 
-                let synonym = cst.type_().map(|cst| recursive::lower_type(state, context, &cst));
+                let type_ = cst.type_().map(|cst| recursive::lower_type(state, context, &cst));
 
-                Some(SynonymIr { variables, synonym })
+                Some(TypeSynonymDeclaration { variables, type_ })
             });
 
             state.end_synonym();
 
-            let kind = TypeItemIr::SynonymGroup { signature, synonym };
+            let kind = TypeItemKind::Synonym { signature, declaration };
             state.tree.type_items.insert(item_id, kind);
         }
 
@@ -707,7 +707,7 @@ fn lower_type_item(
 
             state.end_kind();
 
-            let class = declaration.and_then(|id| {
+            let declaration = declaration.and_then(|id| {
                 let cst =
                     context.stabilized.ast_ptr(id).and_then(|cst| cst.try_to_node(context.root))?;
 
@@ -741,10 +741,10 @@ fn lower_type_item(
                         .collect()
                 };
 
-                Some(ClassIr { constraints, variables, functional_dependencies })
+                Some(ClassDeclaration { constraints, variables, functional_dependencies })
             });
 
-            let kind = TypeItemIr::ClassGroup { signature, class };
+            let kind = TypeItemKind::Class { signature, declaration };
             state.tree.type_items.insert(item_id, kind);
 
             lower_class_members(state, context, item_id);
@@ -764,7 +764,7 @@ fn lower_type_item(
 
             let roles = role.map(|id| lower_roles(context, id)).unwrap_or_default();
 
-            let kind = TypeItemIr::Foreign { signature, roles };
+            let kind = TypeItemKind::Foreign { signature, roles };
             state.tree.type_items.insert(item_id, kind);
         }
 
@@ -797,7 +797,7 @@ fn lower_type_item(
 
             state.end_kind();
 
-            let kind = TypeItemIr::Operator { associativity, precedence, resolution };
+            let kind = TypeItemKind::Operator { associativity, precedence, resolution };
             state.tree.type_items.insert(item_id, kind);
         }
     }
@@ -817,7 +817,7 @@ fn lower_constructors(state: &mut State, context: &Context, id: TypeItemId) {
 
         let arguments = cst.children().map(|t| recursive::lower_type(state, context, &t)).collect();
 
-        let kind = TermItemIr::Constructor { arguments };
+        let kind = TermItemKind::Constructor { arguments };
         state.tree.term_items.insert(item_id, kind);
     }
 }
@@ -836,7 +836,7 @@ fn lower_class_members(state: &mut State, context: &Context, id: TypeItemId) {
 
         let signature = cst.type_().map(|t| recursive::lower_type(state, context, &t));
 
-        let kind = TermItemIr::ClassMember { signature };
+        let kind = TermItemKind::ClassMember { signature };
         state.tree.term_items.insert(item_id, kind);
     }
 }

--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -84,7 +84,7 @@ fn child_token(node: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
 pub(crate) fn lower_binder(state: &mut State, context: &Context, cst: &cst::Binder) -> BinderId {
     let id = context.stabilized.lookup_cst(cst).expect_id();
     let kind = lower_binder_kind(state, context, cst, id);
-    state.associate_binder_info(id, kind);
+    state.associate_binder_kind(id, kind);
     id
 }
 
@@ -211,7 +211,7 @@ pub(crate) fn lower_expression(
 ) -> ExpressionId {
     let id = context.stabilized.lookup_cst(cst).expect_id();
     let kind = lower_expression_kind(state, context, cst);
-    state.associate_expression_info(id, kind);
+    state.associate_expression_kind(id, kind);
     id
 }
 
@@ -789,7 +789,7 @@ fn lower_equation_chunk(
     for &id in &groups {
         state.current_let_binding = Some(id);
 
-        let let_binding = &state.info.let_binding[id];
+        let let_binding = &state.tree.let_binding_groups[id];
         let signature = let_binding.signature;
         let equations = Arc::clone(&let_binding.equations);
 
@@ -959,7 +959,7 @@ fn lower_record_updates(
 pub(crate) fn lower_type(state: &mut State, context: &Context, cst: &cst::Type) -> TypeId {
     let id = context.stabilized.lookup_cst(cst).expect_id();
     let kind = lower_type_kind(state, context, cst, id);
-    state.associate_type_info(id, kind);
+    state.associate_type_kind(id, kind);
     id
 }
 
@@ -1143,7 +1143,7 @@ pub(crate) fn lower_forall(state: &mut State, context: &Context, cst: &cst::Type
             .collect();
         let inner = f.type_().map(|cst| lower_forall(state, context, &cst));
         let kind = TypeKind::Forall { bindings, inner };
-        state.associate_type_info(id, kind);
+        state.associate_type_kind(id, kind);
         id
     } else {
         lower_type(state, context, cst)
@@ -1168,7 +1168,7 @@ fn lower_term_operator(
         return None;
     };
 
-    state.info.term_operator.insert(id, (file_id, term_id));
+    state.tree.term_operators.insert(id, (file_id, term_id));
 
     Some(id)
 }
@@ -1191,7 +1191,7 @@ fn lower_type_operator(
         return None;
     };
 
-    state.info.type_operator.insert(id, (file_id, type_id));
+    state.tree.type_operators.insert(id, (file_id, type_id));
 
     Some(id)
 }

--- a/compiler-core/lowering/src/intermediate.rs
+++ b/compiler-core/lowering/src/intermediate.rs
@@ -229,7 +229,7 @@ pub struct WhereExpression {
 
 /// Group of IDs for a let-bound name
 ///
-/// This mirrors the [`indexing::TermItemKind::Value`] pattern for top-level
+/// This mirrors the [`indexing::IndexedTermItemKind::Value`] pattern for top-level
 /// value declarations, where the declaration group is assigned a stable ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LetBindingNameGroup {

--- a/compiler-core/lowering/src/lib.rs
+++ b/compiler-core/lowering/src/lib.rs
@@ -28,7 +28,7 @@ use syntax::cst;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct LoweredModule {
-    pub info: LoweringInfo,
+    pub tree: LoweredTree,
     pub graph: LoweringGraph,
     pub nodes: LoweringGraphNodes,
     pub term_edges: FxHashSet<(TermItemId, TermItemId)>,
@@ -78,7 +78,7 @@ pub fn lower_module(
     resolved: &ResolvedModule,
 ) -> LoweredModule {
     let algorithm::State {
-        info,
+        tree,
         graph,
         nodes,
         term_edges,
@@ -89,7 +89,7 @@ pub fn lower_module(
         ..
     } = algorithm::lower_module(file_id, source, module, prim, stabilized, indexed, resolved);
 
-    LoweredModule { info, graph, nodes, term_edges, type_edges, kind_edges, synonym_edges, errors }
+    LoweredModule { tree, graph, nodes, term_edges, type_edges, kind_edges, synonym_edges, errors }
 }
 
 pub fn group_module(indexed: &IndexedModule, lowered: &LoweredModule) -> GroupedModule {

--- a/compiler-core/lowering/src/lib.rs
+++ b/compiler-core/lowering/src/lib.rs
@@ -4,18 +4,18 @@ mod recover;
 mod algorithm;
 
 pub mod error;
-pub mod intermediate;
 pub mod scope;
 pub mod source;
+pub mod tree;
 
 use std::hash::Hash;
 use std::slice;
 use std::sync::Arc;
 
 pub use error::*;
-pub use intermediate::*;
 pub use scope::*;
 pub use source::*;
+pub use tree::*;
 
 use files::FileId;
 use indexing::{IndexedModule, TermItemId, TypeItemId};

--- a/compiler-core/lowering/src/scope.rs
+++ b/compiler-core/lowering/src/scope.rs
@@ -4,11 +4,11 @@
 //! a novel take on name resolution which allow resolution semantics to be
 //! represented independent of the language using graphs and graph traversals.
 //!
-//! The scope graph is built during lowering from the CST to the intermediate
-//! representation. Local name resolution is also performed eagerly, which
-//! enriches the IR with resolution information that simplifies associating
-//! information to resolved nodes. For instance, knowing the type of a variable
-//! can be as easy as obtaining the type of a [`BinderId`].
+//! The scope graph is built while constructing the lowered source tree from the
+//! CST. Local name resolution is performed eagerly and attached to that tree,
+//! which simplifies associating information with resolved nodes. For instance,
+//! knowing the type of a variable can be as easy as obtaining the type of a
+//! [`BinderId`].
 //!
 //! [scope graph]: https://pl.ewi.tudelft.nl/research/projects/scope-graphs/
 use std::collections::VecDeque;
@@ -21,8 +21,8 @@ use la_arena::{Arena, Idx, RawIdx};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use smol_str::SmolStr;
 
-use crate::intermediate::LetBindingNameGroupId;
 use crate::source::*;
+use crate::tree::LetBindingNameGroupId;
 
 /// The result of resolving a term variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -1,4 +1,8 @@
-//! Types of intermediate representations.
+//! The lowered source tree, keyed by stable IDs derived from the CST.
+//!
+//! Lowering attaches semantic shape and name resolution while preserving missing or
+//! malformed children with [`Option`]. The later `checking::tree` arena tree contains
+//! checked and elaborated nodes.
 use std::sync::Arc;
 
 use files::FileId;

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -327,6 +327,7 @@ pub enum Associativity {
     Right,
 }
 
+/// The lowered semantic contents associated with an indexed term item.
 #[derive(Debug, PartialEq, Eq)]
 pub enum TermItemKind {
     ClassMember {
@@ -392,6 +393,7 @@ pub struct ClassDeclaration {
     pub functional_dependencies: Arc<[FunctionalDependency]>,
 }
 
+/// The lowered semantic contents associated with an indexed type item.
 #[derive(Debug, PartialEq, Eq)]
 pub enum TypeItemKind {
     Data {
@@ -429,6 +431,11 @@ pub enum Domain {
     Type,
 }
 
+/// Semantic structure and resolutions attached to stable source identities.
+///
+/// Unlike the arena-owned nodes in `checking::tree`, these maps retain the IDs
+/// established from concrete syntax so editor queries can relate semantics back
+/// to source nodes directly.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct LoweredTree {
     pub(crate) binders: FxHashMap<BinderId, BinderKind>,

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -246,7 +246,7 @@ pub type LetBindingNameGroupId = Idx<LetBindingNameGroup>;
 
 /// Core representation of the let-bound name
 ///
-/// This is stored in [`LoweringInfo`] and can be obtained from the stable
+/// This is stored in [`LoweredTree`] and can be obtained from the stable
 /// ID for any given let-bound name group [`LetBindingNameGroupId`].
 #[derive(Debug, PartialEq, Eq)]
 pub struct LetBindingName {
@@ -430,86 +430,86 @@ pub enum Domain {
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct LoweringInfo {
-    pub(crate) binder_kind: FxHashMap<BinderId, BinderKind>,
-    pub(crate) expression_kind: FxHashMap<ExpressionId, ExpressionKind>,
-    pub(crate) type_kind: FxHashMap<TypeId, TypeKind>,
-    pub(crate) term_item: FxHashMap<TermItemId, TermItemIr>,
-    pub(crate) type_item: FxHashMap<TypeItemId, TypeItemIr>,
+pub struct LoweredTree {
+    pub(crate) binders: FxHashMap<BinderId, BinderKind>,
+    pub(crate) expressions: FxHashMap<ExpressionId, ExpressionKind>,
+    pub(crate) types: FxHashMap<TypeId, TypeKind>,
+    pub(crate) term_items: FxHashMap<TermItemId, TermItemIr>,
+    pub(crate) type_items: FxHashMap<TypeItemId, TypeItemIr>,
 
-    pub(crate) do_statement: FxHashMap<DoStatementId, DoStatement>,
-    pub(crate) let_binding: Arena<LetBindingNameGroup>,
-    pub(crate) let_binding_name: ArenaMap<LetBindingNameGroupId, LetBindingName>,
+    pub(crate) do_statements: FxHashMap<DoStatementId, DoStatement>,
+    pub(crate) let_binding_groups: Arena<LetBindingNameGroup>,
+    pub(crate) let_binding_names: ArenaMap<LetBindingNameGroupId, LetBindingName>,
 
-    pub(crate) term_operator: FxHashMap<TermOperatorId, (FileId, TermItemId)>,
-    pub(crate) type_operator: FxHashMap<TypeOperatorId, (FileId, TypeItemId)>,
-    pub(crate) expression_pun: FxHashMap<RecordPunId, TermVariableResolution>,
+    pub(crate) term_operators: FxHashMap<TermOperatorId, (FileId, TermItemId)>,
+    pub(crate) type_operators: FxHashMap<TypeOperatorId, (FileId, TypeItemId)>,
+    pub(crate) expression_puns: FxHashMap<RecordPunId, TermVariableResolution>,
 }
 
-impl LoweringInfo {
+impl LoweredTree {
     pub fn iter_binder(&self) -> impl Iterator<Item = (BinderId, &BinderKind)> {
-        self.binder_kind.iter().map(|(k, v)| (*k, v))
+        self.binders.iter().map(|(k, v)| (*k, v))
     }
 
     pub fn iter_expression(&self) -> impl Iterator<Item = (ExpressionId, &ExpressionKind)> {
-        self.expression_kind.iter().map(|(k, v)| (*k, v))
+        self.expressions.iter().map(|(k, v)| (*k, v))
     }
 
     pub fn iter_type(&self) -> impl Iterator<Item = (TypeId, &TypeKind)> {
-        self.type_kind.iter().map(|(k, v)| (*k, v))
+        self.types.iter().map(|(k, v)| (*k, v))
     }
 
     pub fn iter_do_statement(&self) -> impl Iterator<Item = (DoStatementId, &DoStatement)> {
-        self.do_statement.iter().map(|(k, v)| (*k, v))
+        self.do_statements.iter().map(|(k, v)| (*k, v))
     }
 
     pub fn iter_term_operator(&self) -> impl Iterator<Item = (TermOperatorId, FileId, TermItemId)> {
-        self.term_operator.iter().map(|(o_id, (f_id, t_id))| (*o_id, *f_id, *t_id))
+        self.term_operators.iter().map(|(o_id, (f_id, t_id))| (*o_id, *f_id, *t_id))
     }
 
     pub fn iter_type_operator(&self) -> impl Iterator<Item = (TypeOperatorId, FileId, TypeItemId)> {
-        self.type_operator.iter().map(|(o_id, (f_id, t_id))| (*o_id, *f_id, *t_id))
+        self.type_operators.iter().map(|(o_id, (f_id, t_id))| (*o_id, *f_id, *t_id))
     }
 
     pub fn iter_expression_pun(
         &self,
     ) -> impl Iterator<Item = (RecordPunId, TermVariableResolution)> {
-        self.expression_pun.iter().map(|(k, v)| (*k, *v))
+        self.expression_puns.iter().map(|(k, v)| (*k, *v))
     }
 
     pub fn get_binder_kind(&self, id: BinderId) -> Option<&BinderKind> {
-        self.binder_kind.get(&id)
+        self.binders.get(&id)
     }
 
     pub fn get_expression_kind(&self, id: ExpressionId) -> Option<&ExpressionKind> {
-        self.expression_kind.get(&id)
+        self.expressions.get(&id)
     }
 
     pub fn get_type_kind(&self, id: TypeId) -> Option<&TypeKind> {
-        self.type_kind.get(&id)
+        self.types.get(&id)
     }
 
     pub fn get_do_statement(&self, id: DoStatementId) -> Option<&DoStatement> {
-        self.do_statement.get(&id)
+        self.do_statements.get(&id)
     }
 
     pub fn get_term_item(&self, id: TermItemId) -> Option<&TermItemIr> {
-        self.term_item.get(&id)
+        self.term_items.get(&id)
     }
 
     pub fn get_type_item(&self, id: TypeItemId) -> Option<&TypeItemIr> {
-        self.type_item.get(&id)
+        self.type_items.get(&id)
     }
 
     pub fn get_let_binding_group(&self, id: LetBindingNameGroupId) -> &LetBindingNameGroup {
-        &self.let_binding[id]
+        &self.let_binding_groups[id]
     }
 
     pub fn let_binding_group_for_signature(
         &self,
         signature: crate::source::LetBindingSignatureId,
     ) -> Option<LetBindingNameGroupId> {
-        self.let_binding
+        self.let_binding_groups
             .iter()
             .find_map(|(id, group)| (group.signature == Some(signature)).then_some(id))
     }
@@ -518,32 +518,32 @@ impl LoweringInfo {
         &self,
         equation: crate::source::LetBindingEquationId,
     ) -> Option<LetBindingNameGroupId> {
-        self.let_binding
+        self.let_binding_groups
             .iter()
             .find_map(|(id, group)| group.equations.contains(&equation).then_some(id))
     }
 
     pub fn get_let_binding(&self, id: LetBindingNameGroupId) -> Option<&LetBindingName> {
-        self.let_binding_name.get(id)
+        self.let_binding_names.get(id)
     }
 
     pub fn get_term_operator(&self, id: TermOperatorId) -> Option<(FileId, TermItemId)> {
-        self.term_operator.get(&id).copied()
+        self.term_operators.get(&id).copied()
     }
 
     pub fn get_type_operator(&self, id: TypeOperatorId) -> Option<(FileId, TypeItemId)> {
-        self.type_operator.get(&id).copied()
+        self.type_operators.get(&id).copied()
     }
 
     pub fn get_expression_pun(&self, id: RecordPunId) -> Option<TermVariableResolution> {
-        self.expression_pun.get(&id).copied()
+        self.expression_puns.get(&id).copied()
     }
 
     pub fn find_let_binding_group_by_signature(
         &self,
         signature_id: LetBindingSignatureId,
     ) -> Option<LetBindingNameGroupId> {
-        self.let_binding.iter().find_map(|(let_binding_id, let_binding_group)| {
+        self.let_binding_groups.iter().find_map(|(let_binding_id, let_binding_group)| {
             let_binding_group
                 .signature
                 .is_some_and(|candidate_id| candidate_id == signature_id)
@@ -555,7 +555,7 @@ impl LoweringInfo {
         &self,
         equation_id: LetBindingEquationId,
     ) -> Option<LetBindingNameGroupId> {
-        self.let_binding.iter().find_map(|(let_binding_id, let_binding_group)| {
+        self.let_binding_groups.iter().find_map(|(let_binding_id, let_binding_group)| {
             let_binding_group.equations.contains(&equation_id).then_some(let_binding_id)
         })
     }

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -328,7 +328,7 @@ pub enum Associativity {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum TermItemIr {
+pub enum TermItemKind {
     ClassMember {
         signature: Option<TypeId>,
     },
@@ -355,7 +355,7 @@ pub enum TermItemIr {
         precedence: Option<u8>,
         resolution: Option<(FileId, TermItemId)>,
     },
-    ValueGroup {
+    Value {
         signature: Option<TypeId>,
         equations: Arc<[Equation]>,
     },
@@ -370,47 +370,47 @@ pub enum Role {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DataIr {
+pub struct DataDeclaration {
     pub variables: Arc<[TypeVariableBinding]>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct NewtypeIr {
+pub struct NewtypeDeclaration {
     pub variables: Arc<[TypeVariableBinding]>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SynonymIr {
+pub struct TypeSynonymDeclaration {
     pub variables: Arc<[TypeVariableBinding]>,
-    pub synonym: Option<TypeId>,
+    pub type_: Option<TypeId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ClassIr {
+pub struct ClassDeclaration {
     pub constraints: Arc<[TypeId]>,
     pub variables: Arc<[TypeVariableBinding]>,
     pub functional_dependencies: Arc<[FunctionalDependency]>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum TypeItemIr {
-    DataGroup {
+pub enum TypeItemKind {
+    Data {
         signature: Option<TypeId>,
-        data: Option<DataIr>,
+        declaration: Option<DataDeclaration>,
         roles: Arc<[Role]>,
     },
-    NewtypeGroup {
+    Newtype {
         signature: Option<TypeId>,
-        newtype: Option<NewtypeIr>,
+        declaration: Option<NewtypeDeclaration>,
         roles: Arc<[Role]>,
     },
-    SynonymGroup {
+    Synonym {
         signature: Option<TypeId>,
-        synonym: Option<SynonymIr>,
+        declaration: Option<TypeSynonymDeclaration>,
     },
-    ClassGroup {
+    Class {
         signature: Option<TypeId>,
-        class: Option<ClassIr>,
+        declaration: Option<ClassDeclaration>,
     },
     Foreign {
         signature: Option<TypeId>,
@@ -434,8 +434,8 @@ pub struct LoweredTree {
     pub(crate) binders: FxHashMap<BinderId, BinderKind>,
     pub(crate) expressions: FxHashMap<ExpressionId, ExpressionKind>,
     pub(crate) types: FxHashMap<TypeId, TypeKind>,
-    pub(crate) term_items: FxHashMap<TermItemId, TermItemIr>,
-    pub(crate) type_items: FxHashMap<TypeItemId, TypeItemIr>,
+    pub(crate) term_items: FxHashMap<TermItemId, TermItemKind>,
+    pub(crate) type_items: FxHashMap<TypeItemId, TypeItemKind>,
 
     pub(crate) do_statements: FxHashMap<DoStatementId, DoStatement>,
     pub(crate) let_binding_groups: Arena<LetBindingNameGroup>,
@@ -493,11 +493,11 @@ impl LoweredTree {
         self.do_statements.get(&id)
     }
 
-    pub fn get_term_item(&self, id: TermItemId) -> Option<&TermItemIr> {
+    pub fn get_term_item_kind(&self, id: TermItemId) -> Option<&TermItemKind> {
         self.term_items.get(&id)
     }
 
-    pub fn get_type_item(&self, id: TypeItemId) -> Option<&TypeItemIr> {
+    pub fn get_type_item_kind(&self, id: TypeItemId) -> Option<&TypeItemKind> {
         self.type_items.get(&id)
     }
 

--- a/compiler-core/resolving/src/algorithm.rs
+++ b/compiler-core/resolving/src/algorithm.rs
@@ -1,8 +1,8 @@
 use building_types::QueryResult;
 use files::FileId;
 use indexing::{
-    ExportKind, ImplicitItems, ImportItemId, ImportKind, IndexedImport, IndexedModule, TermItemId,
-    TermItemKind, TypeItemId, TypeItemKind,
+    ExportKind, ImplicitItems, ImportItemId, ImportKind, IndexedImport, IndexedModule,
+    IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
 };
 use smol_str::SmolStr;
 
@@ -242,7 +242,7 @@ fn resolve_exports(state: &mut State, indexed: &IndexedModule, file: FileId) {
 
 fn export_class_members(state: &mut State, indexed: &IndexedModule, file: FileId) {
     for (type_id, type_item) in indexed.items.iter_types() {
-        if !matches!(type_item.kind, TypeItemKind::Class { .. }) {
+        if !matches!(type_item.kind, IndexedTypeItemKind::Class { .. }) {
             continue;
         }
         for member_term_id in indexed.class_members(type_id) {
@@ -350,7 +350,10 @@ fn export_module_items(state: &mut State, indexed: &IndexedModule, file: FileId)
         let item = &indexed.items[id];
         // Instances cannot be referred to directly by their given name yet.
         // They're simply assumed to exist in a global context for coherence.
-        if matches!(item.kind, TermItemKind::Instance { .. } | TermItemKind::Derive { .. }) {
+        if matches!(
+            item.kind,
+            IndexedTermItemKind::Instance { .. } | IndexedTermItemKind::Derive { .. }
+        ) {
             return None;
         }
         Some((name, file, id))
@@ -362,7 +365,7 @@ fn export_module_items(state: &mut State, indexed: &IndexedModule, file: FileId)
     });
 
     let (local_class_items, local_type_items): (Vec<_>, Vec<_>) =
-        local_types.partition(|(_, _, _, kind)| matches!(kind, TypeItemKind::Class { .. }));
+        local_types.partition(|(_, _, _, kind)| matches!(kind, IndexedTypeItemKind::Class { .. }));
 
     let local_types = local_type_items.into_iter().map(|(name, file, id, _)| (name, file, id));
     let local_classes = local_class_items.into_iter().map(|(name, file, id, _)| (name, file, id));
@@ -373,7 +376,10 @@ fn export_module_items(state: &mut State, indexed: &IndexedModule, file: FileId)
 
     let exported_terms = indexed.names.terms.iter().filter_map(|(name, id)| {
         let item = &indexed.items[id];
-        if matches!(item.kind, TermItemKind::Instance { .. } | TermItemKind::Derive { .. }) {
+        if matches!(
+            item.kind,
+            IndexedTermItemKind::Instance { .. } | IndexedTermItemKind::Derive { .. }
+        ) {
             return None;
         }
         if matches!(indexed.kind, ExportKind::Explicit) && !item.exported {
@@ -390,8 +396,8 @@ fn export_module_items(state: &mut State, indexed: &IndexedModule, file: FileId)
         Some((name, file, id, ExportSource::Local, &item.kind))
     });
 
-    let (exported_class_items, exported_type_items): (Vec<_>, Vec<_>) =
-        exported_types.partition(|(_, _, _, _, kind)| matches!(kind, TypeItemKind::Class { .. }));
+    let (exported_class_items, exported_type_items): (Vec<_>, Vec<_>) = exported_types
+        .partition(|(_, _, _, _, kind)| matches!(kind, IndexedTypeItemKind::Class { .. }));
 
     let exported_types =
         exported_type_items.into_iter().map(|(name, file, id, source, _)| (name, file, id, source));

--- a/compiler-core/sugar/src/bracketing.rs
+++ b/compiler-core/sugar/src/bracketing.rs
@@ -27,7 +27,7 @@ use files::FileId;
 use indexing::{TermItemId, TypeItemId};
 use lowering::{
     Associativity, BinderId, BinderKind, ExpressionId, ExpressionKind, IsElement, LoweredModule,
-    OperatorPair, TermItemIr, TermOperatorId, TypeId, TypeItemIr, TypeKind, TypeOperatorId,
+    OperatorPair, TermItemKind, TermOperatorId, TypeId, TypeItemKind, TypeKind, TypeOperatorId,
 };
 use rustc_hash::FxHashMap;
 
@@ -50,8 +50,8 @@ impl ForOperatorId for TermOperatorId {
     }
 
     fn operator_info(lowered: &LoweredModule, id: Self::ItemId) -> Option<(Associativity, u8)> {
-        let Some(TermItemIr::Operator { associativity, precedence, .. }) =
-            lowered.tree.get_term_item(id)
+        let Some(TermItemKind::Operator { associativity, precedence, .. }) =
+            lowered.tree.get_term_item_kind(id)
         else {
             return None;
         };
@@ -67,8 +67,8 @@ impl ForOperatorId for TypeOperatorId {
     }
 
     fn operator_info(lowered: &LoweredModule, id: Self::ItemId) -> Option<(Associativity, u8)> {
-        let Some(TypeItemIr::Operator { associativity, precedence, .. }) =
-            lowered.tree.get_type_item(id)
+        let Some(TypeItemKind::Operator { associativity, precedence, .. }) =
+            lowered.tree.get_type_item_kind(id)
         else {
             return None;
         };

--- a/compiler-core/sugar/src/bracketing.rs
+++ b/compiler-core/sugar/src/bracketing.rs
@@ -46,12 +46,12 @@ impl ForOperatorId for TermOperatorId {
     type ItemId = TermItemId;
 
     fn resolve_operator(lowered: &LoweredModule, id: Self) -> Option<(FileId, Self::ItemId)> {
-        lowered.info.get_term_operator(id)
+        lowered.tree.get_term_operator(id)
     }
 
     fn operator_info(lowered: &LoweredModule, id: Self::ItemId) -> Option<(Associativity, u8)> {
         let Some(TermItemIr::Operator { associativity, precedence, .. }) =
-            lowered.info.get_term_item(id)
+            lowered.tree.get_term_item(id)
         else {
             return None;
         };
@@ -63,12 +63,12 @@ impl ForOperatorId for TypeOperatorId {
     type ItemId = TypeItemId;
 
     fn resolve_operator(lowered: &LoweredModule, id: Self) -> Option<(FileId, Self::ItemId)> {
-        lowered.info.get_type_operator(id)
+        lowered.tree.get_type_operator(id)
     }
 
     fn operator_info(lowered: &LoweredModule, id: Self::ItemId) -> Option<(Associativity, u8)> {
         let Some(TypeItemIr::Operator { associativity, precedence, .. }) =
-            lowered.info.get_type_item(id)
+            lowered.tree.get_type_item(id)
         else {
             return None;
         };
@@ -238,21 +238,21 @@ pub fn bracketed(
     lowered: &LoweredModule,
 ) -> QueryResult<Bracketed> {
     let mut binders = FxHashMap::default();
-    for (id, kind) in lowered.info.iter_binder() {
+    for (id, kind) in lowered.tree.iter_binder() {
         if let BinderKind::OperatorChain { head, tail } = kind {
             binders.insert(id, bracket(queries, lowered, *head, tail));
         }
     }
 
     let mut expressions = FxHashMap::default();
-    for (id, kind) in lowered.info.iter_expression() {
+    for (id, kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::OperatorChain { head, tail } = kind {
             expressions.insert(id, bracket(queries, lowered, *head, tail));
         }
     }
 
     let mut types = FxHashMap::default();
-    for (id, kind) in lowered.info.iter_type() {
+    for (id, kind) in lowered.tree.iter_type() {
         if let TypeKind::OperatorChain { head, tail } = kind {
             types.insert(id, bracket(queries, lowered, *head, tail));
         }

--- a/compiler-core/sugar/src/sections.rs
+++ b/compiler-core/sugar/src/sections.rs
@@ -42,11 +42,11 @@ pub type SectionResult = Vec<ExpressionId>;
 pub fn sectioned(lowered: &LoweredModule) -> Sectioned {
     let mut expressions = FxHashMap::default();
 
-    for (id, kind) in lowered.info.iter_expression() {
+    for (id, kind) in lowered.tree.iter_expression() {
         let mut sections = vec![];
 
         visit_sections(kind, |child_id| {
-            if let Some(ExpressionKind::Section) = lowered.info.get_expression_kind(child_id) {
+            if let Some(ExpressionKind::Section) = lowered.tree.get_expression_kind(child_id) {
                 sections.push(child_id);
             }
         });

--- a/compiler-lsp/analyzer/src/completion/edit.rs
+++ b/compiler-lsp/analyzer/src/completion/edit.rs
@@ -2,7 +2,9 @@ use std::iter;
 
 use building_types::QueryProxy;
 use files::FileId;
-use indexing::{ImportKind, IndexedModule, TermItemId, TermItemKind, TypeItemId, TypeItemKind};
+use indexing::{
+    ImportKind, IndexedModule, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+};
 use itertools::Itertools;
 use lsp_types::Range;
 use resolving::ResolvedImport;
@@ -145,7 +147,7 @@ fn term_import_name(
     term_id: TermItemId,
 ) -> Option<String> {
     let term_item = &import_indexed.items[term_id];
-    if matches!(term_item.kind, TermItemKind::Constructor { .. }) {
+    if matches!(term_item.kind, IndexedTermItemKind::Constructor { .. }) {
         let type_id = import_indexed
             .constructor_type(term_id)
             .expect("invariant violated: floating data constructor");
@@ -155,7 +157,7 @@ fn term_import_name(
             return None;
         };
         Some(format!("{type_name}(..)"))
-    } else if matches!(term_item.kind, TermItemKind::Operator { .. }) {
+    } else if matches!(term_item.kind, IndexedTermItemKind::Operator { .. }) {
         Some(format!("({term_name})"))
     } else {
         Some(term_name.to_string())
@@ -168,9 +170,9 @@ fn type_import_name(
     type_id: TypeItemId,
 ) -> Option<String> {
     let type_item = &import_indexed.items[type_id];
-    if matches!(type_item.kind, TypeItemKind::Class { .. }) {
+    if matches!(type_item.kind, IndexedTypeItemKind::Class { .. }) {
         Some(format!("class {type_name}"))
-    } else if matches!(type_item.kind, TypeItemKind::Operator { .. }) {
+    } else if matches!(type_item.kind, IndexedTypeItemKind::Operator { .. }) {
         Some(format!("type ({type_name})"))
     } else {
         Some(type_name.to_string())

--- a/compiler-lsp/analyzer/src/completion/prelude.rs
+++ b/compiler-lsp/analyzer/src/completion/prelude.rs
@@ -138,12 +138,12 @@ impl<Host: crate::AnalyzerHost> CompletionContext<'_, '_, Host> {
                 cst::LetBinding::LetBindingSignature(signature) => {
                     let ptr = AstPtr::new(&signature);
                     let id = self.stabilized.lookup_ptr(&ptr)?;
-                    lowered.info.find_let_binding_group_by_signature(id)
+                    lowered.tree.find_let_binding_group_by_signature(id)
                 }
                 cst::LetBinding::LetBindingEquation(equation) => {
                     let ptr = AstPtr::new(&equation);
                     let id = self.stabilized.lookup_ptr(&ptr)?;
-                    lowered.info.find_let_binding_group_by_equation(id)
+                    lowered.tree.find_let_binding_group_by_equation(id)
                 }
             }?;
 

--- a/compiler-lsp/analyzer/src/completion/resolve.rs
+++ b/compiler-lsp/analyzer/src/completion/resolve.rs
@@ -166,7 +166,7 @@ fn resolve_binder(
     mut item: CompletionItem,
 ) -> CompletionItem {
     if let Some(signature) = render_local_signature(engine, file_id, &item.label, |checked| {
-        checked.nodes.lookup_binder(binder_id)
+        checked.node_types.lookup_binder(binder_id)
     }) {
         item.detail = Some(signature);
     }
@@ -181,7 +181,7 @@ fn resolve_let(
     mut item: CompletionItem,
 ) -> CompletionItem {
     if let Some(signature) = render_local_signature(engine, file_id, &item.label, |checked| {
-        checked.nodes.lookup_let(let_id)
+        checked.node_types.lookup_let(let_id)
     }) {
         item.detail = Some(signature);
     }
@@ -196,7 +196,7 @@ fn resolve_record_pun(
     mut item: CompletionItem,
 ) -> CompletionItem {
     if let Some(signature) = render_local_signature(engine, file_id, &item.label, |checked| {
-        checked.nodes.lookup_pun(pun_id)
+        checked.node_types.lookup_pun(pun_id)
     }) {
         item.detail = Some(signature);
     }
@@ -211,7 +211,7 @@ fn resolve_forall_type_variable(
     mut item: CompletionItem,
 ) -> CompletionItem {
     if let Some(signature) = render_local_signature(engine, file_id, &item.label, |checked| {
-        checked.nodes.lookup_forall_binding(binding_id)
+        checked.node_types.lookup_forall_binding(binding_id)
     }) {
         item.detail = Some(signature);
     }
@@ -227,7 +227,7 @@ fn resolve_implicit_type_variable(
     mut item: CompletionItem,
 ) -> CompletionItem {
     if let Some(signature) = render_local_signature(engine, file_id, &item.label, |checked| {
-        checked.nodes.lookup_implicit_binding(node_id, binding_id)
+        checked.node_types.lookup_implicit_binding(node_id, binding_id)
     }) {
         item.detail = Some(signature);
     }

--- a/compiler-lsp/analyzer/src/completion/resolve.rs
+++ b/compiler-lsp/analyzer/src/completion/resolve.rs
@@ -113,7 +113,7 @@ fn render_term_signature(
 
     let name = &indexed.items[term_id].name;
     let name = name.as_deref()?;
-    let signature = checked.lookup_term(term_id)?;
+    let signature = checked.lookup_term_item_type(term_id)?;
 
     let pretty = Pretty::with_config(engine, &checked, PRETTY_CONFIG);
     Some(pretty.render_signature(name, signature).to_string())
@@ -153,7 +153,7 @@ fn render_type_signature(
 
     let name = &indexed.items[type_id].name;
     let name = name.as_deref()?;
-    let signature = checked.lookup_type(type_id)?;
+    let signature = checked.lookup_type_item_kind(type_id)?;
 
     let pretty = Pretty::with_config(engine, &checked, PRETTY_CONFIG);
     Some(pretty.render_signature(name, signature).to_string())

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -48,13 +48,13 @@ pub fn implementation(
         locate::Located::TermOperator(operator_id) => {
             let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
-                lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_term(context, f_id, t_id)
         }
         locate::Located::TypeOperator(operator_id) => {
             let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
-                lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_type(context, f_id, t_id)
         }
         locate::Located::TermItem(term_id) => definition_file_term(context, current_file, term_id),
@@ -190,7 +190,7 @@ fn definition_binder(
     binder_id: BinderId,
 ) -> Result<Option<GotoDefinitionResponse>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         BinderKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -213,7 +213,7 @@ fn definition_expression(
     let stabilized = engine.stabilized(current_file)?;
     let lowered = engine.lowered(current_file)?;
 
-    let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
         ExpressionKind::Constructor { resolution, .. } => {
@@ -239,7 +239,7 @@ fn definition_expression(
                 TermVariableResolution::Let(binding_id) => {
                     let root = parsed.syntax_node();
 
-                    let binding = lowered.info.get_let_binding_group(*binding_id);
+                    let binding = lowered.tree.get_let_binding_group(*binding_id);
 
                     let signature = binding
                         .signature
@@ -320,7 +320,7 @@ fn definition_type(
     let stabilized = engine.stabilized(current_file)?;
     let lowered = engine.lowered(current_file)?;
 
-    let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         TypeKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -390,7 +390,7 @@ fn definition_let_binding(
     let root = parsed.syntax_node();
 
     let uri = common::file_uri(context, file_id)?;
-    let group = lowered.info.get_let_binding_group(let_id);
+    let group = lowered.tree.get_let_binding_group(let_id);
 
     let signature = group.signature.and_then(|signature| stabilized.syntax_ptr(signature));
     let equations = group.equations.iter().filter_map(|&equation| stabilized.syntax_ptr(equation));

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -194,7 +194,7 @@ fn highlight_binder(
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
 
-    let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
 
     if let BinderKind::Constructor { resolution: Some((file_id, term_id)), .. } = kind {
         return highlight_file_term(context, current_file, *file_id, *term_id);
@@ -211,7 +211,7 @@ fn highlight_binder(
             .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
     );
 
-    for (expr_id, expr_kind) in lowered.info.iter_expression() {
+    for (expr_id, expr_kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::Variable {
             resolution: Some(TermVariableResolution::Binder(id)), ..
         } = expr_kind
@@ -223,7 +223,7 @@ fn highlight_binder(
         }
     }
 
-    for (pun_id, resolution) in lowered.info.iter_expression_pun() {
+    for (pun_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::Binder(id) = resolution
             && id == binder_id
         {
@@ -242,7 +242,7 @@ fn highlight_expression(
     expression_id: ExpressionId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
         ExpressionKind::Constructor { resolution: Some((file_id, term_id)) }
@@ -273,7 +273,7 @@ fn highlight_type(
     type_id: TypeId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
         TypeKind::Constructor { resolution: Some((file_id, type_id)) }
@@ -300,7 +300,7 @@ fn highlight_file_term(
 
     let mut highlights = vec![];
 
-    for (expression_id, expression_kind) in lowered.info.iter_expression() {
+    for (expression_id, expression_kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::Constructor { resolution: Some((f_id, t_id)) }
         | ExpressionKind::OperatorName { resolution: Some((f_id, t_id)) }
         | ExpressionKind::Variable {
@@ -317,7 +317,7 @@ fn highlight_file_term(
         }
     }
 
-    for (binder_id, binder_kind) in lowered.info.iter_binder() {
+    for (binder_id, binder_kind) in lowered.tree.iter_binder() {
         if let BinderKind::Constructor { resolution: Some((f_id, t_id)), .. } = binder_kind
             && (*f_id, *t_id) == (file_id, term_id)
         {
@@ -329,7 +329,7 @@ fn highlight_file_term(
         }
     }
 
-    for (operator_id, f_id, t_id) in lowered.info.iter_term_operator() {
+    for (operator_id, f_id, t_id) in lowered.tree.iter_term_operator() {
         if (f_id, t_id) == (file_id, term_id) {
             highlights.extend(
                 locate::id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
@@ -339,7 +339,7 @@ fn highlight_file_term(
         }
     }
 
-    for (pun_id, resolution) in lowered.info.iter_expression_pun() {
+    for (pun_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::Reference(f_id, t_id) = resolution
             && (f_id, t_id) == (file_id, term_id)
         {
@@ -395,7 +395,7 @@ fn highlight_file_type(
 
     let mut highlights = vec![];
 
-    for (ty_id, ty_kind) in lowered.info.iter_type() {
+    for (ty_id, ty_kind) in lowered.tree.iter_type() {
         if let TypeKind::Constructor { resolution: Some((f_id, t_id)) }
         | TypeKind::Operator { resolution: Some((f_id, t_id)) } = ty_kind
             && (*f_id, *t_id) == (file_id, type_id)
@@ -406,7 +406,7 @@ fn highlight_file_type(
         }
     }
 
-    for (operator_id, f_id, t_id) in lowered.info.iter_type_operator() {
+    for (operator_id, f_id, t_id) in lowered.tree.iter_type_operator() {
         if (f_id, t_id) == (file_id, type_id) {
             highlights.extend(
                 locate::id_range(&content, &parsed, &stabilized, operator_id).and_then(|range| {
@@ -450,7 +450,7 @@ fn highlight_term_operator(
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
     let (file_id, term_id) =
-        lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+        lowered.tree.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
     highlight_file_term(context, current_file, file_id, term_id)
 }
 
@@ -461,7 +461,7 @@ fn highlight_type_operator(
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
     let (file_id, type_id) =
-        lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+        lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
     highlight_file_type(context, current_file, file_id, type_id)
 }
 
@@ -476,7 +476,7 @@ fn highlight_let(
     let lowered = context.queries().lowered(current_file)?;
 
     let root = parsed.syntax_node();
-    let binding = lowered.info.get_let_binding_group(let_binding_id);
+    let binding = lowered.tree.get_let_binding_group(let_binding_id);
 
     let mut highlights: Vec<DocumentHighlight> = vec![];
 
@@ -498,7 +498,7 @@ fn highlight_let(
         );
     }
 
-    for (expr_id, expr_kind) in lowered.info.iter_expression() {
+    for (expr_id, expr_kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::Variable {
             resolution: Some(TermVariableResolution::Let(id)), ..
         } = expr_kind
@@ -510,7 +510,7 @@ fn highlight_let(
         }
     }
 
-    for (pun_id, resolution) in lowered.info.iter_expression_pun() {
+    for (pun_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::Let(id) = resolution
             && id == let_binding_id
         {
@@ -540,7 +540,7 @@ fn highlight_binder_pun(
             .and_then(|range| document_highlight(&content, context.position_encoding(), range)),
     );
 
-    for (expression_id, expression_kind) in lowered.info.iter_expression() {
+    for (expression_id, expression_kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::Variable {
             resolution: Some(TermVariableResolution::RecordPun(candidate_id)),
         } = expression_kind
@@ -554,7 +554,7 @@ fn highlight_binder_pun(
         }
     }
 
-    for (expression_pun_id, resolution) in lowered.info.iter_expression_pun() {
+    for (expression_pun_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::RecordPun(candidate_id) = resolution
             && candidate_id == pun_id
         {
@@ -575,7 +575,7 @@ fn highlight_expression_pun(
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<DocumentHighlight>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    match lowered.info.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)? {
+    match lowered.tree.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)? {
         TermVariableResolution::Binder(binder_id) => {
             highlight_binder(context, current_file, binder_id)
         }

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -2,7 +2,9 @@ use std::iter;
 
 use building_types::QueryProxy;
 use files::FileId;
-use indexing::{ImportItemId, ImportKind, TermItemId, TermItemKind, TypeItemId, TypeItemKind};
+use indexing::{
+    ImportItemId, ImportKind, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+};
 use lowering::{
     BinderId, BinderKind, ExpressionId, ExpressionKind, LetBindingNameGroupId, RecordPunId,
     TermOperatorId, TermVariableResolution, TypeId, TypeKind, TypeOperatorId,
@@ -613,25 +615,25 @@ fn term_item_highlights(
     }
 
     match &indexed.items[term_id].kind {
-        TermItemKind::ClassMember { id } => {
+        IndexedTermItemKind::ClassMember { id } => {
             push_name_highlights!(position::class_member_name_range; Some(*id));
         }
-        TermItemKind::Constructor { id } => {
+        IndexedTermItemKind::Constructor { id } => {
             push_name_highlights!(position::data_constructor_name_range; Some(*id));
         }
-        TermItemKind::Derive { id } => {
+        IndexedTermItemKind::Derive { id } => {
             push_name_highlights!(position::declaration_name_range; Some(*id));
         }
-        TermItemKind::Foreign { id } => {
+        IndexedTermItemKind::Foreign { id } => {
             push_name_highlights!(position::declaration_name_range; Some(*id));
         }
-        TermItemKind::Instance { id } => {
+        IndexedTermItemKind::Instance { id } => {
             push_name_highlights!(position::instance_declaration_name_range; Some(*id));
         }
-        TermItemKind::Operator { id } => {
+        IndexedTermItemKind::Operator { id } => {
             push_name_highlights!(position::infix_operator_range; Some(*id));
         }
-        TermItemKind::Value { signature, equations } => {
+        IndexedTermItemKind::Value { signature, equations } => {
             push_name_highlights!(position::declaration_name_range; *signature);
 
             for &equation in equations {
@@ -667,22 +669,22 @@ fn type_item_highlights(
     }
 
     match indexed.items[type_id].kind {
-        TypeItemKind::Data { signature, equation, role, .. } => {
+        IndexedTypeItemKind::Data { signature, equation, role, .. } => {
             push_name_highlights!(position::declaration_name_range; signature, equation, role);
         }
-        TypeItemKind::Newtype { signature, equation, role, .. } => {
+        IndexedTypeItemKind::Newtype { signature, equation, role, .. } => {
             push_name_highlights!(position::declaration_name_range; signature, equation, role);
         }
-        TypeItemKind::Synonym { signature, equation } => {
+        IndexedTypeItemKind::Synonym { signature, equation } => {
             push_name_highlights!(position::declaration_name_range; signature, equation);
         }
-        TypeItemKind::Class { signature, declaration, .. } => {
+        IndexedTypeItemKind::Class { signature, declaration, .. } => {
             push_name_highlights!(position::declaration_name_range; signature, declaration);
         }
-        TypeItemKind::Foreign { id, role } => {
+        IndexedTypeItemKind::Foreign { id, role } => {
             push_name_highlights!(position::declaration_name_range; Some(id), role);
         }
-        TypeItemKind::Operator { id } => {
+        IndexedTypeItemKind::Operator { id } => {
             push_name_highlights!(position::infix_operator_range; Some(id));
         }
     }

--- a/compiler-lsp/analyzer/src/extract.rs
+++ b/compiler-lsp/analyzer/src/extract.rs
@@ -1,5 +1,5 @@
 use files::FileId;
-use indexing::{TermItemId, TermItemKind, TypeItemId, TypeItemKind};
+use indexing::{IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId};
 use stabilizing::{AstId, StabilizedModule};
 use syntax::ast::AstNode;
 use syntax::{SyntaxKind, SyntaxNode, SyntaxNodePtr, TextRange};
@@ -111,25 +111,25 @@ impl AnnotationSyntaxRange {
         let item = &indexed.items[term_id];
 
         let range = match &item.kind {
-            TermItemKind::ClassMember { id } => {
+            IndexedTermItemKind::ClassMember { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TermItemKind::Constructor { id } => {
+            IndexedTermItemKind::Constructor { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TermItemKind::Derive { id } => {
+            IndexedTermItemKind::Derive { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TermItemKind::Foreign { id } => {
+            IndexedTermItemKind::Foreign { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TermItemKind::Instance { id } => {
+            IndexedTermItemKind::Instance { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TermItemKind::Operator { id } => {
+            IndexedTermItemKind::Operator { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TermItemKind::Value { signature, equations } => {
+            IndexedTermItemKind::Value { signature, equations } => {
                 let equation = equations.first().copied();
                 signature_equation_range(&stabilized, &root, signature, &equation)
             }
@@ -151,22 +151,22 @@ impl AnnotationSyntaxRange {
         let item = &indexed.items[type_id];
 
         let range = match &item.kind {
-            TypeItemKind::Data { signature, equation, .. } => {
+            IndexedTypeItemKind::Data { signature, equation, .. } => {
                 signature_equation_range(&stabilized, &root, signature, equation)
             }
-            TypeItemKind::Newtype { signature, equation, .. } => {
+            IndexedTypeItemKind::Newtype { signature, equation, .. } => {
                 signature_equation_range(&stabilized, &root, signature, equation)
             }
-            TypeItemKind::Synonym { signature, equation, .. } => {
+            IndexedTypeItemKind::Synonym { signature, equation, .. } => {
                 signature_equation_range(&stabilized, &root, signature, equation)
             }
-            TypeItemKind::Class { signature, declaration, .. } => {
+            IndexedTypeItemKind::Class { signature, declaration, .. } => {
                 signature_equation_range(&stabilized, &root, signature, declaration)
             }
-            TypeItemKind::Foreign { id, .. } => {
+            IndexedTypeItemKind::Foreign { id, .. } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
-            TypeItemKind::Operator { id } => {
+            IndexedTypeItemKind::Operator { id } => {
                 signature_equation_range(&stabilized, &root, &Some(*id), &Some(*id))
             }
         };

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -47,13 +47,13 @@ pub fn implementation(
         locate::Located::TermOperator(operator_id) => {
             let lowered = engine.lowered(current_file)?;
             let (f_id, t_id) =
-                lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             hover_file_term(engine, f_id, t_id)
         }
         locate::Located::TypeOperator(operator_id) => {
             let lowered = engine.lowered(current_file)?;
             let (f_id, t_id) =
-                lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             hover_file_type(engine, f_id, t_id)
         }
         locate::Located::TermItem(term_id) => hover_file_term(engine, current_file, term_id),
@@ -180,7 +180,7 @@ fn hover_binder(
     binder_id: lowering::BinderId,
 ) -> Result<Option<Hover>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
-    let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         BinderKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -203,7 +203,7 @@ fn hover_expression(
     expression_id: lowering::ExpressionId,
 ) -> Result<Option<Hover>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
-    let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
         ExpressionKind::Constructor { resolution, .. } => {
@@ -261,7 +261,7 @@ fn hover_type(
     type_id: lowering::TypeId,
 ) -> Result<Option<Hover>, AnalyzerError> {
     let lowered = engine.lowered(current_file)?;
-    let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
 
     match kind {
         TypeKind::Constructor { resolution, .. } => {

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -189,7 +189,7 @@ fn hover_binder(
         _ => {
             let checked = engine.checked(current_file)?;
 
-            let binder_type = checked.nodes.lookup_binder(binder_id);
+            let binder_type = checked.node_types.lookup_binder(binder_id);
             let binder_type = binder_type.ok_or(AnalyzerError::NonFatal)?;
 
             hover_checked_type(engine, current_file, binder_type)
@@ -234,7 +234,7 @@ fn hover_expression(
         _ => {
             let checked = engine.checked(current_file)?;
 
-            let expression_type = checked.nodes.lookup_expression(expression_id);
+            let expression_type = checked.node_types.lookup_expression(expression_id);
             let expression_type = expression_type.ok_or(AnalyzerError::NonFatal)?;
 
             hover_checked_type(engine, current_file, expression_type)
@@ -249,7 +249,7 @@ fn hover_let(
 ) -> Result<Option<Hover>, AnalyzerError> {
     let checked = engine.checked(current_file)?;
 
-    let let_type = checked.nodes.lookup_let(let_binding_id);
+    let let_type = checked.node_types.lookup_let(let_binding_id);
     let let_type = let_type.ok_or(AnalyzerError::NonFatal)?;
 
     hover_checked_type(engine, current_file, let_type)
@@ -271,7 +271,7 @@ fn hover_type(
         _ => {
             let checked = engine.checked(current_file)?;
 
-            let type_kind = checked.nodes.lookup_type(type_id);
+            let type_kind = checked.node_types.lookup_type_kind(type_id);
             let type_kind = type_kind.ok_or(AnalyzerError::NonFatal)?;
 
             hover_checked_type(engine, current_file, type_kind)
@@ -372,7 +372,7 @@ fn hover_pun(
 ) -> Result<Option<Hover>, AnalyzerError> {
     let checked = engine.checked(current_file)?;
 
-    let pun_type = checked.nodes.lookup_pun(pun_id);
+    let pun_type = checked.node_types.lookup_pun(pun_id);
     let pun_type = pun_type.ok_or(AnalyzerError::NonFatal)?;
 
     hover_checked_type(engine, current_file, pun_type)

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -309,7 +309,7 @@ fn hover_file_term(
     let annotation = range.annotation.and_then(|range| render_annotation(&content, range));
 
     let name = if let Some(name) = &indexed.items[term_id].name { name } else { "<unknown>" };
-    let signature = checked.lookup_term(term_id).ok_or(AnalyzerError::NonFatal)?;
+    let signature = checked.lookup_term_item_type(term_id).ok_or(AnalyzerError::NonFatal)?;
 
     let pretty = Pretty::with_config(engine, &checked, PRETTY_CONFIG);
     let value = pretty.render_signature(name, signature).to_string();
@@ -338,7 +338,7 @@ fn hover_file_type(
     let annotation = range.annotation.and_then(|range| render_annotation(&content, range));
 
     let name = if let Some(name) = &indexed.items[type_id].name { name } else { "<unknown>" };
-    let signature = checked.lookup_type(type_id).ok_or(AnalyzerError::NonFatal)?;
+    let signature = checked.lookup_type_item_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
 
     let pretty = Pretty::with_config(engine, &checked, PRETTY_CONFIG);
     let value = pretty.render_signature(name, signature).to_string();

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -195,12 +195,12 @@ fn locate_node(
             cst::LetBinding::LetBindingSignature(signature) => {
                 let ptr = AstPtr::new(&signature);
                 let id = stabilized.lookup_ptr(&ptr)?;
-                lowered.info.find_let_binding_group_by_signature(id).map(Located::LetBinding)
+                lowered.tree.find_let_binding_group_by_signature(id).map(Located::LetBinding)
             }
             cst::LetBinding::LetBindingEquation(equation) => {
                 let ptr = AstPtr::new(&equation);
                 let id = stabilized.lookup_ptr(&ptr)?;
-                lowered.info.find_let_binding_group_by_equation(id).map(Located::LetBinding)
+                lowered.tree.find_let_binding_group_by_equation(id).map(Located::LetBinding)
             }
         }
     } else if cst::DataConstructor::can_cast(kind) {

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -42,7 +42,8 @@ pub fn value_equation_ranges(
     indexed: &IndexedModule,
     term_id: TermItemId,
 ) -> Option<Vec<Utf8Range>> {
-    let indexing::TermItemKind::Value { signature, equations } = &indexed.items[term_id].kind
+    let indexing::IndexedTermItemKind::Value { signature, equations } =
+        &indexed.items[term_id].kind
     else {
         return None;
     };

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -48,13 +48,13 @@ pub fn implementation(
         locate::Located::TermOperator(operator_id) => {
             let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
-                lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_term(context, current_file, f_id, t_id)
         }
         locate::Located::TypeOperator(operator_id) => {
             let lowered = context.queries().lowered(current_file)?;
             let (f_id, t_id) =
-                lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_type(context, current_file, f_id, t_id)
         }
         locate::Located::TermItem(term_id) => {
@@ -209,7 +209,7 @@ fn references_binder(
     let stabilized = context.queries().stabilized(current_file)?;
     let lowered = context.queries().lowered(current_file)?;
 
-    let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         lowering::BinderKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -218,7 +218,7 @@ fn references_binder(
         lowering::BinderKind::Named { .. } | lowering::BinderKind::Variable { .. } => {
             let mut locations = vec![];
 
-            for (expression_id, expression_kind) in lowered.info.iter_expression() {
+            for (expression_id, expression_kind) in lowered.tree.iter_expression() {
                 if let ExpressionKind::Variable {
                     resolution: Some(TermVariableResolution::Binder(candidate_id)),
                 } = expression_kind
@@ -231,7 +231,7 @@ fn references_binder(
                 }
             }
 
-            for (expression_id, resolution) in lowered.info.iter_expression_pun() {
+            for (expression_id, resolution) in lowered.tree.iter_expression_pun() {
                 if let TermVariableResolution::Binder(resolution_id) = resolution
                     && resolution_id == binder_id
                 {
@@ -254,7 +254,7 @@ fn references_expression(
     expression_id: ExpressionId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    let kind = lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         ExpressionKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -291,7 +291,7 @@ fn references_type(
     type_id: TypeId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
+    let kind = lowered.tree.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
     match kind {
         TypeKind::Constructor { resolution, .. } => {
             let (f_id, t_id) = resolution.as_ref().ok_or(AnalyzerError::NonFatal)?;
@@ -339,7 +339,7 @@ fn references_file_term(
         let stabilized = engine.stabilized(candidate_id)?;
         let lowered = engine.lowered(candidate_id)?;
 
-        for (expr_id, expr_kind) in lowered.info.iter_expression() {
+        for (expr_id, expr_kind) in lowered.tree.iter_expression() {
             if let ExpressionKind::Constructor { resolution: Some((f_id, t_id)) } = expr_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
@@ -363,7 +363,7 @@ fn references_file_term(
             }
         }
 
-        for (binder_id, binder_kind) in lowered.info.iter_binder() {
+        for (binder_id, binder_kind) in lowered.tree.iter_binder() {
             if let BinderKind::Constructor { resolution: Some((f_id, t_id)), .. } = binder_kind
                 && (*f_id, *t_id) == (file_id, term_id)
             {
@@ -373,7 +373,7 @@ fn references_file_term(
             }
         }
 
-        for (operator_id, f_id, t_id) in lowered.info.iter_term_operator() {
+        for (operator_id, f_id, t_id) in lowered.tree.iter_term_operator() {
             if (f_id, t_id) == (file_id, term_id) {
                 let range = id_range(context, &content, &parsed, &stabilized, operator_id)
                     .ok_or(AnalyzerError::NonFatal)?;
@@ -404,7 +404,7 @@ fn references_file_type(
         let stabilized = engine.stabilized(candidate_id)?;
         let lowered = engine.lowered(candidate_id)?;
 
-        for (ty_id, ty_kind) in lowered.info.iter_type() {
+        for (ty_id, ty_kind) in lowered.tree.iter_type() {
             if let TypeKind::Constructor { resolution: Some((f_id, t_id)) } = ty_kind
                 && (*f_id, *t_id) == (file_id, type_id)
             {
@@ -421,7 +421,7 @@ fn references_file_type(
             }
         }
 
-        for (operator_id, f_id, t_id) in lowered.info.iter_type_operator() {
+        for (operator_id, f_id, t_id) in lowered.tree.iter_type_operator() {
             if (f_id, t_id) == (file_id, type_id) {
                 let range = id_range(context, &content, &parsed, &stabilized, operator_id)
                     .ok_or(AnalyzerError::NonFatal)?;
@@ -529,7 +529,7 @@ fn references_let(
 
     let mut locations = vec![];
 
-    for (expression_id, expression_kind) in lowered.info.iter_expression() {
+    for (expression_id, expression_kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::Variable {
             resolution: Some(TermVariableResolution::Let(candidate_id)),
             ..
@@ -543,7 +543,7 @@ fn references_let(
         }
     }
 
-    for (expression_id, resolution) in lowered.info.iter_expression_pun() {
+    for (expression_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::Let(resolution_id) = resolution
             && resolution_id == let_id
         {
@@ -573,7 +573,7 @@ fn references_binder_pun(
 
     let mut locations = vec![];
 
-    for (expression_id, expression_kind) in lowered.info.iter_expression() {
+    for (expression_id, expression_kind) in lowered.tree.iter_expression() {
         if let ExpressionKind::Variable {
             resolution: Some(TermVariableResolution::RecordPun(candidate_id)),
         } = expression_kind
@@ -586,7 +586,7 @@ fn references_binder_pun(
         }
     }
 
-    for (expression_id, resolution) in lowered.info.iter_expression_pun() {
+    for (expression_id, resolution) in lowered.tree.iter_expression_pun() {
         if let TermVariableResolution::RecordPun(resolution_id) = resolution
             && resolution_id == pun_id
         {
@@ -606,7 +606,7 @@ fn references_expression_pun(
     pun_id: RecordPunId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let lowered = context.queries().lowered(current_file)?;
-    match lowered.info.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)? {
+    match lowered.tree.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)? {
         TermVariableResolution::Binder(binder_id) => {
             references_binder(context, current_file, binder_id)
         }

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -1,6 +1,8 @@
 use building_types::QueryProxy;
 use files::FileId;
-use indexing::{ImportId, ImportItemId, TermItemId, TermItemKind, TypeItemId, TypeItemKind};
+use indexing::{
+    ImportId, ImportItemId, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+};
 use lowering::{BinderKind, ExpressionKind, TermVariableResolution, TypeKind};
 use lsp_types::*;
 use syntax::ast::{AstNode, AstPtr};
@@ -409,9 +411,11 @@ fn target_name(
             };
 
             let kind = match item.kind {
-                TermItemKind::Constructor { .. } => NameKind::Upper,
-                TermItemKind::Operator { .. } => NameKind::Operator,
-                TermItemKind::Derive { .. } | TermItemKind::Instance { .. } => return Ok(None),
+                IndexedTermItemKind::Constructor { .. } => NameKind::Upper,
+                IndexedTermItemKind::Operator { .. } => NameKind::Operator,
+                IndexedTermItemKind::Derive { .. } | IndexedTermItemKind::Instance { .. } => {
+                    return Ok(None);
+                }
                 _ => NameKind::Lower,
             };
 
@@ -426,7 +430,7 @@ fn target_name(
             };
 
             let kind = match item.kind {
-                TypeItemKind::Operator { .. } => NameKind::Operator,
+                IndexedTypeItemKind::Operator { .. } => NameKind::Operator,
                 _ => NameKind::Upper,
             };
 

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -232,7 +232,7 @@ fn rename_target(
         }
         locate::Located::ImportItem(import_id) => import_target(context, current_file, import_id)?,
         locate::Located::Binder(binder_id) => {
-            let kind = lowered.info.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+            let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
 
             let BinderKind::Constructor { resolution: Some((file_id, term_id)), .. } = kind else {
                 return Err(AnalyzerError::NonFatal);
@@ -242,7 +242,7 @@ fn rename_target(
         }
         locate::Located::Expression(expression_id) => {
             let kind =
-                lowered.info.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
 
             let resolution = match kind {
                 ExpressionKind::Constructor { resolution: Some(resolution) }
@@ -256,7 +256,7 @@ fn rename_target(
             RenameTarget::Term(resolution.0, resolution.1)
         }
         locate::Located::Type(type_id) => {
-            let kind = lowered.info.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
+            let kind = lowered.tree.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
 
             let resolution = match kind {
                 TypeKind::Constructor { resolution: Some(resolution) }
@@ -268,13 +268,13 @@ fn rename_target(
         }
         locate::Located::TermOperator(operator_id) => {
             let (file_id, term_id) =
-                lowered.info.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_term_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
 
             RenameTarget::Term(file_id, term_id)
         }
         locate::Located::TypeOperator(operator_id) => {
             let (file_id, type_id) =
-                lowered.info.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
+                lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
 
             RenameTarget::Type(file_id, type_id)
         }

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use building_types::QueryProxy;
 use files::FileId;
 use indexing::{
-    ImplicitItems, ImportId, ImportItemId, TermItemId, TermItemKind, TypeItemId, TypeItemKind,
-    TypeSelection,
+    ImplicitItems, ImportId, ImportItemId, IndexedTermItemKind, IndexedTypeItemKind, TermItemId,
+    TypeItemId, TypeSelection,
 };
 use lsp_types::*;
 use stabilizing::AstId;
@@ -324,25 +324,25 @@ where
         let indexed = self.context.queries().indexed(file_id)?;
 
         match &indexed.items[term_id].kind {
-            TermItemKind::ClassMember { id } => {
+            IndexedTermItemKind::ClassMember { id } => {
                 push_name_edits!(self, file_id, new_name, position::class_member_name_range; Some(*id));
             }
-            TermItemKind::Constructor { id } => {
+            IndexedTermItemKind::Constructor { id } => {
                 push_name_edits!(self, file_id, new_name, position::data_constructor_name_range; Some(*id));
             }
-            TermItemKind::Derive { id } => {
+            IndexedTermItemKind::Derive { id } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; Some(*id));
             }
-            TermItemKind::Foreign { id } => {
+            IndexedTermItemKind::Foreign { id } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; Some(*id));
             }
-            TermItemKind::Instance { id } => {
+            IndexedTermItemKind::Instance { id } => {
                 push_name_edits!(self, file_id, new_name, position::instance_declaration_name_range; Some(*id));
             }
-            TermItemKind::Operator { id } => {
+            IndexedTermItemKind::Operator { id } => {
                 push_name_edits!(self, file_id, new_name, position::infix_operator_range; Some(*id));
             }
-            TermItemKind::Value { signature, equations } => {
+            IndexedTermItemKind::Value { signature, equations } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; *signature);
 
                 for &equation in equations {
@@ -363,22 +363,22 @@ where
         let indexed = self.context.queries().indexed(file_id)?;
 
         match indexed.items[type_id].kind {
-            TypeItemKind::Data { signature, equation, role, .. } => {
+            IndexedTypeItemKind::Data { signature, equation, role, .. } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; signature, equation, role);
             }
-            TypeItemKind::Newtype { signature, equation, role, .. } => {
+            IndexedTypeItemKind::Newtype { signature, equation, role, .. } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; signature, equation, role);
             }
-            TypeItemKind::Synonym { signature, equation } => {
+            IndexedTypeItemKind::Synonym { signature, equation } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; signature, equation);
             }
-            TypeItemKind::Class { signature, declaration, .. } => {
+            IndexedTypeItemKind::Class { signature, declaration, .. } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; signature, declaration);
             }
-            TypeItemKind::Foreign { id, role } => {
+            IndexedTypeItemKind::Foreign { id, role } => {
                 push_name_edits!(self, file_id, new_name, position::declaration_name_range; Some(id), role);
             }
-            TypeItemKind::Operator { id } => {
+            IndexedTypeItemKind::Operator { id } => {
                 push_name_edits!(self, file_id, new_name, position::infix_operator_range; Some(id));
             }
         }

--- a/compiler-lsp/analyzer/src/semantic_tokens.rs
+++ b/compiler-lsp/analyzer/src/semantic_tokens.rs
@@ -200,8 +200,7 @@ fn classify_contextual_keyword(token: &SyntaxToken) -> Option<TokenClassificatio
 }
 
 fn classify_name(token: &SyntaxToken) -> Option<TokenClassification> {
-    let mut ancestors = token.parent_ancestors();
-    while let Some(node) = ancestors.next() {
+    for node in token.parent_ancestors() {
         let classification = match node.kind() {
             SyntaxKind::ERROR => return classify_unresolved_name(token),
             SyntaxKind::Qualifier | SyntaxKind::ModuleName => TokenClassification::new(NAMESPACE),

--- a/compiler-lsp/analyzer/src/symbols.rs
+++ b/compiler-lsp/analyzer/src/symbols.rs
@@ -1,33 +1,35 @@
 use std::sync::Arc;
 
 use building_types::QueryProxy;
-use indexing::{TermItemKind, TypeItemKind};
+use indexing::{IndexedTermItemKind, IndexedTypeItemKind};
 use lsp_types::*;
 use radix_trie::Trie;
 
 use crate::{AnalyzerContext, AnalyzerError, common};
 
-fn term_symbol_kind(kind: &TermItemKind) -> SymbolKind {
+fn term_symbol_kind(kind: &IndexedTermItemKind) -> SymbolKind {
     match kind {
-        TermItemKind::Constructor { .. } => SymbolKind::CONSTRUCTOR,
-        TermItemKind::ClassMember { .. } => SymbolKind::METHOD,
-        TermItemKind::Operator { .. } => SymbolKind::OPERATOR,
-        TermItemKind::Value { .. }
-        | TermItemKind::Foreign { .. }
-        | TermItemKind::Derive { .. }
-        | TermItemKind::Instance { .. } => SymbolKind::FUNCTION,
+        IndexedTermItemKind::Constructor { .. } => SymbolKind::CONSTRUCTOR,
+        IndexedTermItemKind::ClassMember { .. } => SymbolKind::METHOD,
+        IndexedTermItemKind::Operator { .. } => SymbolKind::OPERATOR,
+        IndexedTermItemKind::Value { .. }
+        | IndexedTermItemKind::Foreign { .. }
+        | IndexedTermItemKind::Derive { .. }
+        | IndexedTermItemKind::Instance { .. } => SymbolKind::FUNCTION,
     }
 }
 
-fn type_symbol_kind(kind: &TypeItemKind) -> SymbolKind {
+fn type_symbol_kind(kind: &IndexedTypeItemKind) -> SymbolKind {
     match kind {
         // Note: type classes are partitioned out of `iter_types()` and exposed via `iter_classes()`.
         // Keep this arm for exhaustiveness in case that invariant changes.
-        TypeItemKind::Class { .. } => SymbolKind::INTERFACE,
-        TypeItemKind::Operator { .. } => SymbolKind::OPERATOR,
-        TypeItemKind::Data { .. } => SymbolKind::ENUM,
-        TypeItemKind::Synonym { .. } => SymbolKind::TYPE_PARAMETER,
-        TypeItemKind::Newtype { .. } | TypeItemKind::Foreign { .. } => SymbolKind::STRUCT,
+        IndexedTypeItemKind::Class { .. } => SymbolKind::INTERFACE,
+        IndexedTypeItemKind::Operator { .. } => SymbolKind::OPERATOR,
+        IndexedTypeItemKind::Data { .. } => SymbolKind::ENUM,
+        IndexedTypeItemKind::Synonym { .. } => SymbolKind::TYPE_PARAMETER,
+        IndexedTypeItemKind::Newtype { .. } | IndexedTypeItemKind::Foreign { .. } => {
+            SymbolKind::STRUCT
+        }
     }
 }
 

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -78,7 +78,7 @@ impl<'a> TypeEncoder<'a> {
     ) -> Result<schema::TypeSynonymEquation, Error> {
         self.names.reset();
         let binders = self.encode_forall_binder_values(synonym.parameters)?;
-        let expansion = self.encode_type(synonym.synonym)?;
+        let expansion = self.encode_type(synonym.expansion)?;
         Ok(schema::TypeSynonymEquation { binders, expansion })
     }
 

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -298,7 +298,7 @@ impl<'a> ModuleEncoder<'a> {
 
         let name = type_item.name.as_ref().map(|name| name.to_string());
         let documentation = type_documentation.and_then(|t| optional_string(&t.documentation));
-        let signature = self.checked.lookup_type(type_id);
+        let signature = self.checked.lookup_type_item_kind(type_id);
         let signature = signature.map(|signature| self.encode_signature(signature)).transpose()?;
         let instance_ids = instances.into_iter().collect::<Vec<_>>();
 
@@ -477,7 +477,7 @@ fn term_signature(
         indexing::IndexedTermItemKind::Derive { id } => {
             checked.lookup_derived(*id).map(|instance| instance.signature)
         }
-        _ => checked.lookup_term(term_id),
+        _ => checked.lookup_term_item_type(term_id),
     }
 }
 

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -303,7 +303,7 @@ impl<'a> ModuleEncoder<'a> {
         let instance_ids = instances.into_iter().collect::<Vec<_>>();
 
         let form = match &type_item.kind {
-            indexing::TypeItemKind::Data { constructors, .. } => {
+            indexing::IndexedTypeItemKind::Data { constructors, .. } => {
                 let declaration = self.checked.lookup_data_declaration(type_id);
                 let declaration = if let Some(declaration) = declaration {
                     let type_parameters = declaration.type_parameters.iter().copied();
@@ -317,7 +317,7 @@ impl<'a> ModuleEncoder<'a> {
 
                 schema::TypeItemForm::Data { signature, declaration, constructors, instances }
             }
-            indexing::TypeItemKind::Newtype { constructors, .. } => {
+            indexing::IndexedTypeItemKind::Newtype { constructors, .. } => {
                 let declaration = self.checked.lookup_data_declaration(type_id);
                 let declaration = if let Some(declaration) = declaration {
                     let type_parameters = declaration.type_parameters.iter().copied();
@@ -331,7 +331,7 @@ impl<'a> ModuleEncoder<'a> {
 
                 schema::TypeItemForm::Newtype { signature, declaration, constructors, instances }
             }
-            indexing::TypeItemKind::Synonym { .. } => {
+            indexing::IndexedTypeItemKind::Synonym { .. } => {
                 let equation = if let Some(synonym) = self.checked.lookup_synonym(type_id) {
                     Some(self.type_encoder.encode_synonym_equation(synonym)?)
                 } else {
@@ -342,7 +342,7 @@ impl<'a> ModuleEncoder<'a> {
 
                 schema::TypeItemForm::Synonym { signature, equation, instances }
             }
-            indexing::TypeItemKind::Class { members, .. } => {
+            indexing::IndexedTypeItemKind::Class { members, .. } => {
                 let (declaration, superclasses, functional_dependencies) =
                     if let Some(class) = self.checked.lookup_class(type_id) {
                         let (declaration, superclasses) =
@@ -366,12 +366,14 @@ impl<'a> ModuleEncoder<'a> {
                     instances,
                 }
             }
-            indexing::TypeItemKind::Foreign { .. } => {
+            indexing::IndexedTypeItemKind::Foreign { .. } => {
                 let instances = self.encode_term_items(instance_ids.iter().copied())?;
 
                 schema::TypeItemForm::Foreign { signature, instances }
             }
-            indexing::TypeItemKind::Operator { .. } => schema::TypeItemForm::Operator { signature },
+            indexing::IndexedTypeItemKind::Operator { .. } => {
+                schema::TypeItemForm::Operator { signature }
+            }
         };
 
         Ok(schema::TypeItem { name, documentation, form })
@@ -439,11 +441,11 @@ fn optional_string(value: &str) -> Option<String> {
 fn collect_constructors_members(encoder: &ModuleEncoder<'_>, nested_terms: &mut NestedTerms) {
     for (_, type_item) in encoder.indexed.items.iter_types() {
         match &type_item.kind {
-            indexing::TypeItemKind::Data { constructors, .. }
-            | indexing::TypeItemKind::Newtype { constructors, .. } => {
+            indexing::IndexedTypeItemKind::Data { constructors, .. }
+            | indexing::IndexedTypeItemKind::Newtype { constructors, .. } => {
                 nested_terms.extend(constructors.iter().copied());
             }
-            indexing::TypeItemKind::Class { members, .. } => {
+            indexing::IndexedTypeItemKind::Class { members, .. } => {
                 nested_terms.extend(members.iter().copied());
             }
             _ => {}
@@ -451,28 +453,28 @@ fn collect_constructors_members(encoder: &ModuleEncoder<'_>, nested_terms: &mut 
     }
 }
 
-fn term_kind(kind: &indexing::TermItemKind) -> schema::TermKind {
+fn term_kind(kind: &indexing::IndexedTermItemKind) -> schema::TermKind {
     match kind {
-        indexing::TermItemKind::ClassMember { .. } => schema::TermKind::ClassMember,
-        indexing::TermItemKind::Constructor { .. } => schema::TermKind::Constructor,
-        indexing::TermItemKind::Derive { .. } => schema::TermKind::Derive,
-        indexing::TermItemKind::Foreign { .. } => schema::TermKind::Foreign,
-        indexing::TermItemKind::Instance { .. } => schema::TermKind::Instance,
-        indexing::TermItemKind::Operator { .. } => schema::TermKind::Operator,
-        indexing::TermItemKind::Value { .. } => schema::TermKind::Value,
+        indexing::IndexedTermItemKind::ClassMember { .. } => schema::TermKind::ClassMember,
+        indexing::IndexedTermItemKind::Constructor { .. } => schema::TermKind::Constructor,
+        indexing::IndexedTermItemKind::Derive { .. } => schema::TermKind::Derive,
+        indexing::IndexedTermItemKind::Foreign { .. } => schema::TermKind::Foreign,
+        indexing::IndexedTermItemKind::Instance { .. } => schema::TermKind::Instance,
+        indexing::IndexedTermItemKind::Operator { .. } => schema::TermKind::Operator,
+        indexing::IndexedTermItemKind::Value { .. } => schema::TermKind::Value,
     }
 }
 
 fn term_signature(
     term_id: indexing::TermItemId,
-    term_item: &indexing::TermItem,
+    term_item: &indexing::IndexedTermItem,
     checked: &checking::CheckedModule,
 ) -> Option<checking::TypeId> {
     match &term_item.kind {
-        indexing::TermItemKind::Instance { id } => {
+        indexing::IndexedTermItemKind::Instance { id } => {
             checked.lookup_instance(*id).map(|instance| instance.signature)
         }
-        indexing::TermItemKind::Derive { id } => {
+        indexing::IndexedTermItemKind::Derive { id } => {
             checked.lookup_derived(*id).map(|instance| instance.signature)
         }
         _ => checked.lookup_term(term_id),
@@ -492,7 +494,8 @@ fn collect_instances_of(
     for (term_id, term_item) in encoder.indexed.items.iter_terms() {
         if !matches!(
             term_item.kind,
-            indexing::TermItemKind::Instance { .. } | indexing::TermItemKind::Derive { .. }
+            indexing::IndexedTermItemKind::Instance { .. }
+                | indexing::IndexedTermItemKind::Derive { .. }
         ) {
             continue;
         }
@@ -514,13 +517,13 @@ fn collect_instances_of(
 fn instance_parents(
     encoder: &ModuleEncoder<'_>,
     term_id: indexing::TermItemId,
-    term_item: &indexing::TermItem,
+    term_item: &indexing::IndexedTermItem,
 ) -> InstanceParents {
     let mut parents = InstanceParents::new();
 
     let checked_instance = match &term_item.kind {
-        indexing::TermItemKind::Instance { id } => encoder.checked.lookup_instance(*id),
-        indexing::TermItemKind::Derive { id } => encoder.checked.lookup_derived(*id),
+        indexing::IndexedTermItemKind::Instance { id } => encoder.checked.lookup_instance(*id),
+        indexing::IndexedTermItemKind::Derive { id } => encoder.checked.lookup_derived(*id),
         _ => None,
     };
 
@@ -638,9 +641,9 @@ fn collect_instance_type_parents(
 fn instance_type_parent(encoder: &ModuleEncoder<'_>, type_id: indexing::TypeItemId) -> bool {
     matches!(
         encoder.indexed.items[type_id].kind,
-        indexing::TypeItemKind::Data { .. }
-            | indexing::TypeItemKind::Newtype { .. }
-            | indexing::TypeItemKind::Synonym { .. }
-            | indexing::TypeItemKind::Foreign { .. }
+        indexing::IndexedTypeItemKind::Data { .. }
+            | indexing::IndexedTypeItemKind::Newtype { .. }
+            | indexing::IndexedTypeItemKind::Synonym { .. }
+            | indexing::IndexedTypeItemKind::Foreign { .. }
     )
 }

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -264,7 +264,7 @@ impl<'a> ModuleEncoder<'a> {
         declaration: &schema::TypeDeclaration,
     ) -> Vec<schema::FunctionalDependency> {
         let Some(lowering::TypeItemIr::ClassGroup { class: Some(class), .. }) =
-            self.lowered.info.get_type_item(type_id)
+            self.lowered.tree.get_type_item(type_id)
         else {
             return vec![];
         };
@@ -534,7 +534,7 @@ fn instance_parents(
         parents.insert(parent_type);
     }
 
-    let Some(term_item) = encoder.lowered.info.get_term_item(term_id) else {
+    let Some(term_item) = encoder.lowered.tree.get_term_item(term_id) else {
         return parents;
     };
 
@@ -556,7 +556,7 @@ fn collect_instance_type_parents(
     parents: &mut InstanceParents,
     type_id: lowering::TypeId,
 ) {
-    let Some(kind) = encoder.lowered.info.get_type_kind(type_id) else { return };
+    let Some(kind) = encoder.lowered.tree.get_type_kind(type_id) else { return };
 
     match kind {
         lowering::TypeKind::Constructor { resolution } => {

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -475,7 +475,7 @@ fn term_signature(
             checked.lookup_instance(*id).map(|instance| instance.signature)
         }
         indexing::IndexedTermItemKind::Derive { id } => {
-            checked.lookup_derived(*id).map(|instance| instance.signature)
+            checked.lookup_derived_instance(*id).map(|instance| instance.signature)
         }
         _ => checked.lookup_term_item_type(term_id),
     }
@@ -523,7 +523,9 @@ fn instance_parents(
 
     let checked_instance = match &term_item.kind {
         indexing::IndexedTermItemKind::Instance { id } => encoder.checked.lookup_instance(*id),
-        indexing::IndexedTermItemKind::Derive { id } => encoder.checked.lookup_derived(*id),
+        indexing::IndexedTermItemKind::Derive { id } => {
+            encoder.checked.lookup_derived_instance(*id)
+        }
         _ => None,
     };
 

--- a/compiler-lsp/documentation/src/render.rs
+++ b/compiler-lsp/documentation/src/render.rs
@@ -263,8 +263,8 @@ impl<'a> ModuleEncoder<'a> {
         type_id: indexing::TypeItemId,
         declaration: &schema::TypeDeclaration,
     ) -> Vec<schema::FunctionalDependency> {
-        let Some(lowering::TypeItemIr::ClassGroup { class: Some(class), .. }) =
-            self.lowered.tree.get_type_item(type_id)
+        let Some(lowering::TypeItemKind::Class { declaration: Some(class), .. }) =
+            self.lowered.tree.get_type_item_kind(type_id)
         else {
             return vec![];
         };
@@ -534,13 +534,13 @@ fn instance_parents(
         parents.insert(parent_type);
     }
 
-    let Some(term_item) = encoder.lowered.tree.get_term_item(term_id) else {
+    let Some(term_item) = encoder.lowered.tree.get_term_item_kind(term_id) else {
         return parents;
     };
 
     let arguments = match term_item {
-        lowering::TermItemIr::Instance { arguments, .. }
-        | lowering::TermItemIr::Derive { arguments, .. } => arguments,
+        lowering::TermItemKind::Instance { arguments, .. }
+        | lowering::TermItemKind::Derive { arguments, .. } => arguments,
         _ => return parents,
     };
 

--- a/docs/src/wasm/src/lib.rs
+++ b/docs/src/wasm/src/lib.rs
@@ -281,14 +281,14 @@ pub fn check(source: &str) -> JsValue {
         let mut terms = Vec::new();
         for (term_id, IndexedTermItem { name, .. }) in indexed.items.iter_terms() {
             let Some(n) = name else { continue };
-            let Some(t) = checked.lookup_term(term_id) else { continue };
+            let Some(t) = checked.lookup_term_item_type(term_id) else { continue };
             terms.push(pretty.render_signature(n.as_str(), t).to_string());
         }
 
         let mut types = Vec::new();
         for (type_id, IndexedTypeItem { name, .. }) in indexed.items.iter_types() {
             let Some(n) = name else { continue };
-            let Some(t) = checked.lookup_type(type_id) else { continue };
+            let Some(t) = checked.lookup_type_item_kind(type_id) else { continue };
             types.push(pretty.render_signature(n.as_str(), t).to_string());
         }
 

--- a/docs/src/wasm/src/lib.rs
+++ b/docs/src/wasm/src/lib.rs
@@ -7,7 +7,7 @@ use building_types::QueryProxy;
 use checking::core::pretty;
 use diagnostics::{Diagnostic, DiagnosticsContext, ToDiagnostics};
 use engine::WasmQueryEngine;
-use indexing::{TermItem, TypeItem};
+use indexing::{IndexedTermItem, IndexedTypeItem};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 use web_sys::{js_sys, WorkerGlobalScope};
@@ -279,21 +279,21 @@ pub fn check(source: &str) -> JsValue {
 
         // Extract results
         let mut terms = Vec::new();
-        for (term_id, TermItem { name, .. }) in indexed.items.iter_terms() {
+        for (term_id, IndexedTermItem { name, .. }) in indexed.items.iter_terms() {
             let Some(n) = name else { continue };
             let Some(t) = checked.lookup_term(term_id) else { continue };
             terms.push(pretty.render_signature(n.as_str(), t).to_string());
         }
 
         let mut types = Vec::new();
-        for (type_id, TypeItem { name, .. }) in indexed.items.iter_types() {
+        for (type_id, IndexedTypeItem { name, .. }) in indexed.items.iter_types() {
             let Some(n) = name else { continue };
             let Some(t) = checked.lookup_type(type_id) else { continue };
             types.push(pretty.render_signature(n.as_str(), t).to_string());
         }
 
         let mut synonyms = Vec::new();
-        for (type_id, TypeItem { name, .. }) in indexed.items.iter_types() {
+        for (type_id, IndexedTypeItem { name, .. }) in indexed.items.iter_types() {
             let Some(n) = name else { continue };
             let Some(group) = checked.lookup_synonym(type_id) else { continue };
             let mut pretty = pretty.state();

--- a/docs/src/wasm/src/lib.rs
+++ b/docs/src/wasm/src/lib.rs
@@ -297,7 +297,7 @@ pub fn check(source: &str) -> JsValue {
             let Some(n) = name else { continue };
             let Some(group) = checked.lookup_synonym(type_id) else { continue };
             let mut pretty = pretty.state();
-            let expansion = pretty.render(group.synonym);
+            let expansion = pretty.render(group.expansion);
             let parameters = group
                 .parameters
                 .iter()

--- a/tests-integration/fixtures/resolving/1747028700_import_errors/DuplicateLocal.snap
+++ b/tests-integration/fixtures/resolving/1747028700_import_errors/DuplicateLocal.snap
@@ -28,7 +28,7 @@ Local Classes:
 Class Members:
 
 Errors:
-  - ExistingTerm { existing: (Idx::<File>(9), Idx::<TermItem>(0)), duplicate: (Idx::<File>(9), Idx::<TermItem>(1)) }
-  - ExistingType { existing: (Idx::<File>(9), Idx::<TypeItem>(0)), duplicate: (Idx::<File>(9), Idx::<TypeItem>(1)) }
-  - TermExportConflict { existing: (Idx::<File>(9), Idx::<TermItem>(0), Local), duplicate: (Idx::<File>(9), Idx::<TermItem>(1), Local) }
-  - TypeExportConflict { existing: (Idx::<File>(9), Idx::<TypeItem>(0), Local), duplicate: (Idx::<File>(9), Idx::<TypeItem>(1), Local) }
+  - ExistingTerm { existing: (Idx::<File>(9), Idx::<IndexedTermItem>(0)), duplicate: (Idx::<File>(9), Idx::<IndexedTermItem>(1)) }
+  - ExistingType { existing: (Idx::<File>(9), Idx::<IndexedTypeItem>(0)), duplicate: (Idx::<File>(9), Idx::<IndexedTypeItem>(1)) }
+  - TermExportConflict { existing: (Idx::<File>(9), Idx::<IndexedTermItem>(0), Local), duplicate: (Idx::<File>(9), Idx::<IndexedTermItem>(1), Local) }
+  - TypeExportConflict { existing: (Idx::<File>(9), Idx::<IndexedTypeItem>(0), Local), duplicate: (Idx::<File>(9), Idx::<IndexedTypeItem>(1), Local) }

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -319,10 +319,10 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
         writeln!(out, "instance {canonical}").unwrap();
     }
 
-    if !checked.derived.is_empty() {
+    if !checked.derived_instances.is_empty() {
         writeln!(out, "\nDerived").unwrap();
     }
-    let mut derived_entries: Vec<_> = checked.derived.iter().collect();
+    let mut derived_entries: Vec<_> = checked.derived_instances.iter().collect();
     derived_entries.sort_by_key(|(id, _)| *id);
     for (_derive_id, instance) in derived_entries {
         let mut state = pretty.state();

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -227,7 +227,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     writeln!(out, "Terms").unwrap();
     for (id, IndexedTermItem { name, .. }) in indexed.items.iter_terms() {
         let Some(name) = name else { continue };
-        let Some(kind) = checked.lookup_term(id) else { continue };
+        let Some(kind) = checked.lookup_term_item_type(id) else { continue };
         let mut state = pretty.state();
         let signature = state.render_signature(name, kind);
         writeln!(out, "{signature}").unwrap();
@@ -236,7 +236,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     writeln!(out, "\nTypes").unwrap();
     for (id, IndexedTypeItem { name, .. }) in indexed.items.iter_types() {
         let Some(name) = name else { continue };
-        let Some(kind) = checked.lookup_type(id) else { continue };
+        let Some(kind) = checked.lookup_type_item_kind(id) else { continue };
         let mut state = pretty.state();
         let signature = state.render_signature(name, kind);
         writeln!(out, "{signature}").unwrap();
@@ -302,7 +302,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
         for member in &class.members {
             let member_id = member.item_id;
             let Some(member_name) = indexed.items[member_id].name.as_deref() else { continue };
-            let Some(member_type) = checked.lookup_term(member_id) else { continue };
+            let Some(member_type) = checked.lookup_term_item_type(member_id) else { continue };
             let signature = state.render_signature(member_name, member_type);
             writeln!(out, "  {signature}").unwrap();
         }

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -6,7 +6,7 @@ use checking::core::pretty;
 use checking::{PrettyQueries, core};
 use diagnostics::{DiagnosticsContext, ToDiagnostics, format_rustc};
 use files::FileId;
-use indexing::{ImportKind, TermItem, TypeItem, TypeItemId, TypeItemKind};
+use indexing::{ImportKind, IndexedTermItem, IndexedTypeItem, IndexedTypeItemKind, TypeItemId};
 use itertools::Itertools;
 use lowering::{
     ExpressionKind, GraphNode, ImplicitTypeVariable, TermVariableResolution, TypeKind,
@@ -225,7 +225,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     let mut out = String::default();
 
     writeln!(out, "Terms").unwrap();
-    for (id, TermItem { name, .. }) in indexed.items.iter_terms() {
+    for (id, IndexedTermItem { name, .. }) in indexed.items.iter_terms() {
         let Some(name) = name else { continue };
         let Some(kind) = checked.lookup_term(id) else { continue };
         let mut state = pretty.state();
@@ -234,7 +234,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     }
 
     writeln!(out, "\nTypes").unwrap();
-    for (id, TypeItem { name, .. }) in indexed.items.iter_types() {
+    for (id, IndexedTypeItem { name, .. }) in indexed.items.iter_types() {
         let Some(name) = name else { continue };
         let Some(kind) = checked.lookup_type(id) else { continue };
         let mut state = pretty.state();
@@ -245,7 +245,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     if !checked.synonyms.is_empty() {
         writeln!(out, "\nSynonyms").unwrap();
     }
-    for (id, TypeItem { name, .. }) in indexed.items.iter_types() {
+    for (id, IndexedTypeItem { name, .. }) in indexed.items.iter_types() {
         let Some(name) = name else { continue };
         let Some(definition) = checked.lookup_synonym(id) else { continue };
         let mut state = pretty.state();
@@ -260,7 +260,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     if !checked.classes.is_empty() {
         writeln!(out, "\nClasses").unwrap();
     }
-    for (id, TypeItem { .. }) in indexed.items.iter_types() {
+    for (id, IndexedTypeItem { .. }) in indexed.items.iter_types() {
         let Some(class) = checked.lookup_class(id) else { continue };
         let mut state = pretty.state();
 
@@ -333,10 +333,10 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
     if !checked.roles.is_empty() {
         writeln!(out, "\nRoles").unwrap();
     }
-    for (id, TypeItem { name, kind, .. }) in indexed.items.iter_types() {
-        let (TypeItemKind::Data { .. }
-        | TypeItemKind::Newtype { .. }
-        | TypeItemKind::Foreign { .. }) = kind
+    for (id, IndexedTypeItem { name, kind, .. }) in indexed.items.iter_types() {
+        let (IndexedTypeItemKind::Data { .. }
+        | IndexedTypeItemKind::Newtype { .. }
+        | IndexedTypeItemKind::Foreign { .. }) = kind
         else {
             continue;
         };

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -249,7 +249,7 @@ pub fn report_checked(engine: &QueryEngine, id: FileId) -> String {
         let Some(name) = name else { continue };
         let Some(definition) = checked.lookup_synonym(id) else { continue };
         let mut state = pretty.state();
-        let replacement = state.render(definition.synonym);
+        let replacement = state.render(definition.expansion);
         let binders =
             definition.parameters.iter().map(|b| state.display_name(b.name)).collect_vec();
         let binders_formatted =

--- a/tests-integration/src/generated/basic.rs
+++ b/tests-integration/src/generated/basic.rs
@@ -120,7 +120,7 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
     let lowered = engine.lowered(id).unwrap();
 
     let module = parsed.cst();
-    let info = &lowered.info;
+    let tree = &lowered.tree;
     let graph = &lowered.graph;
 
     let mut out = String::default();
@@ -129,8 +129,8 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
     writeln!(out).unwrap();
     writeln!(out, "Expressions:").unwrap();
     writeln!(out).unwrap();
-    for (expression_id, _) in info.iter_expression() {
-        let Some(kind) = info.get_expression_kind(expression_id) else {
+    for (expression_id, _) in tree.iter_expression() {
+        let Some(kind) = tree.get_expression_kind(expression_id) else {
             continue;
         };
         match kind {
@@ -139,7 +139,7 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
                     &content,
                     &stabilized,
                     &module,
-                    info,
+                    tree,
                     &mut out,
                     expression_id,
                     resolution,
@@ -152,7 +152,7 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
                             &content,
                             &stabilized,
                             &module,
-                            info,
+                            tree,
                             &mut out,
                             expression_id,
                             resolution,
@@ -177,8 +177,8 @@ pub fn report_lowered(engine: &QueryEngine, id: FileId, name: &str) -> String {
 
     writeln!(out, "\nTypes:\n").unwrap();
 
-    for (type_id, _) in info.iter_type() {
-        let Some(TypeKind::Variable { resolution, .. }) = info.get_type_kind(type_id) else {
+    for (type_id, _) in tree.iter_type() {
+        let Some(TypeKind::Variable { resolution, .. }) = tree.get_type_kind(type_id) else {
             continue;
         };
 
@@ -391,7 +391,7 @@ fn write_term_resolution(
     content: &str,
     stabilized: &stabilizing::StabilizedModule,
     module: &cst::Module,
-    info: &lowering::LoweringInfo,
+    tree: &lowering::LoweredTree,
     out: &mut String,
     expression_id: lowering::ExpressionId,
     resolution: &Option<TermVariableResolution>,
@@ -408,7 +408,7 @@ fn write_term_resolution(
             writeln!(out, "  -> binder@{}", pos!(content, stabilized, *id)).unwrap();
         }
         Some(TermVariableResolution::Let(let_binding_id)) => {
-            let let_binding = info.get_let_binding_group(*let_binding_id);
+            let let_binding = tree.get_let_binding_group(*let_binding_id);
             if let Some(sig) = let_binding.signature {
                 writeln!(out, "  -> signature@{}", pos!(content, stabilized, sig)).unwrap();
             }

--- a/tests-integration/tests/snapshots/lowering_unit__basic_cycle.snap
+++ b/tests-integration/tests/snapshots/lowering_unit__basic_cycle.snap
@@ -5,58 +5,58 @@ expression: "(terms, types)"
 (
     [
         Base(
-            Idx::<TermItem>(0),
+            Idx::<IndexedTermItem>(0),
         ),
         Recursive(
-            Idx::<TermItem>(1),
+            Idx::<IndexedTermItem>(1),
         ),
         Mutual(
             [
-                Idx::<TermItem>(3),
-                Idx::<TermItem>(2),
+                Idx::<IndexedTermItem>(3),
+                Idx::<IndexedTermItem>(2),
             ],
         ),
         Mutual(
             [
-                Idx::<TermItem>(6),
-                Idx::<TermItem>(5),
-                Idx::<TermItem>(4),
+                Idx::<IndexedTermItem>(6),
+                Idx::<IndexedTermItem>(5),
+                Idx::<IndexedTermItem>(4),
             ],
         ),
         Base(
-            Idx::<TermItem>(7),
+            Idx::<IndexedTermItem>(7),
         ),
         Base(
-            Idx::<TermItem>(8),
+            Idx::<IndexedTermItem>(8),
         ),
         Base(
-            Idx::<TermItem>(9),
+            Idx::<IndexedTermItem>(9),
         ),
         Base(
-            Idx::<TermItem>(10),
+            Idx::<IndexedTermItem>(10),
         ),
         Base(
-            Idx::<TermItem>(11),
+            Idx::<IndexedTermItem>(11),
         ),
     ],
     [
         Base(
-            Idx::<TypeItem>(0),
+            Idx::<IndexedTypeItem>(0),
         ),
         Recursive(
-            Idx::<TypeItem>(1),
+            Idx::<IndexedTypeItem>(1),
         ),
         Mutual(
             [
-                Idx::<TypeItem>(3),
-                Idx::<TypeItem>(2),
+                Idx::<IndexedTypeItem>(3),
+                Idx::<IndexedTypeItem>(2),
             ],
         ),
         Mutual(
             [
-                Idx::<TypeItem>(6),
-                Idx::<TypeItem>(5),
-                Idx::<TypeItem>(4),
+                Idx::<IndexedTypeItem>(6),
+                Idx::<IndexedTypeItem>(5),
+                Idx::<IndexedTypeItem>(4),
             ],
         ),
     ],

--- a/tests-integration/tests/snapshots/lowering_unit__non_cycle_ordering.snap
+++ b/tests-integration/tests/snapshots/lowering_unit__non_cycle_ordering.snap
@@ -5,13 +5,13 @@ expression: "(terms, types)"
 (
     [
         Base(
-            Idx::<TermItem>(2),
+            Idx::<IndexedTermItem>(2),
         ),
         Base(
-            Idx::<TermItem>(1),
+            Idx::<IndexedTermItem>(1),
         ),
         Base(
-            Idx::<TermItem>(0),
+            Idx::<IndexedTermItem>(0),
         ),
     ],
     [],

--- a/tests-integration/tests/snapshots/lowering_unit__operator_cycle.snap
+++ b/tests-integration/tests/snapshots/lowering_unit__operator_cycle.snap
@@ -6,16 +6,16 @@ expression: "(terms, types)"
     [
         Mutual(
             [
-                Idx::<TermItem>(1),
-                Idx::<TermItem>(0),
+                Idx::<IndexedTermItem>(1),
+                Idx::<IndexedTermItem>(0),
             ],
         ),
     ],
     [
         Mutual(
             [
-                Idx::<TypeItem>(1),
-                Idx::<TypeItem>(0),
+                Idx::<IndexedTypeItem>(1),
+                Idx::<IndexedTypeItem>(0),
             ],
         ),
     ],

--- a/tests-integration/tests/snapshots/lowering_unit__recursive_kinds_errors.snap
+++ b/tests-integration/tests/snapshots/lowering_unit__recursive_kinds_errors.snap
@@ -6,16 +6,16 @@ expression: groups.cycle_errors
     RecursiveKinds(
         RecursiveGroup {
             group: [
-                Idx::<TypeItem>(1),
-                Idx::<TypeItem>(0),
+                Idx::<IndexedTypeItem>(1),
+                Idx::<IndexedTypeItem>(0),
             ],
         },
     ),
     RecursiveKinds(
         RecursiveGroup {
             group: [
-                Idx::<TypeItem>(3),
-                Idx::<TypeItem>(2),
+                Idx::<IndexedTypeItem>(3),
+                Idx::<IndexedTypeItem>(2),
             ],
         },
     ),

--- a/tests-integration/tests/snapshots/lowering_unit__recursive_synonym_errors.snap
+++ b/tests-integration/tests/snapshots/lowering_unit__recursive_synonym_errors.snap
@@ -6,15 +6,15 @@ expression: groups.cycle_errors
     RecursiveSynonym(
         RecursiveGroup {
             group: [
-                Idx::<TypeItem>(1),
-                Idx::<TypeItem>(0),
+                Idx::<IndexedTypeItem>(1),
+                Idx::<IndexedTypeItem>(0),
             ],
         },
     ),
     RecursiveSynonym(
         RecursiveGroup {
             group: [
-                Idx::<TypeItem>(2),
+                Idx::<IndexedTypeItem>(2),
             ],
         },
     ),


### PR DESCRIPTION
## Summary

- rename lowering's `intermediate` module to `tree` and give its source-tree items, declarations, and kinds explicit names
- distinguish indexed item descriptors and the checked semantic tree from the concrete syntax tree and lowered source tree
- clarify checked item maps, node type annotations, derived instances, synonym expansions, and core application arguments
- document the representation boundaries between syntax, lowering, indexing, and checking
- remove the affected workspace Clippy warnings and derive traversal member identities from `TraversalKind` rather than passing redundant arguments

## Rationale

The output of lowering is the compiler's semantic source tree, not merely an unspecified intermediate value. Naming the module `tree` and qualifying representation-specific types makes that role visible at call sites and avoids collisions with the indexing and checking trees.

The corresponding checking names make ownership similarly explicit for agents and contributors navigating the pipeline. `Name` and `Depth` retain their established GHC-derived terminology.

This is intended as a behavior-preserving naming and clarity refactor.

## Validation

- `just format`
- `cargo clippy --workspace --tests`
- `cargo check --workspace --tests`
- `just t checking`
- `just t semantic`
- `just t lsp`
- focused Traversable and Bitraversable checking and semantic snapshots
- `git diff --check`
