### PR TITLE
[lsp] Rename local bindings

### DIFF
--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -363,6 +363,16 @@ fn references_file_term(
             }
         }
 
+        for (pun_id, resolution) in lowered.tree.iter_expression_pun() {
+            if let TermVariableResolution::Reference(f_id, t_id) = resolution
+                && (f_id, t_id) == (file_id, term_id)
+            {
+                let range = id_range(context, &content, &parsed, &stabilized, pun_id)
+                    .ok_or(AnalyzerError::NonFatal)?;
+                locations.push(Location { uri: uri.clone(), range });
+            }
+        }
+
         for (binder_id, binder_kind) in lowered.tree.iter_binder() {
             if let BinderKind::Constructor { resolution: Some((f_id, t_id)), .. } = binder_kind
                 && (*f_id, *t_id) == (file_id, term_id)

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -3,7 +3,10 @@ use files::FileId;
 use indexing::{
     ImportId, ImportItemId, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
 };
-use lowering::{BinderKind, ExpressionKind, TermVariableResolution, TypeKind};
+use lowering::{
+    BinderId, BinderKind, ExpressionKind, LetBindingNameGroupId, RecordPunId,
+    TermVariableResolution, TypeKind,
+};
 use lsp_types::*;
 use syntax::ast::{AstNode, AstPtr};
 use syntax::{SyntaxToken, TextRange, TextSize, TokenAtOffset, cst};
@@ -16,6 +19,9 @@ mod edit;
 enum RenameTarget {
     Term(FileId, TermItemId),
     Type(FileId, TypeItemId),
+    Binder(FileId, BinderId),
+    LetBinding(FileId, LetBindingNameGroupId),
+    RecordPun(FileId, RecordPunId),
     Qualifier(FileId, ImportId),
     Module(FileId),
 }
@@ -25,6 +31,9 @@ impl RenameTarget {
         match self {
             RenameTarget::Term(file_id, _)
             | RenameTarget::Type(file_id, _)
+            | RenameTarget::Binder(file_id, _)
+            | RenameTarget::LetBinding(file_id, _)
+            | RenameTarget::RecordPun(file_id, _)
             | RenameTarget::Qualifier(file_id, _)
             | RenameTarget::Module(file_id) => file_id,
         }
@@ -77,6 +86,13 @@ pub fn implementation(
             edits.collect_references(locations, name_kind, &new_name)?;
             edits.collect_declaration(target, &new_name)?;
             edits.collect_item_surfaces(target, &old_name, &new_name)?;
+        }
+        RenameTarget::Binder(_, _)
+        | RenameTarget::LetBinding(_, _)
+        | RenameTarget::RecordPun(_, _) => {
+            let locations = references::implementation(context, uri, position)?.unwrap_or_default();
+            edits.collect_references(locations, name_kind, &new_name)?;
+            edits.collect_declaration(target, &new_name)?;
         }
     }
 
@@ -234,26 +250,31 @@ fn rename_target(
         locate::Located::Binder(binder_id) => {
             let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
 
-            let BinderKind::Constructor { resolution: Some((file_id, term_id)), .. } = kind else {
-                return Err(AnalyzerError::NonFatal);
-            };
-
-            RenameTarget::Term(*file_id, *term_id)
+            match kind {
+                BinderKind::Constructor { resolution: Some((file_id, term_id)), .. } => {
+                    RenameTarget::Term(*file_id, *term_id)
+                }
+                BinderKind::Variable { variable: Some(_) }
+                | BinderKind::Named { named: Some(_), .. } => {
+                    RenameTarget::Binder(current_file, binder_id)
+                }
+                _ => return Err(AnalyzerError::NonFatal),
+            }
         }
         locate::Located::Expression(expression_id) => {
             let kind =
                 lowered.tree.get_expression_kind(expression_id).ok_or(AnalyzerError::NonFatal)?;
 
-            let resolution = match kind {
+            match kind {
                 ExpressionKind::Constructor { resolution: Some(resolution) }
-                | ExpressionKind::OperatorName { resolution: Some(resolution) } => *resolution,
-                ExpressionKind::Variable {
-                    resolution: Some(TermVariableResolution::Reference(file_id, term_id)),
-                } => (*file_id, *term_id),
+                | ExpressionKind::OperatorName { resolution: Some(resolution) } => {
+                    RenameTarget::Term(resolution.0, resolution.1)
+                }
+                ExpressionKind::Variable { resolution: Some(resolution) } => {
+                    target_from_term_resolution(current_file, *resolution)
+                }
                 _ => return Err(AnalyzerError::NonFatal),
-            };
-
-            RenameTarget::Term(resolution.0, resolution.1)
+            }
         }
         locate::Located::Type(type_id) => {
             let kind = lowered.tree.get_type_kind(type_id).ok_or(AnalyzerError::NonFatal)?;
@@ -280,10 +301,33 @@ fn rename_target(
         }
         locate::Located::TermItem(term_id) => RenameTarget::Term(current_file, term_id),
         locate::Located::TypeItem(type_id) => RenameTarget::Type(current_file, type_id),
+        locate::Located::LetBinding(binding_id) => {
+            RenameTarget::LetBinding(current_file, binding_id)
+        }
+        locate::Located::BinderPun(pun_id) => RenameTarget::RecordPun(current_file, pun_id),
+        locate::Located::ExpressionPun(pun_id) => {
+            let resolution =
+                lowered.tree.get_expression_pun(pun_id).ok_or(AnalyzerError::NonFatal)?;
+            target_from_term_resolution(current_file, resolution)
+        }
         _ => return Err(AnalyzerError::NonFatal),
     };
 
     Ok(target)
+}
+
+fn target_from_term_resolution(
+    current_file: FileId,
+    resolution: TermVariableResolution,
+) -> RenameTarget {
+    match resolution {
+        TermVariableResolution::Binder(binder_id) => RenameTarget::Binder(current_file, binder_id),
+        TermVariableResolution::Let(binding_id) => {
+            RenameTarget::LetBinding(current_file, binding_id)
+        }
+        TermVariableResolution::RecordPun(pun_id) => RenameTarget::RecordPun(current_file, pun_id),
+        TermVariableResolution::Reference(file_id, term_id) => RenameTarget::Term(file_id, term_id),
+    }
 }
 
 fn module_target(
@@ -435,6 +479,36 @@ fn target_name(
             };
 
             Some((name.to_string(), kind))
+        }
+        RenameTarget::Binder(file_id, binder_id) => {
+            let lowered = context.queries().lowered(file_id)?;
+            let kind = lowered.tree.get_binder_kind(binder_id).ok_or(AnalyzerError::NonFatal)?;
+
+            let name = match kind {
+                BinderKind::Variable { variable } => variable.as_ref(),
+                BinderKind::Named { named, .. } => named.as_ref(),
+                _ => None,
+            };
+
+            name.map(|name| (name.to_string(), NameKind::Lower))
+        }
+        RenameTarget::LetBinding(file_id, binding_id) => {
+            let lowered = context.queries().lowered(file_id)?;
+            let binding = lowered.tree.get_let_binding_group(binding_id);
+            binding.name.as_ref().map(|name| (name.to_string(), NameKind::Lower))
+        }
+        RenameTarget::RecordPun(file_id, pun_id) => {
+            let content = context.queries().content(file_id);
+            let (parsed, _) = context.queries().parsed(file_id)?;
+            let stabilized = context.queries().stabilized(file_id)?;
+
+            let root = parsed.syntax_node();
+            let ptr = stabilized.syntax_ptr(pun_id).ok_or(AnalyzerError::NonFatal)?;
+            let node = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+            let pun = cst::RecordPun::cast(node).ok_or(AnalyzerError::NonFatal)?;
+            let name = pun.name().ok_or(AnalyzerError::NonFatal)?;
+
+            Some((name.syntax().text(&content).to_string(), NameKind::Lower))
         }
         RenameTarget::Qualifier(file_id, import_id) => {
             let indexed = context.queries().indexed(file_id)?;

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -267,6 +267,21 @@ fn record_field_replacement_range(field: &cst::RecordField) -> Option<TextRange>
     Some(TextRange::new(start, end))
 }
 
+fn record_field_can_collapse(content: &str, field: &cst::RecordField, value: &SyntaxToken) -> bool {
+    let Some(label) = field.name().and_then(|name| name.text()) else {
+        return false;
+    };
+
+    let separator_range = TextRange::new(label.text_range().end(), value.text_range().start());
+    let trailing_range =
+        TextRange::new(value.text_range().end(), field.syntax().text_range().end());
+    let separator = &content[separator_range];
+    let trailing = &content[trailing_range];
+
+    separator.strip_prefix(':').is_some_and(|trivia| trivia.chars().all(char::is_whitespace))
+        && trailing.chars().all(char::is_whitespace)
+}
+
 impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
     Host: AnalyzerHost,
@@ -384,13 +399,17 @@ where
         }
 
         let qualified = token.parent_ancestors().find_map(cst::QualifiedName::cast)?;
