### PR TITLE
[lsp] Resolve classes in instance heads

### DIFF
--- a/compiler-core/diagnostics/src/context.rs
+++ b/compiler-core/diagnostics/src/context.rs
@@ -146,6 +146,13 @@ where
         self.span_from_syntax_node(node.syntax())
     }
 
+    pub fn span_from_instance_head(&self, id: lowering::InstanceHeadId) -> Option<Span> {
+        let ptr = self.stabilized.ast_ptr(id)?;
+        let head = ptr.try_to_node(self.root)?;
+        let qualified = head.qualified()?;
+        self.span_from_syntax_node(qualified.syntax())
+    }
+
     fn span_from_syntax_node(&self, node: &SyntaxNode) -> Option<Span> {
         let range = significant_ranges(node)?;
         Some(Span::new(range.start().into(), range.end().into()))

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -21,6 +21,13 @@ impl ToDiagnostics for LoweringError {
     {
         match self {
             LoweringError::NotInScope(not_in_scope) => {
+                if let lowering::NotInScope::InstanceHead { id } = not_in_scope {
+                    let Some(span) = context.span_from_instance_head(*id) else { return vec![] };
+                    let text = context.text_of(span).trim();
+                    let message = format!("'{text}' is not in scope");
+                    return vec![Diagnostic::error("NotInScope", message, span, "lowering")];
+                }
+
                 let (ptr, name) = match not_in_scope {
                     lowering::NotInScope::ExprConstructor { id } => {
                         (context.stabilized.syntax_ptr(*id), None)
@@ -64,6 +71,7 @@ impl ToDiagnostics for LoweringError {
                     lowering::NotInScope::TypeOperator { id } => {
                         (context.stabilized.syntax_ptr(*id), None)
                     }
+                    lowering::NotInScope::InstanceHead { .. } => unreachable!(),
                 };
 
                 let Some(ptr) = ptr else { return vec![] };

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -9,7 +9,6 @@ use indexing::{
     IndexedTypeItemKind, TermItemId, TypeItemId, TypeRoleId,
 };
 use indexmap::IndexMap;
-use itertools::Itertools;
 use petgraph::prelude::DiGraphMap;
 use resolving::ResolvedModule;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
@@ -426,17 +425,8 @@ fn lower_term_item(
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
 
             let newtype = cst.as_ref().map(|cst| cst.newtype_token().is_some()).unwrap_or(false);
-
-            let resolution = cst.as_ref().and_then(|cst| {
-                let head = cst.instance_head()?;
-                let qualified = head.qualified()?;
-                let (qualifier, name) = recursive::lower_qualified_name(
-                    context.source,
-                    &qualified,
-                    cst::QualifiedName::upper,
-                )?;
-                state.resolve_class_reference(context, qualifier.as_deref(), &name)
-            });
+            let resolution = cst.as_ref().and_then(|cst| cst.instance_head());
+            let resolution = resolution.and_then(|head| lower_instance_head(state, context, &head));
 
             state.push_implicit_scope();
             let arguments = recover! {
@@ -477,17 +467,8 @@ fn lower_term_item(
 
         IndexedTermItemKind::Instance { id } => {
             let cst = context.stabilized.ast_ptr(*id).and_then(|cst| cst.try_to_node(context.root));
-
-            let resolution = cst.as_ref().and_then(|cst| {
-                let head = cst.instance_head()?;
-                let qualified = head.qualified()?;
-                let (qualifier, name) = recursive::lower_qualified_name(
-                    context.source,
-                    &qualified,
-                    cst::QualifiedName::upper,
-                )?;
-                state.resolve_class_reference(context, qualifier.as_deref(), &name)
-            });
+            let resolution = cst.as_ref().and_then(|cst| cst.instance_head());
+            let resolution = resolution.and_then(|head| lower_instance_head(state, context, &head));
 
             state.push_implicit_scope();
             let arguments = recover! {
@@ -588,6 +569,23 @@ fn lower_term_item(
             state.tree.term_items.insert(item_id, kind);
         }
     }
+}
+
+fn lower_instance_head(
+    state: &mut State,
+    context: &Context,
+    head: &cst::InstanceHead,
+) -> Option<(FileId, TypeItemId)> {
+    let id = context.stabilized.lookup_cst(head).expect_id();
+    let qualified = head.qualified()?;
+    let (qualifier, name) =
+        recursive::lower_qualified_name(context.source, &qualified, cst::QualifiedName::upper)?;
+    let resolution = state.resolve_class_reference(context, qualifier.as_deref(), &name);
+    state.tree.instance_heads.insert(id, resolution);
+    if resolution.is_none() {
+        state.errors.push(LoweringError::NotInScope(NotInScope::InstanceHead { id }));
+    }
+    resolution
 }
 
 fn lower_type_item(
@@ -850,49 +848,34 @@ fn lower_instance_statements(
     cst: &cst::InstanceStatements,
     class_resolution: Option<(FileId, TypeItemId)>,
 ) -> Arc<[InstanceMemberGroup]> {
-    let children = cst.children().chunk_by(|statement| match statement {
-        cst::InstanceMemberStatement::InstanceSignatureStatement(s) => s.name_token().map(|t| {
-            let text = t.text(context.source);
-            SmolStr::from(text)
-        }),
-        cst::InstanceMemberStatement::InstanceEquationStatement(e) => e.name_token().map(|t| {
-            let text = t.text(context.source);
-            SmolStr::from(text)
-        }),
-    });
+    let mut in_scope: IndexMap<SmolStr, (Vec<_>, Option<_>, Vec<_>), FxBuildHasher> =
+        IndexMap::default();
+    for statement in cst.children() {
+        let name = match &statement {
+            cst::InstanceMemberStatement::InstanceSignatureStatement(statement) => {
+                statement.name_token()
+            }
+            cst::InstanceMemberStatement::InstanceEquationStatement(statement) => {
+                statement.name_token()
+            }
+        };
+        let Some(name) = name else { continue };
+        let name = SmolStr::from(name.text(context.source));
+        let (statements, signature, equations) = in_scope.entry(name).or_default();
 
-    let mut in_scope: IndexMap<_, _, FxBuildHasher> = IndexMap::default();
-    for (name, mut children) in children.into_iter() {
-        let mut statements = vec![];
-        let mut signature = None;
-        let mut equations = vec![];
-
-        if let Some(statement) = children.next() {
-            let id = context.stabilized.lookup_cst(&statement).expect_id();
-            statements.push(id);
-            match statement {
-                cst::InstanceMemberStatement::InstanceSignatureStatement(cst) => {
-                    let id = context.stabilized.lookup_cst(&cst).expect_id();
-                    signature = Some(id);
-                }
-                cst::InstanceMemberStatement::InstanceEquationStatement(cst) => {
-                    let id = context.stabilized.lookup_cst(&cst).expect_id();
-                    equations.push(id);
+        let id = context.stabilized.lookup_cst(&statement).expect_id();
+        statements.push(id);
+        match statement {
+            cst::InstanceMemberStatement::InstanceSignatureStatement(statement) => {
+                let id = context.stabilized.lookup_cst(&statement).expect_id();
+                if signature.is_none() {
+                    *signature = Some(id);
                 }
             }
-        }
-
-        children.for_each(|statement| {
-            let id = context.stabilized.lookup_cst(&statement).expect_id();
-            statements.push(id);
-            if let cst::InstanceMemberStatement::InstanceEquationStatement(cst) = statement {
-                let id = context.stabilized.lookup_cst(&cst).expect_id();
+            cst::InstanceMemberStatement::InstanceEquationStatement(statement) => {
+                let id = context.stabilized.lookup_cst(&statement).expect_id();
                 equations.push(id);
             }
-        });
-
-        if let Some(name) = name {
-            in_scope.insert(name, (statements, signature, equations));
         }
     }
 

--- a/compiler-core/lowering/src/error.rs
+++ b/compiler-core/lowering/src/error.rs
@@ -19,6 +19,7 @@ pub enum NotInScope {
     TypeConstructor { id: AstId<cst::TypeConstructor> },
     TypeVariable { id: AstId<cst::TypeVariable> },
     TypeOperatorName { id: AstId<cst::TypeOperatorName> },
+    InstanceHead { id: AstId<cst::InstanceHead> },
     DoFn { kind: DoFn, id: AstId<cst::ExpressionDo> },
     AdoFn { kind: AdoFn, id: AstId<cst::ExpressionAdo> },
     NegateFn { id: AstId<cst::ExpressionNegate> },

--- a/compiler-core/lowering/src/source.rs
+++ b/compiler-core/lowering/src/source.rs
@@ -9,6 +9,8 @@ pub type RecordPunId = AstId<cst::RecordPun>;
 pub type TypeId = AstId<cst::Type>;
 pub type TypeVariableBindingId = AstId<cst::TypeVariableBinding>;
 
+pub type InstanceHeadId = AstId<cst::InstanceHead>;
+
 pub type DoStatementId = AstId<cst::DoStatement>;
 pub type LetBindingId = AstId<cst::LetBindingPattern>;
 

--- a/compiler-core/lowering/src/tree.rs
+++ b/compiler-core/lowering/src/tree.rs
@@ -448,6 +448,7 @@ pub struct LoweredTree {
     pub(crate) binders: FxHashMap<BinderId, BinderKind>,
     pub(crate) expressions: FxHashMap<ExpressionId, ExpressionKind>,
     pub(crate) types: FxHashMap<TypeId, TypeKind>,
+    pub(crate) instance_heads: FxHashMap<InstanceHeadId, Option<(FileId, TypeItemId)>>,
     pub(crate) term_items: FxHashMap<TermItemId, TermItemKind>,
     pub(crate) type_items: FxHashMap<TypeItemId, TypeItemKind>,
 
@@ -471,6 +472,12 @@ impl LoweredTree {
 
     pub fn iter_type(&self) -> impl Iterator<Item = (TypeId, &TypeKind)> {
         self.types.iter().map(|(k, v)| (*k, v))
+    }
+
+    pub fn iter_instance_head(
+        &self,
+    ) -> impl Iterator<Item = (InstanceHeadId, Option<(FileId, TypeItemId)>)> + '_ {
+        self.instance_heads.iter().map(|(k, v)| (*k, *v))
     }
 
     pub fn iter_do_statement(&self) -> impl Iterator<Item = (DoStatementId, &DoStatement)> {
@@ -501,6 +508,10 @@ impl LoweredTree {
 
     pub fn get_type_kind(&self, id: TypeId) -> Option<&TypeKind> {
         self.types.get(&id)
+    }
+
+    pub fn get_instance_head(&self, id: InstanceHeadId) -> Option<Option<(FileId, TypeItemId)>> {
+        self.instance_heads.get(&id).copied()
     }
 
     pub fn get_do_statement(&self, id: DoStatementId) -> Option<&DoStatement> {

--- a/compiler-lsp/analyzer/src/completion.rs
+++ b/compiler-lsp/analyzer/src/completion.rs
@@ -15,10 +15,11 @@ use prelude::{CompletionContext, CompletionSource, CursorSemantics, CursorText, 
 use radix_trie::Trie;
 use smol_str::SmolStr;
 use sources::{
-    ImportClasses, ImportedTerms, ImportedTypes, LocalTerms, LocalTypes, PrimTerms, PrimTypes,
+    ImportClasses, ImportedClasses, ImportedTerms, ImportedTypes, LocalClasses, LocalTerms,
+    LocalTypes, PrimClasses, PrimTerms, PrimTypes, QualifiedClasses, QualifiedClassesSuggestions,
     QualifiedModules, QualifiedTerms, QualifiedTermsSuggestions, QualifiedTypes,
-    QualifiedTypesSuggestions, ScopeTerms, ScopeTypes, SuggestedTerms, SuggestedTypes,
-    WorkspaceModules,
+    QualifiedTypesSuggestions, ScopeTerms, ScopeTypes, SuggestedClasses, SuggestedTerms,
+    SuggestedTypes, WorkspaceModules,
 };
 use syntax::{SyntaxKind, TokenAtOffset};
 
@@ -28,8 +29,10 @@ use crate::{AnalyzerContext, AnalyzerError, position};
 pub struct SuggestionsCacheEntry {
     pub terms: Vec<CompletionItem>,
     pub types: Vec<CompletionItem>,
+    pub classes: Vec<CompletionItem>,
     pub qualified_terms: Vec<CompletionItem>,
     pub qualified_types: Vec<CompletionItem>,
+    pub qualified_classes: Vec<CompletionItem>,
 }
 
 pub type SuggestionsCache = Trie<String, Arc<SuggestionsCacheEntry>>;
@@ -118,7 +121,7 @@ fn collect(
         CursorText::None => {
             if context.collect_modules() {
                 WorkspaceModules.collect_into(context, NoFilter, into)?;
-            } else if !context.collect_import_classes() {
+            } else if !context.collect_import_classes() && !context.collect_instance_classes() {
                 QualifiedModules.collect_into(context, NoFilter, into)?;
             }
             if context.collect_import_classes() {
@@ -134,13 +137,17 @@ fn collect(
                 LocalTypes.collect_into(context, NoFilter, into)?;
                 ImportedTypes.collect_into(context, NoFilter, into)?;
             }
+            if context.collect_instance_classes() {
+                LocalClasses.collect_into(context, NoFilter, into)?;
+                ImportedClasses.collect_into(context, NoFilter, into)?;
+            }
         }
         CursorText::Prefix(p) => {
             let p = p.trim_end_matches('.');
 
             if context.collect_modules() {
                 WorkspaceModules.collect_into(context, StartsWith(p), into)?;
-            } else if !context.collect_import_classes() {
+            } else if !context.collect_import_classes() && !context.collect_instance_classes() {
                 QualifiedModules.collect_into(context, StartsWith(p), into)?;
             }
             if context.collect_terms() {
@@ -149,8 +156,14 @@ fn collect(
             if context.collect_types() {
                 QualifiedTypes(p).collect_into(context, NoFilter, into)?;
             }
+            if context.collect_instance_classes() {
+                QualifiedClasses { qualifier: p }.collect_into(context, NoFilter, into)?;
+            }
 
-            if context.collect_terms() || context.collect_types() {
+            if context.collect_terms()
+                || context.collect_types()
+                || context.collect_instance_classes()
+            {
                 let query = format!("prefix:{p}");
                 let suggestions =
                     get_or_populate_suggestions(cache, &query, context, Some(p), NoFilter)?;
@@ -161,12 +174,15 @@ fn collect(
                 if context.collect_types() && !context.has_qualified_import(p) {
                     items.extend(suggestions.qualified_types.iter().cloned());
                 }
+                if context.collect_instance_classes() && !context.has_qualified_import(p) {
+                    items.extend(suggestions.qualified_classes.iter().cloned());
+                }
             }
         }
         CursorText::Name(n) => {
             if context.collect_modules() {
                 WorkspaceModules.collect_into(context, StartsWith(n), into)?;
-            } else if !context.collect_import_classes() {
+            } else if !context.collect_import_classes() && !context.collect_instance_classes() {
                 QualifiedModules.collect_into(context, StartsWith(n), into)?;
             }
             if context.collect_import_classes() {
@@ -188,8 +204,18 @@ fn collect(
                     PrimTypes.collect_into(context, FuzzyMatch(n), into)?;
                 }
             }
+            if context.collect_instance_classes() {
+                LocalClasses.collect_into(context, FuzzyMatch(n), into)?;
+                ImportedClasses.collect_into(context, FuzzyMatch(n), into)?;
+                if context.collect_implicit_prim() {
+                    PrimClasses.collect_into(context, FuzzyMatch(n), into)?;
+                }
+            }
 
-            if context.collect_terms() || context.collect_types() {
+            if context.collect_terms()
+                || context.collect_types()
+                || context.collect_instance_classes()
+            {
                 let query = format!("name:{n}");
                 let suggestions =
                     get_or_populate_suggestions(cache, &query, context, None, StartsWith(n))?;
@@ -200,6 +226,9 @@ fn collect(
                 if context.collect_types() {
                     items.extend(suggestions.types.iter().cloned());
                 }
+                if context.collect_instance_classes() {
+                    items.extend(suggestions.classes.iter().cloned());
+                }
             }
         }
         CursorText::Both(prefix, name) => {
@@ -209,7 +238,7 @@ fn collect(
 
             if context.collect_modules() {
                 WorkspaceModules.collect_into(context, StartsWith(&combined_name), into)?;
-            } else if !context.collect_import_classes() {
+            } else if !context.collect_import_classes() && !context.collect_instance_classes() {
                 QualifiedModules.collect_into(context, StartsWith(&combined_name), into)?;
             }
             if context.collect_terms() {
@@ -218,8 +247,18 @@ fn collect(
             if context.collect_types() {
                 QualifiedTypes(prefix).collect_into(context, FuzzyMatch(name), into)?;
             }
+            if context.collect_instance_classes() {
+                QualifiedClasses { qualifier: prefix }.collect_into(
+                    context,
+                    FuzzyMatch(name),
+                    into,
+                )?;
+            }
 
-            if context.collect_terms() || context.collect_types() {
+            if context.collect_terms()
+                || context.collect_types()
+                || context.collect_instance_classes()
+            {
                 let query = format!("both:{combined_name}");
                 let suggestions = get_or_populate_suggestions(
                     cache,
@@ -236,6 +275,9 @@ fn collect(
                 if context.collect_types() && !context.has_qualified_import(prefix) {
                     items.extend(suggestions.qualified_types.iter().cloned());
                 }
+                if context.collect_instance_classes() && !context.has_qualified_import(prefix) {
+                    items.extend(suggestions.qualified_classes.iter().cloned());
+                }
             }
         }
     }
@@ -250,7 +292,7 @@ fn get_or_populate_suggestions<F: Filter>(
     prefix: Option<&str>,
     filter: F,
 ) -> Result<Arc<SuggestionsCacheEntry>, AnalyzerError> {
-    let query = query.to_lowercase();
+    let query = format!("{:?}:{}", context.current_file, query.to_lowercase());
 
     if let Some(cached) = cache.get(&query) {
         tracing::debug!("Found exact match for '{query}'");
@@ -284,9 +326,15 @@ fn get_or_populate_suggestions<F: Filter>(
             filter,
             &mut suggestions.qualified_types,
         )?;
+        QualifiedClassesSuggestions { qualifier: prefix }.collect_into(
+            context,
+            filter,
+            &mut suggestions.qualified_classes,
+        )?;
     } else {
         SuggestedTerms.collect_into(context, filter, &mut suggestions.terms)?;
         SuggestedTypes.collect_into(context, filter, &mut suggestions.types)?;
+        SuggestedClasses.collect_into(context, filter, &mut suggestions.classes)?;
     }
 
     let key = query.to_string();
@@ -306,11 +354,38 @@ where
     F: Filter,
 {
     SuggestionsCacheEntry {
-        terms: collect_entries(&cached.terms, filter, prefix, context),
-        types: collect_entries(&cached.types, filter, prefix, context),
-        qualified_terms: collect_entries(&cached.qualified_terms, filter, prefix, context),
-        qualified_types: collect_entries(&cached.qualified_types, filter, prefix, context),
+        terms: collect_entries(&cached.terms, filter, prefix, context, ImportNamespace::Term),
+        types: collect_entries(&cached.types, filter, prefix, context, ImportNamespace::Type),
+        classes: collect_entries(&cached.classes, filter, prefix, context, ImportNamespace::Class),
+        qualified_terms: collect_entries(
+            &cached.qualified_terms,
+            filter,
+            prefix,
+            context,
+            ImportNamespace::Term,
+        ),
+        qualified_types: collect_entries(
+            &cached.qualified_types,
+            filter,
+            prefix,
+            context,
+            ImportNamespace::Type,
+        ),
+        qualified_classes: collect_entries(
+            &cached.qualified_classes,
+            filter,
+            prefix,
+            context,
+            ImportNamespace::Class,
+        ),
     }
+}
+
+#[derive(Clone, Copy)]
+enum ImportNamespace {
+    Term,
+    Type,
+    Class,
 }
 
 fn collect_entries<F>(
@@ -318,6 +393,7 @@ fn collect_entries<F>(
     filter: &F,
     prefix: Option<&str>,
     context: &CompletionContext<impl crate::AnalyzerHost>,
+    namespace: ImportNamespace,
 ) -> Vec<CompletionItem>
 where
     F: Filter,
@@ -327,10 +403,10 @@ where
             return false;
         }
         if item.additional_text_edits.is_some() {
-            let has_import = match item.kind {
-                Some(CompletionItemKind::VALUE) => context.has_term_import(prefix, &item.label),
-                Some(CompletionItemKind::STRUCT) => context.has_type_import(prefix, &item.label),
-                _ => false,
+            let has_import = match namespace {
+                ImportNamespace::Term => context.has_term_import(prefix, &item.label),
+                ImportNamespace::Type => context.has_type_import(prefix, &item.label),
+                ImportNamespace::Class => context.has_class_import(prefix, &item.label),
             };
             if has_import {
                 return false;

--- a/compiler-lsp/analyzer/src/completion/prelude.rs
+++ b/compiler-lsp/analyzer/src/completion/prelude.rs
@@ -72,6 +72,10 @@ impl<Host: crate::AnalyzerHost> CompletionContext<'_, '_, Host> {
         matches!(self.semantics, CursorSemantics::ImportClass)
     }
 
+    pub fn collect_instance_classes(&self) -> bool {
+        matches!(self.semantics, CursorSemantics::InstanceClass)
+    }
+
     pub fn import_file_at_cursor(&self) -> Option<FileId> {
         let root = self.parsed.syntax_node();
         let token = match root.token_at_offset(self.offset) {
@@ -104,6 +108,10 @@ impl<Host: crate::AnalyzerHost> CompletionContext<'_, '_, Host> {
     pub fn has_type_import(&self, qualifier: Option<&str>, name: &str) -> bool {
         self.resolved.lookup_type(self.prim_resolved, qualifier, name).is_some()
             || self.resolved.lookup_class(self.prim_resolved, qualifier, name).is_some()
+    }
+
+    pub fn has_class_import(&self, qualifier: Option<&str>, name: &str) -> bool {
+        self.resolved.lookup_class(self.prim_resolved, qualifier, name).is_some()
     }
 
     pub fn scope_node(&self) -> Result<Option<GraphNodeId>, AnalyzerError> {
@@ -198,6 +206,7 @@ pub enum CursorSemantics {
     Type,
     Module,
     ImportClass,
+    InstanceClass,
     General,
     Comment,
 }
@@ -266,6 +275,8 @@ impl CursorSemantics {
                     Some(CursorSemantics::Term)
                 } else if cst::Type::can_cast(kind) || cst::ExpressionTypeArgument::can_cast(kind) {
                     Some(CursorSemantics::Type)
+                } else if cst::InstanceHead::can_cast(kind) {
+                    Some(CursorSemantics::InstanceClass)
                 } else if cst::ImportClass::can_cast(kind) {
                     Some(CursorSemantics::ImportClass)
                 } else if cst::ImportStatement::can_cast(kind) {

--- a/compiler-lsp/analyzer/src/completion/sources.rs
+++ b/compiler-lsp/analyzer/src/completion/sources.rs
@@ -417,6 +417,35 @@ impl CompletionSource for LocalTypes {
     }
 }
 
+pub struct LocalClasses;
+
+impl CompletionSource for LocalClasses {
+    type T = ();
+
+    fn collect_into<F: Filter>(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        filter: F,
+        items: &mut Vec<CompletionItem>,
+    ) -> Result<Self::T, AnalyzerError> {
+        let source = context.resolved.locals.iter_classes();
+        let source = source.filter(move |(name, _, _)| filter.matches(name));
+
+        for (name, file_id, type_id) in source {
+            let mut item = CompletionItemSpec::new(
+                name.to_string(),
+                context.range,
+                CompletionItemKind::STRUCT,
+                CompletionResolveData::TypeItem(file_id, type_id),
+            );
+            item.label_description("Local".to_string());
+            items.push(item.build())
+        }
+
+        Ok(())
+    }
+}
+
 /// Yields terms from unqualified imports.
 pub struct ImportedTerms;
 
@@ -510,6 +539,41 @@ impl CompletionSource for ImportedTypes {
                     item.label_description(description);
                 }
 
+                items.push(item.build())
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct ImportedClasses;
+
+impl CompletionSource for ImportedClasses {
+    type T = ();
+
+    fn collect_into<F: Filter>(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        filter: F,
+        items: &mut Vec<CompletionItem>,
+    ) -> Result<Self::T, AnalyzerError> {
+        let source = context.resolved.unqualified.values().flatten();
+        for import in source {
+            let classes = import.iter_classes().filter(move |(name, _, _, kind)| {
+                filter.matches(name) && !matches!(kind, ImportKind::Hidden)
+            });
+            for (name, file_id, type_id, _) in classes {
+                let description = module_name(context, file_id)?;
+                let mut item = CompletionItemSpec::new(
+                    name.to_string(),
+                    context.range,
+                    CompletionItemKind::STRUCT,
+                    CompletionResolveData::TypeItem(file_id, type_id),
+                );
+                if let Some(description) = description {
+                    item.label_description(description);
+                }
                 items.push(item.build())
             }
         }
@@ -628,11 +692,74 @@ impl CompletionSource for QualifiedTypes<'_> {
     }
 }
 
+pub struct QualifiedClasses<'a> {
+    pub qualifier: &'a str,
+}
+
+impl CompletionSource for QualifiedClasses<'_> {
+    type T = ();
+
+    fn collect_into<F: Filter>(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        filter: F,
+        items: &mut Vec<CompletionItem>,
+    ) -> Result<Self::T, AnalyzerError> {
+        if self.qualifier == "Prim" && !context.resolved.qualified.contains_key(self.qualifier) {
+            let classes = context
+                .prim_resolved
+                .exports
+                .iter_classes()
+                .filter(|(name, _, _)| filter.matches(name));
+            for (name, file_id, type_id) in classes {
+                let mut item = CompletionItemSpec::new(
+                    name.to_string(),
+                    context.range,
+                    CompletionItemKind::STRUCT,
+                    CompletionResolveData::TypeItem(file_id, type_id),
+                );
+                item.edit_text(format!("Prim.{name}"));
+                item.label_description("Prim".to_string());
+                items.push(item.build());
+            }
+            return Ok(());
+        }
+
+        let Some(imports) = context.resolved.qualified.get(self.qualifier) else {
+            return Ok(());
+        };
+
+        for import in imports {
+            let classes = import.iter_classes().filter(|(name, _, _, kind)| {
+                filter.matches(name) && !matches!(kind, ImportKind::Hidden)
+            });
+            for (name, file_id, type_id, _) in classes {
+                let description = module_name(context, file_id)?;
+                let mut item = CompletionItemSpec::new(
+                    name.to_string(),
+                    context.range,
+                    CompletionItemKind::STRUCT,
+                    CompletionResolveData::TypeItem(file_id, type_id),
+                );
+                item.edit_text(format!("{}.{name}", self.qualifier));
+                if let Some(description) = description {
+                    item.label_description(description);
+                }
+                items.push(item.build())
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Yields suggestions for terms.
 pub struct SuggestedTerms;
 
 /// Yields suggestions for types.
 pub struct SuggestedTypes;
+
+pub struct SuggestedClasses;
 
 trait SuggestionsHelper {
     type ItemId;
@@ -752,6 +879,56 @@ impl SuggestionsHelper for SuggestedTypes {
     }
 }
 
+impl SuggestionsHelper for SuggestedClasses {
+    type ItemId = TypeItemId;
+
+    fn exports(
+        resolved: &ResolvedModule,
+    ) -> impl Iterator<Item = (&SmolStr, FileId, Self::ItemId)> {
+        resolved.exports.iter_classes()
+    }
+
+    fn candidate(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        name: &SmolStr,
+        import_id: FileId,
+        file_id: FileId,
+        item_id: Self::ItemId,
+    ) -> Result<Option<CompletionItem>, AnalyzerError> {
+        assert_eq!(import_id, file_id);
+
+        if context.has_class_import(None, name) {
+            return Ok(None);
+        }
+
+        let Some(module_name) = module_name(context, file_id)? else {
+            return Ok(None);
+        };
+
+        let mut item = CompletionItemSpec::new(
+            name.to_string(),
+            context.range,
+            CompletionItemKind::STRUCT,
+            CompletionResolveData::TypeItem(file_id, item_id),
+        );
+
+        let (import_text, import_range) =
+            edit::type_import_item(context, &module_name, name, file_id, item_id);
+        let range = import_range.or_else(|| context.insert_import_range());
+        let Some((range, new_text)) = range.zip(import_text) else {
+            return Ok(None);
+        };
+
+        item.label_detail(format!(" (import {module_name})"));
+        item.label_description(module_name.to_string());
+        item.sort_text(format!("{module_name}.{name}"));
+        item.additional_text_edits(vec![TextEdit { range, new_text }]);
+
+        Ok(Some(item.build()))
+    }
+}
+
 fn suggestions_candidates<T: SuggestionsHelper>(
     this: &T,
     context: &CompletionContext<impl crate::AnalyzerHost>,
@@ -801,6 +978,19 @@ impl CompletionSource for SuggestedTerms {
 }
 
 impl CompletionSource for SuggestedTypes {
+    type T = ();
+
+    fn collect_into<F: Filter>(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        filter: F,
+        items: &mut Vec<CompletionItem>,
+    ) -> Result<Self::T, AnalyzerError> {
+        suggestions_candidates(self, context, filter, items)
+    }
+}
+
+impl CompletionSource for SuggestedClasses {
     type T = ();
 
     fn collect_into<F: Filter>(
@@ -902,11 +1092,47 @@ impl CompletionSource for PrimTypes {
     }
 }
 
+pub struct PrimClasses;
+
+impl CompletionSource for PrimClasses {
+    type T = ();
+
+    fn collect_into<F: Filter>(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        filter: F,
+        items: &mut Vec<CompletionItem>,
+    ) -> Result<Self::T, AnalyzerError> {
+        let source = context
+            .prim_resolved
+            .exports
+            .iter_classes()
+            .filter(move |(name, _, _)| filter.matches(name));
+
+        for (name, file_id, type_id) in source {
+            let mut item = CompletionItemSpec::new(
+                name.to_string(),
+                context.range,
+                CompletionItemKind::STRUCT,
+                CompletionResolveData::TypeItem(file_id, type_id),
+            );
+            item.label_description("Prim".to_string());
+            items.push(item.build())
+        }
+
+        Ok(())
+    }
+}
+
 /// Yields suggestions for qualified terms.
 pub struct QualifiedTermsSuggestions<'a>(pub &'a str);
 
 /// Yields suggestions for qualified types.
 pub struct QualifiedTypesSuggestions<'a>(pub &'a str);
+
+pub struct QualifiedClassesSuggestions<'a> {
+    pub qualifier: &'a str,
+}
 
 impl SuggestionsHelper for QualifiedTermsSuggestions<'_> {
     type ItemId = TermItemId;
@@ -994,6 +1220,28 @@ impl SuggestionsHelper for QualifiedTypesSuggestions<'_> {
     }
 }
 
+impl SuggestionsHelper for QualifiedClassesSuggestions<'_> {
+    type ItemId = TypeItemId;
+
+    fn exports(
+        resolved: &ResolvedModule,
+    ) -> impl Iterator<Item = (&SmolStr, FileId, Self::ItemId)> {
+        resolved.exports.iter_classes()
+    }
+
+    fn candidate(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        name: &SmolStr,
+        import_id: FileId,
+        file_id: FileId,
+        item_id: Self::ItemId,
+    ) -> Result<Option<CompletionItem>, AnalyzerError> {
+        QualifiedTypesSuggestions(self.qualifier)
+            .candidate(context, name, import_id, file_id, item_id)
+    }
+}
+
 fn suggestions_candidates_qualified<T: SuggestionsHelper>(
     this: &T,
     prefix: &str,
@@ -1056,6 +1304,22 @@ impl CompletionSource for QualifiedTypesSuggestions<'_> {
         items: &mut Vec<CompletionItem>,
     ) -> Result<Self::T, AnalyzerError> {
         suggestions_candidates_qualified(self, self.0, context, filter, items)
+    }
+}
+
+impl CompletionSource for QualifiedClassesSuggestions<'_> {
+    type T = ();
+
+    fn collect_into<F: Filter>(
+        &self,
+        context: &CompletionContext<impl crate::AnalyzerHost>,
+        filter: F,
+        items: &mut Vec<CompletionItem>,
+    ) -> Result<Self::T, AnalyzerError> {
+        if self.qualifier == "Prim" {
+            return Ok(());
+        }
+        suggestions_candidates_qualified(self, self.qualifier, context, filter, items)
     }
 }
 

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -60,6 +60,9 @@ pub fn implementation(
         locate::Located::InstanceMember(file_id, term_id) => {
             definition_file_term(context, file_id, term_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            definition_file_type(context, file_id, type_id)
+        }
         locate::Located::TermItem(term_id) => definition_file_term(context, current_file, term_id),
         locate::Located::TypeItem(type_id) => definition_file_type(context, current_file, type_id),
         locate::Located::LetBinding(let_id) => {

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -64,6 +64,7 @@ pub fn implementation(
         }
         locate::Located::ModuleName(_)
         | locate::Located::InstanceMember(_, _)
+        | locate::Located::InstanceHead(_, _)
         | locate::Located::RecordAccessLabel(_)
         | locate::Located::Nothing => Ok(None),
     }

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -62,6 +62,9 @@ pub fn implementation(
         locate::Located::InstanceMember(file_id, term_id) => {
             hover_file_term(engine, file_id, term_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            hover_file_type(engine, file_id, type_id)
+        }
         locate::Located::TermItem(term_id) => hover_file_term(engine, current_file, term_id),
         locate::Located::TypeItem(type_id) => hover_file_type(engine, current_file, type_id),
         locate::Located::LetBinding(let_id) => hover_let(engine, current_file, let_id),

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -87,6 +87,7 @@ pub enum Located {
     TermOperator(TermOperatorId),
     TypeOperator(TypeOperatorId),
     InstanceMember(FileId, TermItemId),
+    InstanceHead(FileId, TypeItemId),
     TermItem(TermItemId),
     TypeItem(TypeItemId),
     LetBinding(LetBindingNameGroupId),
@@ -189,6 +190,13 @@ fn locate_node(
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;
         Some(Located::TypeOperator(id))
+    } else if cst::InstanceHead::can_cast(kind) {
+        let instance_head_ptr = ptr.cast()?;
+        let instance_head_id = stabilized.lookup_ptr(&instance_head_ptr)?;
+        match lowered.tree.get_instance_head(instance_head_id)? {
+            Some((file_id, type_id)) => Some(Located::InstanceHead(file_id, type_id)),
+            None => Some(Located::Nothing),
+        }
     } else if cst::Declaration::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -1,6 +1,6 @@
 use building_types::QueryProxy;
 use files::FileId;
-use indexing::{ImportId, ImportItemId, ImportKind, TermItemId, TypeItemId};
+use indexing::{ImportId, ImportItemId, ImportKind, IndexedTypeItemKind, TermItemId, TypeItemId};
 use lowering::{
     BinderId, BinderKind, ExpressionId, ExpressionKind, LetBindingNameGroupId, RecordPunId,
     TermVariableResolution, TypeId, TypeKind,
@@ -56,6 +56,9 @@ pub fn implementation(
             let (f_id, t_id) =
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_type(context, current_file, f_id, t_id)
+        }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            references_file_type(context, current_file, file_id, type_id)
         }
         locate::Located::TermItem(term_id) => {
             references_file_term(context, current_file, current_file, term_id)
@@ -404,7 +407,16 @@ fn references_file_type(
     type_id: TypeItemId,
 ) -> Result<Option<Vec<Location>>, AnalyzerError> {
     let engine = context.queries();
-    let candidates = probe_type_references(context, current_file, file_id, type_id)?;
+    let indexed = engine.indexed(file_id)?;
+    let type_item = &indexed.items[type_id];
+    let candidates = if file_id == engine.prim_id()
+        && matches!(type_item.kind, IndexedTypeItemKind::Class { .. })
+    {
+        let active_files = context.active_files();
+        active_files.collect::<FxHashSet<_>>()
+    } else {
+        probe_type_references(context, current_file, file_id, type_id)?
+    };
 
     let mut locations = vec![];
     for candidate_id in candidates {
@@ -437,6 +449,25 @@ fn references_file_type(
             if (f_id, t_id) == (file_id, type_id) {
                 let range = id_range(context, &content, &parsed, &stabilized, operator_id)
                     .ok_or(AnalyzerError::NonFatal)?;
+                locations.push(Location { uri: uri.clone(), range });
+            }
+        }
+
+        for (instance_head_id, resolution) in lowered.tree.iter_instance_head() {
+            if resolution == Some((file_id, type_id)) {
+                let instance_head_ptr =
+                    stabilized.syntax_ptr(instance_head_id).ok_or(AnalyzerError::NonFatal)?;
+                let head = instance_head_ptr
+                    .try_to_node(&parsed.syntax_node())
+                    .ok_or(AnalyzerError::NonFatal)?;
+                let head = cst::InstanceHead::cast(head).ok_or(AnalyzerError::NonFatal)?;
+                let qualified = head.qualified().ok_or(AnalyzerError::NonFatal)?;
+                let range = position::text_range_to_protocol(
+                    &content,
+                    qualified.syntax().text_range(),
+                    context.position_encoding(),
+                )
+                .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
         }

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -20,6 +20,7 @@ mod edit;
 enum RenameTarget {
     Term(FileId, TermItemId),
     Type(FileId, TypeItemId),
+    Class(FileId, TypeItemId),
     Binder(FileId, BinderId),
     LetBinding(FileId, LetBindingNameGroupId),
     RecordPun(FileId, RecordPunId),
@@ -32,6 +33,7 @@ impl RenameTarget {
         match self {
             RenameTarget::Term(file_id, _)
             | RenameTarget::Type(file_id, _)
+            | RenameTarget::Class(file_id, _)
             | RenameTarget::Binder(file_id, _)
             | RenameTarget::LetBinding(file_id, _)
             | RenameTarget::RecordPun(file_id, _)
@@ -90,7 +92,7 @@ pub fn implementation(
         RenameTarget::Module(file_id) => {
             edits.collect_module(file_id, &new_name)?;
         }
-        RenameTarget::Term(_, _) | RenameTarget::Type(_, _) => {
+        RenameTarget::Term(_, _) | RenameTarget::Type(_, _) | RenameTarget::Class(_, _) => {
             let locations = references::implementation(context, uri, position)?.unwrap_or_default();
             edits.collect_references(locations, name_kind, &new_name)?;
             edits.collect_declaration(target, &new_name)?;
@@ -118,7 +120,10 @@ fn rename_conflicts(
             term_item_conflicts(context, file_id, term_id, new_name)
         }
         RenameTarget::Type(file_id, type_id) => {
-            type_item_conflicts(context, file_id, type_id, new_name)
+            type_item_conflicts(context, file_id, type_id, new_name, false)
+        }
+        RenameTarget::Class(file_id, type_id) => {
+            type_item_conflicts(context, file_id, type_id, new_name, true)
         }
         RenameTarget::Binder(file_id, binder_id) => {
             let target = TermVariableResolution::Binder(binder_id);
@@ -275,14 +280,23 @@ fn type_item_conflicts(
     target_file: FileId,
     target_type: TypeItemId,
     new_name: &str,
+    class: bool,
 ) -> Result<bool, AnalyzerError> {
-    if type_item_conflicts_in_file(context, target_file, target_file, target_type, new_name)? {
+    if type_item_conflicts_in_file(context, target_file, target_file, target_type, new_name, class)?
+    {
         return Ok(true);
     }
 
     for file_id in context.active_files() {
         if file_id != target_file
-            && type_item_conflicts_in_file(context, file_id, target_file, target_type, new_name)?
+            && type_item_conflicts_in_file(
+                context,
+                file_id,
+                target_file,
+                target_type,
+                new_name,
+                class,
+            )?
         {
             return Ok(true);
         }
@@ -297,18 +311,26 @@ fn type_item_conflicts_in_file(
     target_file: FileId,
     target_type: TypeItemId,
     new_name: &str,
+    class: bool,
 ) -> Result<bool, AnalyzerError> {
     let prim_id = context.queries().prim_id();
     let prim = context.queries().resolved(prim_id)?;
     let resolved = context.queries().resolved(file_id)?;
 
     let import_contains_target = |import: &resolving::ResolvedImport| {
-        let types = import.iter_types();
-        let classes = import.iter_classes();
-        types.chain(classes).any(|(_, imported_file, imported_type, kind)| {
+        let is_target = |(_, imported_file, imported_type, kind)| {
             kind != ImportKind::Hidden
                 && (imported_file, imported_type) == (target_file, target_type)
-        })
+        };
+        if class {
+            let mut classes = import.iter_classes();
+            classes.any(is_target)
+        } else {
+            let types = import.iter_types();
+            let classes = import.iter_classes();
+            let mut types_and_classes = types.chain(classes);
+            types_and_classes.any(is_target)
+        }
     };
     let target_unqualified = if file_id == target_file {
         true
@@ -317,9 +339,16 @@ fn type_item_conflicts_in_file(
         imports.any(&import_contains_target)
     };
     if target_unqualified {
-        let candidate = resolved
-            .lookup_type(&prim, None, new_name)
-            .or_else(|| resolved.lookup_class(&prim, None, new_name));
+        if class && file_id == target_file && resolved.locals.lookup_type(new_name).is_some() {
+            return Ok(true);
+        }
+        let candidate = if class {
+            resolved.lookup_class(&prim, None, new_name)
+        } else {
+            resolved
+                .lookup_type(&prim, None, new_name)
+                .or_else(|| resolved.lookup_class(&prim, None, new_name))
+        };
         if candidate.is_some_and(|candidate| candidate != (target_file, target_type)) {
             return Ok(true);
         }
@@ -327,9 +356,13 @@ fn type_item_conflicts_in_file(
 
     for (qualifier, imports) in &resolved.qualified {
         if imports.iter().any(&import_contains_target) {
-            let candidate = resolved
-                .lookup_type(&prim, Some(qualifier), new_name)
-                .or_else(|| resolved.lookup_class(&prim, Some(qualifier), new_name));
+            let candidate = if class {
+                resolved.lookup_class(&prim, Some(qualifier), new_name)
+            } else {
+                resolved
+                    .lookup_type(&prim, Some(qualifier), new_name)
+                    .or_else(|| resolved.lookup_class(&prim, Some(qualifier), new_name))
+            };
             if candidate.is_some_and(|candidate| candidate != (target_file, target_type)) {
                 return Ok(true);
             }
@@ -611,7 +644,7 @@ fn rename_target(
                 _ => return Err(AnalyzerError::NonFatal),
             };
 
-            RenameTarget::Type(resolution.0, resolution.1)
+            type_or_class_target(context, resolution.0, resolution.1)?
         }
         locate::Located::TermOperator(operator_id) => {
             let (file_id, term_id) =
@@ -625,8 +658,9 @@ fn rename_target(
 
             RenameTarget::Type(file_id, type_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => RenameTarget::Class(file_id, type_id),
         locate::Located::TermItem(term_id) => RenameTarget::Term(current_file, term_id),
-        locate::Located::TypeItem(type_id) => RenameTarget::Type(current_file, type_id),
+        locate::Located::TypeItem(type_id) => type_or_class_target(context, current_file, type_id)?,
         locate::Located::LetBinding(binding_id) => {
             RenameTarget::LetBinding(current_file, binding_id)
         }
@@ -640,6 +674,20 @@ fn rename_target(
     };
 
     Ok(target)
+}
+
+fn type_or_class_target(
+    context: &AnalyzerContext<impl crate::AnalyzerHost>,
+    file_id: FileId,
+    type_id: TypeItemId,
+) -> Result<RenameTarget, AnalyzerError> {
+    let indexed = context.queries().indexed(file_id)?;
+    let item = &indexed.items[type_id];
+    if matches!(item.kind, IndexedTypeItemKind::Class { .. }) {
+        Ok(RenameTarget::Class(file_id, type_id))
+    } else {
+        Ok(RenameTarget::Type(file_id, type_id))
+    }
 }
 
 fn target_from_term_resolution(
@@ -725,7 +773,7 @@ fn import_target(
                 .or_else(|| resolved.exports.lookup_type(name))
                 .ok_or(AnalyzerError::NonFatal)?;
 
-            RenameTarget::Type(file_id, type_id)
+            type_or_class_target(context, file_id, type_id)?
         }
         cst::ImportItem::ImportType(item) => {
             let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
@@ -736,7 +784,7 @@ fn import_target(
                 .or_else(|| resolved.exports.lookup_class(name))
                 .ok_or(AnalyzerError::NonFatal)?;
 
-            RenameTarget::Type(file_id, type_id)
+            type_or_class_target(context, file_id, type_id)?
         }
         cst::ImportItem::ImportOperator(item) => {
             let name = item.name_token().ok_or(AnalyzerError::NonFatal)?.text(&content);
@@ -791,7 +839,7 @@ fn target_name(
 
             Some((name.to_string(), kind))
         }
-        RenameTarget::Type(file_id, type_id) => {
+        RenameTarget::Type(file_id, type_id) | RenameTarget::Class(file_id, type_id) => {
             let indexed = context.queries().indexed(file_id)?;
             let item = &indexed.items[type_id];
 

--- a/compiler-lsp/analyzer/src/rename/edit.rs
+++ b/compiler-lsp/analyzer/src/rename/edit.rs
@@ -437,7 +437,7 @@ where
             RenameTarget::Term(file_id, term_id) => {
                 self.term_declaration_edits(file_id, term_id, new_name)
             }
-            RenameTarget::Type(file_id, type_id) => {
+            RenameTarget::Type(file_id, type_id) | RenameTarget::Class(file_id, type_id) => {
                 self.type_declaration_edits(file_id, type_id, new_name)
             }
             RenameTarget::Binder(file_id, binder_id) => {
@@ -667,13 +667,25 @@ where
                     )?;
                 }
                 RenameTarget::Type(target_file, target_type) => {
-                    let imported_types = import.iter_types().chain(import.iter_classes()).filter(
-                        |(_, file_id, type_id, _)| {
-                            (*file_id, *type_id) == (target_file, target_type)
-                        },
-                    );
+                    let types = import.iter_types();
+                    let classes = import.iter_classes();
+                    let imported_types = types.chain(classes).filter(|(_, file_id, type_id, _)| {
+                        (*file_id, *type_id) == (target_file, target_type)
+                    });
 
                     for (name, _, _, _) in imported_types {
+                        if let Some((import_item_id, _)) = indexed_import.types.get(name) {
+                            self.push_import_item_edit(file_id, *import_item_id, new_name)?;
+                        }
+                    }
+                }
+                RenameTarget::Class(target_file, target_type) => {
+                    let imported_classes =
+                        import.iter_classes().filter(|(_, file_id, type_id, _)| {
+                            (*file_id, *type_id) == (target_file, target_type)
+                        });
+
+                    for (name, _, _, _) in imported_classes {
                         if let Some((import_item_id, _)) = indexed_import.types.get(name) {
                             self.push_import_item_edit(file_id, *import_item_id, new_name)?;
                         }
@@ -775,6 +787,15 @@ where
                         .or_else(|| resolved.exports.lookup_class(&export.name));
 
                     if exported_type == Some((target_file, target_type)) {
+                        self.push_export_item_edit(file_id, export.id, new_name)?;
+                    }
+                }
+            }
+            RenameTarget::Class(target_file, target_type) => {
+                for export in &indexed.exports.types {
+                    let exported_class = resolved.exports.lookup_class(&export.name);
+
+                    if exported_class == Some((target_file, target_type)) {
                         self.push_export_item_edit(file_id, export.id, new_name)?;
                     }
                 }

--- a/tests-integration/fixtures/checking/1786002960_instance_class_not_in_scope/Main.purs
+++ b/tests-integration/fixtures/checking/1786002960_instance_class_not_in_scope/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+data Value = Value
+
+instance Missing Value where

--- a/tests-integration/fixtures/checking/1786002960_instance_class_not_in_scope/Main.snap
+++ b/tests-integration/fixtures/checking/1786002960_instance_class_not_in_scope/Main.snap
@@ -1,0 +1,13 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+Value :: Main.Value
+
+Types
+Value :: Prim.Type
+
+Roles
+Value = []

--- a/tests-integration/fixtures/checking/1786002960_instance_class_not_in_scope/Main.snap
+++ b/tests-integration/fixtures/checking/1786002960_instance_class_not_in_scope/Main.snap
@@ -11,3 +11,10 @@ Value :: Prim.Type
 
 Roles
 Value = []
+
+Diagnostics
+error[NotInScope]: 'Missing' is not in scope
+  --> 5:10..5:17
+  |
+5 | instance Missing Value where
+  |          ^~~~~~~

--- a/tests-integration/fixtures/lowering/1786005780_non_adjacent_instance_members/Main.purs
+++ b/tests-integration/fixtures/lowering/1786005780_non_adjacent_instance_members/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+class Choose a where
+  choose :: Boolean -> a -> a -> a
+  identity :: a -> a
+
+instance Choose Int where
+  choose true left _ = left
+  identity value = value
+  choose false _ right = right

--- a/tests-integration/fixtures/lowering/1786005780_non_adjacent_instance_members/Main.snap
+++ b/tests-integration/fixtures/lowering/1786005780_non_adjacent_instance_members/Main.snap
@@ -1,0 +1,28 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 85
+expression: report
+---
+module Main
+
+Expressions:
+
+left@7:22
+  -> binder@7:13
+value@8:18
+  -> binder@8:10
+right@9:24
+  -> binder@9:16
+
+Types:
+
+a@3:22
+  -> forall@2:12
+a@4:18
+  -> forall@2:12
+a@3:32
+  -> forall@2:12
+a@4:13
+  -> forall@2:12
+a@3:27
+  -> forall@2:12

--- a/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/HiddenLib.purs
+++ b/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/HiddenLib.purs
@@ -1,0 +1,4 @@
+module HiddenLib where
+
+class Hidden f where
+  hidden :: forall a. f a -> a

--- a/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Lib.purs
+++ b/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Lib.purs
@@ -1,0 +1,12 @@
+module Lib where
+
+class Functor f where
+  map :: forall a b. (a -> b) -> f a -> f b
+
+class Collision f where
+  collide :: forall a. f a -> a
+
+class Original f where
+  original :: forall a. f a -> a
+
+instance Partial

--- a/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.purs
+++ b/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.purs
@@ -1,0 +1,43 @@
+module Main where
+
+import Lib (class Functor, class Original)
+import Lib as L
+import Lib as FunctorModule
+import HiddenLib hiding (class Hidden)
+
+newtype Box a = Box a
+
+data Collision
+
+data Renamed
+
+class Example a where
+--    /
+  example :: a
+
+instance Functor Box where
+--       @$%
+  map function (Box value) = Box (function value)
+
+instance Fu Box
+--       @ ^
+
+instance L.Fu Box
+--           ^
+
+instance Coll Box
+--           ^
+
+instance Hid Box
+--          ^
+
+instance Partial
+--       %
+
+foreign import requiresPartial :: Prim.Partial => Int
+
+instance Prim.Par
+--               *
+
+instance Original Box
+--       /

--- a/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.snap
+++ b/tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.snap
@@ -1,0 +1,204 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Rename at Position { line: 13, character: 6 }
+
+```
+class Example a where
+--    /
+```
+
+Rename may change name resolution (confirmation required)
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -11,7 +11,7 @@
+
+ data Renamed
+
+-class Example a where
++class Renamed a where
+ --    /
+   example :: a
+
+```
+
+Without change annotations: Rename rejected: Cannot rename `Example` to `Renamed` because it would change name resolution
+
+
+GotoDefinition at Position { line: 17, character: 9 }
+
+```
+instance Functor Box where
+--       @$%
+```
+
+file:///tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Lib.purs @ 2:0..3:43
+
+
+Hover at Position { line: 17, character: 10 }
+
+```
+instance Functor Box where
+--       @$%
+```
+
+```purescript
+Functor :: (Type -> Type) -> Constraint
+```
+
+
+References at Position { line: 17, character: 11 }
+
+```
+instance Functor Box where
+--       @$%
+```
+
+file:///tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.purs @ 17:9..17:16
+
+
+GotoDefinition at Position { line: 21, character: 9 }
+
+```
+instance Fu Box
+--       @ ^
+```
+
+<empty>
+
+
+Completion at Position { line: 21, character: 11 }
+
+```
+instance Fu Box
+--       @ ^
+```
+
+╭───────────┬────────────────┬─────────────────────┬─────────────┬───────────────┬───────────────┬─────────────────────────╮
+│  label    │  label_detail  │  label_description  │  sort_text  │  filter_text  │  text_edit    │  additional_text_edits  │
+├───────────┼────────────────┼─────────────────────┼─────────────┼───────────────┼───────────────┼─────────────────────────┤
+│  Functor  │   ...          │  Lib                │  Functor    │  Functor      │  21:9..21:11  │  ...                    │
+│           │                │                     │             │               │  Functor      │                         │
+╰───────────┴────────────────┴─────────────────────┴─────────────┴───────────────┴───────────────┴─────────────────────────╯
+
+
+Completion at Position { line: 24, character: 13 }
+
+```
+instance L.Fu Box
+--           ^
+```
+
+╭───────────┬────────────────┬─────────────────────┬─────────────┬───────────────┬───────────────┬─────────────────────────╮
+│  label    │  label_detail  │  label_description  │  sort_text  │  filter_text  │  text_edit    │  additional_text_edits  │
+├───────────┼────────────────┼─────────────────────┼─────────────┼───────────────┼───────────────┼─────────────────────────┤
+│  Functor  │   ...          │  Lib                │  L.Functor  │  L.Functor    │  24:9..24:13  │  ...                    │
+│           │                │                     │             │               │  L.Functor    │                         │
+╰───────────┴────────────────┴─────────────────────┴─────────────┴───────────────┴───────────────┴─────────────────────────╯
+
+
+Completion at Position { line: 27, character: 13 }
+
+```
+instance Coll Box
+--           ^
+```
+
+╭─────────────┬─────────────────┬─────────────────────┬─────────────────┬───────────────┬───────────────┬───────────────────────────────────────────────────────────────╮
+│  label      │  label_detail   │  label_description  │  sort_text      │  filter_text  │  text_edit    │  additional_text_edits                                        │
+├─────────────┼─────────────────┼─────────────────────┼─────────────────┼───────────────┼───────────────┼───────────────────────────────────────────────────────────────┤
+│  Collision  │   (import Lib)  │  Lib                │  Lib.Collision  │  Collision    │  27:9..27:13  │  2:0..2:42                                                    │
+│             │                 │                     │                 │               │  Collision    │  import Lib (class Functor, class Original, class Collision)  │
+╰─────────────┴─────────────────┴─────────────────────┴─────────────────┴───────────────┴───────────────┴───────────────────────────────────────────────────────────────╯
+
+
+Completion at Position { line: 30, character: 12 }
+
+```
+instance Hid Box
+--          ^
+```
+
+╭─────────┬────────────────┬─────────────────────┬─────────────┬───────────────┬─────────────┬─────────────────────────╮
+│  label  │  label_detail  │  label_description  │  sort_text  │  filter_text  │  text_edit  │  additional_text_edits  │
+╰─────────┴────────────────┴─────────────────────┴─────────────┴───────────────┴─────────────┴─────────────────────────╯
+
+
+References at Position { line: 33, character: 9 }
+
+```
+instance Partial
+--       %
+```
+
+file:///tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.purs @ 36:34..36:46
+file:///tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Main.purs @ 33:9..33:16
+file:///tests-integration/fixtures/lsp/1786002960_instance_head_language_features/Lib.purs @ 11:9..11:16
+
+
+CompletionApplied at Position { line: 38, character: 17 }
+
+```
+instance Prim.Par
+--               *
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -36,7 +36,7 @@
+
+ foreign import requiresPartial :: Prim.Partial => Int
+
+-instance Prim.Par
++instance Prim.Partial
+ --               *
+
+ instance Original Box
+```
+
+
+Rename at Position { line: 41, character: 9 }
+
+```
+instance Original Box
+--       /
+```
+
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -6,7 +6,7 @@
+ class Collision f where
+   collide :: forall a. f a -> a
+
+-class Original f where
++class Renamed f where
+   original :: forall a. f a -> a
+
+ instance Partial
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -1,6 +1,6 @@
+ module Main where
+
+-import Lib (class Functor, class Original)
++import Lib (class Functor, class Renamed)
+ import Lib as L
+ import Lib as FunctorModule
+ import HiddenLib hiding (class Hidden)
+@@ -39,5 +39,5 @@
+ instance Prim.Par
+ --               *
+
+-instance Original Box
++instance Renamed Box
+ --       /
+```

--- a/tests-integration/src/generated/lsp.rs
+++ b/tests-integration/src/generated/lsp.rs
@@ -11,10 +11,11 @@ use itertools::Itertools;
 use line_index::{LineIndex, TextSize};
 use lsp_types::{
     CodeActionContext, CodeActionKind, CodeActionOrCommand, CodeActionResponse,
-    CodeActionTriggerKind, CompletionItemKind, CompletionList, CompletionResponse, DocumentChanges,
-    DocumentHighlight, DocumentSymbolResponse, GotoDefinitionResponse, HoverContents,
-    LanguageString, Location, MarkedString, OneOf, Position, PrepareRenameResponse, Range,
-    SemanticTokens, SymbolInformation, TextEdit, Url, WorkspaceEdit, WorkspaceSymbolResponse,
+    CodeActionTriggerKind, CompletionItemKind, CompletionList, CompletionResponse,
+    CompletionTextEdit, DocumentChanges, DocumentHighlight, DocumentSymbolResponse,
+    GotoDefinitionResponse, HoverContents, LanguageString, Location, MarkedString, OneOf, Position,
+    PrepareRenameResponse, Range, SemanticTokens, SymbolInformation, TextEdit, Url, WorkspaceEdit,
+    WorkspaceSymbolResponse,
 };
 use render::{TabledCompletionItem, TabledDetailedCompletionItem};
 use similar::TextDiff;
@@ -59,6 +60,7 @@ enum CursorKind {
     Hover,
     Completion,
     CompletionCached,
+    CompletionApplied,
     References,
     Rename,
     PrepareRename,
@@ -68,7 +70,7 @@ enum CursorKind {
 }
 
 impl CursorKind {
-    const CHARACTERS: &[char] = &['@', '$', '^', '~', '%', '/', '?', '!', '&', '.'];
+    const CHARACTERS: &[char] = &['@', '$', '^', '~', '*', '%', '/', '?', '!', '&', '.'];
 
     fn parse(text: &str) -> Option<CursorKind> {
         match text {
@@ -76,6 +78,7 @@ impl CursorKind {
             "$" => Some(CursorKind::Hover),
             "^" => Some(CursorKind::Completion),
             "~" => Some(CursorKind::CompletionCached),
+            "*" => Some(CursorKind::CompletionApplied),
             "%" => Some(CursorKind::References),
             "/" => Some(CursorKind::Rename),
             "?" => Some(CursorKind::PrepareRename),
@@ -560,9 +563,9 @@ fn dispatch_cursor(
                 writeln!(result, "<empty>").unwrap();
             }
         }
-        CursorKind::Completion | CursorKind::CompletionCached => {
+        CursorKind::Completion | CursorKind::CompletionCached | CursorKind::CompletionApplied => {
             if let Ok(Some(response)) =
-                analyzer::completion::implementation(&context, cache, uri, position)
+                analyzer::completion::implementation(&context, cache, uri.clone(), position)
             {
                 match response {
                     CompletionResponse::Array(items)
@@ -573,6 +576,34 @@ fn dispatch_cursor(
                                 analyzer::completion::resolve::implementation(engine, item).ok()
                             })
                             .collect();
+
+                        if matches!(cursor, CursorKind::CompletionApplied) {
+                            let [item] = items.as_slice() else {
+                                writeln!(result, "<expected one completion item>").unwrap();
+                                return;
+                            };
+                            let Some(CompletionTextEdit::Edit(edit)) = item.text_edit.clone()
+                            else {
+                                writeln!(result, "<completion item has no text edit>").unwrap();
+                                return;
+                            };
+                            let mut edits = item.additional_text_edits.clone().unwrap_or_default();
+                            edits.push(edit);
+
+                            let file_id = files
+                                .id(uri.as_str())
+                                .expect("completion edit references a loaded file");
+                            let content = engine.content(file_id);
+                            let changed = apply_text_edits(&content, edits, encoding);
+                            let diff = TextDiff::from_lines(content.as_ref(), changed.as_str());
+                            let diff =
+                                diff.unified_diff().header("Main.purs", "Main.purs").to_string();
+                            let mut diff =
+                                diff.lines().map(|line| if line == " " { "" } else { line });
+                            let diff = diff.join("\n");
+                            writeln!(result, "```diff\n{diff}\n```").unwrap();
+                            return;
+                        }
 
                         let has_values =
                             items.iter().any(|item| item.kind == Some(CompletionItemKind::VALUE));
@@ -626,6 +657,20 @@ fn dispatch_cursor(
                 analyzer::rename::implementation(&context, uri.clone(), position, new_name.clone());
             if let Ok(Some(edit)) = response {
                 let annotated = edit.change_annotations.is_some();
+                if !annotated {
+                    let context = analyzer::AnalyzerContext::new(
+                        &host,
+                        encoding,
+                        AnalyzerCapabilities::default(),
+                    );
+                    let plain_edit = analyzer::rename::implementation(
+                        &context,
+                        uri.clone(),
+                        position,
+                        new_name.clone(),
+                    );
+                    assert_eq!(plain_edit.ok().flatten(), Some(edit.clone()));
+                }
                 let edit = render_rename_edit(edit, files, encoding);
                 writeln!(result, "{edit}").unwrap();
                 if annotated {


### PR DESCRIPTION
## Summary

Complete only class names in instance heads.

Resolve instance-head classes for definition, hover, references, and rename requests. Report the class name when it is not in scope. Preserve all equations and statements when declarations for one member are not adjacent.

This pull request depends on the explicit-import completion branch.

## Commit structure

1. Add failing LSP and diagnostic fixtures.
2. Add instance-head class resolution and update the fixture snapshots.

## Verification

- `cargo check -p analyzer --tests`
- `cargo check -p diagnostics --tests`
- `just t lsp 1786002960_instance_head_language_features`
- `just t checking 1786002960_instance_class_not_in_scope`
- `just format`
- `git diff --check`