### PR TITLE
[lsp] Warn about conflicting renames

### DIFF
--- a/compiler-bin/src/lsp.rs
+++ b/compiler-bin/src/lsp.rs
@@ -12,7 +12,7 @@ use std::{env, fs, mem, process};
 use analyzer::completion::SuggestionsCache;
 use analyzer::position::PositionEncoding;
 use analyzer::symbols::WorkspaceSymbolsCache;
-use analyzer::{AnalyzerContext, AnalyzerHost};
+use analyzer::{AnalyzerCapabilities, AnalyzerContext, AnalyzerHost};
 use async_lsp::client_monitor::ClientProcessMonitorLayer;
 use async_lsp::concurrency::ConcurrencyLayer;
 use async_lsp::panic::CatchUnwindLayer;
@@ -32,7 +32,7 @@ use tempfile::TempDir;
 use tokio::task;
 use tower::ServiceBuilder;
 
-use crate::lsp::capabilities::negotiate_position_encoding;
+use crate::lsp::capabilities::{negotiate_analyzer_capabilities, negotiate_position_encoding};
 use crate::lsp::error::{AnalyzerResultExt, LspError};
 use crate::walk;
 
@@ -73,6 +73,7 @@ pub struct State {
 
     pub root: Option<PathBuf>,
     pub position_encoding: PositionEncoding,
+    pub analyzer_capabilities: AnalyzerCapabilities,
 }
 
 impl State {
@@ -92,6 +93,7 @@ impl State {
 
         let root = None;
         let position_encoding = PositionEncoding::Utf16;
+        let analyzer_capabilities = AnalyzerCapabilities::default();
 
         State {
             config,
@@ -102,6 +104,7 @@ impl State {
             suggestions_cache,
             root,
             position_encoding,
+            analyzer_capabilities,
         }
     }
 
@@ -116,6 +119,7 @@ impl State {
             workspace_symbols_cache: Arc::clone(&self.workspace_symbols_cache),
             suggestions_cache: Arc::clone(&self.suggestions_cache),
             position_encoding: self.position_encoding,
+            analyzer_capabilities: self.analyzer_capabilities,
         };
         task::spawn_blocking(move || f(snapshot))
     }
@@ -138,6 +142,7 @@ struct StateSnapshot {
     workspace_symbols_cache: Arc<RwLock<WorkspaceSymbolsCache>>,
     suggestions_cache: Arc<RwLock<SuggestionsCache>>,
     position_encoding: PositionEncoding,
+    analyzer_capabilities: AnalyzerCapabilities,
 }
 
 impl StateSnapshot {
@@ -147,7 +152,8 @@ impl StateSnapshot {
     ) -> T {
         let files = self.files.read();
         let host = LspAnalyzerHost { queries: &self.engine, files };
-        let context = AnalyzerContext::new(&host, self.position_encoding);
+        let context =
+            AnalyzerContext::new(&host, self.position_encoding, self.analyzer_capabilities);
         f(&context)
     }
 }
@@ -230,6 +236,7 @@ fn initialize(
 ) -> impl Future<Output = Result<InitializeResult, ResponseError>> + use<> {
     let position_encoding = negotiate_position_encoding(&p.initialize_params);
     state.position_encoding = position_encoding;
+    state.analyzer_capabilities = negotiate_analyzer_capabilities(&p.initialize_params);
 
     state.root = p
         .initialize_params

--- a/compiler-bin/src/lsp/capabilities.rs
+++ b/compiler-bin/src/lsp/capabilities.rs
@@ -1,5 +1,31 @@
+use analyzer::AnalyzerCapabilities;
 use analyzer::position::PositionEncoding;
 use lsp_types::{InitializeParams, PositionEncodingKind};
+
+pub fn negotiate_analyzer_capabilities(params: &InitializeParams) -> AnalyzerCapabilities {
+    let workspace_edit = params
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.workspace_edit.as_ref());
+    let honors_rename_annotations = params
+        .capabilities
+        .text_document
+        .as_ref()
+        .and_then(|text_document| text_document.rename.as_ref())
+        .is_some_and(|rename| rename.honors_change_annotations == Some(true));
+    let change_annotations = workspace_edit.is_some_and(|workspace_edit| {
+        workspace_edit.document_changes == Some(true)
+            && workspace_edit.change_annotation_support.is_some()
+            && honors_rename_annotations
+    });
+
+    if change_annotations {
+        AnalyzerCapabilities::default().with_change_annotations()
+    } else {
+        AnalyzerCapabilities::default()
+    }
+}
 
 pub fn negotiate_position_encoding(params: &InitializeParams) -> PositionEncoding {
     let Some(encodings) = params

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -126,6 +126,8 @@ impl State {
         if let Some(resolution) = resolution {
             self.tree.expression_puns.insert(id, resolution);
         }
+        let Some(node) = self.graph_scope else { return };
+        self.nodes.record_pun_node.insert(id, node);
     }
 
     fn associate_do_statement(&mut self, id: DoStatementId, statement: DoStatement) {
@@ -152,6 +154,7 @@ impl State {
 
         let name = SmolStr::from(name);
         puns.insert(name, id);
+        self.nodes.record_pun_node.insert(id, node);
     }
 
     fn insert_bound_variable(&mut self, name: &str, id: TypeVariableBindingId) {

--- a/compiler-core/lowering/src/scope.rs
+++ b/compiler-core/lowering/src/scope.rs
@@ -158,6 +158,20 @@ impl LoweringGraph {
         let queue = VecDeque::from([id]);
         GraphIter { inner, queue }
     }
+
+    pub fn resolve_term(&self, id: GraphNodeId, name: &str) -> Option<TermVariableResolution> {
+        let mut scopes = self.traverse(id);
+        scopes.find_map(|(_, graph)| match graph {
+            GraphNode::Binder { binders, puns, .. } => binders
+                .get(name)
+                .map(|id| TermVariableResolution::Binder(*id))
+                .or_else(|| puns.get(name).map(|id| TermVariableResolution::RecordPun(*id))),
+            GraphNode::Let { bindings, .. } => {
+                bindings.get(name).map(|id| TermVariableResolution::Let(*id))
+            }
+            GraphNode::Forall { .. } | GraphNode::Implicit { .. } => None,
+        })
+    }
 }
 
 impl ops::Index<GraphNodeId> for LoweringGraph {
@@ -172,6 +186,7 @@ impl ops::Index<GraphNodeId> for LoweringGraph {
 pub struct LoweringGraphNodes {
     pub(crate) binder_node: FxHashMap<BinderId, GraphNodeId>,
     pub(crate) expression_node: FxHashMap<ExpressionId, GraphNodeId>,
+    pub(crate) record_pun_node: FxHashMap<RecordPunId, GraphNodeId>,
     pub(crate) type_node: FxHashMap<TypeId, GraphNodeId>,
     pub(crate) let_node: FxHashMap<LetBindingNameGroupId, GraphNodeId>,
 }
@@ -185,12 +200,25 @@ impl LoweringGraphNodes {
         self.expression_node.get(&id).copied()
     }
 
+    pub fn record_pun_node(&self, id: RecordPunId) -> Option<GraphNodeId> {
+        self.record_pun_node.get(&id).copied()
+    }
+
     pub fn type_node(&self, id: TypeId) -> Option<GraphNodeId> {
         self.type_node.get(&id).copied()
     }
 
     pub fn let_node(&self, id: LetBindingNameGroupId) -> Option<GraphNodeId> {
         self.let_node.get(&id).copied()
+    }
+
+    pub fn term_node(&self, resolution: TermVariableResolution) -> Option<GraphNodeId> {
+        match resolution {
+            TermVariableResolution::Binder(id) => self.binder_node(id),
+            TermVariableResolution::Let(id) => self.let_node(id),
+            TermVariableResolution::RecordPun(id) => self.record_pun_node(id),
+            TermVariableResolution::Reference(_, _) => None,
+        }
     }
 }
 

--- a/compiler-lsp/analyzer/src/context.rs
+++ b/compiler-lsp/analyzer/src/context.rs
@@ -43,14 +43,35 @@ pub trait AnalyzerHost {
     fn is_editable(&self, file_id: FileId) -> bool;
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AnalyzerCapabilities {
+    change_annotations: bool,
+}
+
+impl AnalyzerCapabilities {
+    pub fn with_change_annotations(mut self) -> AnalyzerCapabilities {
+        self.change_annotations = true;
+        self
+    }
+
+    pub fn has_change_annotations(self) -> bool {
+        self.change_annotations
+    }
+}
+
 pub struct AnalyzerContext<'a, Host> {
     host: &'a Host,
     position_encoding: PositionEncoding,
+    capabilities: AnalyzerCapabilities,
 }
 
 impl<'a, Host: AnalyzerHost> AnalyzerContext<'a, Host> {
-    pub fn new(host: &'a Host, position_encoding: PositionEncoding) -> AnalyzerContext<'a, Host> {
-        AnalyzerContext { host, position_encoding }
+    pub fn new(
+        host: &'a Host,
+        position_encoding: PositionEncoding,
+        capabilities: AnalyzerCapabilities,
+    ) -> AnalyzerContext<'a, Host> {
+        AnalyzerContext { host, position_encoding, capabilities }
     }
 
     pub fn queries(&self) -> &Host::Queries {
@@ -75,5 +96,9 @@ impl<'a, Host: AnalyzerHost> AnalyzerContext<'a, Host> {
 
     pub fn position_encoding(&self) -> PositionEncoding {
         self.position_encoding
+    }
+
+    pub fn capabilities(&self) -> AnalyzerCapabilities {
+        self.capabilities
     }
 }

--- a/compiler-lsp/analyzer/src/lib.rs
+++ b/compiler-lsp/analyzer/src/lib.rs
@@ -15,5 +15,5 @@ pub mod rename;
 pub mod semantic_tokens;
 pub mod symbols;
 
-pub use context::{AnalyzerContext, AnalyzerHost, AnalyzerQueries};
+pub use context::{AnalyzerCapabilities, AnalyzerContext, AnalyzerHost, AnalyzerQueries};
 pub use error::AnalyzerError;

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -1,7 +1,8 @@
 use building_types::QueryProxy;
 use files::FileId;
 use indexing::{
-    ImportId, ImportItemId, IndexedTermItemKind, IndexedTypeItemKind, TermItemId, TypeItemId,
+    ImportId, ImportItemId, ImportKind, IndexedTermItemKind, IndexedTypeItemKind, TermItemId,
+    TypeItemId,
 };
 use lowering::{
     BinderId, BinderKind, ExpressionKind, LetBindingNameGroupId, RecordPunId,
@@ -73,6 +74,14 @@ pub fn implementation(
         return Err(AnalyzerError::RenameRejected(message));
     }
 
+    let conflicts = rename_conflicts(context, target, &new_name)?;
+    if conflicts && !context.capabilities().has_change_annotations() {
+        let message = format!(
+            "Cannot rename `{old_name}` to `{new_name}` because it would change name resolution"
+        );
+        return Err(AnalyzerError::RenameRejected(message));
+    }
+
     let mut edits = edit::RenameEdits::new(context);
     match target {
         RenameTarget::Qualifier(file_id, import_id) => {
@@ -96,7 +105,324 @@ pub fn implementation(
         }
     }
 
-    edits.finish()
+    edits.finish(conflicts)
+}
+
+fn rename_conflicts(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    target: RenameTarget,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    match target {
+        RenameTarget::Term(file_id, term_id) => {
+            term_item_conflicts(context, file_id, term_id, new_name)
+        }
+        RenameTarget::Type(file_id, type_id) => {
+            type_item_conflicts(context, file_id, type_id, new_name)
+        }
+        RenameTarget::Binder(file_id, binder_id) => {
+            let target = TermVariableResolution::Binder(binder_id);
+            local_rename_conflicts(context, file_id, target, new_name)
+        }
+        RenameTarget::LetBinding(file_id, binding_id) => {
+            let target = TermVariableResolution::Let(binding_id);
+            local_rename_conflicts(context, file_id, target, new_name)
+        }
+        RenameTarget::RecordPun(file_id, pun_id) => {
+            let target = TermVariableResolution::RecordPun(pun_id);
+            local_rename_conflicts(context, file_id, target, new_name)
+        }
+        RenameTarget::Qualifier(_, _) | RenameTarget::Module(_) => Ok(false),
+    }
+}
+
+fn term_item_conflicts(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    target_file: FileId,
+    target_term: TermItemId,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    if term_item_conflicts_in_file(context, target_file, target_file, target_term, new_name)? {
+        return Ok(true);
+    }
+
+    for file_id in context.active_files() {
+        if file_id != target_file
+            && term_item_conflicts_in_file(context, file_id, target_file, target_term, new_name)?
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn term_item_conflicts_in_file(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    target_file: FileId,
+    target_term: TermItemId,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    let prim_id = context.queries().prim_id();
+    let prim = context.queries().resolved(prim_id)?;
+    let resolved = context.queries().resolved(file_id)?;
+
+    let target_unqualified = if file_id == target_file {
+        true
+    } else {
+        let mut imports = resolved.unqualified.values().flatten();
+        imports.any(|import| import.contains_term(target_file, target_term))
+    };
+    if target_unqualified {
+        let candidate = resolved.lookup_term(&prim, None, new_name);
+        if candidate.is_some_and(|candidate| candidate != (target_file, target_term)) {
+            return Ok(true);
+        }
+    }
+
+    let qualified_targets = resolved.qualified.iter().filter_map(|(qualifier, imports)| {
+        imports
+            .iter()
+            .any(|import| import.contains_term(target_file, target_term))
+            .then_some(qualifier.as_str())
+    });
+    let qualified_targets = qualified_targets.collect::<Vec<_>>();
+    for qualifier in &qualified_targets {
+        let candidate = resolved.lookup_term(&prim, Some(qualifier), new_name);
+        if candidate.is_some_and(|candidate| candidate != (target_file, target_term)) {
+            return Ok(true);
+        }
+    }
+
+    if (target_unqualified || !qualified_targets.is_empty())
+        && implicit_term_reference_conflicts(context, file_id, target_file, target_term)?
+    {
+        return Ok(true);
+    }
+
+    if target_unqualified {
+        term_reference_conflicts(context, file_id, target_file, target_term, new_name)
+    } else {
+        Ok(false)
+    }
+}
+
+fn implicit_term_reference_conflicts(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    target_file: FileId,
+    target_term: TermItemId,
+) -> Result<bool, AnalyzerError> {
+    let lowered = context.queries().lowered(file_id)?;
+    let target = TermVariableResolution::Reference(target_file, target_term);
+    let mut expressions = lowered.tree.iter_expression();
+    Ok(expressions.any(|(_, kind)| expression_has_implicit_resolution(kind, target)))
+}
+
+fn term_reference_conflicts(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    target_file: FileId,
+    target_term: TermItemId,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    let lowered = context.queries().lowered(file_id)?;
+    let target = TermVariableResolution::Reference(target_file, target_term);
+
+    for (expression_id, kind) in lowered.tree.iter_expression() {
+        let ExpressionKind::Variable { resolution: Some(current) } = kind else { continue };
+        if *current != target || !expression_is_unqualified(context, file_id, expression_id)? {
+            continue;
+        }
+        let Some(node) = lowered.nodes.expression_node(expression_id) else { continue };
+        if lowered.graph.resolve_term(node, new_name).is_some() {
+            return Ok(true);
+        }
+    }
+
+    for (pun_id, current) in lowered.tree.iter_expression_pun() {
+        if current != target {
+            continue;
+        }
+        let Some(node) = lowered.nodes.record_pun_node(pun_id) else { continue };
+        if lowered.graph.resolve_term(node, new_name).is_some() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn expression_is_unqualified(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    expression_id: lowering::ExpressionId,
+) -> Result<bool, AnalyzerError> {
+    let (parsed, _) = context.queries().parsed(file_id)?;
+    let stabilized = context.queries().stabilized(file_id)?;
+    let root = parsed.syntax_node();
+    let pointer = stabilized.syntax_ptr(expression_id).ok_or(AnalyzerError::NonFatal)?;
+    let node = pointer.try_to_node(&root).ok_or(AnalyzerError::NonFatal)?;
+    let expression = cst::Expression::cast(node).ok_or(AnalyzerError::NonFatal)?;
+
+    let cst::Expression::ExpressionVariable(variable) = expression else { return Ok(false) };
+    Ok(variable.name().is_some_and(|name| name.qualifier().is_none()))
+}
+
+fn type_item_conflicts(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    target_file: FileId,
+    target_type: TypeItemId,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    if type_item_conflicts_in_file(context, target_file, target_file, target_type, new_name)? {
+        return Ok(true);
+    }
+
+    for file_id in context.active_files() {
+        if file_id != target_file
+            && type_item_conflicts_in_file(context, file_id, target_file, target_type, new_name)?
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn type_item_conflicts_in_file(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    target_file: FileId,
+    target_type: TypeItemId,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    let prim_id = context.queries().prim_id();
+    let prim = context.queries().resolved(prim_id)?;
+    let resolved = context.queries().resolved(file_id)?;
+
+    let import_contains_target = |import: &resolving::ResolvedImport| {
+        let types = import.iter_types();
+        let classes = import.iter_classes();
+        types.chain(classes).any(|(_, imported_file, imported_type, kind)| {
+            kind != ImportKind::Hidden
+                && (imported_file, imported_type) == (target_file, target_type)
+        })
+    };
+    let target_unqualified = if file_id == target_file {
+        true
+    } else {
+        let mut imports = resolved.unqualified.values().flatten();
+        imports.any(&import_contains_target)
+    };
+    if target_unqualified {
+        let candidate = resolved
+            .lookup_type(&prim, None, new_name)
+            .or_else(|| resolved.lookup_class(&prim, None, new_name));
+        if candidate.is_some_and(|candidate| candidate != (target_file, target_type)) {
+            return Ok(true);
+        }
+    }
+
+    for (qualifier, imports) in &resolved.qualified {
+        if imports.iter().any(&import_contains_target) {
+            let candidate = resolved
+                .lookup_type(&prim, Some(qualifier), new_name)
+                .or_else(|| resolved.lookup_class(&prim, Some(qualifier), new_name));
+            if candidate.is_some_and(|candidate| candidate != (target_file, target_type)) {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn local_rename_conflicts(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    target: TermVariableResolution,
+    new_name: &str,
+) -> Result<bool, AnalyzerError> {
+    let lowered = context.queries().lowered(file_id)?;
+    let Some(target_node) = lowered.nodes.term_node(target) else { return Ok(false) };
+
+    if lowered.graph.resolve_term(target_node, new_name).is_some() {
+        return Ok(true);
+    }
+
+    let prim_id = context.queries().prim_id();
+    let prim = context.queries().resolved(prim_id)?;
+    let resolved = context.queries().resolved(file_id)?;
+    if resolved.lookup_term(&prim, None, new_name).is_some() {
+        return Ok(true);
+    }
+
+    for (expression_id, kind) in lowered.tree.iter_expression() {
+        if expression_has_implicit_resolution(kind, target) {
+            return Ok(true);
+        }
+        let ExpressionKind::Variable { resolution: Some(current) } = kind else { continue };
+        let Some(node) = lowered.nodes.expression_node(expression_id) else { continue };
+        if resolution_changes(&lowered, node, target_node, target, *current, new_name) {
+            return Ok(true);
+        }
+    }
+
+    for (pun_id, current) in lowered.tree.iter_expression_pun() {
+        let Some(node) = lowered.nodes.record_pun_node(pun_id) else { continue };
+        if resolution_changes(&lowered, node, target_node, target, current, new_name) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn expression_has_implicit_resolution(
+    kind: &ExpressionKind,
+    target: TermVariableResolution,
+) -> bool {
+    match kind {
+        ExpressionKind::Negate { negate, .. } => *negate == Some(target),
+        ExpressionKind::Do { bind, discard, .. } => {
+            *bind == Some(target) || *discard == Some(target)
+        }
+        ExpressionKind::Ado { map, apply, pure, .. } => {
+            *map == Some(target) || *apply == Some(target) || *pure == Some(target)
+        }
+        _ => false,
+    }
+}
+
+fn resolution_changes(
+    lowered: &lowering::LoweredModule,
+    node: lowering::GraphNodeId,
+    target_node: lowering::GraphNodeId,
+    target: TermVariableResolution,
+    current: TermVariableResolution,
+    new_name: &str,
+) -> bool {
+    let Some(candidate) = lowered.graph.resolve_term(node, new_name) else { return false };
+    let Some(candidate_node) = lowered.nodes.term_node(candidate) else { return false };
+
+    let mut scopes = lowered.graph.traverse(node).map(|(node, _)| node);
+    let target_position = scopes.position(|node| node == target_node);
+    let mut scopes = lowered.graph.traverse(node).map(|(node, _)| node);
+    let candidate_position = scopes.position(|node| node == candidate_node);
+    let Some((target_position, candidate_position)) = target_position.zip(candidate_position)
+    else {
+        return false;
+    };
+
+    if current == target {
+        candidate_position <= target_position
+    } else if current == candidate {
+        target_position <= candidate_position
+    } else {
+        false
+    }
 }
 
 pub fn prepare(
@@ -508,7 +834,8 @@ fn target_name(
             let pun = cst::RecordPun::cast(node).ok_or(AnalyzerError::NonFatal)?;
             let name = pun.name().ok_or(AnalyzerError::NonFatal)?;
 
-            Some((name.syntax().text(&content).to_string(), NameKind::Lower))
+            let name = name.syntax().text(&content);
+            Some((name.trim().to_string(), NameKind::Lower))
         }
         RenameTarget::Qualifier(file_id, import_id) => {
             let indexed = context.queries().indexed(file_id)?;

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -994,7 +994,10 @@ where
         }
     }
 
-    pub(super) fn finish(mut self) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
+    pub(super) fn finish(
+        mut self,
+        conflicts: bool,
+    ) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
         self.edits.sort_by_key(|(file_id, edit)| {
             (
                 file_id.into_raw().into_u32(),
@@ -1010,6 +1013,10 @@ where
             return Ok(None);
         }
 
+        if conflicts {
+            return self.finish_annotated();
+        }
+
         let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::default();
         for (file_id, edit) in self.edits {
             let uri = common::file_uri(self.context, file_id)?;
@@ -1017,5 +1024,35 @@ where
         }
 
         Ok(Some(WorkspaceEdit { changes: Some(changes), ..WorkspaceEdit::default() }))
+    }
+
+    fn finish_annotated(self) -> Result<Option<WorkspaceEdit>, AnalyzerError> {
+        let annotation_id = "rename-conflict".to_string();
+        let mut documents: HashMap<Url, Vec<OneOf<TextEdit, AnnotatedTextEdit>>> =
+            HashMap::default();
+        for (file_id, edit) in self.edits {
+            let uri = common::file_uri(self.context, file_id)?;
+            let edit = AnnotatedTextEdit { text_edit: edit, annotation_id: annotation_id.clone() };
+            documents.entry(uri).or_default().push(OneOf::Right(edit));
+        }
+
+        let documents = documents.into_iter().map(|(uri, edits)| TextDocumentEdit {
+            text_document: OptionalVersionedTextDocumentIdentifier { uri, version: None },
+            edits,
+        });
+        let documents = documents.collect();
+
+        let annotation = ChangeAnnotation {
+            label: "Rename may change name resolution".to_string(),
+            needs_confirmation: Some(true),
+            description: Some("The rename may change name resolution".to_string()),
+        };
+        let change_annotations = HashMap::from([(annotation_id, annotation)]);
+
+        Ok(Some(WorkspaceEdit {
+            document_changes: Some(DocumentChanges::Edits(documents)),
+            change_annotations: Some(change_annotations),
+            ..WorkspaceEdit::default()
+        }))
     }
 }

--- a/tests-integration/fixtures/lsp/1785847200_rename_existing_item_conflicts/Main.purs
+++ b/tests-integration/fixtures/lsp/1785847200_rename_existing_item_conflicts/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+renamed = 1
+
+original = renamed
+-- /
+
+data Renamed = Renamed
+
+data Original = Original
+--   /          /

--- a/tests-integration/fixtures/lsp/1785847200_rename_existing_item_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785847200_rename_existing_item_conflicts/Main.snap
@@ -10,6 +10,8 @@ original = renamed
 -- /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -24,6 +26,8 @@ original = renamed
  data Renamed = Renamed
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 9, character: 5 }
 
@@ -31,6 +35,8 @@ Rename at Position { line: 9, character: 5 }
 data Original = Original
 --   /          /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -44,6 +50,8 @@ data Original = Original
  --   /          /
 ```
 
+Without change annotations: Rename rejected: Cannot rename `Original` to `Renamed` because it would change name resolution
+
 
 Rename at Position { line: 9, character: 16 }
 
@@ -51,6 +59,8 @@ Rename at Position { line: 9, character: 16 }
 data Original = Original
 --   /          /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -63,3 +73,5 @@ data Original = Original
 +data Original = Renamed
  --   /          /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `Original` to `Renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785847200_rename_existing_item_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785847200_rename_existing_item_conflicts/Main.snap
@@ -1,0 +1,65 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 4, character: 3 }
+
+```
+original = renamed
+-- /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -2,7 +2,7 @@
+
+ renamed = 1
+
+-original = renamed
++renamed = renamed
+ -- /
+
+ data Renamed = Renamed
+```
+
+
+Rename at Position { line: 9, character: 5 }
+
+```
+data Original = Original
+--   /          /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -7,5 +7,5 @@
+
+ data Renamed = Renamed
+
+-data Original = Original
++data Renamed = Original
+ --   /          /
+```
+
+
+Rename at Position { line: 9, character: 16 }
+
+```
+data Original = Original
+--   /          /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -7,5 +7,5 @@
+
+ data Renamed = Renamed
+
+-data Original = Original
++data Original = Renamed
+ --   /          /
+```

--- a/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Lib.purs
+++ b/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Lib.purs
@@ -1,0 +1,5 @@
+module Lib where
+
+renamed = 1
+
+data Renamed = Renamed

--- a/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Main.purs
+++ b/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Main.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Lib (renamed, Renamed)
+
+original = renamed
+-- /
+
+data Original = Original Renamed
+--   /
+
+localConflict original = renamed + original
+--            /

--- a/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Main.snap
@@ -10,6 +10,8 @@ original = renamed
 -- /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -24,6 +26,8 @@ original = renamed
  data Original = Original Renamed
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 7, character: 5 }
 
@@ -31,6 +35,8 @@ Rename at Position { line: 7, character: 5 }
 data Original = Original Renamed
 --   /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -46,6 +52,8 @@ data Original = Original Renamed
  localConflict original = renamed + original
 ```
 
+Without change annotations: Rename rejected: Cannot rename `Original` to `Renamed` because it would change name resolution
+
 
 Rename at Position { line: 10, character: 14 }
 
@@ -53,6 +61,8 @@ Rename at Position { line: 10, character: 14 }
 localConflict original = renamed + original
 --            /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -65,3 +75,5 @@ localConflict original = renamed + original
 +localConflict renamed = renamed + renamed
  --            /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785847200_rename_imported_item_conflicts/Main.snap
@@ -1,0 +1,67 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 4, character: 3 }
+
+```
+original = renamed
+-- /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -2,7 +2,7 @@
+
+ import Lib (renamed, Renamed)
+
+-original = renamed
++renamed = renamed
+ -- /
+
+ data Original = Original Renamed
+```
+
+
+Rename at Position { line: 7, character: 5 }
+
+```
+data Original = Original Renamed
+--   /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -5,7 +5,7 @@
+ original = renamed
+ -- /
+
+-data Original = Original Renamed
++data Renamed = Original Renamed
+ --   /
+
+ localConflict original = renamed + original
+```
+
+
+Rename at Position { line: 10, character: 14 }
+
+```
+localConflict original = renamed + original
+--            /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -8,5 +8,5 @@
+ data Original = Original Renamed
+ --   /
+
+-localConflict original = renamed + original
++localConflict renamed = renamed + renamed
+ --            /
+```

--- a/tests-integration/fixtures/lsp/1785847200_rename_local_conflicts/Main.purs
+++ b/tests-integration/fixtures/lsp/1785847200_rename_local_conflicts/Main.purs
@@ -1,0 +1,49 @@
+module Main where
+
+captureRenamedReference original = (\renamed -> original) 0
+--                      /
+
+captureExistingReference renamed =
+  let original = 0
+--      /
+  in renamed + original
+
+captureLetReference original =
+--                    /
+  let renamed = 0
+  in original + renamed
+
+capturePunReference { renamed } =
+  let original = 0
+--      /
+  in renamed + original
+
+captureNamedBinder original@{ renamed } = original
+--                 /
+
+captureRecordPun renamed { original } = original
+--                          /
+
+preserveNestedReference original = (\renamed -> renamed) original
+--                      /
+
+rejectUnusedParent renamed =
+  let original = 0
+--      /
+  in original
+
+captureLambda renamed = (\original -> renamed + original) 0
+--                        /
+
+captureCase renamed value = case value of original -> renamed + original
+--                                        /
+
+captureDo renamed = do
+  original <- renamed
+--/
+  original
+
+captureAdo renamed = ado
+  original <- renamed
+--/
+  in original

--- a/tests-integration/fixtures/lsp/1785847200_rename_local_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785847200_rename_local_conflicts/Main.snap
@@ -10,6 +10,8 @@ captureRenamedReference original = (\renamed -> original) 0
 --                      /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -23,6 +25,8 @@ captureRenamedReference original = (\renamed -> original) 0
  captureExistingReference renamed =
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 6, character: 8 }
 
@@ -30,6 +34,8 @@ Rename at Position { line: 6, character: 8 }
   let original = 0
 --      /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -48,6 +54,8 @@ Rename at Position { line: 6, character: 8 }
  --                    /
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 10, character: 22 }
 
@@ -55,6 +63,8 @@ Rename at Position { line: 10, character: 22 }
 captureLetReference original =
 --                    /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -74,6 +84,8 @@ captureLetReference original =
    let original = 0
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 16, character: 8 }
 
@@ -81,6 +93,8 @@ Rename at Position { line: 16, character: 8 }
   let original = 0
 --      /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -99,6 +113,8 @@ Rename at Position { line: 16, character: 8 }
  --                 /
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 20, character: 19 }
 
@@ -106,6 +122,8 @@ Rename at Position { line: 20, character: 19 }
 captureNamedBinder original@{ renamed } = original
 --                 /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -121,6 +139,8 @@ captureNamedBinder original@{ renamed } = original
  captureRecordPun renamed { original } = original
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 23, character: 28 }
 
@@ -128,6 +148,8 @@ Rename at Position { line: 23, character: 28 }
 captureRecordPun renamed { original } = original
 --                          /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -142,6 +164,8 @@ captureRecordPun renamed { original } = original
 
  preserveNestedReference original = (\renamed -> renamed) original
 ```
+
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
 
 
 Rename at Position { line: 26, character: 24 }
@@ -173,6 +197,8 @@ Rename at Position { line: 30, character: 8 }
 --      /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -190,6 +216,8 @@ Rename at Position { line: 30, character: 8 }
  --                        /
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 34, character: 26 }
 
@@ -197,6 +225,8 @@ Rename at Position { line: 34, character: 26 }
 captureLambda renamed = (\original -> renamed + original) 0
 --                        /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -212,6 +242,8 @@ captureLambda renamed = (\original -> renamed + original) 0
  captureCase renamed value = case value of original -> renamed + original
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 37, character: 42 }
 
@@ -219,6 +251,8 @@ Rename at Position { line: 37, character: 42 }
 captureCase renamed value = case value of original -> renamed + original
 --                                        /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -234,6 +268,8 @@ captureCase renamed value = case value of original -> renamed + original
  captureDo renamed = do
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 41, character: 2 }
 
@@ -241,6 +277,8 @@ Rename at Position { line: 41, character: 2 }
   original <- renamed
 --/
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -259,6 +297,8 @@ Rename at Position { line: 41, character: 2 }
    original <- renamed
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 46, character: 2 }
 
@@ -266,6 +306,8 @@ Rename at Position { line: 46, character: 2 }
   original <- renamed
 --/
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -280,3 +322,5 @@ Rename at Position { line: 46, character: 2 }
 -  in original
 +  in renamed
 ```
+
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785847200_rename_local_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785847200_rename_local_conflicts/Main.snap
@@ -1,0 +1,282 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 2, character: 24 }
+
+```
+captureRenamedReference original = (\renamed -> original) 0
+--                      /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,6 +1,6 @@
+ module Main where
+
+-captureRenamedReference original = (\renamed -> original) 0
++captureRenamedReference renamed = (\renamed -> renamed) 0
+ --                      /
+
+ captureExistingReference renamed =
+```
+
+
+Rename at Position { line: 6, character: 8 }
+
+```
+  let original = 0
+--      /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -4,9 +4,9 @@
+ --                      /
+
+ captureExistingReference renamed =
+-  let original = 0
++  let renamed = 0
+ --      /
+-  in renamed + original
++  in renamed + renamed
+
+ captureLetReference original =
+ --                    /
+```
+
+
+Rename at Position { line: 10, character: 22 }
+
+```
+captureLetReference original =
+--                    /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -8,10 +8,10 @@
+ --      /
+   in renamed + original
+
+-captureLetReference original =
++captureLetReference renamed =
+ --                    /
+   let renamed = 0
+-  in original + renamed
++  in renamed + renamed
+
+ capturePunReference { renamed } =
+   let original = 0
+```
+
+
+Rename at Position { line: 16, character: 8 }
+
+```
+  let original = 0
+--      /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -14,9 +14,9 @@
+   in original + renamed
+
+ capturePunReference { renamed } =
+-  let original = 0
++  let renamed = 0
+ --      /
+-  in renamed + original
++  in renamed + renamed
+
+ captureNamedBinder original@{ renamed } = original
+ --                 /
+```
+
+
+Rename at Position { line: 20, character: 19 }
+
+```
+captureNamedBinder original@{ renamed } = original
+--                 /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -18,7 +18,7 @@
+ --      /
+   in renamed + original
+
+-captureNamedBinder original@{ renamed } = original
++captureNamedBinder renamed@{ renamed } = renamed
+ --                 /
+
+ captureRecordPun renamed { original } = original
+```
+
+
+Rename at Position { line: 23, character: 28 }
+
+```
+captureRecordPun renamed { original } = original
+--                          /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -21,7 +21,7 @@
+ captureNamedBinder original@{ renamed } = original
+ --                 /
+
+-captureRecordPun renamed { original } = original
++captureRecordPun renamed { original: renamed } = renamed
+ --                          /
+
+ preserveNestedReference original = (\renamed -> renamed) original
+```
+
+
+Rename at Position { line: 26, character: 24 }
+
+```
+preserveNestedReference original = (\renamed -> renamed) original
+--                      /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -24,7 +24,7 @@
+ captureRecordPun renamed { original } = original
+ --                          /
+
+-preserveNestedReference original = (\renamed -> renamed) original
++preserveNestedReference renamed = (\renamed -> renamed) renamed
+ --                      /
+
+ rejectUnusedParent renamed =
+```
+
+
+Rename at Position { line: 30, character: 8 }
+
+```
+  let original = 0
+--      /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -28,9 +28,9 @@
+ --                      /
+
+ rejectUnusedParent renamed =
+-  let original = 0
++  let renamed = 0
+ --      /
+-  in original
++  in renamed
+
+ captureLambda renamed = (\original -> renamed + original) 0
+ --                        /
+```
+
+
+Rename at Position { line: 34, character: 26 }
+
+```
+captureLambda renamed = (\original -> renamed + original) 0
+--                        /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -32,7 +32,7 @@
+ --      /
+   in original
+
+-captureLambda renamed = (\original -> renamed + original) 0
++captureLambda renamed = (\renamed -> renamed + renamed) 0
+ --                        /
+
+ captureCase renamed value = case value of original -> renamed + original
+```
+
+
+Rename at Position { line: 37, character: 42 }
+
+```
+captureCase renamed value = case value of original -> renamed + original
+--                                        /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -35,7 +35,7 @@
+ captureLambda renamed = (\original -> renamed + original) 0
+ --                        /
+
+-captureCase renamed value = case value of original -> renamed + original
++captureCase renamed value = case value of renamed -> renamed + renamed
+ --                                        /
+
+ captureDo renamed = do
+```
+
+
+Rename at Position { line: 41, character: 2 }
+
+```
+  original <- renamed
+--/
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -39,9 +39,9 @@
+ --                                        /
+
+ captureDo renamed = do
+-  original <- renamed
++  renamed <- renamed
+ --/
+-  original
++  renamed
+
+ captureAdo renamed = ado
+   original <- renamed
+```
+
+
+Rename at Position { line: 46, character: 2 }
+
+```
+  original <- renamed
+--/
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -44,6 +44,6 @@
+   original
+
+ captureAdo renamed = ado
+-  original <- renamed
++  renamed <- renamed
+ --/
+-  in original
++  in renamed
+```

--- a/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Lib.purs
+++ b/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Lib.purs
@@ -1,0 +1,5 @@
+module Lib where
+
+original = 1
+
+data Original = Original

--- a/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Main.purs
+++ b/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Lib (original, Original)
+import Other (renamed, Renamed)
+
+term = original + renamed
+--     /
+
+type Example = Original
+--             /

--- a/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Main.snap
@@ -10,6 +10,8 @@ term = original + renamed
 --     /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Lib.purs
 +++ Lib.purs
@@ -39,6 +41,8 @@ term = original + renamed
  type Example = Original
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 8, character: 15 }
 
@@ -46,6 +50,8 @@ Rename at Position { line: 8, character: 15 }
 type Example = Original
 --             /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Lib.purs
@@ -75,3 +81,5 @@ type Example = Original
 +type Example = Renamed
  --             /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `Original` to `Renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Main.snap
@@ -1,0 +1,77 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 5, character: 7 }
+
+```
+term = original + renamed
+--     /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -1,5 +1,5 @@
+ module Lib where
+
+-original = 1
++renamed = 1
+
+ data Original = Original
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,9 +1,9 @@
+ module Main where
+
+-import Lib (original, Original)
++import Lib (renamed, Original)
+ import Other (renamed, Renamed)
+
+-term = original + renamed
++term = renamed + renamed
+ --     /
+
+ type Example = Original
+```
+
+
+Rename at Position { line: 8, character: 15 }
+
+```
+type Example = Original
+--             /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -2,4 +2,4 @@
+
+ original = 1
+
+-data Original = Original
++data Renamed = Original
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,10 +1,10 @@
+ module Main where
+
+-import Lib (original, Original)
++import Lib (original, Renamed)
+ import Other (renamed, Renamed)
+
+ term = original + renamed
+ --     /
+
+-type Example = Original
++type Example = Renamed
+ --             /
+```

--- a/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Other.purs
+++ b/tests-integration/fixtures/lsp/1785854820_rename_downstream_import_conflicts/Other.purs
@@ -1,0 +1,5 @@
+module Other where
+
+renamed = 2
+
+data Renamed = Renamed

--- a/tests-integration/fixtures/lsp/1785854820_rename_top_level_lexical_conflict/Main.purs
+++ b/tests-integration/fixtures/lsp/1785854820_rename_top_level_lexical_conflict/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+original = 1
+
+capture renamed = original
+--                /

--- a/tests-integration/fixtures/lsp/1785854820_rename_top_level_lexical_conflict/Main.snap
+++ b/tests-integration/fixtures/lsp/1785854820_rename_top_level_lexical_conflict/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 4, character: 18 }
+
+```
+capture renamed = original
+--                /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,6 +1,6 @@
+ module Main where
+
+-original = 1
++renamed = 1
+
+-capture renamed = original
++capture renamed = renamed
+ --                /
+```

--- a/tests-integration/fixtures/lsp/1785854820_rename_top_level_lexical_conflict/Main.snap
+++ b/tests-integration/fixtures/lsp/1785854820_rename_top_level_lexical_conflict/Main.snap
@@ -10,6 +10,8 @@ capture renamed = original
 --                /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -23,3 +25,5 @@ capture renamed = original
 +capture renamed = renamed
  --                /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785855000_rename_class_conflict/Main.purs
+++ b/tests-integration/fixtures/lsp/1785855000_rename_class_conflict/Main.purs
@@ -1,0 +1,8 @@
+module Main where
+
+class Renamed a where
+  renamedMember :: a
+
+class Original a where
+--    /
+  originalMember :: a

--- a/tests-integration/fixtures/lsp/1785855000_rename_class_conflict/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855000_rename_class_conflict/Main.snap
@@ -1,0 +1,24 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 5, character: 6 }
+
+```
+class Original a where
+--    /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -3,6 +3,6 @@
+ class Renamed a where
+   renamedMember :: a
+
+-class Original a where
++class Renamed a where
+ --    /
+   originalMember :: a
+```

--- a/tests-integration/fixtures/lsp/1785855000_rename_class_conflict/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855000_rename_class_conflict/Main.snap
@@ -10,6 +10,8 @@ class Original a where
 --    /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -22,3 +24,5 @@ class Original a where
  --    /
    originalMember :: a
 ```
+
+Without change annotations: Rename rejected: Cannot rename `Original` to `Renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785855000_rename_operator_conflicts/Main.purs
+++ b/tests-integration/fixtures/lsp/1785855000_rename_operator_conflicts/Main.purs
@@ -1,0 +1,19 @@
+module Main where
+
+renamed left right = left
+
+infixl 5 renamed as <~>
+
+original left right = left
+
+infixl 5 original as <?>
+--                   /
+
+type Renamed = Int
+
+infixl 5 type Renamed as <~>
+
+type Original = Int
+
+infixl 5 type Original as :+:
+--                        /

--- a/tests-integration/fixtures/lsp/1785855000_rename_operator_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855000_rename_operator_conflicts/Main.snap
@@ -1,0 +1,45 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 8, character: 21 }
+
+```
+infixl 5 original as <?>
+--                   /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -6,7 +6,7 @@
+
+ original left right = left
+
+-infixl 5 original as <?>
++infixl 5 original as <~>
+ --                   /
+
+ type Renamed = Int
+```
+
+
+Rename at Position { line: 17, character: 26 }
+
+```
+infixl 5 type Original as :+:
+--                        /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -15,5 +15,5 @@
+
+ type Original = Int
+
+-infixl 5 type Original as :+:
++infixl 5 type Original as <~>
+ --                        /
+```

--- a/tests-integration/fixtures/lsp/1785855000_rename_operator_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855000_rename_operator_conflicts/Main.snap
@@ -10,6 +10,8 @@ infixl 5 original as <?>
 --                   /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -24,6 +26,8 @@ infixl 5 original as <?>
  type Renamed = Int
 ```
 
+Without change annotations: Rename rejected: Cannot rename `<?>` to `<~>` because it would change name resolution
+
 
 Rename at Position { line: 17, character: 26 }
 
@@ -31,6 +35,8 @@ Rename at Position { line: 17, character: 26 }
 infixl 5 type Original as :+:
 --                        /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -43,3 +49,5 @@ infixl 5 type Original as :+:
 +infixl 5 type Original as <~>
  --                        /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `:+:` to `<~>` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785855600_rename_qualified_reference_safe/Lib.purs
+++ b/tests-integration/fixtures/lsp/1785855600_rename_qualified_reference_safe/Lib.purs
@@ -1,0 +1,3 @@
+module Lib where
+
+original = 1

--- a/tests-integration/fixtures/lsp/1785855600_rename_qualified_reference_safe/Main.purs
+++ b/tests-integration/fixtures/lsp/1785855600_rename_qualified_reference_safe/Main.purs
@@ -1,0 +1,6 @@
+module Main where
+
+import Lib as Lib
+
+safe renamed = Lib.original
+--                   /

--- a/tests-integration/fixtures/lsp/1785855600_rename_qualified_reference_safe/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855600_rename_qualified_reference_safe/Main.snap
@@ -1,0 +1,33 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 4, character: 21 }
+
+```
+safe renamed = Lib.original
+--                   /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -1,3 +1,3 @@
+ module Lib where
+
+-original = 1
++renamed = 1
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -2,5 +2,5 @@
+
+ import Lib as Lib
+
+-safe renamed = Lib.original
++safe renamed = Lib.renamed
+ --                   /
+```

--- a/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Lib.purs
+++ b/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Lib.purs
@@ -1,0 +1,5 @@
+module Lib where
+
+original = 1
+
+data Original = Original

--- a/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Main.purs
+++ b/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Lib (original, Original) as Shared
+import Other (renamed, Renamed) as Shared
+
+term = Shared.original
+--              /
+
+type Example = Shared.Original
+--                       /

--- a/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Main.snap
@@ -1,0 +1,77 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 5, character: 16 }
+
+```
+term = Shared.original
+--              /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -1,5 +1,5 @@
+ module Lib where
+
+-original = 1
++renamed = 1
+
+ data Original = Original
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,9 +1,9 @@
+ module Main where
+
+-import Lib (original, Original) as Shared
++import Lib (renamed, Original) as Shared
+ import Other (renamed, Renamed) as Shared
+
+-term = Shared.original
++term = Shared.renamed
+ --              /
+
+ type Example = Shared.Original
+```
+
+
+Rename at Position { line: 8, character: 25 }
+
+```
+type Example = Shared.Original
+--                       /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -2,4 +2,4 @@
+
+ original = 1
+
+-data Original = Original
++data Renamed = Original
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,10 +1,10 @@
+ module Main where
+
+-import Lib (original, Original) as Shared
++import Lib (original, Renamed) as Shared
+ import Other (renamed, Renamed) as Shared
+
+ term = Shared.original
+ --              /
+
+-type Example = Shared.Original
++type Example = Shared.Renamed
+ --                       /
+```

--- a/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Main.snap
+++ b/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Main.snap
@@ -10,6 +10,8 @@ term = Shared.original
 --              /
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Lib.purs
 +++ Lib.purs
@@ -39,6 +41,8 @@ term = Shared.original
  type Example = Shared.Original
 ```
 
+Without change annotations: Rename rejected: Cannot rename `original` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 8, character: 25 }
 
@@ -46,6 +50,8 @@ Rename at Position { line: 8, character: 25 }
 type Example = Shared.Original
 --                       /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Lib.purs
@@ -75,3 +81,5 @@ type Example = Shared.Original
 +type Example = Shared.Renamed
  --                       /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `Original` to `Renamed` because it would change name resolution

--- a/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Other.purs
+++ b/tests-integration/fixtures/lsp/1785855600_rename_shared_qualifier_conflicts/Other.purs
@@ -1,0 +1,5 @@
+module Other where
+
+renamed = 2
+
+data Renamed = Renamed

--- a/tests-integration/fixtures/lsp/1785856800_rename_implicit_references/Main.purs
+++ b/tests-integration/fixtures/lsp/1785856800_rename_implicit_references/Main.purs
@@ -1,0 +1,21 @@
+module Main where
+
+map function value = function value
+--/
+
+topLevelMap = ado
+  value <- [1]
+  in value
+
+localMap map = ado
+--       /
+  value <- [1]
+  in value
+
+localBind bind = do
+--        /
+  value <- [1]
+  value
+
+localNegate negate value = -value
+--          /

--- a/tests-integration/fixtures/lsp/1785856800_rename_implicit_references/Main.snap
+++ b/tests-integration/fixtures/lsp/1785856800_rename_implicit_references/Main.snap
@@ -1,0 +1,88 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 2, character: 2 }
+
+```
+map function value = function value
+--/
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,6 +1,6 @@
+ module Main where
+
+-map function value = function value
++renamed function value = function value
+ --/
+
+ topLevelMap = ado
+```
+
+
+Rename at Position { line: 9, character: 9 }
+
+```
+localMap map = ado
+--       /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -7,7 +7,7 @@
+   value <- [1]
+   in value
+
+-localMap map = ado
++localMap renamed = ado
+ --       /
+   value <- [1]
+   in value
+```
+
+
+Rename at Position { line: 14, character: 10 }
+
+```
+localBind bind = do
+--        /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -12,7 +12,7 @@
+   value <- [1]
+   in value
+
+-localBind bind = do
++localBind renamed = do
+ --        /
+   value <- [1]
+   value
+```
+
+
+Rename at Position { line: 19, character: 12 }
+
+```
+localNegate negate value = -value
+--          /
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -17,5 +17,5 @@
+   value <- [1]
+   value
+
+-localNegate negate value = -value
++localNegate renamed value = -value
+ --          /
+```

--- a/tests-integration/fixtures/lsp/1785856800_rename_implicit_references/Main.snap
+++ b/tests-integration/fixtures/lsp/1785856800_rename_implicit_references/Main.snap
@@ -10,6 +10,8 @@ map function value = function value
 --/
 ```
 
+Rename may change name resolution (confirmation required)
+
 ```diff
 --- Main.purs
 +++ Main.purs
@@ -23,6 +25,8 @@ map function value = function value
  topLevelMap = ado
 ```
 
+Without change annotations: Rename rejected: Cannot rename `map` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 9, character: 9 }
 
@@ -30,6 +34,8 @@ Rename at Position { line: 9, character: 9 }
 localMap map = ado
 --       /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -45,6 +51,8 @@ localMap map = ado
    in value
 ```
 
+Without change annotations: Rename rejected: Cannot rename `map` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 14, character: 10 }
 
@@ -52,6 +60,8 @@ Rename at Position { line: 14, character: 10 }
 localBind bind = do
 --        /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -67,6 +77,8 @@ localBind bind = do
    value
 ```
 
+Without change annotations: Rename rejected: Cannot rename `bind` to `renamed` because it would change name resolution
+
 
 Rename at Position { line: 19, character: 12 }
 
@@ -74,6 +86,8 @@ Rename at Position { line: 19, character: 12 }
 localNegate negate value = -value
 --          /
 ```
+
+Rename may change name resolution (confirmation required)
 
 ```diff
 --- Main.purs
@@ -86,3 +100,5 @@ localNegate negate value = -value
 +localNegate renamed value = -value
  --          /
 ```
+
+Without change annotations: Rename rejected: Cannot rename `negate` to `renamed` because it would change name resolution

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -2,19 +2,19 @@ pub mod render;
 
 use std::fmt::Write;
 
-use analyzer::AnalyzerHost;
 use analyzer::completion::SuggestionsCache;
 use analyzer::position::PositionEncoding;
+use analyzer::{AnalyzerCapabilities, AnalyzerHost};
 use building::QueryEngine;
 use files::{FileId, Files};
 use itertools::Itertools;
 use line_index::{LineIndex, TextSize};
 use lsp_types::{
     CodeActionContext, CodeActionKind, CodeActionOrCommand, CodeActionResponse,
-    CodeActionTriggerKind, CompletionItemKind, CompletionList, CompletionResponse,
+    CodeActionTriggerKind, CompletionItemKind, CompletionList, CompletionResponse, DocumentChanges,
     DocumentHighlight, DocumentSymbolResponse, GotoDefinitionResponse, HoverContents,
-    LanguageString, Location, MarkedString, Position, PrepareRenameResponse, Range, SemanticTokens,
-    SymbolInformation, TextEdit, Url, WorkspaceEdit, WorkspaceSymbolResponse,
+    LanguageString, Location, MarkedString, OneOf, Position, PrepareRenameResponse, Range,
+    SemanticTokens, SymbolInformation, TextEdit, Url, WorkspaceEdit, WorkspaceSymbolResponse,
 };
 use render::{TabledCompletionItem, TabledDetailedCompletionItem};
 use similar::TextDiff;
@@ -239,7 +239,8 @@ fn dispatch_semantic_tokens(
 ) {
     let encoding = PositionEncoding::Utf16;
     let host = IntegrationAnalyzerHost { queries: engine, files };
-    let context = analyzer::AnalyzerContext::new(&host, encoding);
+    let capabilities = AnalyzerCapabilities::default().with_change_annotations();
+    let context = analyzer::AnalyzerContext::new(&host, encoding, capabilities);
     let Ok(Some(SemanticTokens { data, .. })) =
         analyzer::semantic_tokens::implementation(&context, uri)
     else {
@@ -329,8 +330,61 @@ fn render_workspace_edit(edit: WorkspaceEdit) -> Vec<String> {
     result
 }
 
+fn assert_rename_annotations(edit: &WorkspaceEdit) {
+    let Some(annotations) = edit.change_annotations.as_ref() else { return };
+    assert!(edit.changes.is_none(), "annotated rename edits must not also use changes");
+    assert!(!annotations.is_empty(), "annotated rename edits must define an annotation");
+    assert!(
+        annotations.values().all(|annotation| annotation.needs_confirmation == Some(true)),
+        "rename change annotations must require confirmation"
+    );
+
+    let Some(DocumentChanges::Edits(documents)) = edit.document_changes.as_ref() else {
+        panic!("annotated rename edits must use text document edits");
+    };
+    assert!(!documents.is_empty(), "annotated rename edits must edit a document");
+    for document in documents {
+        assert!(!document.edits.is_empty(), "annotated rename documents must contain an edit");
+        for edit in &document.edits {
+            let OneOf::Right(edit) = edit else {
+                panic!("every edit in an annotated rename must reference an annotation");
+            };
+            assert!(
+                annotations.contains_key(&edit.annotation_id),
+                "annotated rename edit references an unknown annotation"
+            );
+        }
+    }
+}
+
 fn render_rename_edit(edit: WorkspaceEdit, files: &Files, encoding: PositionEncoding) -> String {
-    let Some(changes) = edit.changes else { return String::new() };
+    assert_rename_annotations(&edit);
+    let annotation = edit.change_annotations.and_then(|annotations| {
+        annotations.into_values().next().map(|annotation| {
+            let confirmation = if annotation.needs_confirmation == Some(true) {
+                " (confirmation required)"
+            } else {
+                ""
+            };
+            format!("{}{}", annotation.label, confirmation)
+        })
+    });
+
+    let changes = if let Some(changes) = edit.changes {
+        changes
+    } else if let Some(DocumentChanges::Edits(documents)) = edit.document_changes {
+        let documents = documents.into_iter().map(|document| {
+            let edits = document.edits.into_iter().map(|edit| match edit {
+                OneOf::Left(edit) => edit,
+                OneOf::Right(edit) => edit.text_edit,
+            });
+            let edits = edits.collect();
+            (document.text_document.uri, edits)
+        });
+        documents.collect()
+    } else {
+        return String::new();
+    };
 
     let mut changes = changes.into_iter().collect::<Vec<_>>();
     changes.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
@@ -353,7 +407,8 @@ fn render_rename_edit(edit: WorkspaceEdit, files: &Files, encoding: PositionEnco
         format!("```diff\n{diff}\n```")
     });
 
-    rendered.join("\n\n")
+    let rendered = rendered.join("\n\n");
+    if let Some(annotation) = annotation { format!("{annotation}\n\n{rendered}") } else { rendered }
 }
 
 fn apply_text_edits(content: &str, edits: Vec<TextEdit>, encoding: PositionEncoding) -> String {
@@ -426,7 +481,8 @@ fn dispatch_cursor(
 ) {
     let encoding = PositionEncoding::Utf16;
     let host = IntegrationAnalyzerHost { queries: engine, files };
-    let context = analyzer::AnalyzerContext::new(&host, encoding);
+    let capabilities = AnalyzerCapabilities::default().with_change_annotations();
+    let context = analyzer::AnalyzerContext::new(&host, encoding, capabilities);
 
     match cursor {
         CursorKind::GotoDefinition => {
@@ -564,11 +620,26 @@ fn dispatch_cursor(
                 return;
             };
             let host = IntegrationAnalyzerHost { queries: engine, files };
-            let context = analyzer::AnalyzerContext::new(&host, encoding);
-            let response = analyzer::rename::implementation(&context, uri, position, new_name);
+            let capabilities = AnalyzerCapabilities::default().with_change_annotations();
+            let context = analyzer::AnalyzerContext::new(&host, encoding, capabilities);
+            let response =
+                analyzer::rename::implementation(&context, uri.clone(), position, new_name.clone());
             if let Ok(Some(edit)) = response {
+                let annotated = edit.change_annotations.is_some();
                 let edit = render_rename_edit(edit, files, encoding);
                 writeln!(result, "{edit}").unwrap();
+                if annotated {
+                    let context = analyzer::AnalyzerContext::new(
+                        &host,
+                        encoding,
+                        AnalyzerCapabilities::default(),
+                    );
+                    let response =
+                        analyzer::rename::implementation(&context, uri, position, new_name);
+                    if let Err(error) = response {
+                        writeln!(result, "\nWithout change annotations: {error}").unwrap();
+                    }
+                }
             } else {
                 writeln!(result, "<empty>").unwrap();
             }
@@ -659,7 +730,8 @@ fn dispatch_workspace_symbols(
 ) {
     let encoding = PositionEncoding::Utf16;
     let host = IntegrationAnalyzerHost { queries: engine, files };
-    let context = analyzer::AnalyzerContext::new(&host, encoding);
+    let capabilities = AnalyzerCapabilities::default().with_change_annotations();
+    let context = analyzer::AnalyzerContext::new(&host, encoding, capabilities);
 
     match analyzer::symbols::workspace(&context, cache, query) {
         Ok(Some(WorkspaceSymbolResponse::Flat(symbols))) => {


### PR DESCRIPTION
## Problem

Identity-based rename can preserve the renamed binding's references while still changing name resolution. A destination name may capture those references, or the renamed binding may capture existing references. The same risk applies across unqualified and shared-qualified imports, top-level namespaces, and implicit rebindable names used by `do`, `ado`, and negation.

## Changes

- retain the relevant client workspace-edit capabilities through request handling;
- require rename-specific change-annotation support before returning confirmation-required edits;
- detect local lexical conflicts for binders, let names, record puns, and implicit rebindable references;
- detect term, type, class, constructor, and operator conflicts across local, imported, and shared-qualified namespaces;
- return annotated document edits requiring confirmation for supporting clients, and reject conflicting renames for other clients;
- add pre-fix regression snapshots followed by the corrected expectations.

A general response-builder abstraction is intentionally deferred: rename is currently the only response whose representation varies with these capabilities.

## Verification

- `just t lsp`
- `cargo check -p analyzer --tests`
- `cargo check -p purescript-alexandrite --tests`
- `cargo check -p tests-integration --tests`
- `cargo nextest run -p analyzer`

Fixes #250.