-        let field = token.parent_ancestors().find_map(cst::RecordField::cast)?;
-        let expression = field.expression()?;
+        if qualified.qualifier().is_some() {
+            return None;
+        }
 
-        let expression_text = expression.syntax().text(content);
-        let qualified_text = qualified.syntax().text(content);
-        let direct_reference = expression_text.trim() == qualified_text;
-        (direct_reference && record_field_has_name(content, &field, new_name)).then_some(field)
+        let field = token.parent_ancestors().find_map(cst::RecordField::cast)?;
+        field.expression()?;
+        let value = qualified.lower()?;
+
+        (record_field_has_name(content, &field, new_name)
+            && record_field_can_collapse(content, &field, &value))
+        .then_some(field)
     }
 
     fn qualified_name_token(token: &SyntaxToken, name_kind: NameKind) -> Option<SyntaxToken> {
@@ -449,11 +468,13 @@ where
         let ptr = stabilized.syntax_ptr(binder_id).ok_or(AnalyzerError::NonFatal)?;
         let node = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
 
-        if cst::BinderVariable::cast(node.clone()).is_some()
+        if let Some(variable) = cst::BinderVariable::cast(node.clone())
             && let Some(field) = node.ancestors().find_map(cst::RecordField::cast)
             && let Some(binder) = field.binder()
+            && let Some(value) = variable.name_token()
             && binder.syntax().text_range() == node.text_range()
             && record_field_has_name(&content, &field, new_name)
+            && record_field_can_collapse(&content, &field, &value)
         {
             let range = record_field_replacement_range(&field).ok_or(AnalyzerError::NonFatal)?;
             return self.push_text_range_edit(file_id, range, new_name);

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -6,6 +6,7 @@ use indexing::{
     ImplicitItems, ImportId, ImportItemId, IndexedTermItemKind, IndexedTypeItemKind, TermItemId,
     TypeItemId, TypeSelection,
 };
+use lowering::{BinderId, LetBindingNameGroupId, RecordPunId};
 use lsp_types::*;
 use stabilizing::AstId;
 use syntax::ast::AstNode;
@@ -221,6 +222,51 @@ where
     }
 }
 
