### PR TITLE
[checking] Recognize wrapped true guards as exhaustive

### DIFF
--- a/compiler-core/checking/src/core/exhaustive.rs
+++ b/compiler-core/checking/src/core/exhaustive.rs
@@ -1177,6 +1177,16 @@ where
     let Some(expression_id) = guard.expression else {
         return false;
     };
+    is_trivially_true_expression(context, expression_id)
+}
+
+fn is_trivially_true_expression<Q>(
+    context: &CheckContext<Q>,
+    expression_id: lowering::ExpressionId,
+) -> bool
+where
+    Q: ExternalQueries,
+{
     let Some(kind) = context.lowered.tree.get_expression_kind(expression_id) else {
         return false;
     };
@@ -1185,6 +1195,10 @@ where
         lowering::ExpressionKind::Variable {
             resolution: Some(lowering::TermVariableResolution::Reference(file_id, term_id)),
         } => context.known_terms.otherwise == Some((*file_id, *term_id)),
+        lowering::ExpressionKind::Parenthesized { parenthesized: Some(expression_id) }
+        | lowering::ExpressionKind::Typed { expression: Some(expression_id), .. } => {
+            is_trivially_true_expression(context, *expression_id)
+        }
         _ => false,
     }
 }

--- a/tests-integration/fixtures/checking/1785829800_exhaustive_guard_wrappers/Main.purs
+++ b/tests-integration/fixtures/checking/1785829800_exhaustive_guard_wrappers/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+parenthesized x
+  | (true) = x
+
+typed x
+  | (true :: Boolean) = x

--- a/tests-integration/fixtures/checking/1785829800_exhaustive_guard_wrappers/Main.snap
+++ b/tests-integration/fixtures/checking/1785829800_exhaustive_guard_wrappers/Main.snap
@@ -1,0 +1,22 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+parenthesized :: forall (t0 :: Prim.Type). Prim.Partial => (t0 :: Prim.Type) -> (t0 :: Prim.Type)
+typed :: forall (t0 :: Prim.Type). Prim.Partial => (t0 :: Prim.Type) -> (t0 :: Prim.Type)
+
+Types
+
+Diagnostics
+warning[MissingPatterns]: Pattern match is not exhaustive. Missing: _
+  --> 3:1..4:15
+  |
+3 | parenthesized x
+  | ^~~~~~~~~~~~~~~
+warning[MissingPatterns]: Pattern match is not exhaustive. Missing: _
+  --> 6:1..7:26
+  |
+6 | typed x
+  | ^~~~~~~

--- a/tests-integration/fixtures/checking/1785829800_exhaustive_guard_wrappers/Main.snap
+++ b/tests-integration/fixtures/checking/1785829800_exhaustive_guard_wrappers/Main.snap
@@ -4,19 +4,7 @@ assertion_line: 50
 expression: report
 ---
 Terms
-parenthesized :: forall (t0 :: Prim.Type). Prim.Partial => (t0 :: Prim.Type) -> (t0 :: Prim.Type)
-typed :: forall (t0 :: Prim.Type). Prim.Partial => (t0 :: Prim.Type) -> (t0 :: Prim.Type)
+parenthesized :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> (t0 :: Prim.Type)
+typed :: forall (t0 :: Prim.Type). (t0 :: Prim.Type) -> (t0 :: Prim.Type)
 
 Types
-
-Diagnostics
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: _
-  --> 3:1..4:15
-  |
-3 | parenthesized x
-  | ^~~~~~~~~~~~~~~
-warning[MissingPatterns]: Pattern match is not exhaustive. Missing: _
-  --> 6:1..7:26
-  |
-6 | typed x
-  | ^~~~~~~


### PR DESCRIPTION
## Problem

The exhaustiveness checker recognizes a bare `true` guard as unconditional, but reports `Partial` when the same guard is wrapped in parentheses or a type annotation.

## Change

Look through parenthesized and typed expression wrappers when deciding whether a guard is trivially true. The history first records the failing checking fixture, then updates that fixture with the corrected inferred types and diagnostics.

## Verification

- `just t checking exhaustive`
- `cargo check -p checking --tests`
- `just format --check`