### PR TITLE
[meta] Prepare 0.0.16 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "purescript-alexandrite"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "analyzer",
  "async-lsp",

--- a/compiler-bin/Cargo.toml
+++ b/compiler-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purescript-alexandrite"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 authors = ["Justin Garcia <git@purefunctor.me>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Prepare the purescript-alexandrite 0.0.16 release by updating the package manifest and lockfile version.

## Verification

- `cargo check -p purescript-alexandrite --tests --locked`
- `cargo run -p purescript-alexandrite --locked --bin purescript-alexandrite -- --version` prints `purescript-alexandrite 0.0.16`
- `git diff --check`