+fn binder_name_range(content: &str, root: &SyntaxNode, ptr: &SyntaxNodePtr) -> Option<Utf8Range> {
+    let node = ptr.try_to_node(root)?;
+
+    if let Some(binder) = cst::BinderVariable::cast(node.clone()) {
+        let token = binder.name_token()?;
+        return position::text_range_to_utf8_range(content, token.text_range());
+    }
+
+    let binder = cst::BinderNamed::cast(node)?;
+    let token = binder.name_token()?;
+    position::text_range_to_utf8_range(content, token.text_range())
+}
+
+fn let_binding_signature_name_range(
+    content: &str,
+    root: &SyntaxNode,
+    ptr: &SyntaxNodePtr,
+) -> Option<Utf8Range> {
+    let node = ptr.try_to_node(root)?;
+    let signature = cst::LetBindingSignature::cast(node)?;
+    let token = signature.name_token()?;
+    position::text_range_to_utf8_range(content, token.text_range())
+}
+
+fn let_binding_equation_name_range(
+    content: &str,
+    root: &SyntaxNode,
+    ptr: &SyntaxNodePtr,
+) -> Option<Utf8Range> {
+    let node = ptr.try_to_node(root)?;
+    let equation = cst::LetBindingEquation::cast(node)?;
+    let token = equation.name_token()?;
+    position::text_range_to_utf8_range(content, token.text_range())
+}
+
+fn record_field_has_name(content: &str, field: &cst::RecordField, name: &str) -> bool {
+    field.name().and_then(|name| name.text()).is_some_and(|token| token.text(content) == name)
+}
+
+fn record_field_replacement_range(field: &cst::RecordField) -> Option<TextRange> {
+    let start = field.name()?.text()?.text_range().start();
+    let end = field.syntax().text_range().end();
+    Some(TextRange::new(start, end))
+}
+
 impl<'edits, 'language, Host> RenameEdits<'edits, 'language, Host>
 where
     Host: AnalyzerHost,
@@ -238,19 +284,21 @@ where
                 continue;
             }
 
