### PR TITLE
[agents] Add optional Jujutsu Orb setup

### DIFF
--- a/.agents/scripts/setup-jj
+++ b/.agents/scripts/setup-jj
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+signing_key=$(/usr/bin/git config --system user.signingkey || true)
+user_name=$(git config user.name || true)
+user_email=$(git config user.email || true)
+
+if [[ -z "$user_name" || -z "$user_email" ]]; then
+  echo "AMP_USE_JJ requires Git user.name and user.email configuration." >&2
+  exit 1
+fi
+if [[ -z "$signing_key" ]]; then
+  echo "AMP_USE_JJ requires an Orb SSH signing key." >&2
+  exit 1
+fi
+if ! github_login=$(gh api user --jq .login); then
+  echo "AMP_USE_JJ requires an authenticated GitHub CLI session." >&2
+  exit 1
+fi
+if ! public_signing_keys=$( \
+  gh api "users/${github_login}/ssh_signing_keys" --jq '.[].key'
+); then
+  echo "Could not load public SSH signing keys from GitHub." >&2
+  exit 1
+fi
+if [[ -z "$public_signing_keys" ]]; then
+  echo "AMP_USE_JJ requires a public SSH signing key configured on GitHub." >&2
+  exit 1
+fi
+
+if [[ ! -x "$HOME/.nix-profile/bin/nix" ]]; then
+  curl --proto '=https' --tlsv1.2 -sSfL https://nixos.org/nix/install \
+    | sh -s -- --no-daemon --yes --no-channel-add --no-modify-profile
+fi
+
+. "$HOME/.nix-profile/etc/profile.d/nix.sh"
+
+nix_config_directory="${XDG_CONFIG_HOME:-$HOME/.config}/nix"
+nix_config="$nix_config_directory/nix.conf"
+install -d -m 700 "$nix_config_directory"
+touch "$nix_config"
+chmod 600 "$nix_config"
+if ! grep -qxF 'experimental-features = nix-command flakes' "$nix_config"; then
+  printf '%s\n' 'experimental-features = nix-command flakes' >> "$nix_config"
+fi
+
+nix_profile="$HOME/.local/state/nix/profiles/amp-jj"
+nixpkgs_revision=445d861c6d31b4af0c79d8d4be2331f762a361d7
+nixpkgs_url="tarball+https://github.com/NixOS/nixpkgs/archive/${nixpkgs_revision}.tar.gz"
+install -d -m 700 "$(dirname "$nix_profile")"
+nix_packages=()
+[[ -x "$nix_profile/bin/git" ]] || nix_packages+=("${nixpkgs_url}#git")
+[[ -x "$nix_profile/bin/jj" ]] || nix_packages+=("${nixpkgs_url}#jujutsu")
+if (( ${#nix_packages[@]} > 0 )); then
+  nix profile add \
+    --profile "$nix_profile" \
+    "${nix_packages[@]}"
+fi
+
+install -d -m 700 "$HOME/.local/bin"
+ln -sfn "$nix_profile/bin/git" "$HOME/.local/bin/git"
+ln -sfn "$nix_profile/bin/jj" "$HOME/.local/bin/jj"
+ln -sfn "$HOME/.nix-profile/bin/nix" "$HOME/.local/bin/nix"
+export PATH="$HOME/.local/bin:$PATH"
+hash -r
+
+cat > "$HOME/.local/bin/jj-amp-sign-commit" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ "$#" -eq 6 ] \
+  && [ "$1" = "-Y" ] \
+  && [ "$2" = "sign" ] \
+  && [ "$3" = "-f" ] \
+  && [ -f "$4" ] \
+  && [ "$5" = "-n" ] \
+  && [ "$6" = "git" ]; then
+  signing_key=$(cat -- "$4")
+  umask 077
+  signing_buffer=$(mktemp)
+  signature_file="${signing_buffer}.sig"
+  trap 'rm -f -- "$signing_buffer" "$signature_file"' EXIT HUP INT TERM
+  cat > "$signing_buffer"
+  amp-sign-commit -Y sign -n git -f "$signing_key" "$signing_buffer"
+  cat -- "$signature_file"
+  rm -f -- "$signing_buffer" "$signature_file"
+  trap - EXIT HUP INT TERM
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "-Y" ] && [ "$2" = "sign" ]; then
+  exec amp-sign-commit "$@"
+fi
+
+exec ssh-keygen "$@"
+EOF
+chmod 700 "$HOME/.local/bin/jj-amp-sign-commit"
+
+signing_program="$HOME/.local/bin/jj-amp-sign-commit"
+jj config set --user user.name "$user_name"
+jj config set --user user.email "$user_email"
+jj config set --user signing.backend ssh
+jj config set --user signing.key "$signing_key"
+jj config set --user signing.backends.ssh.program "$signing_program"
+jj config set --user signing.behavior own
+
+allowed_signers="$HOME/.config/git/allowed_signers"
+install -d -m 700 "$(dirname "$allowed_signers")"
+allowed_signers_temporary=$(mktemp "${allowed_signers}.XXXXXX")
+trap 'rm -f -- "$allowed_signers_temporary"' EXIT HUP INT TERM
+printf '%s\n' "$public_signing_keys" \
+  | awk -v principal="$user_email" '{ print principal, $0 }' \
+  > "$allowed_signers_temporary"
+chmod 600 "$allowed_signers_temporary"
+mv -f -- "$allowed_signers_temporary" "$allowed_signers"
+trap - EXIT HUP INT TERM
+jj config set --user signing.backends.ssh.allowed-signers "$allowed_signers"
+git config --global --replace-all gpg.format ssh
+git config --global --replace-all gpg.ssh.program "$signing_program"
+git config --global --replace-all gpg.ssh.allowedSignersFile "$allowed_signers"
+git config --global --replace-all user.signingkey "$signing_key"
+git config --global --replace-all commit.gpgSign true
+
+if [[ "$(git rev-parse --is-shallow-repository)" == true ]]; then
+  git fetch --unshallow --tags
+fi
+
+if ! jj root >/dev/null 2>&1; then
+  jj git init --colocate .
+fi

--- a/.agents/setup
+++ b/.agents/setup
@@ -19,3 +19,7 @@ if ! command -v cargo-binstall >/dev/null 2>&1; then
 fi
 
 cargo binstall --no-confirm just cargo-nextest cargo-insta
+
+if [[ -n "${AMP_USE_JJ:-}" ]]; then
+  .agents/scripts/setup-jj
+fi


### PR DESCRIPTION
## Summary

- gate Jujutsu Orb setup behind `AMP_USE_JJ`
- install single-user Nix and provision Git and Jujutsu from a dedicated Nix profile
- fetch a pinned nixpkgs archive directly, avoiding rate-limited GitHub flake API resolution
- initialize a colocated repository and bridge Jujutsu SSH signing to Amp’s Orb signer
- configure local SSH signature verification from the authenticated user’s public GitHub signing keys

## Motivation

Orb images currently provide Git 2.39, while current Jujutsu remote operations require Git 2.41 or newer. Installing both tools through Nix avoids compiling Git in every opted-in Orb and establishes Nix as the package source for future Orb tooling.

Amp’s SSH signer follows Git’s file-based signing interface, while Jujutsu streams signing input and materializes the signing key in a temporary file. The adapter translates between those interfaces and delegates verification to `ssh-keygen`.

## Reliability

The setup performs identity, authentication, and public signing-key preflight checks before installing or mutating configuration. It exposes Nix, Git, and Jujutsu through `~/.local/bin`, persists `nix-command` and `flakes`, installs profile elements only when absent, and writes the allowed-signers file atomically.

## Verification

An independent fresh Orb test plus follow-up validation confirmed:

- first setup succeeds without preinstalled Nix, Jujutsu, or user-local Git
- pinned nixpkgs downloads directly without GitHub API rate-limit failures
- a second setup does not reinstall Nix or duplicate profile elements
- fresh shells resolve Nix 2.35.1, Git 2.54, and Jujutsu 0.41 through `~/.local/bin`
- plain `nix profile list` works with persisted experimental features
- the checkout is unshallowed and colocated, and `jj git fetch` succeeds
- automatically signed Git and Jujutsu commits both report `Good "git" signature`
- no verification commits or refs were pushed

Local checks also include `bash -n`, `git diff --check`, `git verify-commit`, and an isolated two-run profile test that remains at exactly two elements.