### PR TITLE
[lowering] Report unresolved instance classes

### DIFF
--- a/compiler-core/diagnostics/src/context.rs
+++ b/compiler-core/diagnostics/src/context.rs
@@ -146,6 +146,20 @@ where
         self.span_from_syntax_node(node.syntax())
     }
 
+    pub(crate) fn span_from_ast_ptr_child<N, C>(
+        &self,
+        ptr: &AstPtr<N>,
+        child: impl FnOnce(&N) -> Option<C>,
+    ) -> Option<Span>
+    where
+        N: AstNode,
+        C: AstNode,
+    {
+        let node = ptr.try_to_node(self.root)?;
+        let child = child(&node)?;
+        self.span_from_syntax_node(child.syntax())
+    }
+
     fn span_from_syntax_node(&self, node: &SyntaxNode) -> Option<Span> {
         let range = significant_ranges(node)?;
         Some(Span::new(range.start().into(), range.end().into()))

--- a/compiler-core/diagnostics/src/convert.rs
+++ b/compiler-core/diagnostics/src/convert.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use lowering::LoweringError;
 use resolving::ResolvingError;
 use syntax::ast::AstNode;
+use syntax::cst;
 
 use crate::{Diagnostic, DiagnosticsContext, ExternalQueries, Severity};
 
@@ -29,6 +30,9 @@ impl ToDiagnostics for LoweringError {
                         (context.stabilized.syntax_ptr(*id), None)
                     }
                     lowering::NotInScope::ExprOperatorName { id } => {
+                        (context.stabilized.syntax_ptr(*id), None)
+                    }
+                    lowering::NotInScope::TypeClass { id } => {
                         (context.stabilized.syntax_ptr(*id), None)
                     }
                     lowering::NotInScope::TypeConstructor { id } => {
@@ -67,7 +71,15 @@ impl ToDiagnostics for LoweringError {
                 };
 
                 let Some(ptr) = ptr else { return vec![] };
-                let Some(span) = context.span_from_syntax_ptr(&ptr) else { return vec![] };
+                let span = match not_in_scope {
+                    lowering::NotInScope::TypeClass { id } => {
+                        context.stabilized.ast_ptr(*id).and_then(|ptr| {
+                            context.span_from_ast_ptr_child(&ptr, cst::InstanceHead::qualified)
+                        })
+                    }
+                    _ => context.span_from_syntax_ptr(&ptr),
+                };
+                let Some(span) = span else { return vec![] };
 
                 let message = if let Some(name) = name {
                     format!("'{name}' is not in scope")

--- a/compiler-core/lowering/src/algorithm.rs
+++ b/compiler-core/lowering/src/algorithm.rs
@@ -411,6 +411,24 @@ pub(super) fn lower_module(
     state
 }
 
+fn lower_instance_class_reference(
+    state: &mut State,
+    context: &Context,
+    head: &cst::InstanceHead,
+) -> Option<(FileId, TypeItemId)> {
+    let qualified = head.qualified()?;
+    let (qualifier, name) =
+        recursive::lower_qualified_name(context.source, &qualified, cst::QualifiedName::upper)?;
+    let resolution = state.resolve_class_reference(context, qualifier.as_deref(), &name);
+
+    if resolution.is_none() {
+        let id = context.stabilized.lookup_cst(head).expect_id();
+        state.errors.push(LoweringError::NotInScope(NotInScope::TypeClass { id }));
+    }
+
+    resolution
+}
+
 fn lower_term_item(
     state: &mut State,
     context: &Context,
@@ -429,13 +447,7 @@ fn lower_term_item(
 
             let resolution = cst.as_ref().and_then(|cst| {
                 let head = cst.instance_head()?;
-                let qualified = head.qualified()?;
-                let (qualifier, name) = recursive::lower_qualified_name(
-                    context.source,
-                    &qualified,
-                    cst::QualifiedName::upper,
-                )?;
-                state.resolve_class_reference(context, qualifier.as_deref(), &name)
+                lower_instance_class_reference(state, context, &head)
             });
 
             state.push_implicit_scope();
@@ -480,13 +492,7 @@ fn lower_term_item(
 
             let resolution = cst.as_ref().and_then(|cst| {
                 let head = cst.instance_head()?;
-                let qualified = head.qualified()?;
-                let (qualifier, name) = recursive::lower_qualified_name(
-                    context.source,
-                    &qualified,
-                    cst::QualifiedName::upper,
-                )?;
-                state.resolve_class_reference(context, qualifier.as_deref(), &name)
+                lower_instance_class_reference(state, context, &head)
             });
 
             state.push_implicit_scope();

--- a/compiler-core/lowering/src/error.rs
+++ b/compiler-core/lowering/src/error.rs
@@ -16,6 +16,7 @@ pub enum NotInScope {
     ExprConstructor { id: AstId<cst::ExpressionConstructor> },
     ExprVariable { id: AstId<cst::ExpressionVariable> },
     ExprOperatorName { id: AstId<cst::ExpressionOperatorName> },
+    TypeClass { id: AstId<cst::InstanceHead> },
     TypeConstructor { id: AstId<cst::TypeConstructor> },
     TypeVariable { id: AstId<cst::TypeVariable> },
     TypeOperatorName { id: AstId<cst::TypeOperatorName> },

--- a/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.purs
+++ b/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+instance Functor Array where
+
+instance Missing.Functor Array where

--- a/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.snap
+++ b/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.snap
@@ -1,0 +1,8 @@
+---
+source: tests-integration/src/fixtures.rs
+assertion_line: 50
+expression: report
+---
+Terms
+
+Types

--- a/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.snap
+++ b/tests-integration/fixtures/checking/1786028940_unresolved_instance_class/Main.snap
@@ -6,3 +6,15 @@ expression: report
 Terms
 
 Types
+
+Diagnostics
+error[NotInScope]: 'Functor' is not in scope
+  --> 3:10..3:17
+  |
+3 | instance Functor Array where
+  |          ^~~~~~~
+error[NotInScope]: 'Missing.Functor' is not in scope
+  --> 5:10..5:25
+  |
+5 | instance Missing.Functor Array where
+  |          ^~~~~~~~~~~~~~~


### PR DESCRIPTION
## Purpose

Report a visible name-resolution diagnostic when an instance or derived instance refers to a type class that is not in scope. Previously, class-head lookup silently produced no resolution, so source such as `instance Functor Array where` had no diagnostic for the undefined `Functor` name.

## Implementation

- record unresolved instance class heads as `NotInScope::TypeClass` lowering errors
- render the diagnostic over only the class name
- share the behavior between ordinary and derived instances
- add an auditable regression fixture whose first commit captures the missing diagnostic

## Verification

- `cargo check -p lowering --tests`
- `cargo check -p diagnostics --tests`
- `just t checking`