-            let range = self.reference_name_range(file_id, location.range, name_kind)?;
-            self.push_protocol_edit(file_id, range, new_name)?;
+            let (range, new_text) =
+                self.reference_name_edit(file_id, location.range, name_kind, new_name)?;
+            self.push_protocol_edit(file_id, range, &new_text)?;
         }
 
         Ok(())
     }
 
-    fn reference_name_range(
+    fn reference_name_edit(
         &self,
         file_id: FileId,
         range: Range,
         name_kind: NameKind,
-    ) -> Result<Range, AnalyzerError> {
+        new_name: &str,
+    ) -> Result<(Range, String), AnalyzerError> {
         let content = self.context.queries().content(file_id);
         let position = position::protocol_position_to_utf8(
             &content,
@@ -268,18 +316,81 @@ where
             TokenAtOffset::None => return Err(AnalyzerError::NonFatal),
             TokenAtOffset::Single(token) => token,
             TokenAtOffset::Between(left, right) => {
-                if Self::qualified_name_token(&right, name_kind).is_some() { right } else { left }
+                if Self::qualified_name_token(&right, name_kind).is_some()
+                    || Self::record_pun(&right, name_kind).is_some()
+                {
+                    right
+                } else {
+                    left
+                }
             }
         };
 
-        let token = Self::qualified_name_token(&token, name_kind).ok_or(AnalyzerError::NonFatal)?;
+        if matches!(name_kind, NameKind::Lower)
+            && let Some(pun) = Self::record_pun(&token, name_kind)
+        {
+            let name = pun.name().ok_or(AnalyzerError::NonFatal)?;
+            let old_name = name.syntax().text(&content);
+            let range = position::text_range_to_protocol(
+                &content,
+                name.syntax().text_range(),
+                self.context.position_encoding(),
+            )
+            .ok_or(AnalyzerError::NonFatal)?;
 
-        position::text_range_to_protocol(
+            return Ok((range, format!("{old_name}: {new_name}")));
+        }
+
+        if let Some(field) = Self::collapsible_record_field(&token, &content, name_kind, new_name) {
+            let text_range =
+                record_field_replacement_range(&field).ok_or(AnalyzerError::NonFatal)?;
+            let range = position::text_range_to_protocol(
+                &content,
+                text_range,
+                self.context.position_encoding(),
+            )
+            .ok_or(AnalyzerError::NonFatal)?;
+
+            return Ok((range, new_name.to_string()));
+        }
+
+        let token = Self::qualified_name_token(&token, name_kind).ok_or(AnalyzerError::NonFatal)?;
+        let range = position::text_range_to_protocol(
             &content,
             token.text_range(),
             self.context.position_encoding(),
         )
-        .ok_or(AnalyzerError::NonFatal)
+        .ok_or(AnalyzerError::NonFatal)?;
+
+        Ok((range, new_name.to_string()))
+    }
+
+    fn record_pun(token: &SyntaxToken, name_kind: NameKind) -> Option<cst::RecordPun> {
+        if !matches!(name_kind, NameKind::Lower) {
+            return None;
+        }
+
+        token.parent_ancestors().find_map(cst::RecordPun::cast)
+    }
+
+    fn collapsible_record_field(
+        token: &SyntaxToken,
+        content: &str,
+        name_kind: NameKind,
+        new_name: &str,
+    ) -> Option<cst::RecordField> {
+        if !matches!(name_kind, NameKind::Lower) {
+            return None;
+        }
+
+        let qualified = token.parent_ancestors().find_map(cst::QualifiedName::cast)?;
+        let field = token.parent_ancestors().find_map(cst::RecordField::cast)?;
+        let expression = field.expression()?;
+
+        let expression_text = expression.syntax().text(content);
+        let qualified_text = qualified.syntax().text(content);
+        let direct_reference = expression_text.trim() == qualified_text;
+        (direct_reference && record_field_has_name(content, &field, new_name)).then_some(field)
     }
 
     fn qualified_name_token(token: &SyntaxToken, name_kind: NameKind) -> Option<SyntaxToken> {
@@ -310,9 +421,96 @@ where
             RenameTarget::Type(file_id, type_id) => {
                 self.type_declaration_edits(file_id, type_id, new_name)
             }
+            RenameTarget::Binder(file_id, binder_id) => {
+                self.binder_declaration_edit(file_id, binder_id, new_name)
+            }
+            RenameTarget::LetBinding(file_id, binding_id) => {
+                self.let_binding_declaration_edits(file_id, binding_id, new_name)
+            }
+            RenameTarget::RecordPun(file_id, pun_id) => {
+                self.record_pun_declaration_edit(file_id, pun_id, new_name)
+            }
             RenameTarget::Qualifier(_, _) => Ok(()),
             RenameTarget::Module(_) => Ok(()),
         }
+    }
+
+    fn binder_declaration_edit(
+        &mut self,
+        file_id: FileId,
+        binder_id: BinderId,
+        new_name: &str,
+    ) -> Result<(), AnalyzerError> {
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
+        let root = parsed.syntax_node();
+        let stabilized = self.context.queries().stabilized(file_id)?;
+
+        let ptr = stabilized.syntax_ptr(binder_id).ok_or(AnalyzerError::NonFatal)?;
+        let node = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+
+        if cst::BinderVariable::cast(node.clone()).is_some()
+            && let Some(field) = node.ancestors().find_map(cst::RecordField::cast)
+            && let Some(binder) = field.binder()
+            && binder.syntax().text_range() == node.text_range()
+            && record_field_has_name(&content, &field, new_name)
+        {
+            let range = record_field_replacement_range(&field).ok_or(AnalyzerError::NonFatal)?;
+            return self.push_text_range_edit(file_id, range, new_name);
+        }
+
+        self.push_name_edit(file_id, Some(binder_id), binder_name_range, new_name)
+    }
+
+    fn let_binding_declaration_edits(
+        &mut self,
+        file_id: FileId,
+        binding_id: LetBindingNameGroupId,
+        new_name: &str,
+    ) -> Result<(), AnalyzerError> {
+        let lowered = self.context.queries().lowered(file_id)?;
+        let binding = lowered.tree.get_let_binding_group(binding_id);
+
+        push_name_edits!(
+            self,
+            file_id,
+            new_name,
+            let_binding_signature_name_range;
+            binding.signature,
+        );
+
+        for &equation in binding.equations.iter() {
+            push_name_edits!(
+                self,
+                file_id,
+                new_name,
+                let_binding_equation_name_range;
+                Some(equation),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn record_pun_declaration_edit(
+        &mut self,
+        file_id: FileId,
+        pun_id: RecordPunId,
+        new_name: &str,
+    ) -> Result<(), AnalyzerError> {
+        let content = self.context.queries().content(file_id);
+        let (parsed, _) = self.context.queries().parsed(file_id)?;
+        let root = parsed.syntax_node();
+        let stabilized = self.context.queries().stabilized(file_id)?;
+
+        let ptr = stabilized.syntax_ptr(pun_id).ok_or(AnalyzerError::NonFatal)?;
+        let node = ptr.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+        let pun = cst::RecordPun::cast(node).ok_or(AnalyzerError::NonFatal)?;
+        let name = pun.name().ok_or(AnalyzerError::NonFatal)?;
+        let old_name = name.syntax().text(&content);
+        let new_text = format!("{old_name}: {new_name}");
+
+        self.push_text_range_edit(file_id, name.syntax().text_range(), &new_text)
     }
 
     fn term_declaration_edits(
@@ -460,8 +658,11 @@ where
                         }
                     }
                 }
-                RenameTarget::Qualifier(_, _) => {}
-                RenameTarget::Module(_) => {}
+                RenameTarget::Binder(_, _)
+                | RenameTarget::LetBinding(_, _)
+                | RenameTarget::RecordPun(_, _)
+                | RenameTarget::Qualifier(_, _)
+                | RenameTarget::Module(_) => {}
             }
         }
 
