### PR TITLE
[checking] Report missing instance members

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -301,6 +301,7 @@ where
         | ErrorKind::InvalidFinalBind
         | ErrorKind::InvalidFinalLet
         | ErrorKind::InstanceHeadMismatch { .. }
+        | ErrorKind::MissingClassMember { .. }
         | ErrorKind::InvalidNewtypeDeriveSkolemArguments
         | ErrorKind::PartialSynonymApplication { .. }
         | ErrorKind::RecursiveSynonymExpansion { .. }

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -94,6 +94,9 @@ pub enum ErrorKind {
         expected: TypeId,
         actual: TypeId,
     },
+    MissingClassMember {
+        members: Arc<[SmolStr]>,
+    },
     InvalidTypeApplication {
         function_type: TypeId,
         function_kind: TypeId,

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -4,7 +4,7 @@ use building_types::QueryResult;
 use files::FileId;
 use indexing::{IndexedTermItemKind, TermItemId, TypeItemId};
 use lowering::TermItemKind;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::context::CheckContext;
 use crate::core::constraint::ConstraintInScope;
@@ -321,9 +321,48 @@ where
                     }
                 }
 
+                let mut has_fail_constraint = false;
+                if members.is_empty() {
+                    for &constraint in &instance_constraints {
+                        let Some(canonical) =
+                            constraint::canonical::canonicalise(state, context, constraint)?
+                        else {
+                            continue;
+                        };
+                        if constraint::compiler::is_fail_constraint(state, context, canonical) {
+                            has_fail_constraint = true;
+                            break;
+                        }
+                    }
+                }
+
                 if let Some(class) =
                     toolkit::lookup_file_class(state, context, class_file, class_id)?
                 {
+                    let implemented_members = members.iter().filter_map(|member| {
+                        if member.equations.is_empty() {
+                            return None;
+                        }
+
+                        let (member_file, member_id) = member.resolution?;
+                        (member_file == class_file).then_some(member_id)
+                    });
+                    let implemented_members = implemented_members.collect::<FxHashSet<_>>();
+                    let class_indexed = context.queries.indexed(class_file)?;
+                    let missing_members = class.members.iter().filter_map(|member| {
+                        if implemented_members.contains(&member.item_id) {
+                            return None;
+                        }
+
+                        class_indexed.items[member.item_id].name.clone()
+                    });
+                    let missing_members = missing_members.collect::<Arc<[_]>>();
+                    if !has_fail_constraint && !missing_members.is_empty() {
+                        state.insert_error(ErrorKind::MissingClassMember {
+                            members: missing_members,
+                        });
+                    }
+
                     let positions = class
                         .members
                         .iter()
@@ -331,8 +370,9 @@ where
                         .map(|(position, member)| (member.item_id, position));
                     let positions = positions.collect::<FxHashMap<_, _>>();
                     checked_members.sort_by_key(|member| {
-                        if member.resolution.0 == class_file {
-                            positions.get(&member.resolution.1).copied().unwrap_or(usize::MAX)
+                        let (member_file, member_id) = member.resolution;
+                        if member_file == class_file {
+                            positions.get(&member_id).copied().unwrap_or(usize::MAX)
                         } else {
                             usize::MAX
                         }

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -350,6 +350,14 @@ impl ToDiagnostics for CheckingError {
                     format!("Instance member type mismatch: expected '{expected}', got '{actual}'"),
                 )
             }
+            ErrorKind::MissingClassMember { members } => {
+                let members = members.iter().join(", ");
+                (
+                    Severity::Error,
+                    "MissingClassMember",
+                    format!("The following type class members have not been implemented: {members}"),
+                )
+            }
             ErrorKind::InvalidTypeApplication { function_type, function_kind, argument_type } => {
                 let function_type = render_type(*function_type);
                 let function_kind = render_type(*function_kind);

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
@@ -24,3 +24,8 @@ error[OverlappingInstances]: Overlapping type class instances found for: C X Y
   | ^~~~~~~~~~~~~~~~~~~~~
   trivia: forall (t0 :: Type). C X (t0 :: Type) is matching
   trivia: C X Y is matching
+error[MissingClassMember]: The following type class members have not been implemented: test
+  --> 7:1..7:22
+  |
+7 | instance cxy :: C X Y
+  | ^~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786002840_missing_instance_members/Main.purs
+++ b/tests-integration/fixtures/checking/1786002840_missing_instance_members/Main.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Prim.TypeError (class Fail, Text)
+
+class Render a where
+  render :: a -> String
+  renderCompact :: a -> String
+  renderVerbose :: a -> String
+
+instance Render Int where
+  render _ = "Int"
+  renderCompact _ = "Int"
+  render :: Int -> String
+  renderVerbose :: Int -> String
+
+data Unreachable
+
+instance Fail (Text "unreachable") => Render Unreachable
+
+data PartiallyUnreachable
+
+instance Fail (Text "partially unreachable") => Render PartiallyUnreachable where
+  render _ = "PartiallyUnreachable"

--- a/tests-integration/fixtures/checking/1786002840_missing_instance_members/Main.snap
+++ b/tests-integration/fixtures/checking/1786002840_missing_instance_members/Main.snap
@@ -12,6 +12,8 @@ renderVerbose ::
 
 Types
 Render :: Prim.Type -> Prim.Constraint
+Unreachable :: Prim.Type
+PartiallyUnreachable :: Prim.Type
 
 Classes
 class forall (a :: Prim.Type). Main.Render (a :: Prim.Type)
@@ -23,3 +25,22 @@ class forall (a :: Prim.Type). Main.Render (a :: Prim.Type)
 
 Instances
 instance Main.Render Prim.Int
+instance Prim.TypeError.Fail (Prim.TypeError.Text "unreachable") => Main.Render Main.Unreachable
+instance Prim.TypeError.Fail (Prim.TypeError.Text "partially unreachable") =>
+Main.Render Main.PartiallyUnreachable
+
+Roles
+Unreachable = []
+PartiallyUnreachable = []
+
+Diagnostics
+error[MissingClassMember]: The following type class members have not been implemented: renderVerbose
+  --> 10:1..14:33
+   |
+10 | instance Render Int where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~
+error[MissingClassMember]: The following type class members have not been implemented: renderCompact, renderVerbose
+  --> 22:1..23:36
+   |
+22 | instance Fail (Text "partially unreachable") => Render PartiallyUnreachable where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests-integration/fixtures/checking/1786002840_missing_instance_members/Main.snap
+++ b/tests-integration/fixtures/checking/1786002840_missing_instance_members/Main.snap
@@ -1,0 +1,25 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+render :: forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+renderCompact ::
+  forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+renderVerbose ::
+  forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+
+Types
+Render :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Render (a :: Prim.Type)
+  render :: forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+  renderCompact ::
+  forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+  renderVerbose ::
+  forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+
+Instances
+instance Main.Render Prim.Int


### PR DESCRIPTION
## Summary

Report required type class members that have no equation in an instance.

The diagnostic lists all missing members in declaration order. A signature without an equation does not implement a member. An equation still implements a member when a separate type error exists.

This pull request depends on the instance-head class branch.

## Commit structure

1. Add a failing regression fixture.
2. Add the missing-member diagnostic and update the fixture snapshot.

## Verification

- `cargo check -p checking --tests`
- `cargo check -p diagnostics --tests`
- `just t checking 1786002840_missing_instance_members 1772475900_instance_member_signature_mismatch`
- `just format`
- `git diff --check`