### PR TITLE
[checking] Warn about missing instance members

### DIFF
--- a/compiler-core/checking/src/core/zonk.rs
+++ b/compiler-core/checking/src/core/zonk.rs
@@ -301,6 +301,7 @@ where
         | ErrorKind::InvalidFinalBind
         | ErrorKind::InvalidFinalLet
         | ErrorKind::InstanceHeadMismatch { .. }
+        | ErrorKind::MissingInstanceMembers { .. }
         | ErrorKind::InvalidNewtypeDeriveSkolemArguments
         | ErrorKind::PartialSynonymApplication { .. }
         | ErrorKind::RecursiveSynonymExpansion { .. }

--- a/compiler-core/checking/src/error.rs
+++ b/compiler-core/checking/src/error.rs
@@ -94,6 +94,9 @@ pub enum ErrorKind {
         expected: TypeId,
         actual: TypeId,
     },
+    MissingInstanceMembers {
+        members: Arc<[SmolStr]>,
+    },
     InvalidTypeApplication {
         function_type: TypeId,
         function_kind: TypeId,

--- a/compiler-core/checking/src/source/term_items.rs
+++ b/compiler-core/checking/src/source/term_items.rs
@@ -321,9 +321,38 @@ where
                     }
                 }
 
+                let mut suppress_missing_member_warning = false;
+                if members.is_empty() {
+                    for &constraint in &instance_constraints {
+                        let Some(canonical) =
+                            constraint::canonical::canonicalise(state, context, constraint)?
+                        else {
+                            continue;
+                        };
+                        if constraint::compiler::is_fail_constraint(state, context, canonical) {
+                            suppress_missing_member_warning = true;
+                            break;
+                        }
+                    }
+                }
+
                 if let Some(class) =
                     toolkit::lookup_file_class(state, context, class_file, class_id)?
                 {
+                    let indexed = context.queries.indexed(class_file)?;
+                    let missing_members = class.members.iter().filter_map(|member| {
+                        let implemented = checked_members.iter().any(|implementation| {
+                            implementation.resolution == (class_file, member.item_id)
+                        });
+                        if implemented { None } else { indexed.items[member.item_id].name.clone() }
+                    });
+                    let missing_members = missing_members.collect::<Arc<[_]>>();
+                    if !missing_members.is_empty() && !suppress_missing_member_warning {
+                        state.insert_error(ErrorKind::MissingInstanceMembers {
+                            members: missing_members,
+                        });
+                    }
+
                     let positions = class
                         .members
                         .iter()

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -342,6 +342,11 @@ impl ToDiagnostics for CheckingError {
                     format!("Instance member type mismatch: expected '{expected}', got '{actual}'"),
                 )
             }
+            ErrorKind::MissingInstanceMembers { .. } => (
+                Severity::Warning,
+                "MissingInstanceMembers",
+                "Instance is missing class members".to_string(),
+            ),
             ErrorKind::InvalidTypeApplication { function_type, function_kind, argument_type } => {
                 let function_type = render_type(*function_type);
                 let function_kind = render_type(*function_kind);
@@ -497,6 +502,12 @@ impl ToDiagnostics for CheckingError {
                 let trivia = format!("The inferred type was: {inferred}");
                 diagnostic = diagnostic.with_trivia(trivia);
                 diagnostic = diagnostic.with_trivia("Try adding a type signature.");
+            }
+            ErrorKind::MissingInstanceMembers { members } => {
+                for member in members.iter() {
+                    let trivia = format!("{member} is not implemented");
+                    diagnostic = diagnostic.with_trivia(trivia);
+                }
             }
             _ => {}
         }

--- a/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
+++ b/tests-integration/fixtures/checking/1779903960_overlapping_instances_cross_module/Main.snap
@@ -24,3 +24,9 @@ error[OverlappingInstances]: Overlapping type class instances found for: C X Y
   | ^~~~~~~~~~~~~~~~~~~~~
   trivia: forall (t0 :: Type). C X (t0 :: Type) is matching
   trivia: C X Y is matching
+warning[MissingInstanceMembers]: Instance is missing class members
+  --> 7:1..7:22
+  |
+7 | instance cxy :: C X Y
+  | ^~~~~~~~~~~~~~~~~~~~~
+  trivia: test is not implemented

--- a/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.purs
+++ b/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.purs
@@ -1,0 +1,7 @@
+module Main where
+
+class Render a where
+  render :: a -> String
+  renderWithIndent :: Int -> a -> String
+
+instance Render Int

--- a/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.purs
+++ b/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.purs
@@ -1,7 +1,14 @@
 module Main where
 
+import Prim.TypeError (class Fail, Text)
+
 class Render a where
   render :: a -> String
   renderWithIndent :: Int -> a -> String
 
 instance Render Int
+
+instance Fail (Text "empty") => Render Boolean
+
+instance Fail (Text "partial") => Render String where
+  render value = value

--- a/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.snap
+++ b/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.snap
@@ -21,3 +21,20 @@ class forall (a :: Prim.Type). Main.Render (a :: Prim.Type)
 
 Instances
 instance Main.Render Prim.Int
+instance Prim.TypeError.Fail (Prim.TypeError.Text "empty") => Main.Render Prim.Boolean
+instance Prim.TypeError.Fail (Prim.TypeError.Text "partial") => Main.Render Prim.String
+
+Diagnostics
+warning[MissingInstanceMembers]: Instance is missing class members
+  --> 9:1..9:20
+  |
+9 | instance Render Int
+  | ^~~~~~~~~~~~~~~~~~~
+  trivia: render is not implemented
+  trivia: renderWithIndent is not implemented
+warning[MissingInstanceMembers]: Instance is missing class members
+  --> 13:1..14:23
+   |
+13 | instance Fail (Text "partial") => Render String where
+   | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  trivia: renderWithIndent is not implemented

--- a/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.snap
+++ b/tests-integration/fixtures/checking/1786015260_missing_instance_members/Main.snap
@@ -1,0 +1,23 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+render :: forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+renderWithIndent ::
+  forall (@a :: Prim.Type).
+    Main.Render (a :: Prim.Type) => Prim.Int -> (a :: Prim.Type) -> Prim.String
+
+Types
+Render :: Prim.Type -> Prim.Constraint
+
+Classes
+class forall (a :: Prim.Type). Main.Render (a :: Prim.Type)
+  render :: forall (@a :: Prim.Type). Main.Render (a :: Prim.Type) => (a :: Prim.Type) -> Prim.String
+  renderWithIndent ::
+  forall (@a :: Prim.Type).
+    Main.Render (a :: Prim.Type) => Prim.Int -> (a :: Prim.Type) -> Prim.String
+
+Instances
+instance Main.Render Prim.Int


### PR DESCRIPTION
## Summary

Type class instances can currently omit required class members without producing a diagnostic. This makes incomplete dictionaries appear valid until their missing implementation is needed.

Emit a checking warning for incomplete instance declarations and list each unimplemented class member as diagnostic trivia. Members are reported in class declaration order, including members from imported classes.

## Test plan

- Add a baseline checking fixture that records the previously accepted incomplete instance.
- Update the same snapshot with the missing-member warning and trivia.
- Verify a complete Functor instance remains diagnostic-free.
- Run checks for the checking and diagnostics crates.