@@ -557,8 +758,11 @@ where
                     }
                 }
             }
-            RenameTarget::Qualifier(_, _) => {}
-            RenameTarget::Module(_) => {}
+            RenameTarget::Binder(_, _)
+            | RenameTarget::LetBinding(_, _)
+            | RenameTarget::RecordPun(_, _)
+            | RenameTarget::Qualifier(_, _)
+            | RenameTarget::Module(_) => {}
         }
 
         Ok(())

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Lib.purs
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Lib.purs
@@ -1,0 +1,5 @@
+module Lib where
+
+imported = 1
+
+qualified = 2

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.purs
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.purs
@@ -1,5 +1,8 @@
 module Main where
 
+import Lib (imported)
+import Lib as Lib
+
 data Maybe a = Just a | Nothing
 
 renameArgument argument =
@@ -29,3 +32,17 @@ renamePun' { renamed: original } = original
 
 punReference' original = { renamed: original }
 --                                  /
+
+topLevel = 1
+
+topLevelPun = { topLevel }
+--              /
+
+importedPun = { imported }
+--              /
+
+qualifiedField = { renamed: Lib.qualified }
+--                              /
+
+commentedBinder { renamed: {- keep -} original } = original
+--                                    /

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.purs
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.purs
@@ -1,0 +1,31 @@
+module Main where
+
+data Maybe a = Just a | Nothing
+
+renameArgument argument =
+--             /
+  let shadowed = argument
+  in argument
+--   ?
+
+renameLet input =
+  let local :: Maybe Int -> Int
+      local (Just item) = item
+      local Nothing = input
+  in local (Just input)
+--   /
+
+renameNamed whole@(Just item) = whole
+--          /
+
+renamePun { field } = field
+--          /
+
+punReference value = { value }
+--                     /
+
+renamePun' { renamed: original } = original
+--                    /
+
+punReference' original = { renamed: original }
+--                                  /

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
@@ -3,7 +3,7 @@ source: tests-integration/src/fixtures.rs
 assertion_line: 134
 expression: report
 ---
