### PR TITLE
[lsp] Show intermediate record access types on hover

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -66,6 +66,7 @@ where
     zonk_type_map!(binders);
     zonk_type_map!(lets);
     zonk_type_map!(puns);
+    zonk_type_map!(record_access_labels);
     zonk_type_map!(sections);
     zonk_type_map!(forall_bindings);
     zonk_type_map!(implicit_bindings);

--- a/compiler-core/checking/src/lib.rs
+++ b/compiler-core/checking/src/lib.rs
@@ -85,6 +85,7 @@ pub struct CheckedNodeTypes {
     pub binders: FxHashMap<lowering::BinderId, TypeId>,
     pub lets: FxHashMap<lowering::LetBindingNameGroupId, TypeId>,
     pub puns: FxHashMap<lowering::RecordPunId, TypeId>,
+    pub record_access_labels: FxHashMap<lowering::RecordAccessLabelId, TypeId>,
     pub sections: FxHashMap<lowering::ExpressionId, TypeId>,
     pub forall_bindings: FxHashMap<lowering::TypeVariableBindingId, TypeId>,
     pub implicit_bindings: FxHashMap<(lowering::GraphNodeId, lowering::ImplicitBindingId), TypeId>,
@@ -164,6 +165,10 @@ impl CheckedNodeTypes {
 
     pub fn lookup_pun(&self, id: lowering::RecordPunId) -> Option<TypeId> {
         self.puns.get(&id).copied()
+    }
+
+    pub fn lookup_record_access_label(&self, id: lowering::RecordAccessLabelId) -> Option<TypeId> {
+        self.record_access_labels.get(&id).copied()
     }
 
     pub fn lookup_section(&self, id: lowering::ExpressionId) -> Option<TypeId> {

--- a/compiler-core/checking/src/source/terms/collections.rs
+++ b/compiler-core/checking/src/source/terms/collections.rs
@@ -350,29 +350,33 @@ pub fn infer_record_access<Q>(
     state: &mut CheckState,
     context: &CheckContext<Q>,
     record: lowering::ExpressionId,
-    labels: &[SmolStr],
+    labels: &[lowering::RecordAccessLabel],
 ) -> QueryResult<ElaboratedExpression>
 where
     Q: ExternalQueries,
 {
     let record = super::infer_expression(state, context, record)?;
     let mut current_type = record.type_id;
+    let mut checked_labels = Vec::with_capacity(labels.len());
 
     for label in labels.iter() {
-        let label = SmolStr::clone(label);
+        let name = SmolStr::clone(&label.name);
 
         let field_type = state.fresh_unification(context.queries, context.prim.t);
         let tail_type = state.fresh_unification(context.queries, context.prim.row_type);
 
-        let row_type = context.intern_row([RowField { label, id: field_type }], Some(tail_type));
+        let field = RowField { label: SmolStr::clone(&name), id: field_type };
+        let row_type = context.intern_row([field], Some(tail_type));
         let record_type = context.intern_application(context.prim.record, row_type);
 
         unification::subtype(state, context, current_type, record_type)?;
+        state.checked.node_types.record_access_labels.insert(label.id, field_type);
         current_type = field_type;
+        checked_labels.push(name);
     }
 
-    let kind =
-        tree::ExpressionKind::RecordAccess { record: record.expression, labels: Arc::from(labels) };
+    let labels = Arc::from(checked_labels);
+    let kind = tree::ExpressionKind::RecordAccess { record: record.expression, labels };
     Ok(super::allocate_expression(state, current_type, kind))
 }
 

--- a/compiler-core/lowering/src/algorithm/recursive.rs
+++ b/compiler-core/lowering/src/algorithm/recursive.rs
@@ -566,8 +566,10 @@ fn lower_expression_kind(
             let labels = cst
                 .children()
                 .map(|cst| {
-                    let token = cst.text()?;
-                    Some(string_text(context.source, token))
+                    let id = context.stabilized.lookup_cst(&cst).expect_id();
+                    let token = cst.name()?.text()?;
+                    let name = string_text(context.source, token);
+                    Some(RecordAccessLabel { id, name })
                 })
                 .collect();
             ExpressionKind::RecordAccess { record, labels }

--- a/compiler-core/lowering/src/source.rs
+++ b/compiler-core/lowering/src/source.rs
@@ -3,6 +3,7 @@ use syntax::cst;
 
 pub type BinderId = AstId<cst::Binder>;
 pub type ExpressionId = AstId<cst::Expression>;
+pub type RecordAccessLabelId = AstId<cst::RecordAccessLabel>;
 pub type RecordPunId = AstId<cst::RecordPun>;
 
 pub type TypeId = AstId<cst::Type>;

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -76,6 +76,12 @@ pub enum ExpressionRecordItem {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct RecordAccessLabel {
+    pub id: RecordAccessLabelId,
+    pub name: SmolStr,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum ExpressionKind {
     Typed {
         expression: Option<ExpressionId>,
@@ -164,7 +170,7 @@ pub enum ExpressionKind {
     },
     RecordAccess {
         record: Option<ExpressionId>,
-        labels: Option<Arc<[SmolStr]>>,
+        labels: Option<Arc<[RecordAccessLabel]>>,
     },
     RecordUpdate {
         record: Option<ExpressionId>,

--- a/compiler-core/parsing/src/parser/expressions.rs
+++ b/compiler-core/parsing/src/parser/expressions.rs
@@ -402,8 +402,11 @@ fn expression_7(p: &mut Parser) {
     let mut i = 0;
 
     expression_atom(p);
-    while p.eat(SyntaxKind::PERIOD) && !p.at_eof() {
+    while p.at(SyntaxKind::PERIOD) && !p.at_eof() {
+        let mut label = p.start();
+        p.expect(SyntaxKind::PERIOD);
         names::label(p);
+        label.end(p, SyntaxKind::RecordAccessLabel);
         i += 1;
     }
 

--- a/compiler-core/parsing/tests/parser/expression_record_access.purs
+++ b/compiler-core/parsing/tests/parser/expression_record_access.purs
@@ -3,6 +3,8 @@ module ExpressionRecordAccess where
 access = record.foo
 access = record.foo.bar
 
+section = _.foo.bar
+
 keyword = record.forall
 keyword = record.forall.forall
 

--- a/compiler-core/parsing/tests/snapshots/parser__expression_record_access.snap
+++ b/compiler-core/parsing/tests/snapshots/parser__expression_record_access.snap
@@ -1,9 +1,9 @@
 ---
 source: compiler-core/parsing/tests/parser.rs
-expression: "(node, errors)"
+expression: "(node.debug(&content), errors)"
 ---
 (
-    Module@0..273
+    Module@0..294
       ModuleHeader@0..35
         MODULE@0..6 "module"
         Annotation@6..7
@@ -14,7 +14,7 @@ expression: "(node, errors)"
           TEXT@29..30 " "
         WHERE@30..35 "where"
       LAYOUT_START@35..35 ""
-      ModuleStatements@35..272
+      ModuleStatements@35..293
         ValueEquation@35..56
           Annotation@35..37
             TEXT@35..37 "\n\n"
@@ -30,9 +30,10 @@ expression: "(node, errors)"
                     TEXT@45..46 " "
                   QualifiedName@46..52
                     LOWER@46..52 "record"
-                PERIOD@52..53 "."
-                LabelName@53..56
-                  TEXT@53..56 "foo"
+                RecordAccessLabel@52..56
+                  PERIOD@52..53 "."
+                  LabelName@53..56
+                    TEXT@53..56 "foo"
         LAYOUT_SEPARATOR@56..56 ""
         ValueEquation@56..80
           Annotation@56..57
@@ -49,139 +50,173 @@ expression: "(node, errors)"
                     TEXT@65..66 " "
                   QualifiedName@66..72
                     LOWER@66..72 "record"
-                PERIOD@72..73 "."
-                LabelName@73..76
-                  TEXT@73..76 "foo"
-                PERIOD@76..77 "."
-                LabelName@77..80
-                  TEXT@77..80 "bar"
+                RecordAccessLabel@72..76
+                  PERIOD@72..73 "."
+                  LabelName@73..76
+                    TEXT@73..76 "foo"
+                RecordAccessLabel@76..80
+                  PERIOD@76..77 "."
+                  LabelName@77..80
+                    TEXT@77..80 "bar"
         LAYOUT_SEPARATOR@80..80 ""
-        ValueEquation@80..105
+        ValueEquation@80..101
           Annotation@80..82
             TEXT@80..82 "\n\n"
-          LOWER@82..89 "keyword"
-          Unconditional@89..105
+          LOWER@82..89 "section"
+          Unconditional@89..101
             Annotation@89..90
               TEXT@89..90 " "
             EQUAL@90..91 "="
-            WhereExpression@91..105
-              ExpressionRecordAccess@91..105
-                ExpressionVariable@91..98
+            WhereExpression@91..101
+              ExpressionRecordAccess@91..101
+                ExpressionSection@91..93
                   Annotation@91..92
                     TEXT@91..92 " "
-                  QualifiedName@92..98
-                    LOWER@92..98 "record"
-                PERIOD@98..99 "."
-                LabelName@99..105
-                  TEXT@99..105 "forall"
-        LAYOUT_SEPARATOR@105..105 ""
-        ValueEquation@105..136
-          Annotation@105..106
-            TEXT@105..106 "\n"
-          LOWER@106..113 "keyword"
-          Unconditional@113..136
-            Annotation@113..114
-              TEXT@113..114 " "
-            EQUAL@114..115 "="
-            WhereExpression@115..136
-              ExpressionRecordAccess@115..136
-                ExpressionVariable@115..122
-                  Annotation@115..116
-                    TEXT@115..116 " "
-                  QualifiedName@116..122
-                    LOWER@116..122 "record"
-                PERIOD@122..123 "."
-                LabelName@123..129
-                  TEXT@123..129 "forall"
-                PERIOD@129..130 "."
-                LabelName@130..136
-                  TEXT@130..136 "forall"
-        LAYOUT_SEPARATOR@136..136 ""
-        ValueEquation@136..161
-          Annotation@136..138
-            TEXT@136..138 "\n\n"
-          LOWER@138..144 "string"
-          Unconditional@144..161
-            Annotation@144..145
-              TEXT@144..145 " "
-            EQUAL@145..146 "="
-            WhereExpression@146..161
-              ExpressionRecordAccess@146..161
-                ExpressionVariable@146..153
-                  Annotation@146..147
-                    TEXT@146..147 " "
-                  QualifiedName@147..153
-                    LOWER@147..153 "record"
-                PERIOD@153..154 "."
-                LabelName@154..161
-                  TEXT@154..161 "\"error\""
-        LAYOUT_SEPARATOR@161..161 ""
-        ValueEquation@161..193
-          Annotation@161..162
-            TEXT@161..162 "\n"
-          LOWER@162..168 "string"
-          Unconditional@168..193
-            Annotation@168..169
-              TEXT@168..169 " "
-            EQUAL@169..170 "="
-            WhereExpression@170..193
-              ExpressionRecordAccess@170..193
-                ExpressionVariable@170..177
-                  Annotation@170..171
-                    TEXT@170..171 " "
-                  QualifiedName@171..177
-                    LOWER@171..177 "record"
-                PERIOD@177..178 "."
-                LabelName@178..185
-                  TEXT@178..185 "\"error\""
-                PERIOD@185..186 "."
-                LabelName@186..193
-                  TEXT@186..193 "\"error\""
-        LAYOUT_SEPARATOR@193..193 ""
-        ValueEquation@193..226
-          Annotation@193..195
-            TEXT@193..195 "\n\n"
-          LOWER@195..205 "raw_string"
-          Unconditional@205..226
-            Annotation@205..206
-              TEXT@205..206 " "
-            EQUAL@206..207 "="
-            WhereExpression@207..226
-              ExpressionRecordAccess@207..226
-                ExpressionVariable@207..214
-                  Annotation@207..208
-                    TEXT@207..208 " "
-                  QualifiedName@208..214
-                    LOWER@208..214 "record"
-                PERIOD@214..215 "."
-                LabelName@215..226
-                  TEXT@215..226 "\"\"\"error\"\"\""
-        LAYOUT_SEPARATOR@226..226 ""
-        ValueEquation@226..272
-          Annotation@226..227
-            TEXT@226..227 "\n"
-          LOWER@227..237 "raw_string"
-          Unconditional@237..272
-            Annotation@237..238
-              TEXT@237..238 " "
-            EQUAL@238..239 "="
-            WhereExpression@239..272
-              ExpressionRecordAccess@239..272
-                ExpressionVariable@239..246
-                  Annotation@239..240
-                    TEXT@239..240 " "
-                  QualifiedName@240..246
-                    LOWER@240..246 "record"
-                PERIOD@246..247 "."
-                LabelName@247..258
-                  TEXT@247..258 "\"\"\"error\"\"\""
-                PERIOD@258..259 "."
-                LabelName@259..272
-                  TEXT@259..272 "\"\"\"\"error\"\"\"\""
-      LAYOUT_END@272..272 ""
-      Annotation@272..273
-        TEXT@272..273 "\n"
-      END_OF_FILE@273..273 ""
+                  UNDERSCORE@92..93 "_"
+                RecordAccessLabel@93..97
+                  PERIOD@93..94 "."
+                  LabelName@94..97
+                    TEXT@94..97 "foo"
+                RecordAccessLabel@97..101
+                  PERIOD@97..98 "."
+                  LabelName@98..101
+                    TEXT@98..101 "bar"
+        LAYOUT_SEPARATOR@101..101 ""
+        ValueEquation@101..126
+          Annotation@101..103
+            TEXT@101..103 "\n\n"
+          LOWER@103..110 "keyword"
+          Unconditional@110..126
+            Annotation@110..111
+              TEXT@110..111 " "
+            EQUAL@111..112 "="
+            WhereExpression@112..126
+              ExpressionRecordAccess@112..126
+                ExpressionVariable@112..119
+                  Annotation@112..113
+                    TEXT@112..113 " "
+                  QualifiedName@113..119
+                    LOWER@113..119 "record"
+                RecordAccessLabel@119..126
+                  PERIOD@119..120 "."
+                  LabelName@120..126
+                    TEXT@120..126 "forall"
+        LAYOUT_SEPARATOR@126..126 ""
+        ValueEquation@126..157
+          Annotation@126..127
+            TEXT@126..127 "\n"
+          LOWER@127..134 "keyword"
+          Unconditional@134..157
+            Annotation@134..135
+              TEXT@134..135 " "
+            EQUAL@135..136 "="
+            WhereExpression@136..157
+              ExpressionRecordAccess@136..157
+                ExpressionVariable@136..143
+                  Annotation@136..137
+                    TEXT@136..137 " "
+                  QualifiedName@137..143
+                    LOWER@137..143 "record"
+                RecordAccessLabel@143..150
+                  PERIOD@143..144 "."
+                  LabelName@144..150
+                    TEXT@144..150 "forall"
+                RecordAccessLabel@150..157
+                  PERIOD@150..151 "."
+                  LabelName@151..157
+                    TEXT@151..157 "forall"
+        LAYOUT_SEPARATOR@157..157 ""
+        ValueEquation@157..182
+          Annotation@157..159
+            TEXT@157..159 "\n\n"
+          LOWER@159..165 "string"
+          Unconditional@165..182
+            Annotation@165..166
+              TEXT@165..166 " "
+            EQUAL@166..167 "="
+            WhereExpression@167..182
+              ExpressionRecordAccess@167..182
+                ExpressionVariable@167..174
+                  Annotation@167..168
+                    TEXT@167..168 " "
+                  QualifiedName@168..174
+                    LOWER@168..174 "record"
+                RecordAccessLabel@174..182
+                  PERIOD@174..175 "."
+                  LabelName@175..182
+                    TEXT@175..182 "\"error\""
+        LAYOUT_SEPARATOR@182..182 ""
+        ValueEquation@182..214
+          Annotation@182..183
+            TEXT@182..183 "\n"
+          LOWER@183..189 "string"
+          Unconditional@189..214
+            Annotation@189..190
+              TEXT@189..190 " "
+            EQUAL@190..191 "="
+            WhereExpression@191..214
+              ExpressionRecordAccess@191..214
+                ExpressionVariable@191..198
+                  Annotation@191..192
+                    TEXT@191..192 " "
+                  QualifiedName@192..198
+                    LOWER@192..198 "record"
+                RecordAccessLabel@198..206
+                  PERIOD@198..199 "."
+                  LabelName@199..206
+                    TEXT@199..206 "\"error\""
+                RecordAccessLabel@206..214
+                  PERIOD@206..207 "."
+                  LabelName@207..214
+                    TEXT@207..214 "\"error\""
+        LAYOUT_SEPARATOR@214..214 ""
+        ValueEquation@214..247
+          Annotation@214..216
+            TEXT@214..216 "\n\n"
+          LOWER@216..226 "raw_string"
+          Unconditional@226..247
+            Annotation@226..227
+              TEXT@226..227 " "
+            EQUAL@227..228 "="
+            WhereExpression@228..247
+              ExpressionRecordAccess@228..247
+                ExpressionVariable@228..235
+                  Annotation@228..229
+                    TEXT@228..229 " "
+                  QualifiedName@229..235
+                    LOWER@229..235 "record"
+                RecordAccessLabel@235..247
+                  PERIOD@235..236 "."
+                  LabelName@236..247
+                    TEXT@236..247 "\"\"\"error\"\"\""
+        LAYOUT_SEPARATOR@247..247 ""
+        ValueEquation@247..293
+          Annotation@247..248
+            TEXT@247..248 "\n"
+          LOWER@248..258 "raw_string"
+          Unconditional@258..293
+            Annotation@258..259
+              TEXT@258..259 " "
+            EQUAL@259..260 "="
+            WhereExpression@260..293
+              ExpressionRecordAccess@260..293
+                ExpressionVariable@260..267
+                  Annotation@260..261
+                    TEXT@260..261 " "
+                  QualifiedName@261..267
+                    LOWER@261..267 "record"
+                RecordAccessLabel@267..279
+                  PERIOD@267..268 "."
+                  LabelName@268..279
+                    TEXT@268..279 "\"\"\"error\"\"\""
+                RecordAccessLabel@279..293
+                  PERIOD@279..280 "."
+                  LabelName@280..293
+                    TEXT@280..293 "\"\"\"\"error\"\"\"\""
+      LAYOUT_END@293..293 ""
+      Annotation@293..294
+        TEXT@293..294 "\n"
+      END_OF_FILE@294..294 ""
     ,
     [],
 )

--- a/compiler-core/syntax/src/cst.rs
+++ b/compiler-core/syntax/src/cst.rs
@@ -214,7 +214,7 @@ create_cst_enum!(LetBinding | LetBindingPattern | LetBindingSignature | LetBindi
 
 create_cst_enum!(RecordItem | RecordField | RecordPun);
 
-create_cst_struct!(RecordUpdates);
+create_cst_struct!(RecordAccessLabel, RecordUpdates);
 
 create_cst_enum!(RecordUpdate | RecordUpdateLeaf | RecordUpdateBranch);
 
@@ -935,7 +935,17 @@ has_child!(
 
 has_children!(
     ExpressionRecordAccess
-    | children() -> LabelName
+    | children() -> RecordAccessLabel
+);
+
+has_token!(
+    RecordAccessLabel
+    | period() -> PERIOD
+);
+
+has_child!(
+    RecordAccessLabel
+    | name() -> LabelName
 );
 
 has_child!(

--- a/compiler-core/syntax/src/lib.rs
+++ b/compiler-core/syntax/src/lib.rs
@@ -228,6 +228,7 @@ pub enum SyntaxKind {
     DoStatementLet,
     DoStatementDiscard,
 
+    RecordAccessLabel,
     RecordField,
     RecordPun,
     RecordUpdates,

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -67,6 +67,7 @@ pub fn implementation(
         }
         locate::Located::BinderPun(_) => Ok(None),
         locate::Located::ExpressionPun(_) => Ok(None),
+        locate::Located::RecordAccessLabel(_) => Ok(None),
         locate::Located::Nothing => Ok(None),
     }
 }

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -64,6 +64,7 @@ pub fn implementation(
         }
         locate::Located::ModuleName(_)
         | locate::Located::InstanceMember(_, _)
+        | locate::Located::RecordAccessLabel(_)
         | locate::Located::Nothing => Ok(None),
     }
 }

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -41,6 +41,9 @@ pub fn implementation(
         locate::Located::Expression(expression_id) => {
             hover_expression(engine, current_file, expression_id)
         }
+        locate::Located::RecordAccessLabel(label_id) => {
+            hover_record_access_label(engine, current_file, label_id)
+        }
         locate::Located::Type(type_id) => hover_type(engine, current_file, type_id),
         locate::Located::BinderPun(pun_id) => hover_pun(engine, current_file, pun_id),
         locate::Located::ExpressionPun(pun_id) => hover_pun(engine, current_file, pun_id),
@@ -243,6 +246,17 @@ fn hover_expression(
             hover_checked_type(engine, current_file, expression_type)
         }
     }
+}
+
+fn hover_record_access_label(
+    engine: &impl AnalyzerQueries,
+    current_file: FileId,
+    label_id: lowering::RecordAccessLabelId,
+) -> Result<Option<Hover>, AnalyzerError> {
+    let checked = engine.checked(current_file)?;
+    let label_type = checked.node_types.lookup_record_access_label(label_id);
+    let label_type = label_type.ok_or(AnalyzerError::NonFatal)?;
+    hover_checked_type(engine, current_file, label_type)
 }
 
 fn hover_let(

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -5,8 +5,8 @@ use std::iter;
 use files::FileId;
 use indexing::{ImportItemId, IndexedModule, TermItemId, TypeItemId};
 use lowering::{
-    BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordPunId, TermOperatorId,
-    TypeId, TypeOperatorId,
+    BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordAccessLabelId, RecordPunId,
+    TermOperatorId, TypeId, TypeOperatorId,
 };
 use stabilizing::{AstId, StabilizedModule};
 use syntax::ast::{AstNode, AstPtr};
@@ -80,6 +80,7 @@ pub enum Located {
     ImportItem(ImportItemId),
     Binder(BinderId),
     Expression(ExpressionId),
+    RecordAccessLabel(RecordAccessLabelId),
     Type(TypeId),
     BinderPun(RecordPunId),
     ExpressionPun(RecordPunId),
@@ -153,6 +154,10 @@ fn locate_node(
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;
         Some(Located::Binder(id))
+    } else if cst::RecordAccessLabel::can_cast(kind) {
+        let ptr = ptr.cast()?;
+        let id = stabilized.lookup_ptr(&ptr)?;
+        Some(Located::RecordAccessLabel(id))
     } else if cst::Expression::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -69,6 +69,7 @@ pub fn implementation(
             references_expression_pun(context, current_file, pun_id)
         }
         locate::Located::InstanceMember(_, _) => Ok(None),
+        locate::Located::RecordAccessLabel(_) => Ok(None),
         locate::Located::Nothing => Ok(None),
     }
 }

--- a/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.purs
+++ b/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+record :: { nested :: { value :: Int } }
+record = { nested: { value: 42 } }
+
+access = record.nested.value
+--              $      $

--- a/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.snap
+++ b/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.snap
@@ -1,0 +1,27 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 5, character: 16 }
+
+```
+access = record.nested.value
+--              $      $
+```
+
+```purescript
+Int
+```
+
+
+Hover at Position { line: 5, character: 23 }
+
+```
+access = record.nested.value
+--              $      $
+```
+
+```purescript
+Int
+```

--- a/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.snap
+++ b/tests-integration/fixtures/lsp/1785823140_record_access_label_hover/Main.snap
@@ -11,7 +11,7 @@ access = record.nested.value
 ```
 
 ```purescript
-Int
+{ value :: Int }
 ```
 
 

--- a/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
+++ b/tests-integration/fixtures/semantic/1784908680_section_expressions/Main.snap
@@ -26,26 +26,26 @@ access = \v82 -> v82.value
 
 update :: forall t0 t1 t2 t3 t4.
   { first :: t0, second :: t1 | t2 } -> t3 -> t4 -> { first :: t3, second :: t4 | t2 }
-update = \v87 v90 v92 -> v87 { first = v90, second = v92 }
+update = \v88 v91 v93 -> v88 { first = v91, second = v93 }
 
 conditional :: forall t0. Prim.Boolean -> t0 -> t0 -> t0
-conditional = \v98 v100 v102 ->
-  if v98 then v100 else v102
+conditional = \v99 v101 v103 ->
+  if v99 then v101 else v103
 
 caseScrutinee :: Prim.Boolean -> Prim.Int
-caseScrutinee = \v108 ->
-  case v108 of
+caseScrutinee = \v109 ->
+  case v109 of
     true -> 1
     false -> 0
 
 caseScrutinees :: Prim.Boolean -> Prim.Int -> Prim.Int
-caseScrutinees = \v127 v128 ->
-  case v127, v128 of
+caseScrutinees = \v128 v129 ->
+  case v128, v129 of
     true, value -> value
     false, _ -> 0
 
 caseAlternatives :: forall t0 t1. Prim.Boolean -> { value :: t0 | t1 } -> t0
-caseAlternatives = \v149 ->
-  case v149 of
-    true -> \v157 -> v157.value
-    false -> \v164 -> v164.value
+caseAlternatives = \v150 ->
+  case v150 of
+    true -> \v158 -> v158.value
+    false -> \v166 -> v166.value

--- a/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_access_sections/Main.snap
@@ -16,43 +16,43 @@ test1 :: forall t0 t1. { prop :: t0 | t1 } -> t0
 test1 = \v74 -> v74.prop
 
 test2 :: forall t0 t1 t2 t3. { a :: { b :: { c :: t0 | t1 } | t2 } | t3 } -> t0
-test2 = \v79 -> v79.a.b.c
+test2 = \v80 -> v80.a.b.c
 
 test3 :: forall t0 t1. { poly :: t0 | t1 } -> t0
-test3 = \v84 -> v84.poly
+test3 = \v88 -> v88.poly
 
 test4 :: forall t0 t1. Prim.Array { prop :: t0 | t1 } -> Prim.Array t0
-test4 = map @{ prop :: t0 | t1 } @t0 \v92 -> v92.prop
+test4 = map @{ prop :: t0 | t1 } @t0 \v97 -> v97.prop
 
 test5 :: Prim.Int
-test5 = f \v100 -> v100.foo
+test5 = f \v106 -> v106.foo
 
 test6 :: forall t0 t1 t2 t3. t0 -> (({ bar :: t1 | t2 } -> t1) -> t3) -> t3
-test6 = \r -> \g -> g \v111 -> v111.bar
+test6 = \r -> \g -> g \v118 -> v118.bar
 
 test7 :: forall t0 t1. { nonexistent :: t0 | t1 } -> t0
-test7 = \r -> (\v120 -> v120.nonexistent) r
+test7 = \r -> (\v128 -> v128.nonexistent) r
 
 test8 :: forall t0 t1 t2. (({ foo :: t0 | t1 } -> t0) -> t2) -> t2
-test8 = \v128 -> v128 \v131 -> v131.foo
+test8 = \v137 -> v137 \v140 -> v140.foo
 
 test9 :: forall t0 t1 t2. Prim.Array (({ prop :: t0 | t1 } -> t0) -> t2) -> Prim.Array t2
-test9 = map @(({ prop :: t0 | t1 } -> t0) -> t2) @t2 \v140 -> v140 \v143 -> v143.prop
+test9 = map @(({ prop :: t0 | t1 } -> t0) -> t2) @t2 \v150 -> v150 \v153 -> v153.prop
 
 test10 :: forall t0 t1 t2. { a :: { b :: t0 | t1 } | t2 } -> t0
-test10 = apply @{ a :: { b :: t0 | t1 } | t2 } @t0 \v152 -> v152.a.b
+test10 = apply @{ a :: { b :: t0 | t1 } | t2 } @t0 \v163 -> v163.a.b
 
 test11 :: forall t0 t1 t2. t0 -> { a :: t0, b :: { foo :: t1 | t2 } -> t1 }
-test11 = \v158 -> { a: v158, b: \v161 -> v161.foo }
+test11 = \v171 -> { a: v171, b: \v174 -> v174.foo }
 
 test12 :: forall t0 t1. ({ bar :: t0 | t1 } -> t0) -> Prim.Array ({ bar :: t0 | t1 } -> t0)
-test12 = \v166 -> [v166, \v168 -> v168.bar]
+test12 = \v180 -> [v180, \v182 -> v182.bar]
 
 test13 :: forall t0 t1 t2. t0 -> { prop :: t1 | t2 } -> t1
-test13 = \v174 ->
-  case v174 of
-    _ -> \v182 -> v182.prop
+test13 = \v189 ->
+  case v189 of
+    _ -> \v197 -> v197.prop
 
 test14 :: forall t0 t1. Prim.Boolean -> { a :: t0, b :: t0 | t1 } -> t0
-test14 = \v188 ->
-  if v188 then \v191 -> v191.a else \v194 -> v194.b
+test14 = \v204 ->
+  if v204 then \v207 -> v207.a else \v211 -> v211.b

--- a/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
+++ b/tests-integration/fixtures/semantic/1784910000_record_update_sections/Main.snap
@@ -39,7 +39,7 @@ recordAccessSectionUpdate :: forall t0 t1 t2 t3. { a :: t0 | t1 } -> { a :: { b 
 recordAccessSectionUpdate = \v116 -> v116 { a = \v120 -> v120.b }
 
 concreteRecordUpdateSection :: forall t0. t0 -> { a :: t0 }
-concreteRecordUpdateSection = \v131 -> { a: 1 } { a = v131 }
+concreteRecordUpdateSection = \v132 -> { a: 1 } { a = v132 }
 
 map :: forall a b. (a -> b) -> Prim.Array a -> Prim.Array b
 map = \f -> \x -> []


### PR DESCRIPTION
## Summary

- represent each field in a record access chain as a stable `RecordAccessLabel` syntax node
- preserve label IDs through lowering and associate each label with its checked field type
- locate record access labels independently so hover reports each intermediate result type
- retain the existing section elaboration of `_.a.b.c` as a single lambda over the complete access chain

## Motivation

A chained access such as `record.nested.value` previously stored only one source expression ID and its final type. Hovering `nested` therefore displayed `value`'s type instead of the intermediate `{ value :: Int }` type.

The first commit adds an LSP fixture that captures that incorrect behavior; the second updates the same snapshot with the corrected hover result.

Fixes #158.

## Verification

- `cargo nextest run -p parsing`
- `cargo nextest run -p checking`
- `cargo nextest run -p analyzer`
- `cargo check -p lowering --tests`
- `cargo check -p checking --tests`
- `cargo check -p analyzer --tests`
- `just t checking`
- `just t semantic`
- `just t lsp`