### PR TITLE
[lsp] Hover instance member declarations

### DIFF
--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -893,43 +893,37 @@ fn lower_instance_statements(
         }
     }
 
-    in_scope
-        .into_iter()
-        .map(|(name, (statements, signature, equations))| {
-            // Resolve the class member using the class type ID
-            let resolution = class_resolution
-                .and_then(|(_, class_id)| context.resolved.lookup_class_member(class_id, &name));
-            let statements: Arc<[InstanceMemberId]> = Arc::from(statements);
+    let member_groups = in_scope.into_iter().map(|(name, (statements, signature, equations))| {
+        // Resolve the class member using the class type ID
+        let resolution = class_resolution.and_then(|(class_file, class_id)| {
+            context.resolved.lookup_class_member(class_file, class_id, &name)
+        });
+        let statements: Arc<[InstanceMemberId]> = Arc::from(statements);
 
-            state.with_scope(|state| {
-                state.push_forall_scope();
-                let signature = signature.and_then(|id| {
+        state.with_scope(|state| {
+            state.push_forall_scope();
+            let signature = signature.and_then(|id| {
+                let cst = context.stabilized.ast_ptr(id)?.try_to_node(context.root)?;
+                cst.type_().map(|t| recursive::lower_forall(state, context, &t))
+            });
+            let equations = equations
+                .iter()
+                .filter_map(|&id| {
                     let cst = context.stabilized.ast_ptr(id)?.try_to_node(context.root)?;
-                    cst.type_().map(|t| recursive::lower_forall(state, context, &t))
-                });
-                let equations = equations
-                    .iter()
-                    .filter_map(|&id| {
-                        let cst = context.stabilized.ast_ptr(id)?.try_to_node(context.root)?;
-                        Some(recursive::lower_equation_like(
-                            state,
-                            context,
-                            Some(EquationSourceId::Instance(id)),
-                            cst,
-                            cst::InstanceEquationStatement::function_binders,
-                            cst::InstanceEquationStatement::guarded_expression,
-                        ))
-                    })
-                    .collect();
-                InstanceMemberGroup {
-                    statements: statements.clone(),
-                    resolution,
-                    signature,
-                    equations,
-                }
-            })
+                    Some(recursive::lower_equation_like(
+                        state,
+                        context,
+                        Some(EquationSourceId::Instance(id)),
+                        cst,
+                        cst::InstanceEquationStatement::function_binders,
+                        cst::InstanceEquationStatement::guarded_expression,
+                    ))
+                })
+                .collect();
+            InstanceMemberGroup { statements: statements.clone(), resolution, signature, equations }
         })
-        .collect()
+    });
+    member_groups.collect()
 }
 
 fn lower_roles(context: &Context, id: TypeRoleId) -> Arc<[Role]> {

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -860,10 +860,13 @@ fn lower_instance_statements(
 
     let mut in_scope: IndexMap<_, _, FxBuildHasher> = IndexMap::default();
     for (name, mut children) in children.into_iter() {
+        let mut statements = vec![];
         let mut signature = None;
         let mut equations = vec![];
 
         if let Some(statement) = children.next() {
+            let id = context.stabilized.lookup_cst(&statement).expect_id();
+            statements.push(id);
             match statement {
                 cst::InstanceMemberStatement::InstanceSignatureStatement(cst) => {
                     let id = context.stabilized.lookup_cst(&cst).expect_id();
@@ -877,6 +880,8 @@ fn lower_instance_statements(
         }
 
         children.for_each(|statement| {
+            let id = context.stabilized.lookup_cst(&statement).expect_id();
+            statements.push(id);
             if let cst::InstanceMemberStatement::InstanceEquationStatement(cst) = statement {
                 let id = context.stabilized.lookup_cst(&cst).expect_id();
                 equations.push(id);
@@ -884,16 +889,17 @@ fn lower_instance_statements(
         });
 
         if let Some(name) = name {
-            in_scope.insert(name, (signature, equations));
+            in_scope.insert(name, (statements, signature, equations));
         }
     }
 
     in_scope
         .into_iter()
-        .map(|(name, (signature, equations))| {
+        .map(|(name, (statements, signature, equations))| {
             // Resolve the class member using the class type ID
             let resolution = class_resolution
                 .and_then(|(_, class_id)| context.resolved.lookup_class_member(class_id, &name));
+            let statements: Arc<[InstanceMemberId]> = Arc::from(statements);
 
             state.with_scope(|state| {
                 state.push_forall_scope();
@@ -915,7 +921,12 @@ fn lower_instance_statements(
                         ))
                     })
                     .collect();
-                InstanceMemberGroup { resolution, signature, equations }
+                InstanceMemberGroup {
+                    statements: statements.clone(),
+                    resolution,
+                    signature,
+                    equations,
+                }
             })
         })
         .collect()

--- a/compiler-core/lowering/src/source.rs
+++ b/compiler-core/lowering/src/source.rs
@@ -14,6 +14,7 @@ pub type LetBindingId = AstId<cst::LetBindingPattern>;
 pub type LetBindingSignatureId = AstId<cst::LetBindingSignature>;
 pub type LetBindingEquationId = AstId<cst::LetBindingEquation>;
 
+pub type InstanceMemberId = AstId<cst::InstanceMemberStatement>;
 pub type InstanceSignatureId = AstId<cst::InstanceSignatureStatement>;
 pub type InstanceEquationId = AstId<cst::InstanceEquationStatement>;
 

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -312,6 +312,7 @@ pub struct InfixPair<T> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InstanceMemberGroup {
+    pub statements: Arc<[InstanceMemberId]>,
     pub resolution: Option<(FileId, TermItemId)>,
     pub signature: Option<TypeId>,
     pub equations: Arc<[Equation]>,
@@ -564,6 +565,19 @@ impl LoweredTree {
     ) -> Option<LetBindingNameGroupId> {
         self.let_binding_groups.iter().find_map(|(let_binding_id, let_binding_group)| {
             let_binding_group.equations.contains(&equation_id).then_some(let_binding_id)
+        })
+    }
+
+    pub fn find_instance_member_resolution(
+        &self,
+        statement_id: InstanceMemberId,
+    ) -> Option<(FileId, TermItemId)> {
+        self.term_items.values().find_map(|item| {
+            let TermItemKind::Instance { members, .. } = item else {
+                return None;
+            };
+            let member = members.iter().find(|member| member.statements.contains(&statement_id))?;
+            member.resolution
         })
     }
 }

--- a/compiler-core/resolving/src/algorithm.rs
+++ b/compiler-core/resolving/src/algorithm.rs
@@ -134,13 +134,15 @@ fn resolve_import(
     }
 
     // Copy class members AFTER kind adjustments so hidden types are properly filtered
-    for (_, _, type_id, import_kind) in resolved.iter_classes() {
+    for (_, class_file, type_id, import_kind) in resolved.iter_classes() {
         if matches!(import_kind, ImportKind::Hidden) {
             continue;
         }
-        for (member_name, member_file, member_id) in import_resolved.class.class_members(type_id) {
+        for (member_name, member_file, member_id) in
+            import_resolved.class.class_members(class_file, type_id)
+        {
             let member_name = SmolStr::clone(member_name);
-            class_members.insert(type_id, member_name, member_file, member_id);
+            class_members.insert(class_file, type_id, member_name, member_file, member_id);
         }
     }
 
@@ -249,7 +251,7 @@ fn export_class_members(state: &mut State, indexed: &IndexedModule, file: FileId
             let member_item = &indexed.items[member_term_id];
             if let Some(name) = &member_item.name {
                 let name = SmolStr::clone(name);
-                state.class.insert(type_id, name, file, member_term_id);
+                state.class.insert(file, type_id, name, file, member_term_id);
             }
         }
     }

--- a/compiler-core/resolving/src/lib.rs
+++ b/compiler-core/resolving/src/lib.rs
@@ -17,37 +17,46 @@ pub trait ExternalQueries:
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ResolvedClassMembers {
-    members: FxHashMap<(TypeItemId, SmolStr), (FileId, TermItemId)>,
+    members: FxHashMap<(FileId, TypeItemId, SmolStr), (FileId, TermItemId)>,
 }
 
 impl ResolvedClassMembers {
     pub fn insert(
         &mut self,
+        class_file: FileId,
         class_id: TypeItemId,
         name: SmolStr,
-        file: FileId,
+        member_file: FileId,
         term_id: TermItemId,
     ) {
-        self.members.insert((class_id, name), (file, term_id));
+        self.members.insert((class_file, class_id, name), (member_file, term_id));
     }
 
-    pub fn lookup(&self, class_id: TypeItemId, name: &str) -> Option<(FileId, TermItemId)> {
-        let key = &(class_id, SmolStr::new(name));
+    pub fn lookup(
+        &self,
+        class_file: FileId,
+        class_id: TypeItemId,
+        name: &str,
+    ) -> Option<(FileId, TermItemId)> {
+        let key = &(class_file, class_id, SmolStr::new(name));
         self.members.get(key).copied()
     }
 
     pub fn class_members(
         &self,
+        class_file: FileId,
         class_id: TypeItemId,
     ) -> impl Iterator<Item = (&SmolStr, FileId, TermItemId)> + '_ {
         self.members
             .iter()
-            .filter(move |((type_id, _), _)| *type_id == class_id)
-            .map(|((_, name), (file, id))| (name, *file, *id))
+            .filter(move |((file_id, type_id, _), _)| {
+                *file_id == class_file && *type_id == class_id
+            })
+            .map(|((_, _, name), (file, id))| (name, *file, *id))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (TypeItemId, &SmolStr, FileId, TermItemId)> + '_ {
-        self.members.iter().map(|((class_id, name), (file, id))| (*class_id, name, *file, *id))
+        self.members.iter().map(|((_, class_id, name), (file, id))| (*class_id, name, *file, *id))
     }
 }
 
@@ -197,10 +206,11 @@ impl ResolvedModule {
 
     pub fn lookup_class_member(
         &self,
+        class_file: FileId,
         class_id: TypeItemId,
         name: &str,
     ) -> Option<(FileId, TermItemId)> {
-        self.class.lookup(class_id, name)
+        self.class.lookup(class_file, class_id, name)
     }
 
     pub fn is_term_in_scope(

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -57,6 +57,9 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_type(context, f_id, t_id)
         }
+        locate::Located::InstanceMember(file_id, term_id) => {
+            definition_file_term(context, file_id, term_id)
+        }
         locate::Located::TermItem(term_id) => definition_file_term(context, current_file, term_id),
         locate::Located::TypeItem(type_id) => definition_file_type(context, current_file, type_id),
         locate::Located::LetBinding(let_id) => {

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -62,7 +62,9 @@ pub fn implementation(
         locate::Located::TypeOperator(operator_id) => {
             highlight_type_operator(context, current_file, operator_id)
         }
-        locate::Located::ModuleName(_) | locate::Located::Nothing => Ok(None),
+        locate::Located::ModuleName(_)
+        | locate::Located::InstanceMember(_, _)
+        | locate::Located::Nothing => Ok(None),
     }
 }
 

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -56,6 +56,9 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             hover_file_type(engine, f_id, t_id)
         }
+        locate::Located::InstanceMember(file_id, term_id) => {
+            hover_file_term(engine, file_id, term_id)
+        }
         locate::Located::TermItem(term_id) => hover_file_term(engine, current_file, term_id),
         locate::Located::TypeItem(type_id) => hover_file_type(engine, current_file, type_id),
         locate::Located::LetBinding(let_id) => hover_let(engine, current_file, let_id),

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -85,6 +85,7 @@ pub enum Located {
     ExpressionPun(RecordPunId),
     TermOperator(TermOperatorId),
     TypeOperator(TypeOperatorId),
+    InstanceMember(FileId, TermItemId),
     TermItem(TermItemId),
     TypeItem(TypeItemId),
     LetBinding(LetBindingNameGroupId),
@@ -213,6 +214,11 @@ fn locate_node(
         let id = stabilized.lookup_ptr(&ptr)?;
         let id = indexed.pairs.class_member_to_term(id)?;
         Some(Located::TermItem(id))
+    } else if cst::InstanceMemberStatement::can_cast(kind) {
+        let ptr = ptr.cast()?;
+        let id = stabilized.lookup_ptr(&ptr)?;
+        let (file_id, term_id) = lowered.tree.find_instance_member_resolution(id)?;
+        Some(Located::InstanceMember(file_id, term_id))
     } else {
         None
     }

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -68,6 +68,7 @@ pub fn implementation(
         locate::Located::ExpressionPun(pun_id) => {
             references_expression_pun(context, current_file, pun_id)
         }
+        locate::Located::InstanceMember(_, _) => Ok(None),
         locate::Located::Nothing => Ok(None),
     }
 }

--- a/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Data.Functor.purs
+++ b/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Data.Functor.purs
@@ -1,0 +1,4 @@
+module Data.Functor where
+
+class Functor f where
+  map :: forall a b. (a -> b) -> f a -> f b

--- a/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.purs
+++ b/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.purs
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.Functor (class Functor)
+
+newtype Continuation r a = Continuation ((a -> r) -> r)
+
+instance Functor (Continuation r) where
+  map :: forall a b. (a -> b) -> Continuation r a -> Continuation r b
+-- $
+  map function (Continuation program) =
+-- $
+    Continuation \return ->
+      program \a ->
+        return (function a)
+
+value :: Int
+value = 42
+-- $

--- a/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.snap
@@ -10,7 +10,15 @@ Hover at Position { line: 7, character: 3 }
 -- $
 ```
 
-<empty>
+```purescript
+map ::
+  forall (@f :: Type -> Type).
+    Functor (f :: Type -> Type) =>
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
+```
 
 
 Hover at Position { line: 9, character: 3 }
@@ -20,7 +28,15 @@ Hover at Position { line: 9, character: 3 }
 -- $
 ```
 
-<empty>
+```purescript
+map ::
+  forall (@f :: Type -> Type).
+    Functor (f :: Type -> Type) =>
+    (forall (a :: Type) (b :: Type).
+      ((a :: Type) -> (b :: Type)) ->
+      (f :: Type -> Type) (a :: Type) ->
+      (f :: Type -> Type) (b :: Type))
+```
 
 
 Hover at Position { line: 16, character: 3 }

--- a/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763200_hover_instance_member/Main.snap
@@ -1,0 +1,35 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 7, character: 3 }
+
+```
+  map :: forall a b. (a -> b) -> Continuation r a -> Continuation r b
+-- $
+```
+
+<empty>
+
+
+Hover at Position { line: 9, character: 3 }
+
+```
+  map function (Continuation program) =
+-- $
+```
+
+<empty>
+
+
+Hover at Position { line: 16, character: 3 }
+
+```
+value = 42
+-- $
+```
+
+```purescript
+value :: Int
+```

--- a/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Alpha.purs
+++ b/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Alpha.purs
@@ -1,0 +1,4 @@
+module Alpha where
+
+class Alpha a where
+  execute :: a -> Int

--- a/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Beta.purs
+++ b/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Beta.purs
@@ -1,0 +1,4 @@
+module Beta where
+
+class Beta a where
+  execute :: a -> Int

--- a/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.purs
+++ b/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Alpha as Alpha
+import Beta as Beta
+
+instance Alpha.Alpha Int where
+  execute value = value
+-- $ @
+
+instance Beta.Beta Int where
+  execute value = value
+-- $ @

--- a/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.snap
+++ b/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.snap
@@ -33,7 +33,7 @@ Hover at Position { line: 10, character: 3 }
 ```
 
 ```purescript
-execute :: forall (@a :: Type). Alpha (a :: Type) => (a :: Type) -> Int
+execute :: forall (@a :: Type). Beta (a :: Type) => (a :: Type) -> Int
 ```
 
 
@@ -44,4 +44,4 @@ GotoDefinition at Position { line: 10, character: 5 }
 -- $ @
 ```
 
-file:///tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Alpha.purs @ 3:2..3:21
+file:///tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Beta.purs @ 3:2..3:21

--- a/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.snap
+++ b/tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Main.snap
@@ -1,0 +1,47 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 6, character: 3 }
+
+```
+  execute value = value
+-- $ @
+```
+
+```purescript
+execute :: forall (@a :: Type). Alpha (a :: Type) => (a :: Type) -> Int
+```
+
+
+GotoDefinition at Position { line: 6, character: 5 }
+
+```
+  execute value = value
+-- $ @
+```
+
+file:///tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Alpha.purs @ 3:2..3:21
+
+
+Hover at Position { line: 10, character: 3 }
+
+```
+  execute value = value
+-- $ @
+```
+
+```purescript
+execute :: forall (@a :: Type). Alpha (a :: Type) => (a :: Type) -> Int
+```
+
+
+GotoDefinition at Position { line: 10, character: 5 }
+
+```
+  execute value = value
+-- $ @
+```
+
+file:///tests-integration/fixtures/lsp/1785768000_qualified_instance_member_collision/Alpha.purs @ 3:2..3:21


### PR DESCRIPTION
## Problem

Hover lookup recognizes ordinary value signatures and equations, but instance member statements are not connected back to their resolved class member. As a result, hovering either the signature or equation name in an instance body returns no information.

Implementing that connection also exposed a name-resolution bug: class members were keyed by the module-local `TypeItemId` and member name. Two imported classes with the same local type ID and member name could therefore collide, causing an instance of one qualified class to resolve hover and go-to-definition to the other class.

## Change

Retain the stable source IDs for each grouped instance member during lowering and expose their class-member resolution to editor queries. The LSP locator now identifies instance member statements explicitly, and hover uses the existing resolved term signature renderer. Go-to-definition follows the same unambiguous class-member target, while rename, references, and document highlights remain disabled until they can account for instance labels completely.

Class-member resolution now uses the complete class identity `(FileId, TypeItemId)` together with the member name. Imported and re-exported class members preserve that identity, preventing collisions between module-local IDs.

The commit history includes failing snapshots for both the missing instance-member hovers and a qualified `Alpha`/`Beta` class-member collision, followed by their respective fixes.

## Verification

- `just format`
- `cargo check -p resolving --tests`
- `cargo check -p lowering --tests`
- `cargo check -p analyzer --tests`
- `cargo nextest run -p analyzer`
- complete resolving integration suite
- complete LSP integration suite
- `git diff --check`