-Rename at Position { line: 4, character: 15 }
+Rename at Position { line: 7, character: 15 }
 
 ```
 renameArgument argument =
@@ -13,7 +13,7 @@ renameArgument argument =
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -2,10 +2,10 @@
+@@ -5,10 +5,10 @@
 
  data Maybe a = Just a | Nothing
 
@@ -30,17 +30,17 @@ renameArgument argument =
 ```
 
 
-PrepareRename at Position { line: 7, character: 5 }
+PrepareRename at Position { line: 10, character: 5 }
 
 ```
   in argument
 --   ?
 ```
 
-7:5..7:13 argument
+10:5..10:13 argument
 
 
-Rename at Position { line: 14, character: 5 }
+Rename at Position { line: 17, character: 5 }
 
 ```
   in local (Just input)
@@ -50,7 +50,7 @@ Rename at Position { line: 14, character: 5 }
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -9,10 +9,10 @@
+@@ -12,10 +12,10 @@
  --   ?
 
  renameLet input =
@@ -68,7 +68,7 @@ Rename at Position { line: 14, character: 5 }
 ```
 
 
-Rename at Position { line: 17, character: 12 }
+Rename at Position { line: 20, character: 12 }
 
 ```
 renameNamed whole@(Just item) = whole
@@ -78,7 +78,7 @@ renameNamed whole@(Just item) = whole
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -15,7 +15,7 @@
+@@ -18,7 +18,7 @@
    in local (Just input)
  --   /
 
@@ -90,7 +90,7 @@ renameNamed whole@(Just item) = whole
 ```
 
 
-Rename at Position { line: 20, character: 12 }
+Rename at Position { line: 23, character: 12 }
 
 ```
 renamePun { field } = field
@@ -100,7 +100,7 @@ renamePun { field } = field
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -18,7 +18,7 @@
+@@ -21,7 +21,7 @@
  renameNamed whole@(Just item) = whole
  --          /
 
@@ -112,7 +112,7 @@ renamePun { field } = field
 ```
 
 
-Rename at Position { line: 23, character: 23 }
+Rename at Position { line: 26, character: 23 }
 
 ```
 punReference value = { value }
@@ -122,7 +122,7 @@ punReference value = { value }
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -21,7 +21,7 @@
+@@ -24,7 +24,7 @@
  renamePun { field } = field
  --          /
 
@@ -134,7 +134,7 @@ punReference value = { value }
 ```
 
 
-Rename at Position { line: 26, character: 22 }
+Rename at Position { line: 29, character: 22 }
 
 ```
 renamePun' { renamed: original } = original
@@ -144,7 +144,7 @@ renamePun' { renamed: original } = original
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -24,7 +24,7 @@
+@@ -27,7 +27,7 @@
  punReference value = { value }
  --                     /
 
@@ -156,7 +156,7 @@ renamePun' { renamed: original } = original
 ```
 
 
