### PR TITLE
[lsp] Locate classes in instance heads

### DIFF
--- a/compiler-core/indexing/src/algorithm.rs
+++ b/compiler-core/indexing/src/algorithm.rs
@@ -148,6 +148,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
                 let instance_id = stabilized.lookup_cst(&cst).expect_id();
                 let term_id = index_instance(state, instance_id, &cst);
                 state.pairs.instance_chain.push((chain_id, instance_id));
+                state.pairs.instance_to_term.push((instance_id, term_id));
                 state.pairs.declaration_to_term.push((declaration_id, term_id));
                 if let Some(cst) = cst.instance_statements() {
                     for cst in cst.children() {
@@ -414,6 +415,7 @@ fn index_declaration(state: &mut State, stabilized: &StabilizedModule, cst: &cst
         cst::Declaration::DeriveDeclaration(cst) => {
             let id = stabilized.lookup_cst(cst).expect_id();
             let term_id = index_derive(state, id, cst);
+            state.pairs.derive_to_term.push((id, term_id));
             state.pairs.declaration_to_term.push((declaration_id, term_id));
         }
     }

--- a/compiler-core/indexing/src/lib.rs
+++ b/compiler-core/indexing/src/lib.rs
@@ -255,7 +255,9 @@ impl IndexedImport {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct IndexedPairs {
+    derive_to_term: Vec<(DeriveId, TermItemId)>,
     instance_chain: Vec<(InstanceChainId, InstanceId)>,
+    instance_to_term: Vec<(InstanceId, TermItemId)>,
     instance_members: Vec<(InstanceId, InstanceMemberId)>,
 
     declaration_to_term: Vec<(DeclarationId, TermItemId)>,
@@ -265,6 +267,20 @@ pub struct IndexedPairs {
 }
 
 impl IndexedPairs {
+    pub fn derive_to_term(&self, id: DeriveId) -> Option<TermItemId> {
+        self.derive_to_term.iter().find_map(
+            move |(derive_id, term_id)| {
+                if *derive_id == id { Some(*term_id) } else { None }
+            },
+        )
+    }
+
+    pub fn instance_to_term(&self, id: InstanceId) -> Option<TermItemId> {
+        self.instance_to_term.iter().find_map(move |(instance_id, term_id)| {
+            if *instance_id == id { Some(*term_id) } else { None }
+        })
+    }
+
     pub fn declaration_to_term(&self, id: DeclarationId) -> Option<TermItemId> {
         self.declaration_to_term.iter().find_map(move |(declaration_id, term_id)| {
             if *declaration_id == id { Some(*term_id) } else { None }

--- a/compiler-lsp/analyzer/src/definition.rs
+++ b/compiler-lsp/analyzer/src/definition.rs
@@ -57,6 +57,9 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             definition_file_type(context, f_id, t_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            definition_file_type(context, file_id, type_id)
+        }
         locate::Located::InstanceMember(file_id, term_id) => {
             definition_file_term(context, file_id, term_id)
         }

--- a/compiler-lsp/analyzer/src/document_highlight.rs
+++ b/compiler-lsp/analyzer/src/document_highlight.rs
@@ -62,6 +62,9 @@ pub fn implementation(
         locate::Located::TypeOperator(operator_id) => {
             highlight_type_operator(context, current_file, operator_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            highlight_file_type(context, current_file, file_id, type_id)
+        }
         locate::Located::ModuleName(_)
         | locate::Located::InstanceMember(_, _)
         | locate::Located::RecordAccessLabel(_)
@@ -417,6 +420,18 @@ fn highlight_file_type(
                 }),
             );
         }
+    }
+
+    let ranges = locate::instance_head_ranges(
+        &content,
+        &parsed,
+        &stabilized,
+        &indexed,
+        &lowered,
+        (file_id, type_id),
+    );
+    for range in ranges {
+        highlights.extend(document_highlight(&content, context.position_encoding(), range));
     }
 
     for imports in resolved.unqualified.values().chain(resolved.qualified.values()) {

--- a/compiler-lsp/analyzer/src/hover.rs
+++ b/compiler-lsp/analyzer/src/hover.rs
@@ -59,6 +59,9 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             hover_file_type(engine, f_id, t_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            hover_file_type(engine, file_id, type_id)
+        }
         locate::Located::InstanceMember(file_id, term_id) => {
             hover_file_term(engine, file_id, term_id)
         }

--- a/compiler-lsp/analyzer/src/locate.rs
+++ b/compiler-lsp/analyzer/src/locate.rs
@@ -3,10 +3,10 @@
 use std::iter;
 
 use files::FileId;
-use indexing::{ImportItemId, IndexedModule, TermItemId, TypeItemId};
+use indexing::{ImportItemId, IndexedModule, IndexedTermItemKind, TermItemId, TypeItemId};
 use lowering::{
     BinderId, ExpressionId, LetBindingNameGroupId, LoweredModule, RecordAccessLabelId, RecordPunId,
-    TermOperatorId, TypeId, TypeOperatorId,
+    TermItemKind, TermOperatorId, TypeId, TypeOperatorId,
 };
 use stabilizing::{AstId, StabilizedModule};
 use syntax::ast::{AstNode, AstPtr};
@@ -33,6 +33,58 @@ where
     let root = parsed.syntax_node();
     let ptr = stabilized.syntax_ptr(item_id)?;
     syntax_range(content, &root, &ptr)
+}
+
+pub fn instance_head_ranges(
+    content: &str,
+    parsed: &parsing::ParsedModule,
+    stabilized: &StabilizedModule,
+    indexed: &IndexedModule,
+    lowered: &LoweredModule,
+    target: (FileId, TypeItemId),
+) -> Vec<Utf8Range> {
+    let root = parsed.syntax_node();
+    let ranges = indexed.items.iter_terms().filter_map(|(term_id, item)| {
+        let kind = lowered.tree.get_term_item_kind(term_id)?;
+        let resolution = match kind {
+            TermItemKind::Instance { resolution, .. } | TermItemKind::Derive { resolution, .. } => {
+                resolution.as_ref()
+            }
+            _ => None,
+        }?;
+        if *resolution != target {
+            return None;
+        }
+
+        match &item.kind {
+            IndexedTermItemKind::Instance { id } => {
+                instance_head_range(content, &root, stabilized, *id)
+            }
+            IndexedTermItemKind::Derive { id } => {
+                instance_head_range(content, &root, stabilized, *id)
+            }
+            _ => None,
+        }
+    });
+    ranges.collect()
+}
+
+fn instance_head_range<T>(
+    content: &str,
+    root: &SyntaxNode,
+    stabilized: &StabilizedModule,
+    id: AstId<T>,
+) -> Option<Utf8Range>
+where
+    T: AstNode,
+{
+    let ptr = stabilized.syntax_ptr(id)?;
+    let node = ptr.try_to_node(root)?;
+    let head = cst::InstanceDeclaration::cast(node.clone())
+        .and_then(|instance| instance.instance_head())
+        .or_else(|| cst::DeriveDeclaration::cast(node)?.instance_head())?;
+    let token = head.qualified()?.upper()?;
+    position::text_range_to_utf8_range(content, token.text_range())
 }
 
 pub fn value_equation_ranges(
@@ -86,6 +138,7 @@ pub enum Located {
     ExpressionPun(RecordPunId),
     TermOperator(TermOperatorId),
     TypeOperator(TypeOperatorId),
+    InstanceHead(FileId, TypeItemId),
     InstanceMember(FileId, TermItemId),
     TermItem(TermItemId),
     TypeItem(TypeItemId),
@@ -189,6 +242,27 @@ fn locate_node(
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;
         Some(Located::TypeOperator(id))
+    } else if cst::InstanceHead::can_cast(kind) {
+        let term_id =
+            if let Some(instance) = node.ancestors().find_map(cst::InstanceDeclaration::cast) {
+                let ptr = AstPtr::new(&instance);
+                let instance_id = stabilized.lookup_ptr(&ptr)?;
+                indexed.pairs.instance_to_term(instance_id)?
+            } else {
+                let derive = node.ancestors().find_map(cst::DeriveDeclaration::cast)?;
+                let ptr = AstPtr::new(&derive);
+                let derive_id = stabilized.lookup_ptr(&ptr)?;
+                indexed.pairs.derive_to_term(derive_id)?
+            };
+        let kind = lowered.tree.get_term_item_kind(term_id)?;
+        let resolution = match kind {
+            TermItemKind::Instance { resolution, .. } | TermItemKind::Derive { resolution, .. } => {
+                resolution.as_ref()
+            }
+            _ => None,
+        }?;
+        let (file_id, type_id) = resolution;
+        Some(Located::InstanceHead(*file_id, *type_id))
     } else if cst::Declaration::can_cast(kind) {
         let ptr = ptr.cast()?;
         let id = stabilized.lookup_ptr(&ptr)?;

--- a/compiler-lsp/analyzer/src/references.rs
+++ b/compiler-lsp/analyzer/src/references.rs
@@ -57,6 +57,9 @@ pub fn implementation(
                 lowered.tree.get_type_operator(operator_id).ok_or(AnalyzerError::NonFatal)?;
             references_file_type(context, current_file, f_id, t_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => {
+            references_file_type(context, current_file, file_id, type_id)
+        }
         locate::Located::TermItem(term_id) => {
             references_file_term(context, current_file, current_file, term_id)
         }
@@ -414,6 +417,7 @@ fn references_file_type(
         let (parsed, _) = engine.parsed(candidate_id)?;
 
         let stabilized = engine.stabilized(candidate_id)?;
+        let indexed = engine.indexed(candidate_id)?;
         let lowered = engine.lowered(candidate_id)?;
 
         for (ty_id, ty_kind) in lowered.tree.iter_type() {
@@ -439,6 +443,21 @@ fn references_file_type(
                     .ok_or(AnalyzerError::NonFatal)?;
                 locations.push(Location { uri: uri.clone(), range });
             }
+        }
+
+        let ranges = locate::instance_head_ranges(
+            &content,
+            &parsed,
+            &stabilized,
+            &indexed,
+            &lowered,
+            (file_id, type_id),
+        );
+        for range in ranges {
+            let range =
+                position::utf8_range_to_protocol(&content, range, context.position_encoding())
+                    .ok_or(AnalyzerError::NonFatal)?;
+            locations.push(Location { uri: uri.clone(), range });
         }
     }
 

--- a/compiler-lsp/analyzer/src/rename.rs
+++ b/compiler-lsp/analyzer/src/rename.rs
@@ -625,6 +625,7 @@ fn rename_target(
 
             RenameTarget::Type(file_id, type_id)
         }
+        locate::Located::InstanceHead(file_id, type_id) => RenameTarget::Type(file_id, type_id),
         locate::Located::TermItem(term_id) => RenameTarget::Term(current_file, term_id),
         locate::Located::TypeItem(type_id) => RenameTarget::Type(current_file, type_id),
         locate::Located::LetBinding(binding_id) => {

--- a/tests-integration/fixtures/lsp/1780504560_document_highlight_types_and_imports/Main.snap
+++ b/tests-integration/fixtures/lsp/1780504560_document_highlight_types_and_imports/Main.snap
@@ -1,6 +1,6 @@
 ---
 source: tests-integration/src/fixtures.rs
-assertion_line: 101
+assertion_line: 134
 expression: report
 ---
 DocumentHighlight at Position { line: 2, character: 12 }
@@ -132,6 +132,7 @@ class LocalClass a where
 ```
 
 20:6..20:16
+28:28..28:38
 53:42..53:52
 
 
@@ -263,6 +264,7 @@ foreign import localClassUse :: forall a. LocalClass a => a -> a
 ```
 
 20:6..20:16
+28:28..28:38
 53:42..53:52
 
 

--- a/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Lib.purs
+++ b/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Lib.purs
@@ -1,0 +1,3 @@
+module Lib where
+
+class ImportedFunctor f

--- a/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs
+++ b/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs
@@ -1,0 +1,31 @@
+module Main where
+
+import Lib as Lib
+
+class Functor f
+--    $ @ %
+
+data Identity a = Identity a
+
+instance Functor Identity
+--       $@%&/?
+
+foreign import functor :: forall f. Functor f => f
+
+data Derived = Derived
+
+derive instance Functor Derived
+--              $@%
+
+newtype Wrapper = Wrapper Identity
+
+derive newtype instance Functor Wrapper
+--                      $@%
+
+data ChainFirst = ChainFirst
+
+data ChainSecond = ChainSecond
+
+instance Functor ChainFirst
+else instance Lib.ImportedFunctor ChainSecond
+--                $@%/

--- a/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
+++ b/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
@@ -1,0 +1,195 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 134
+expression: report
+---
+Hover at Position { line: 4, character: 6 }
+
+```
+class Functor f
+--    $ @ %
+```
+
+```purescript
+Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+```
+
+
+GotoDefinition at Position { line: 4, character: 8 }
+
+```
+class Functor f
+--    $ @ %
+```
+
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 4:0..4:15
+
+
+References at Position { line: 4, character: 10 }
+
+```
+class Functor f
+--    $ @ %
+```
+
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 12:36..12:43
+
+
+Hover at Position { line: 9, character: 9 }
+
+```
+instance Functor Identity
+--       $@%&/?
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 9, character: 10 }
+
+```
+instance Functor Identity
+--       $@%&/?
+```
+
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 7:28..9:25
+
+
+References at Position { line: 9, character: 11 }
+
+```
+instance Functor Identity
+--       $@%&/?
+```
+
+
+
+
+DocumentHighlight at Position { line: 9, character: 12 }
+
+```
+instance Functor Identity
+--       $@%&/?
+```
+
+<empty>
+
+
+Rename at Position { line: 9, character: 13 }
+
+```
+instance Functor Identity
+--       $@%&/?
+```
+
+<empty>
+
+
+PrepareRename at Position { line: 9, character: 14 }
+
+```
+instance Functor Identity
+--       $@%&/?
+```
+
+<empty>
+
+
+Hover at Position { line: 16, character: 16 }
+
+```
+derive instance Functor Derived
+--              $@%
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 16, character: 17 }
+
+```
+derive instance Functor Derived
+--              $@%
+```
+
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 16:0..16:31
+
+
+References at Position { line: 16, character: 18 }
+
+```
+derive instance Functor Derived
+--              $@%
+```
+
+
+
+
+Hover at Position { line: 21, character: 24 }
+
+```
+derive newtype instance Functor Wrapper
+--                      $@%
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 21, character: 25 }
+
+```
+derive newtype instance Functor Wrapper
+--                      $@%
+```
+
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 21:0..21:39
+
+
+References at Position { line: 21, character: 26 }
+
+```
+derive newtype instance Functor Wrapper
+--                      $@%
+```
+
+
+
+
+Hover at Position { line: 29, character: 18 }
+
+```
+else instance Lib.ImportedFunctor ChainSecond
+--                $@%/
+```
+
+<empty>
+
+
+GotoDefinition at Position { line: 29, character: 19 }
+
+```
+else instance Lib.ImportedFunctor ChainSecond
+--                $@%/
+```
+
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 26:30..29:45
+
+
+References at Position { line: 29, character: 20 }
+
+```
+else instance Lib.ImportedFunctor ChainSecond
+--                $@%/
+```
+
+
+
+
+Rename at Position { line: 29, character: 21 }
+
+```
+else instance Lib.ImportedFunctor ChainSecond
+--                $@%/
+```
+
+<empty>

--- a/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
+++ b/tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.snap
@@ -33,6 +33,10 @@ class Functor f
 ```
 
 file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 12:36..12:43
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 9:9..9:16
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 16:16..16:23
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 21:24..21:31
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 28:9..28:16
 
 
 Hover at Position { line: 9, character: 9 }
@@ -42,7 +46,9 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-<empty>
+```purescript
+Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+```
 
 
 GotoDefinition at Position { line: 9, character: 10 }
@@ -52,7 +58,7 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 7:28..9:25
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 4:0..4:15
 
 
 References at Position { line: 9, character: 11 }
@@ -62,7 +68,11 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 12:36..12:43
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 9:9..9:16
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 16:16..16:23
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 21:24..21:31
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 28:9..28:16
 
 
 DocumentHighlight at Position { line: 9, character: 12 }
@@ -72,7 +82,12 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-<empty>
+4:6..4:13
+9:9..9:16
+12:36..12:43
+16:16..16:23
+21:24..21:31
+28:9..28:16
 
 
 Rename at Position { line: 9, character: 13 }
@@ -82,7 +97,47 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-<empty>
+```diff
+--- Main.purs
++++ Main.purs
+@@ -2,30 +2,30 @@
+
+ import Lib as Lib
+
+-class Functor f
++class Renamed f
+ --    $ @ %
+
+ data Identity a = Identity a
+
+-instance Functor Identity
++instance Renamed Identity
+ --       $@%&/?
+
+-foreign import functor :: forall f. Functor f => f
++foreign import functor :: forall f. Renamed f => f
+
+ data Derived = Derived
+
+-derive instance Functor Derived
++derive instance Renamed Derived
+ --              $@%
+
+ newtype Wrapper = Wrapper Identity
+
+-derive newtype instance Functor Wrapper
++derive newtype instance Renamed Wrapper
+ --                      $@%
+
+ data ChainFirst = ChainFirst
+
+ data ChainSecond = ChainSecond
+
+-instance Functor ChainFirst
++instance Renamed ChainFirst
+ else instance Lib.ImportedFunctor ChainSecond
+ --                $@%/
+```
 
 
 PrepareRename at Position { line: 9, character: 14 }
@@ -92,7 +147,7 @@ instance Functor Identity
 --       $@%&/?
 ```
 
-<empty>
+9:9..9:16 Functor
 
 
 Hover at Position { line: 16, character: 16 }
@@ -102,7 +157,9 @@ derive instance Functor Derived
 --              $@%
 ```
 
-<empty>
+```purescript
+Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+```
 
 
 GotoDefinition at Position { line: 16, character: 17 }
@@ -112,7 +169,7 @@ derive instance Functor Derived
 --              $@%
 ```
 
-file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 16:0..16:31
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 4:0..4:15
 
 
 References at Position { line: 16, character: 18 }
@@ -122,7 +179,11 @@ derive instance Functor Derived
 --              $@%
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 12:36..12:43
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 9:9..9:16
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 16:16..16:23
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 21:24..21:31
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 28:9..28:16
 
 
 Hover at Position { line: 21, character: 24 }
@@ -132,7 +193,9 @@ derive newtype instance Functor Wrapper
 --                      $@%
 ```
 
-<empty>
+```purescript
+Functor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+```
 
 
 GotoDefinition at Position { line: 21, character: 25 }
@@ -142,7 +205,7 @@ derive newtype instance Functor Wrapper
 --                      $@%
 ```
 
-file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 21:0..21:39
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 4:0..4:15
 
 
 References at Position { line: 21, character: 26 }
@@ -152,7 +215,11 @@ derive newtype instance Functor Wrapper
 --                      $@%
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 12:36..12:43
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 9:9..9:16
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 16:16..16:23
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 21:24..21:31
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 28:9..28:16
 
 
 Hover at Position { line: 29, character: 18 }
@@ -162,7 +229,9 @@ else instance Lib.ImportedFunctor ChainSecond
 --                $@%/
 ```
 
-<empty>
+```purescript
+ImportedFunctor :: forall (t0 :: Type). (t0 :: Type) -> Constraint
+```
 
 
 GotoDefinition at Position { line: 29, character: 19 }
@@ -172,7 +241,7 @@ else instance Lib.ImportedFunctor ChainSecond
 --                $@%/
 ```
 
-file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 26:30..29:45
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Lib.purs @ 2:0..2:23
 
 
 References at Position { line: 29, character: 20 }
@@ -182,7 +251,7 @@ else instance Lib.ImportedFunctor ChainSecond
 --                $@%/
 ```
 
-
+file:///tests-integration/fixtures/lsp/1786015920_locate_instance_head/Main.purs @ 29:18..29:33
 
 
 Rename at Position { line: 29, character: 21 }
@@ -192,4 +261,24 @@ else instance Lib.ImportedFunctor ChainSecond
 --                $@%/
 ```
 
-<empty>
+```diff
+--- Lib.purs
++++ Lib.purs
+@@ -1,3 +1,3 @@
+ module Lib where
+
+-class ImportedFunctor f
++class Renamed f
+```
+
+```diff
+--- Main.purs
++++ Main.purs
+@@ -27,5 +27,5 @@
+ data ChainSecond = ChainSecond
+
+ instance Functor ChainFirst
+-else instance Lib.ImportedFunctor ChainSecond
++else instance Lib.Renamed ChainSecond
+ --                $@%/
+```


### PR DESCRIPTION
## Problem

Class names in instance heads are currently located as the enclosing instance term. As a result, editor operations on `Functor` in `instance Functor Identity` return an empty hover, navigate back to the instance declaration, or fail to find the class references.

## Solution

Record the indexed term corresponding to each instance declaration, then resolve an `InstanceHead` location through the lowered instance's class resolution. Route that resolved class type item through hover, definition, references, document highlighting, and rename handling.

The instance-to-term relationship is stored per instance rather than per declaration so instance chains retain the correct mapping.

## Testing

- Added an LSP regression fixture that first records the broken hover, definition, and references behavior
- Updated the snapshot to require class hover information, navigation to the class declaration, and class references
- `just t lsp 1786015920`
- `cargo check -p indexing --tests`
- `cargo check -p analyzer --tests`