-Rename at Position { line: 29, character: 36 }
+Rename at Position { line: 32, character: 36 }
 
 ```
 punReference' original = { renamed: original }
@@ -166,11 +166,121 @@ punReference' original = { renamed: original }
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -27,5 +27,5 @@
+@@ -30,7 +30,7 @@
  renamePun' { renamed: original } = original
  --                    /
 
 -punReference' original = { renamed: original }
 +punReference' renamed = { renamed }
  --                                  /
+
+ topLevel = 1
+```
+
+
+Rename at Position { line: 37, character: 16 }
+
+```
+topLevelPun = { topLevel }
+--              /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -33,7 +33,7 @@
+ punReference' original = { renamed: original }
+ --                                  /
+
+-topLevel = 1
++renamed = 1
+
+ topLevelPun = { topLevel }
+ --              /
+```
+
+
+Rename at Position { line: 40, character: 16 }
+
+```
+importedPun = { imported }
+--              /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -1,5 +1,5 @@
+ module Lib where
+
+-imported = 1
++renamed = 1
+
+ qualified = 2
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,6 +1,6 @@
+ module Main where
+
+-import Lib (imported)
++import Lib (renamed)
+ import Lib as Lib
+
+ data Maybe a = Just a | Nothing
+```
+
+
+Rename at Position { line: 43, character: 32 }
+
+```
+qualifiedField = { renamed: Lib.qualified }
+--                              /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -2,4 +2,4 @@
+
+ imported = 1
+
+-qualified = 2
++renamed = 2
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -41,7 +41,7 @@
+ importedPun = { imported }
+ --              /
+
+-qualifiedField = { renamed: Lib.qualified }
++qualifiedField = { renamed }
+ --                              /
+
+ commentedBinder { renamed: {- keep -} original } = original
+```
+
+
+Rename at Position { line: 46, character: 38 }
+
+```
+commentedBinder { renamed: {- keep -} original } = original
+--                                    /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -44,5 +44,5 @@
+ qualifiedField = { renamed: Lib.qualified }
+ --                              /
+
+-commentedBinder { renamed: {- keep -} original } = original
++commentedBinder { renamed } = renamed
+ --                                    /
 ```

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
@@ -188,15 +188,18 @@ topLevelPun = { topLevel }
 ```diff
 --- Main.purs
 +++ Main.purs
-@@ -33,7 +33,7 @@
+@@ -33,9 +33,9 @@
  punReference' original = { renamed: original }
  --                                  /
 
 -topLevel = 1
 +renamed = 1
 
- topLevelPun = { topLevel }
+-topLevelPun = { topLevel }
++topLevelPun = { topLevel: renamed }
  --              /
+
+ importedPun = { imported }
 ```
 
 
@@ -230,6 +233,15 @@ importedPun = { imported }
  import Lib as Lib
 
  data Maybe a = Just a | Nothing
+@@ -38,7 +38,7 @@
+ topLevelPun = { topLevel }
+ --              /
+
+-importedPun = { imported }
++importedPun = { imported: renamed }
+ --              /
+
+ qualifiedField = { renamed: Lib.qualified }
 ```
 
 
@@ -259,7 +271,7 @@ qualifiedField = { renamed: Lib.qualified }
  --              /
 
 -qualifiedField = { renamed: Lib.qualified }
-+qualifiedField = { renamed }
++qualifiedField = { renamed: Lib.renamed }
  --                              /
 
  commentedBinder { renamed: {- keep -} original } = original
@@ -281,6 +293,6 @@ commentedBinder { renamed: {- keep -} original } = original
  --                              /
 
 -commentedBinder { renamed: {- keep -} original } = original
-+commentedBinder { renamed } = renamed
++commentedBinder { renamed: {- keep -} renamed } = renamed
  --                                    /
 ```

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
@@ -10,7 +10,24 @@ renameArgument argument =
 --             /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -2,10 +2,10 @@
+
+ data Maybe a = Just a | Nothing
+
+-renameArgument argument =
++renameArgument renamed =
+ --             /
+-  let shadowed = argument
+-  in argument
++  let shadowed = renamed
++  in renamed
+ --   ?
+
+ renameLet input =
+```
 
 
 PrepareRename at Position { line: 7, character: 5 }
@@ -20,7 +37,7 @@ PrepareRename at Position { line: 7, character: 5 }
 --   ?
 ```
 
-<empty>
+7:5..7:13 argument
 
 
 Rename at Position { line: 14, character: 5 }
@@ -30,7 +47,25 @@ Rename at Position { line: 14, character: 5 }
 --   /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -9,10 +9,10 @@
+ --   ?
+
+ renameLet input =
+-  let local :: Maybe Int -> Int
+-      local (Just item) = item
+-      local Nothing = input
+-  in local (Just input)
++  let renamed :: Maybe Int -> Int
++      renamed (Just item) = item
++      renamed Nothing = input
++  in renamed (Just input)
+ --   /
+
+ renameNamed whole@(Just item) = whole
+```
 
 
 Rename at Position { line: 17, character: 12 }
@@ -40,7 +75,19 @@ renameNamed whole@(Just item) = whole
 --          /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -15,7 +15,7 @@
+   in local (Just input)
+ --   /
+
+-renameNamed whole@(Just item) = whole
++renameNamed renamed@(Just item) = renamed
+ --          /
+
+ renamePun { field } = field
+```
 
 
 Rename at Position { line: 20, character: 12 }
@@ -50,7 +97,19 @@ renamePun { field } = field
 --          /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -18,7 +18,7 @@
+ renameNamed whole@(Just item) = whole
+ --          /
+
+-renamePun { field } = field
++renamePun { field: renamed } = renamed
+ --          /
+
+ punReference value = { value }
+```
 
 
 Rename at Position { line: 23, character: 23 }
@@ -60,7 +119,19 @@ punReference value = { value }
 --                     /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -21,7 +21,7 @@
+ renamePun { field } = field
+ --          /
+
+-punReference value = { value }
++punReference renamed = { value: renamed }
+ --                     /
+
+ renamePun' { renamed: original } = original
+```
 
 
 Rename at Position { line: 26, character: 22 }
@@ -70,7 +141,19 @@ renamePun' { renamed: original } = original
 --                    /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -24,7 +24,7 @@
+ punReference value = { value }
+ --                     /
+
+-renamePun' { renamed: original } = original
++renamePun' { renamed } = renamed
+ --                    /
+
+ punReference' original = { renamed: original }
+```
 
 
 Rename at Position { line: 29, character: 36 }
@@ -80,4 +163,14 @@ punReference' original = { renamed: original }
 --                                  /
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -27,5 +27,5 @@
+ renamePun' { renamed: original } = original
+ --                    /
+
+-punReference' original = { renamed: original }
++punReference' renamed = { renamed }
+ --                                  /
+```

--- a/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
+++ b/tests-integration/fixtures/lsp/1785763080_rename_local_bindings/Main.snap
@@ -1,0 +1,83 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 4, character: 15 }
+
+```
+renameArgument argument =
+--             /
+```
+
+<empty>
+
+
+PrepareRename at Position { line: 7, character: 5 }
+
+```
+  in argument
+--   ?
+```
+
+<empty>
+
+
+Rename at Position { line: 14, character: 5 }
+
+```
+  in local (Just input)
+--   /
+```
+
+<empty>
+
+
+Rename at Position { line: 17, character: 12 }
+
+```
+renameNamed whole@(Just item) = whole
+--          /
+```
+
+<empty>
+
+
+Rename at Position { line: 20, character: 12 }
+
+```
+renamePun { field } = field
+--          /
+```
+
+<empty>
+
+
+Rename at Position { line: 23, character: 23 }
+
+```
+punReference value = { value }
+--                     /
+```
+
+<empty>
+
+
+Rename at Position { line: 26, character: 22 }
+
+```
+renamePun' { renamed: original } = original
+--                    /
+```
+
+<empty>
+
+
+Rename at Position { line: 29, character: 36 }
+
+```
+punReference' original = { renamed: original }
+--                                  /
+```
+
+<empty>

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -18,7 +18,8 @@ use lsp_types::{
 };
 use render::{TabledCompletionItem, TabledDetailedCompletionItem};
 use similar::TextDiff;
-use syntax::{SyntaxKind, TokenAtOffset};
+use syntax::ast::AstNode;
+use syntax::{SyntaxKind, TokenAtOffset, cst};
 use tabled::Table;
 use tabled::settings::{Padding, Style};
 
@@ -630,6 +631,9 @@ fn rename_target_name(
 
     if token.parent().kind() == SyntaxKind::Qualifier {
         return Some("Renamed".to_string());
+    }
+    if token.parent_ancestors().any(|node| cst::RecordPun::can_cast(node.kind())) {
+        return Some("renamed".to_string());
     }
 
     match token.kind() {


### PR DESCRIPTION
## Summary

- Enable prepare-rename and rename for local binders and named local binding groups.
- Follow resolved binding identities so shadowed locals remain distinct without adding ahead-of-time scope-conflict checks.
- Fix reference collection for top-level and imported terms used through record puns. Rename previously could update a declaration while leaving the selected pun unresolved.
- Preserve record labels and source trivia by expanding puns when names diverge and collapsing explicit fields only when the reference is unqualified and the removed trivia is whitespace.

## Testing

- `cargo nextest run -p analyzer`
- `cargo check -p tests-integration --tests`
- `just t lsp rename --count 20`